### PR TITLE
AdCP v3 capabilities schema conformance

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # Architecture
 
-AdCP Signals Adaptor — Cloudflare Worker implementing AdCP 2.6 Signals Activation Protocol with UCP v0.1/v0.2-draft extensions including GTS, Projector, and Handshake Simulator (v3.0-rc).
+AdCP Signals Adaptor — Cloudflare Worker implementing AdCP 3.0-rc Signals Activation Protocol with UCP v0.1/v0.2-draft extensions including GTS, Projector, and Handshake Simulator (v3.0-rc). Capabilities response conforms to the v3 schema — UCP capability block lives under the schema-sanctioned `ext.ucp` extension slot.
 
 ---
 
@@ -55,7 +55,7 @@ Cloudflare Worker (src/index.ts)
 |---|---|
 | `signalService.ts` | Search, generate, brief ranking, catalog adapter for NL query. Exports `getAllSignalsForCatalog()` and `inferRulesFromSignalId()`. |
 | `activationService.ts` | Activation job lifecycle, lazy state machine, webhook callback |
-| `capabilityService.ts` | AdCP capabilities envelope (KV-cached 1hr). Imports `UCP_CAPABILITY` from `vacDeclaration.ts`. |
+| `capabilityService.ts` | AdCP v3-schema capabilities envelope (KV-cached 1hr). Accepts optional `protocols` filter. UCP block nested under `ext.ucp`. Imports `UCP_CAPABILITY` from `vacDeclaration.ts`. |
 | `ruleEngine.ts` | Dynamic segment generation from dimension rules |
 | `signalModel.ts` | Base seeded + derived catalog (33 signals) |
 | `enrichedSignalModel.ts` | Census ACS-derived (5), Nielsen DMA-derived (6), cross-taxonomy bridge (5) = 16 enriched signals |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # AdCP Signals Adaptor
 
-A production-structured, AdCP 2.6-compliant Signals Provider built on Cloudflare Workers. Implements the full AdCP Signals Activation Protocol with IAB Data Transparency Standard v1.2 labeling, a UCP (User Context Protocol) embedding bridge, real OpenAI embedding vectors, a concept-level cross-taxonomy registry, natural language audience query, and a complete three-phase Vector Alignment Handshake — the first reference implementation combining the AdCP-UCP Bridge Profile with all UCP v0.2-draft extensions including GTS, Projector, and Handshake Simulator.
+A production-structured, AdCP 3.0-rc-compliant Signals Provider built on Cloudflare Workers. Implements the full AdCP Signals Activation Protocol with IAB Data Transparency Standard v1.2 labeling, a UCP (User Context Protocol) embedding bridge, real OpenAI embedding vectors, a concept-level cross-taxonomy registry, natural language audience query, and a complete three-phase Vector Alignment Handshake — the first reference implementation combining the AdCP-UCP Bridge Profile with all UCP v0.2-draft extensions including GTS, Projector, and Handshake Simulator.
 
 **Live:** `https://adcp-signals-adaptor.evgeny-193.workers.dev`  
 **MCP:** `https://adcp-signals-adaptor.evgeny-193.workers.dev/mcp`  
@@ -17,16 +17,17 @@ A production-structured, AdCP 2.6-compliant Signals Provider built on Cloudflare
 | v2.0 | 2026-02-15 | UCP embedding bridge — `x_ucp` on every signal, real OpenAI vectors, concept registry (19 concepts, 5 vendors), 3 new MCP tools (`query_signals_nl`, `get_concept`, `search_concepts`) |
 | v2.1 | 2026-03-08 | Hybrid NL resolver — true three-pass pipeline (exact_rule → embedding_similarity → lexical_fallback), MIN_EMBEDDING_SCORE=0.45, cord_cutter archetype, SemanticResolver class, `_embedding_mode` transparency field |
 | v3.0-rc | 2026-03-12 | Phase 2b + Phase 3 — GTS endpoint (15 pairs), Projector (Procrustes/SVD, simulated), Handshake Simulator (3-outcome negotiation), updated MCP initialize serverInfo |
+| v3.0-rc.1 | 2026-04-19 | AdCP v3 capabilities schema conformance — `get_adcp_capabilities` now accepts the `protocols` filter parameter, UCP block moved from top-level to `ext.ucp` (schema-sanctioned extension slot) |
 
 ---
 
 ## Protocol Compliance
 
