### PR TITLE
Allow MCP Streamable HTTP headers in CORS preflight

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -136,19 +136,9 @@ export default {
                 response = await handleActivateDispatch(request, env as any, platform);
 
                 // ── MCP ───────────────────────────────────────────────────────────────
+                // OPTIONS is handled by the early global preflight at the top of fetch.
             } else if (path === "/mcp" || path.startsWith("/mcp")) {
-                if (method === "OPTIONS") {
-                    response = new Response(null, {
-                        status: 204,
-                        headers: {
-                            "Access-Control-Allow-Origin": "*",
-                            "Access-Control-Allow-Methods": "POST, OPTIONS",
-                            "Access-Control-Allow-Headers": "Content-Type, Authorization, Mcp-Session-Id",
-                        },
-                    });
-                } else {
-                    response = await handleMcpRequest(request, env, logger);
-                }
+                response = await handleMcpRequest(request, env, logger);
 
                 // ── Signal search ────────────────────────────────────────────────────
             } else if (
@@ -203,11 +193,16 @@ export default {
     },
 };
 
-function corsHeaders(): Record<string, string> {
+export function corsHeaders(): Record<string, string> {
     return {
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
-        "Access-Control-Allow-Headers": "Content-Type, Authorization",
+        // Mcp-Session-Id, Mcp-Protocol-Version and Last-Event-ID are required by
+        // the MCP Streamable HTTP transport. Omitting them causes browser-based
+        // MCP clients to fail preflight and report it as a generic "blocked"
+        // (which LLM-driven probes sometimes mislabel as CSRF).
+        "Access-Control-Allow-Headers": "Content-Type, Authorization, Mcp-Session-Id, Mcp-Protocol-Version, Last-Event-ID",
+        "Access-Control-Expose-Headers": "Mcp-Session-Id",
         "Access-Control-Max-Age": "86400",
     };
 }

--- a/tests/security.test.ts
+++ b/tests/security.test.ts
@@ -7,6 +7,42 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { constantTimeEqual, requireAuth } from "../src/routes/shared";
 import { escapeHtml, escapeHtmlAttr, handleLinkedInAuthInit, handleLinkedInAuthCallback } from "../src/activations/auth/linkedin";
+import { corsHeaders } from "../src/index";
+
+// ── CORS headers ──────────────────────────────────────────────────────────────
+//
+// MCP Streamable HTTP clients send Mcp-Session-Id (and a couple of related
+// headers) on the wire. If they're not in the preflight allow-list, browser
+// MCP clients fail with what looks like a generic CORS block — and at least
+// one LLM-driven probe agent has been observed mislabelling that as "CSRF".
+// This test pins the allow-list so a future edit can't silently break it.
+
+describe("corsHeaders", () => {
+  const headers = corsHeaders();
+  const allowed = headers["Access-Control-Allow-Headers"]?.toLowerCase() ?? "";
+
+  it("allows the standard request headers", () => {
+    expect(allowed).toContain("content-type");
+    expect(allowed).toContain("authorization");
+  });
+
+  it("allows the MCP Streamable HTTP transport headers", () => {
+    expect(allowed).toContain("mcp-session-id");
+    expect(allowed).toContain("mcp-protocol-version");
+    expect(allowed).toContain("last-event-id");
+  });
+
+  it("exposes Mcp-Session-Id so browser clients can read it from responses", () => {
+    expect((headers["Access-Control-Expose-Headers"] ?? "").toLowerCase())
+      .toContain("mcp-session-id");
+  });
+
+  it("permits POST and OPTIONS for MCP", () => {
+    const methods = headers["Access-Control-Allow-Methods"]?.toUpperCase() ?? "";
+    expect(methods).toContain("POST");
+    expect(methods).toContain("OPTIONS");
+  });
+});
 
 // ── constant-time compare ─────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
Browser-based MCP clients send `Mcp-Session-Id` (plus `Mcp-Protocol-Version` and `Last-Event-ID` for SSE resume). The Worker's preflight only allowed `Content-Type, Authorization`, so the actual request was blocked by CORS. An LLM-driven probe agent at agenticadvertising.org observed this and labelled it "CSRF" — there is **no CSRF middleware** in the Worker; this was a CORS preflight failure. Verified against live deploy:

```
curl -s -i -X OPTIONS https://adcp-signals-adaptor.evgeny-193.workers.dev/mcp \
  -H "Origin: https://agenticadvertising.org" \
  -H "Access-Control-Request-Method: POST" \
  -H "Access-Control-Request-Headers: Content-Type, Authorization, Mcp-Session-Id"
# → Access-Control-Allow-Headers: Content-Type, Authorization     ← Mcp-Session-Id missing
```

## Changes
- Add `Mcp-Session-Id`, `Mcp-Protocol-Version`, `Last-Event-ID` to `Access-Control-Allow-Headers`
- Add `Mcp-Session-Id` to `Access-Control-Expose-Headers` so browser MCP clients can read it from the response
- Export `corsHeaders` for unit testing
- Remove dead-code per-route OPTIONS branch in `/mcp` (the early global preflight returns first; the inner branch was unreachable and would have drifted)
- 4 new unit tests pin the allow-list so a future edit can't silently drop a required MCP header

## Test plan
- [x] `vitest run tests/security.test.ts` — 21/21 pass
- [x] Type-check — zero new errors
- [ ] Deploy + re-run the OPTIONS probe — expect `Mcp-Session-Id` echoed in `Access-Control-Allow-Headers`
- [ ] Re-test the probe at agenticadvertising.org/chat — should connect

🤖 Generated with [Claude Code](https://claude.com/claude-code)