### PR TITLE
Security hardening: auth chain + webhook + seed gating + parse safety

### DIFF
--- a/src/activations/auth/linkedin.ts
+++ b/src/activations/auth/linkedin.ts
@@ -46,9 +46,14 @@ const KV_ACCESS_TOKEN  = 'linkedin:access_token';
 const KV_REFRESH_TOKEN = 'linkedin:refresh_token';
 const KV_TOKEN_EXPIRES = 'linkedin:token_expires';
 const KV_TOKEN_META    = 'linkedin:token_meta';
+const KV_OAUTH_STATE_PREFIX = 'linkedin:oauth_state:';
 
 // Refresh buffer: refresh 5 minutes before expiry
 const REFRESH_BUFFER_MS = 5 * 60 * 1000;
+
+// OAuth state TTL — must match the time a user reasonably takes to complete
+// the provider login. 10 minutes balances user grace against CSRF window.
+const OAUTH_STATE_TTL_SECONDS = 10 * 60;
 
 // ─── Env shape ────────────────────────────────────────────────────────────────
 
@@ -72,8 +77,16 @@ export interface LinkedInTokenSet {
 
 // ─── Route: GET /auth/linkedin/init ──────────────────────────────────────────
 
-export function handleLinkedInAuthInit(env: LinkedInAuthEnv): Response {
+export async function handleLinkedInAuthInit(env: LinkedInAuthEnv): Promise<Response> {
   const state = crypto.randomUUID();
+  // Persist state so the callback can verify it — CSRF protection.
+  // Single-use: deleted on successful callback or expires via TTL.
+  await env.SIGNALS_CACHE.put(
+    KV_OAUTH_STATE_PREFIX + state,
+    '1',
+    { expirationTtl: OAUTH_STATE_TTL_SECONDS },
+  );
+
   const params = new URLSearchParams({
     response_type: 'code',
     client_id: env.LINKEDIN_CLIENT_ID,
@@ -103,7 +116,7 @@ export function handleLinkedInAuthInit(env: LinkedInAuthEnv): Response {
   <h1>AdCP → LinkedIn Authorization</h1>
   <p>One-time setup. After you authorize, the Worker stores your tokens and handles all refreshes automatically — no manual steps ever again.</p>
   <div class="scope">Scopes: r_ads · rw_ads · r_organization_social · w_organization_social</div>
-  <a href="${authUrl}">Authorize with LinkedIn →</a>
+  <a href="${escapeHtmlAttr(authUrl)}">Authorize with LinkedIn →</a>
   <p style="font-size: 12px; color: #3a3a5a;">App ID: 239110166 · Development Tier · Advertising API</p>
 </body>
 </html>`,
@@ -119,13 +132,25 @@ export async function handleLinkedInAuthCallback(
 ): Promise<Response> {
   const url = new URL(request.url);
   const code      = url.searchParams.get('code');
+  const state     = url.searchParams.get('state');
   const error     = url.searchParams.get('error');
   const errorDesc = url.searchParams.get('error_description');
+
+  // Verify state first — rejects CSRF regardless of whether LinkedIn
+  // returned an error or a code. Provider-supplied values are escaped
+  // below because the error path still renders them.
+  if (!state || !(await consumeOAuthState(state, env.SIGNALS_CACHE))) {
+    return htmlResponse('Invalid State', `
+      <p style="color:#ef4444">OAuth state missing, expired, or already used.</p>
+      <p>This protects against CSRF. Start the flow fresh.</p>
+      <a href="/auth/linkedin/init">Start over →</a>
+    `);
+  }
 
   if (error) {
     return htmlResponse('Authorization Failed', `
       <p style="color:#ef4444">LinkedIn returned an error:</p>
-      <pre style="color:#fb923c">${error}: ${errorDesc}</pre>
+      <pre style="color:#fb923c">${escapeHtml(error)}: ${escapeHtml(errorDesc ?? '')}</pre>
       <p>Common causes: user denied access, or scopes not approved on your app.</p>
       <a href="/auth/linkedin/init">Try again →</a>
     `);
@@ -145,7 +170,7 @@ export async function handleLinkedInAuthCallback(
     const msg = err instanceof Error ? err.message : String(err);
     return htmlResponse('Token Exchange Failed', `
       <p style="color:#ef4444">Failed to exchange code for tokens:</p>
-      <pre style="color:#fb923c">${msg}</pre>
+      <pre style="color:#fb923c">${escapeHtml(msg)}</pre>
       <p>Check LINKEDIN_CLIENT_SECRET is set correctly.</p>
       <a href="/auth/linkedin/init">Try again →</a>
     `);
@@ -156,13 +181,26 @@ export async function handleLinkedInAuthCallback(
   return htmlResponse('Authorization Successful ✓', `
     <p style="color:#00ff88; font-size: 20px;">✓ LinkedIn authorization complete.</p>
     <p>Tokens stored securely in KV. The Worker will handle all refreshes automatically.</p>
-    <div class="info-row"><span>Scope:</span><span>${tokenSet.scope}</span></div>
-    <div class="info-row"><span>Access token expires:</span><span>${new Date(tokenSet.expires_at).toLocaleString()}</span></div>
+    <div class="info-row"><span>Scope:</span><span>${escapeHtml(tokenSet.scope)}</span></div>
+    <div class="info-row"><span>Access token expires:</span><span>${escapeHtml(new Date(tokenSet.expires_at).toLocaleString())}</span></div>
     <div class="info-row"><span>Refresh token:</span><span>stored (12 month validity)</span></div>
-    <div class="info-row"><span>Ad account:</span><span>${env.LINKEDIN_AD_ACCOUNT_ID}</span></div>
+    <div class="info-row"><span>Ad account:</span><span>${escapeHtml(env.LINKEDIN_AD_ACCOUNT_ID)}</span></div>
     <p style="margin-top: 24px; font-size: 13px; color: #4a4a6a;">You can close this tab. Setup is complete.</p>
     <a href="/auth/linkedin/status">Check status →</a>
   `);
+}
+
+/**
+ * Verify and consume an OAuth state value.
+ * Returns true only if the state existed — and deletes it so it cannot be
+ * replayed. A missing state returns false (causes callback to reject).
+ */
+async function consumeOAuthState(state: string, kv: KVNamespace): Promise<boolean> {
+  const key = KV_OAUTH_STATE_PREFIX + state;
+  const existed = await kv.get(key);
+  if (!existed) return false;
+  await kv.delete(key);
+  return true;
 }
 
 // ─── Route: GET /auth/linkedin/status ────────────────────────────────────────
@@ -364,4 +402,27 @@ function json(body: unknown): Response {
   return new Response(JSON.stringify(body, null, 2), {
     headers: { 'Content-Type': 'application/json' },
   });
+}
+
+// ─── HTML escaping ────────────────────────────────────────────────────────────
+
+/**
+ * Escape a string for safe interpolation inside HTML text content.
+ * Prevents XSS from provider-supplied OAuth error strings.
+ */
+export function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+/**
+ * Escape a string for safe interpolation inside a double-quoted HTML attribute.
+ * (Same set as escapeHtml — kept as a named helper for intent clarity.)
+ */
+export function escapeHtmlAttr(s: string): string {
+  return escapeHtml(s);
 }

--- a/src/domain/activationService.ts
+++ b/src/domain/activationService.ts
@@ -152,6 +152,26 @@ export async function getOperationService(
   };
 }
 
+// 5-second timeout — webhooks should be quick acks, not long-running work.
+const WEBHOOK_TIMEOUT_MS = 5000;
+
+/**
+ * Validate that a webhook URL is safe to call.
+ * Only https is allowed (http permits plaintext tokens and MITM on the
+ * payload — our payload contains the segment ID and destination). The
+ * underlying Workers runtime cannot reach private networks from Cloudflare's
+ * edge, so SSRF to internal ranges is not a concern here; scheme + parse
+ * validation is the meaningful defence.
+ */
+function isValidWebhookUrl(raw: string): boolean {
+  try {
+    const u = new URL(raw);
+    return u.protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
 /**
  * Fire webhook with activation completion payload.
  * Non-fatal: logs error but doesn't throw.
@@ -164,6 +184,19 @@ async function fireWebhook(
   webhookUrl: string,
   logger: Logger
 ): Promise<void> {
+  if (!isValidWebhookUrl(webhookUrl)) {
+    logger.warn("webhook_rejected", {
+      operationId: opId,
+      reason: "invalid_url_or_scheme",
+    });
+    // Mark fired so we don't retry invalid URLs on every poll.
+    await markWebhookFired(db, opId);
+    return;
+  }
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), WEBHOOK_TIMEOUT_MS);
+
   try {
     const platformSegmentId = `${destination}_${signalId}`;
     const payload = {
@@ -186,13 +219,16 @@ async function fireWebhook(
       method: "POST",
       headers: { "Content-Type": "application/json", "User-Agent": "adcp-signals-adaptor/1.0" },
       body: JSON.stringify(payload),
+      signal: controller.signal,
     });
 
     await markWebhookFired(db, opId);
-    logger.info("webhook_fired", { operationId: opId, webhookUrl, statusCode: res.status });
+    logger.info("webhook_fired", { operationId: opId, statusCode: res.status });
   } catch (err) {
-    logger.error("webhook_failed", { operationId: opId, webhookUrl, error: String(err) });
+    logger.error("webhook_failed", { operationId: opId, error: String(err) });
     // Non-fatal — caller can re-poll
+  } finally {
+    clearTimeout(timeout);
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,6 +29,19 @@ import { handleActivateDispatch } from "./activations/routes/activate";
 // Seed data imported as text modules via wrangler assets
 import { taxonomyTsv, demographicsCsv, interestsCsv, geoCsv } from "./seedData";
 
+// KV flag + module-level memoization gate the auto-seed.
+// Workers isolates persist across requests; the module-level boolean short-circuits
+// the KV read after the first successful check. The KV flag covers isolate recycling.
+const KV_SEED_COMPLETE = "seed:complete";
+let seedCheckedInIsolate = false;
+
+// Paths that don't interact with the signal catalog — skip auto-seed entirely
+// to keep the hot path (health, OAuth callbacks) quick.
+const SEED_SKIP_PREFIXES = [
+    "/health",
+    "/auth/",
+];
+
 export default {
     async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
         const reqId = requestId();
@@ -57,7 +70,6 @@ export default {
             "/auth/linkedin/init",
             "/auth/linkedin/callback",
             "/auth/linkedin/status",
-            '/auth/linkedin/token-debug',
         ];
         const isPublic = publicPaths.some((p) => path === p || path.startsWith(p + "/"));
 
@@ -70,14 +82,11 @@ export default {
         logger.info("request_received", { method, path });
 
         try {
-            // Auto-seed on first request if DB is empty
-            ctx.waitUntil(
-                runSeedPipeline(
-                    getDb(env),
-                    { taxonomyTsv, demographicsCsv, interestsCsv, geoCsv },
-                    logger
-                ).catch((err) => logger.error("auto_seed_failed", { error: String(err) }))
-            );
+            // Auto-seed on first request if DB is empty.
+            // Gated by isolate-local + KV flag so it's not a per-request pipeline run.
+            if (!seedCheckedInIsolate && !SEED_SKIP_PREFIXES.some((p) => path.startsWith(p))) {
+                ctx.waitUntil(maybeSeed(env, logger));
+            }
 
             let response: Response;
 
@@ -85,10 +94,6 @@ export default {
 
             if (method === "GET" && path === "/health") {
                 response = jsonResponse({ status: "ok", version: "3.0-rc" });
-
-            } else if (method === 'GET' && path === '/auth/linkedin/token-debug') {
-                const token = await env.SIGNALS_CACHE.get('linkedin:access_token');
-                response = jsonResponse({ token });
 
             } else if (method === "GET" && path === "/capabilities") {
                 response = await handleGetCapabilities(request, env, logger);
@@ -107,7 +112,7 @@ export default {
 
                 // ── LinkedIn OAuth (public — no auth required) ───────────────────────
             } else if (method === "GET" && path === "/auth/linkedin/init") {
-                response = handleLinkedInAuthInit(env);
+                response = await handleLinkedInAuthInit(env);
 
             } else if (method === "GET" && path === "/auth/linkedin/callback") {
                 response = await handleLinkedInAuthCallback(request, env);
@@ -216,4 +221,33 @@ function withCors(response: Response): Response {
         status: response.status,
         headers,
     });
+}
+
+/**
+ * Run the seed pipeline at most once per isolate, and at most once per
+ * deployment (KV flag persists across isolates). Safe to call concurrently —
+ * runSeedPipeline itself is idempotent.
+ */
+async function maybeSeed(env: Env, logger: ReturnType<typeof createLogger>): Promise<void> {
+    seedCheckedInIsolate = true;
+    try {
+        const flag = await env.SIGNALS_CACHE.get(KV_SEED_COMPLETE);
+        if (flag) return;
+
+        const result = await runSeedPipeline(
+            getDb(env),
+            { taxonomyTsv, demographicsCsv, interestsCsv, geoCsv },
+            logger
+        );
+
+        // Either fresh-seeded or count-check found prior seed — either way,
+        // the catalog is populated and we can short-circuit on future requests.
+        if (result.seeded > 0 || result.skipped) {
+            await env.SIGNALS_CACHE.put(KV_SEED_COMPLETE, "1");
+        }
+    } catch (err) {
+        // Reset isolate flag so a transient failure can be retried on the next request.
+        seedCheckedInIsolate = false;
+        logger.error("auto_seed_failed", { error: String(err) });
+    }
 }

--- a/src/routes/shared.ts
+++ b/src/routes/shared.ts
@@ -42,5 +42,21 @@ export function requireAuth(request: Request, expectedKey: string): boolean {
 
   // Support both "Bearer <key>" and "ApiKey <key>"
   const match = authHeader.match(/^(?:Bearer|ApiKey)\s+(.+)$/i);
-  return match !== null && match[1] === expectedKey;
+  if (!match) return false;
+  return constantTimeEqual(match[1] ?? "", expectedKey);
+}
+
+/**
+ * Length-independent constant-time string compare.
+ * Compares against the longer of the two strings (zero-padded conceptually
+ * via XOR of indexed bytes) so both length and content leak no information.
+ * Sufficient for short shared-secret tokens; not a substitute for HMAC.
+ */
+export function constantTimeEqual(a: string, b: string): boolean {
+  const len = Math.max(a.length, b.length);
+  let diff = a.length ^ b.length;
+  for (let i = 0; i < len; i++) {
+    diff |= (a.charCodeAt(i) || 0) ^ (b.charCodeAt(i) || 0);
+  }
+  return diff === 0;
 }

--- a/src/storage/signalRepo.ts
+++ b/src/storage/signalRepo.ts
@@ -39,6 +39,18 @@ interface RuleRow {
 
 // ── Serialization ──────────────────────────────────────────────────────────────
 
+/**
+ * Parse a JSON column safely — a single corrupted row should not 500 the
+ * whole list endpoint. Returns the fallback if the value is unparseable.
+ */
+function safeJsonParse<T>(raw: string, fallback: T): T {
+  try {
+    return JSON.parse(raw) as T;
+  } catch {
+    return fallback;
+  }
+}
+
 function rowToSignal(row: SignalRow, rules: RuleRow[] = []): CanonicalSignal {
   return {
     signalId: row.signal_id,
@@ -48,20 +60,22 @@ function rowToSignal(row: SignalRow, rules: RuleRow[] = []): CanonicalSignal {
     description: row.description,
     categoryType: row.category_type as CanonicalSignal["categoryType"],
     ...(row.parent_signal_id ? { parentSignalId: row.parent_signal_id } : {}),
-    sourceSystems: JSON.parse(row.source_systems) as string[],
-    destinations: JSON.parse(row.destinations) as string[],
+    sourceSystems: safeJsonParse<string[]>(row.source_systems, []),
+    destinations: safeJsonParse<string[]>(row.destinations, []),
     activationSupported: row.activation_supported === 1,
     ...(row.estimated_audience_size !== null
       ? { estimatedAudienceSize: row.estimated_audience_size }
       : {}),
-    ...(row.geography ? { geography: JSON.parse(row.geography) as string[] } : {}),
-    ...(row.pricing ? { pricing: JSON.parse(row.pricing) as CanonicalSignal["pricing"] } : {}),
+    ...(row.geography ? { geography: safeJsonParse<string[]>(row.geography, []) } : {}),
+    ...(row.pricing
+      ? { pricing: safeJsonParse<CanonicalSignal["pricing"]>(row.pricing, undefined as CanonicalSignal["pricing"]) }
+      : {}),
     ...(row.freshness ? { freshness: row.freshness } : {}),
     accessPolicy: row.access_policy as CanonicalSignal["accessPolicy"],
     generationMode: row.generation_mode as CanonicalSignal["generationMode"],
     status: row.status as CanonicalSignal["status"],
     ...(row.raw_source_refs
-      ? { rawSourceRefs: JSON.parse(row.raw_source_refs) as string[] }
+      ? { rawSourceRefs: safeJsonParse<string[]>(row.raw_source_refs, []) }
       : {}),
     ...(rules.length > 0
       ? {
@@ -72,7 +86,7 @@ function rowToSignal(row: SignalRow, rules: RuleRow[] = []): CanonicalSignal {
             operator: r.operator as CanonicalSignal["rules"] extends Array<infer R>
               ? R["operator"]
               : never,
-            value: JSON.parse(r.value) as string | number | string[],
+            value: safeJsonParse<string | number | string[]>(r.value, r.value as string),
             ...(r.weight !== null ? { weight: r.weight } : {}),
           })),
         }

--- a/tests/security.test.ts
+++ b/tests/security.test.ts
@@ -1,0 +1,211 @@
+// tests/security.test.ts
+// Unit tests for the security-hardening changes:
+//   - constantTimeEqual API key compare
+//   - escapeHtml / escapeHtmlAttr
+//   - OAuth state KV-roundtrip behaviour (consume-once semantics)
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { constantTimeEqual, requireAuth } from "../src/routes/shared";
+import { escapeHtml, escapeHtmlAttr, handleLinkedInAuthInit, handleLinkedInAuthCallback } from "../src/activations/auth/linkedin";
+
+// ── constant-time compare ─────────────────────────────────────────────────────
+
+describe("constantTimeEqual", () => {
+  it("returns true for identical strings", () => {
+    expect(constantTimeEqual("abc", "abc")).toBe(true);
+    expect(constantTimeEqual("", "")).toBe(true);
+  });
+
+  it("returns false for different content of equal length", () => {
+    expect(constantTimeEqual("abc", "abd")).toBe(false);
+    expect(constantTimeEqual("abc", "xbc")).toBe(false);
+  });
+
+  it("returns false for different lengths", () => {
+    expect(constantTimeEqual("abc", "abcd")).toBe(false);
+    expect(constantTimeEqual("abcd", "abc")).toBe(false);
+    expect(constantTimeEqual("", "x")).toBe(false);
+  });
+
+  it("does not short-circuit on length mismatch", () => {
+    // Property: regardless of input lengths, returns boolean (no throw).
+    expect(typeof constantTimeEqual("a".repeat(1000), "b")).toBe("boolean");
+  });
+});
+
+// ── requireAuth ───────────────────────────────────────────────────────────────
+
+describe("requireAuth", () => {
+  const KEY = "demo-key-adcp-signals-v1";
+
+  function req(authHeader?: string): Request {
+    const headers = new Headers();
+    if (authHeader) headers.set("Authorization", authHeader);
+    return new Request("https://example.com/", { headers });
+  }
+
+  it("accepts Bearer with the right key", () => {
+    expect(requireAuth(req(`Bearer ${KEY}`), KEY)).toBe(true);
+  });
+
+  it("accepts ApiKey with the right key (case-insensitive scheme)", () => {
+    expect(requireAuth(req(`ApiKey ${KEY}`), KEY)).toBe(true);
+    expect(requireAuth(req(`apikey ${KEY}`), KEY)).toBe(true);
+  });
+
+  it("rejects wrong key", () => {
+    expect(requireAuth(req(`Bearer wrong`), KEY)).toBe(false);
+  });
+
+  it("rejects missing header", () => {
+    expect(requireAuth(req(), KEY)).toBe(false);
+  });
+
+  it("rejects malformed header", () => {
+    expect(requireAuth(req("Basic abc"), KEY)).toBe(false);
+    expect(requireAuth(req(KEY), KEY)).toBe(false);
+  });
+});
+
+// ── HTML escape ───────────────────────────────────────────────────────────────
+
+describe("escapeHtml", () => {
+  it("escapes the five XSS-relevant characters", () => {
+    expect(escapeHtml("<script>")).toBe("&lt;script&gt;");
+    expect(escapeHtml("a & b")).toBe("a &amp; b");
+    expect(escapeHtml('say "hi"')).toBe("say &quot;hi&quot;");
+    expect(escapeHtml("it's")).toBe("it&#39;s");
+  });
+
+  it("renders a script-tag payload inert", () => {
+    const payload = `</pre><script>alert(document.cookie)</script><pre>`;
+    const escaped = escapeHtml(payload);
+    expect(escaped).not.toContain("<script>");
+    expect(escaped).not.toContain("</pre>");
+    expect(escaped).toContain("&lt;script&gt;");
+  });
+
+  it("escapeHtmlAttr matches escapeHtml (single-source)", () => {
+    expect(escapeHtmlAttr(`" onclick="alert(1)`)).toBe(escapeHtml(`" onclick="alert(1)`));
+  });
+
+  it("is a no-op on safe strings", () => {
+    expect(escapeHtml("hello world")).toBe("hello world");
+  });
+});
+
+// ── OAuth state roundtrip ─────────────────────────────────────────────────────
+//
+// We don't mock LinkedIn here — only the KV side of the state lifecycle is
+// under test. handleLinkedInAuthInit must write the state into KV; the
+// callback must reject if state is missing or replayed.
+
+interface FakeKV {
+  store: Map<string, string>;
+}
+
+function makeKv(): KVNamespace {
+  const store = new Map<string, string>();
+  return {
+    async get(key: string) { return store.get(key) ?? null; },
+    async put(key: string, value: string) { store.set(key, value); },
+    async delete(key: string) { store.delete(key); },
+    // not used in these tests:
+    async list() { return { keys: [], list_complete: true, cacheStatus: null } as never; },
+    async getWithMetadata() { return { value: null, metadata: null, cacheStatus: null } as never; },
+  } as unknown as KVNamespace;
+}
+
+function makeEnv(kv: KVNamespace) {
+  return {
+    LINKEDIN_CLIENT_ID: "client",
+    LINKEDIN_CLIENT_SECRET: "secret",
+    LINKEDIN_REDIRECT_URI: "https://example.com/cb",
+    LINKEDIN_AD_ACCOUNT_ID: "1234",
+    SIGNALS_CACHE: kv,
+  };
+}
+
+function extractState(authUrl: string): string {
+  return new URL(authUrl).searchParams.get("state") ?? "";
+}
+
+describe("OAuth state lifecycle", () => {
+  it("init persists state in KV; callback consumes it once", async () => {
+    const kv = makeKv();
+    const env = makeEnv(kv);
+
+    const initRes = await handleLinkedInAuthInit(env);
+    const html = await initRes.text();
+    const match = html.match(/href="([^"]*linkedin\.com[^"]*)"/);
+    if (!match || !match[1]) throw new Error("authorize URL not found in init HTML");
+    const state = extractState(match[1].replace(/&amp;/g, "&"));
+    expect(state.length).toBeGreaterThan(0);
+
+    // KV should contain the state key
+    expect(await kv.get(`linkedin:oauth_state:${state}`)).toBe("1");
+
+    // First callback with that state passes the state check (will then fail
+    // at the missing `code` step, which is fine — we only assert that the
+    // state-check branch did not reject).
+    const cb1 = await handleLinkedInAuthCallback(
+      new Request(`https://example.com/cb?state=${state}`),
+      env,
+    );
+    const cb1Body = await cb1.text();
+    expect(cb1Body).not.toContain("Invalid State");
+    expect(cb1Body).toContain("Missing Code"); // expected: state OK, code missing
+
+    // KV entry was deleted (single-use)
+    expect(await kv.get(`linkedin:oauth_state:${state}`)).toBeNull();
+
+    // Replay rejected
+    const cb2 = await handleLinkedInAuthCallback(
+      new Request(`https://example.com/cb?state=${state}`),
+      env,
+    );
+    expect(await cb2.text()).toContain("Invalid State");
+  });
+
+  it("callback rejects when state is missing", async () => {
+    const kv = makeKv();
+    const env = makeEnv(kv);
+    const res = await handleLinkedInAuthCallback(
+      new Request("https://example.com/cb"),
+      env,
+    );
+    expect(await res.text()).toContain("Invalid State");
+  });
+
+  it("callback rejects when state was never issued", async () => {
+    const kv = makeKv();
+    const env = makeEnv(kv);
+    const res = await handleLinkedInAuthCallback(
+      new Request("https://example.com/cb?state=fabricated"),
+      env,
+    );
+    expect(await res.text()).toContain("Invalid State");
+  });
+
+  it("callback escapes provider-supplied error_description", async () => {
+    const kv = makeKv();
+    const env = makeEnv(kv);
+
+    // Issue a state we can use
+    const initRes = await handleLinkedInAuthInit(env);
+    const html = await initRes.text();
+    const m = html.match(/href="([^"]*linkedin\.com[^"]*)"/);
+    if (!m || !m[1]) throw new Error("authorize URL not found in init HTML");
+    const state = extractState(m[1].replace(/&amp;/g, "&"));
+
+    const payload = "<script>alert(1)</script>";
+    const url =
+      `https://example.com/cb?state=${state}` +
+      `&error=access_denied&error_description=${encodeURIComponent(payload)}`;
+    const res = await handleLinkedInAuthCallback(new Request(url), env);
+    const body = await res.text();
+
+    expect(body).not.toContain("<script>alert(1)</script>");
+    expect(body).toContain("&lt;script&gt;alert(1)&lt;/script&gt;");
+  });
+});


### PR DESCRIPTION
## Summary
Closes the three critical auth issues from the recent code review (token-debug + OAuth state + XSS in callback HTML), plus four high-severity items. All changes are scoped, additive, and covered by 17 new unit tests.

## Critical (token exfiltration chain)
- **Remove `/auth/linkedin/token-debug`** — public route that returned the raw KV-stored access token to anyone.
- **Validate OAuth `state`** — persisted in KV with 10-min TTL on init, consumed (deleted) on callback. Missing/expired/replayed state is rejected before any token work.
- **HTML-escape callback rendering** — `error`, `error_description`, exception `msg`, scope, expires_at, ad_account_id all escaped via `escapeHtml`. Defangs reflected XSS from provider-supplied error strings (which combined with the token-debug endpoint enabled token exfiltration in one hop).

## High
- **Webhook fetch hardening** — https-only scheme check + 5s `AbortController` timeout. Invalid URLs are marked-fired so we don't retry on every poll.
- **Auto-seed gating** — KV `seed:complete` flag + isolate-local memo, skip `/health` and `/auth/*`. Was running the seed pipeline (or at minimum a D1 `COUNT`) on every request.
- **Safe `JSON.parse` in `signalRepo.rowToSignal`** — one corrupted row no longer 500s the whole list endpoint.
- **Constant-time API key compare** — length + content via XOR, no early exit.

## Tests
- 17 new unit tests in `tests/security.test.ts`:
  - `constantTimeEqual` — identical / differ-by-one / length mismatch / no-throw on huge inputs
  - `requireAuth` — Bearer / ApiKey / malformed / missing / wrong key
  - `escapeHtml` + `escapeHtmlAttr` — all five XSS chars + script-tag inertness
  - OAuth state lifecycle — issue → consume-once → replay rejection → fabricated rejection → escaped `error_description`
- Touched-file suite (`index` + `mcp` + `security`): **79/79 pass**.
- Pre-existing failures in `nlaq.unit` / `ucp-phase2-3` / `queryResolver` are unrelated and present on master baseline.
- Type-check: **zero new errors**. All remaining errors are pre-existing `exactOptionalPropertyTypes` noise.

## Deferred
- `/signals/search` persists brief-generated proposals to D1 on a read path. Removing this would break dynamic-proposal activation: the MCP `activate_signal` handler doesn't pass `proposalData`, so the lazy-create path can't resolve by ID. Proper fix needs a coordinated activation-side change (deterministic ID regeneration, or always pass `proposalData` from MCP). Filed for a follow-up.

## Test plan
- [ ] CI green
- [ ] Live smoke: `GET /auth/linkedin/token-debug` should 404
- [ ] Live smoke: `GET /auth/linkedin/callback?state=fabricated` should render "Invalid State"
- [ ] Live smoke: `GET /capabilities` and `GET /health` still return 200
- [ ] MCP smoke: `tools/call get_adcp_capabilities` still returns the v3-conformant shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)