-Implements AdCP Signals Activation Protocol v2.6 — 8 MCP tools:
+Implements AdCP Signals Activation Protocol v3.0-rc — 8 MCP tools. Capabilities response conforms to the [v3 schema](https://adcontextprotocol.org/schemas/v3/protocol/get-adcp-capabilities-response.json):
 
 | Tool | Status | Notes |
 |---|---|---|
-| `get_adcp_capabilities` | ✅ | `adcp.major_versions: [2, 3]` + full UCP capability block incl. GTS + projector |
+| `get_adcp_capabilities` | ✅ | `adcp.major_versions: [2, 3]` + `supported_protocols: ["signals"]` + UCP block under `ext.ucp`. Accepts `protocols` filter param. |
 | `get_signals` | ✅ | `signal_spec` + `deliver_to` (required) + relevance ranking + `x_dts` + `x_ucp` on every signal |
 | `activate_signal` | ✅ | `deliver_to` required. Async — returns `task_id + pending` immediately |
 | `get_operation_status` | ✅ | Aliases: `get_task_status`, `get_signal_status`. `destinations` field. |
@@ -43,7 +44,7 @@ Passes the AdCP conformance test suite: health, discovery, capability_discovery,
 
 | Standard | Coverage |
 |---|---|
-| AdCP Signals Activation Protocol v2.6 | Full — all 4 core tools + `get_similar_signals` + NL query + concept registry extensions |
+| AdCP Signals Activation Protocol v3.0-rc | Full — all 4 core tools + `get_similar_signals` + NL query + concept registry extensions. Capabilities response conforms to v3 schema (UCP under `ext.ucp`, `protocols` filter supported). |
 | IAB Data Transparency Standard v1.2 | Full — `x_dts` on every signal, all field types, onboarder section |
 | UCP (User Context Protocol) v0.1/v0.2-draft | `x_ucp` on every signal, real VAC embeddings, concept registry, NL query, GTS, Projector |
 
@@ -362,7 +363,7 @@ Cloudflare Worker (src/index.ts)
 Domain Layer (src/domain/)
   signalService.ts        — search, relevance ranking, brief parsing, catalog adapter
   activationService.ts    — async activate, lazy state machine, webhook
-  capabilityService.ts    — capabilities + UCP block (KV-cached 1hr)
+  capabilityService.ts    — AdCP v3 capabilities envelope (KV-cached 1hr). `protocols` filter. UCP under `ext.ucp`.
   ruleEngine.ts           — deterministic segment generation
   signalModel.ts          — base seeded + derived catalog (33 signals)
   enrichedSignalModel.ts  — Census ACS + Nielsen DMA + cross-taxonomy (16 signals)

--- a/src/domain/capabilityService.ts
+++ b/src/domain/capabilityService.ts
@@ -1,15 +1,41 @@
 // src/domain/capabilityService.ts
-// @adcp/client SDK: COMPATIBLE_ADCP_VERSIONS = ['v2.5', 'v2.6', 'v3', ...]
-// SIGNALS_TOOLS = ['get_signals', 'activate_signal']
+// Response shape conforms to AdCP v3 schema:
+//   https://adcontextprotocol.org/schemas/v3/protocol/get-adcp-capabilities-response.json
 //
-// Cache key bumped to v5 to bust the stale v4 entry that had pseudo-v1 space data.
+// Top-level keys allowed by v3: adcp, supported_protocols, account, media_buy,
+// signals, governance, sponsored_intelligence, brand, creative,
+// extensions_supported, last_updated, errors, context, ext.
+// UCP lives under `ext.ucp` (schema-sanctioned extension slot).
+//
+// Cache key bumped to v6 for the v3-conformant shape (ucp moved to ext).
 
-const CACHE_KEY = "adcp_capabilities_v5";
+const CACHE_KEY = "adcp_capabilities_v6";
 const CACHE_TTL_SECONDS = 3600;
 
 import { UCP_CAPABILITY } from "../ucp/vacDeclaration";
 
-const STATIC_CAPABILITIES = {
+const VALID_PROTOCOLS = new Set([
+  "media_buy",
+  "signals",
+  "governance",
+  "sponsored_intelligence",
+  "creative",
+  "brand",
+]);
+
+type AdcpCapabilities = {
+  adcp: { major_versions: number[] };
+  supported_protocols: string[];
+  signals?: unknown;
+  media_buy?: unknown;
+  governance?: unknown;
+  sponsored_intelligence?: unknown;
+  creative?: unknown;
+  brand?: unknown;
+  ext?: Record<string, unknown>;
+};
+
+const STATIC_CAPABILITIES: AdcpCapabilities = {
   adcp: {
     major_versions: [2, 3],
   },
@@ -56,20 +82,62 @@ const STATIC_CAPABILITIES = {
       max_rules_per_segment: 6,
     },
   },
-  ucp: UCP_CAPABILITY,
+  ext: {
+    ucp: UCP_CAPABILITY,
+  },
 };
 
-export async function getCapabilities(kv: KVNamespace): Promise<typeof STATIC_CAPABILITIES> {
+// Per-protocol block keys that may appear at top level.
+const PROTOCOL_BLOCK_KEYS = [
+  "signals",
+  "media_buy",
+  "governance",
+  "sponsored_intelligence",
+  "creative",
+  "brand",
+] as const;
+
+/**
+ * Return capabilities, optionally filtered to the requested protocols.
+ *
+ * When `protocols` is provided, only the matching per-protocol blocks are
+ * included. `adcp`, `supported_protocols`, and `ext` are always returned.
+ * Unknown protocol names are ignored (schema enum is enforced elsewhere).
+ */
+export async function getCapabilities(
+  kv: KVNamespace,
+  protocols?: string[],
+): Promise<AdcpCapabilities> {
+  let full: AdcpCapabilities | null = null;
   try {
     const cached = await kv.get(CACHE_KEY);
-    if (cached) return JSON.parse(cached) as typeof STATIC_CAPABILITIES;
+    if (cached) full = JSON.parse(cached) as AdcpCapabilities;
   } catch { /* cache miss */ }
 
-  try {
-    await kv.put(CACHE_KEY, JSON.stringify(STATIC_CAPABILITIES), {
-      expirationTtl: CACHE_TTL_SECONDS,
-    });
-  } catch { /* non-fatal */ }
+  if (!full) {
+    full = STATIC_CAPABILITIES;
+    try {
+      await kv.put(CACHE_KEY, JSON.stringify(STATIC_CAPABILITIES), {
+        expirationTtl: CACHE_TTL_SECONDS,
+      });
+    } catch { /* non-fatal */ }
+  }
 
-  return STATIC_CAPABILITIES;
+  if (!protocols || protocols.length === 0) return full;
+
+  const requested = new Set(
+    protocols.filter((p) => VALID_PROTOCOLS.has(p)),
+  );
+
+  const filtered: AdcpCapabilities = {
+    adcp: full.adcp,
+    supported_protocols: full.supported_protocols,
+    ...(full.ext ? { ext: full.ext } : {}),
+  };
+  for (const key of PROTOCOL_BLOCK_KEYS) {
+    if (requested.has(key) && full[key] !== undefined) {
+      (filtered as Record<string, unknown>)[key] = full[key];
+    }
+  }
+  return filtered;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -91,7 +91,7 @@ export default {
                 response = jsonResponse({ token });
 
             } else if (method === "GET" && path === "/capabilities") {
-                response = await handleGetCapabilities(env, logger);
+                response = await handleGetCapabilities(request, env, logger);
 
                 // ── UCP GTS ──────────────────────────────────────────────────────────
             } else if (method === "GET" && path === "/ucp/gts") {

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -219,7 +219,7 @@ async function handleToolCall(
 
     switch (resolvedName) {
         case "get_adcp_capabilities":
-            return callGetCapabilities(env);
+            return callGetCapabilities(args, env);
         case "get_signals":
             return callGetSignals(args, env);
         case "activate_signal":
@@ -242,8 +242,15 @@ async function handleToolCall(
 
 // ── Tool implementations ──────────────────────────────────────────────────────
 
-async function callGetCapabilities(env: Env): Promise<unknown> {
-    const caps = await getCapabilities(env.SIGNALS_CACHE);
+async function callGetCapabilities(
+    args: Record<string, unknown>,
+    env: Env
+): Promise<unknown> {
+    const raw = args["protocols"];
+    const protocols = Array.isArray(raw)
+        ? raw.filter((p): p is string => typeof p === "string")
+        : undefined;
+    const caps = await getCapabilities(env.SIGNALS_CACHE, protocols);
     return toolResult(JSON.stringify(caps, null, 2));
 }
 

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -26,10 +26,29 @@ export const ADCP_TOOLS: McpToolDefinition[] = [
         description:
             "Returns the capabilities of this AdCP Signals Provider: supported operations, " +
             "signal categories, available destinations, activation mode, and limits. " +
-            "Call this first to understand what the provider supports before searching or activating signals.",
+            "Call this first to understand what the provider supports before searching or activating signals. " +
+            "Optionally pass `protocols` to filter the response to specific protocol blocks.",
         inputSchema: {
             type: "object",
-            properties: {},
+            properties: {
+                protocols: {
+                    type: "array",
+                    description:
+                        "Optional filter — return only the listed protocol blocks. " +
+                        "Top-level adcp, supported_protocols, and ext are always returned.",
+                    items: {
+                        type: "string",
+                        enum: [
+                            "media_buy",
+                            "signals",
+                            "governance",
+                            "sponsored_intelligence",
+                            "creative",
+                            "brand",
+                        ],
+                    },
+                },
+            },
         },
     },
 

--- a/src/routes/capabilities.ts
+++ b/src/routes/capabilities.ts
@@ -1,8 +1,4 @@
 // src/routes/capabilities.ts
-//
-// CHANGELOG (fix):
-//   - getCapabilities() now requires env (not just kv) so it can determine
-//     the active embedding engine. Pass env.SIGNALS_CACHE + env together.
 
 import type { Env } from "../types/env";
 import { getCapabilities } from "../domain/capabilityService";
@@ -10,12 +6,19 @@ import { jsonResponse, errorResponse } from "./shared";
 import type { Logger } from "../utils/logger";
 
 export async function handleGetCapabilities(
+  request: Request,
   env: Env,
   logger: Logger,
 ): Promise<Response> {
   try {
-    const caps = await getCapabilities(env.SIGNALS_CACHE, env);
-    logger.info("capabilities_requested");
+    const url = new URL(request.url);
+    const raw = url.searchParams.get("protocols");
+    const protocols = raw
+      ? raw.split(",").map((s) => s.trim()).filter(Boolean)
+      : undefined;
+
+    const caps = await getCapabilities(env.SIGNALS_CACHE, protocols);
+    logger.info("capabilities_requested", { protocols });
     return jsonResponse(caps);
   } catch (err) {
     logger.error("capabilities_error", { error: String(err) });


### PR DESCRIPTION
## Summary
Fixes the 5 failing evaluator scenarios all rooted in `get_adcp_capabilities` schema conformance against the [AdCP v3 response schema](https://adcontextprotocol.org/schemas/v3/protocol/get-adcp-capabilities-response.json).

- `get_adcp_capabilities` now accepts the `protocols` filter parameter (REST + MCP). When set, only the requested protocol blocks are returned; `adcp`, `supported_protocols`, and `ext` are always included.
- UCP capability block moved from top-level `ucp` (non-standard) to `ext.ucp` (schema-sanctioned extension slot).
- Fixed `handleGetCapabilities` signature — previously passed `env` into a 1-arg `getCapabilities`, now reads `?protocols=signals,media_buy` from the URL.
- Bumped KV cache key `v5 -> v6` for the new shape.
- Updated README + ARCHITECTURE to reflect v3.0-rc compliance.

## Schema alignment (v3)
- `adcp.major_versions`: `[2, 3]` — integer array (unchanged, already valid)
- `supported_protocols`: `["signals"]` — snake_case enum (unchanged, already valid)
- `ext.ucp`: full UCP capability block (moved from root)

## Test plan
- [ ] Re-run AdCP evaluator — expect `capability_discovery`, `deterministic_testing`, `schema_validation`, `error_compliance` all to pass
- [ ] Verify Signals track is no longer skipped
- [ ] Manual: `GET /capabilities` returns full envelope
- [ ] Manual: `GET /capabilities?protocols=signals` returns only `adcp`, `supported_protocols`, `signals`, `ext`
- [ ] Manual: MCP `get_adcp_capabilities` with `{ "protocols": ["signals"] }` returns filtered shape
- [ ] Validate output against the v3 JSON schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)