### PR TITLE
chore: ignore .claude worktree metadata + local probe dumps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -361,3 +361,9 @@ MigrationBackup/
 
 # Fody - auto-generated XML schema
 FodyWeavers.xsd
+
+# Claude Code worktree metadata
+.claude/
+
+# Local probe / evaluator output dumps
+/JSON Results.txt


### PR DESCRIPTION
## Summary
Tiny housekeeping. Two entries to keep `git status` clean across worktrees:

- `.claude/` — Claude Code worktree metadata. Has been showing as untracked in every status output.
- `/JSON Results.txt` — local file produced by ad-hoc probe runs; not meant to be tracked.

No code or behavior change.

## Test plan
- [ ] After merge, `git status` in either worktree shows clean tree (only intentional changes appear).