### PR TITLE
HEAD-schema conformance: adcp.idempotency + context echo

### DIFF
--- a/scripts/test-live.sh
+++ b/scripts/test-live.sh
@@ -75,6 +75,8 @@ run "health"                          200 'b.status==="ok"'                     
 run "capabilities unfiltered"         200 'b.adcp && Array.isArray(b.adcp.major_versions) && b.ext && b.ext.ucp' "$BASE/capabilities"
 run "capabilities ?protocols=signals" 200 'b.signals && b.ext && b.ext.ucp && !("media_buy" in b)'               "$BASE/capabilities?protocols=signals"
 run "capabilities ?protocol=signals (singular alias)" 200 'b.signals && b.ext && b.ext.ucp && !("media_buy" in b)' "$BASE/capabilities?protocol=signals"
+run "capabilities has adcp.idempotency.replay_ttl_seconds (HEAD schema)" 200 'b.adcp.idempotency && typeof b.adcp.idempotency.replay_ttl_seconds==="number" && b.adcp.idempotency.replay_ttl_seconds>=3600 && b.adcp.idempotency.replay_ttl_seconds<=604800' "$BASE/capabilities"
+run "capabilities echoes ?correlation_id=" 200 'b.context && b.context.correlation_id==="test-corr-abc"' "$BASE/capabilities?correlation_id=test-corr-abc"
 
 echo ""
 echo "=== UCP HANDSHAKE ==="
@@ -143,6 +145,8 @@ run "mcp: get_adcp_capabilities (protocols filter)"    200 'b.result.structuredC
 # the alias, the singular `protocol` arg is ignored and the unfiltered response
 # (which DOES include `signals`) is returned.
 run "mcp: get_adcp_capabilities (singular protocol alias actually filters)" 200 '!("signals" in b.result.structuredContent)' -X POST "$BASE/mcp" -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"get_adcp_capabilities","arguments":{"protocol":"media_buy"}}}'
+run "mcp: get_adcp_capabilities idempotency block (HEAD schema req)" 200 'b.result.structuredContent.adcp.idempotency && b.result.structuredContent.adcp.idempotency.replay_ttl_seconds>=3600' -X POST "$BASE/mcp" -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"get_adcp_capabilities","arguments":{}}}'
+run "mcp: get_adcp_capabilities echoes context.correlation_id" 200 'b.result.structuredContent.context && b.result.structuredContent.context.correlation_id==="probe-xyz-123"' -X POST "$BASE/mcp" -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"get_adcp_capabilities","arguments":{"context":{"correlation_id":"probe-xyz-123"}}}}'
 run "mcp: query_signals_nl (structuredContent)"        200 'b.result.structuredContent'  -X POST "$BASE/mcp" -H "Authorization: Bearer $KEY" -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"query_signals_nl","arguments":{"query":"affluent streaming families","limit":5}}}'
 run "mcp: get_concept (structuredContent)"             200 'b.result.structuredContent && b.result.structuredContent.concept_id==="SOCCER_MOM_US"' -X POST "$BASE/mcp" -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","id":5,"method":"tools/call","params":{"name":"get_concept","arguments":{"concept_id":"SOCCER_MOM_US"}}}'
 run "mcp: search_concepts (structuredContent)"         200 'b.result.structuredContent && Array.isArray(b.result.structuredContent.results)'      -X POST "$BASE/mcp" -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","id":6,"method":"tools/call","params":{"name":"search_concepts","arguments":{"q":"high income household","limit":5}}}'

--- a/src/domain/capabilityService.ts
+++ b/src/domain/capabilityService.ts
@@ -7,9 +7,10 @@
 // extensions_supported, last_updated, errors, context, ext.
 // UCP lives under `ext.ucp` (schema-sanctioned extension slot).
 //
-// Cache key bumped to v6 for the v3-conformant shape (ucp moved to ext).
+// Cache key bumped to v6 for the v3-conformant shape (ucp moved to ext)
+// then v7 for the HEAD-schema-conformant shape (adds adcp.idempotency).
 
-const CACHE_KEY = "adcp_capabilities_v6";
+const CACHE_KEY = "adcp_capabilities_v7";
 const CACHE_TTL_SECONDS = 3600;
 
 import { UCP_CAPABILITY } from "../ucp/vacDeclaration";
@@ -24,7 +25,17 @@ const VALID_PROTOCOLS = new Set([
 ]);
 
 type AdcpCapabilities = {
-  adcp: { major_versions: number[] };
+  adcp: {
+    major_versions: number[];
+    /**
+     * Idempotency replay-window declaration. Required by the HEAD AdCP
+     * capabilities schema (per upstream PR #2315 — the field landed without
+     * a versioned schema tag, so rc.{1,2,3} validators don't catch its
+     * absence; the live evaluator runs HEAD and does). Seller declares how
+     * long a canonical response is retained for an idempotency_key.
+     */
+    idempotency: { replay_ttl_seconds: number };
+  };
   supported_protocols: string[];
   signals?: unknown;
   media_buy?: unknown;
@@ -33,11 +44,21 @@ type AdcpCapabilities = {
   creative?: unknown;
   brand?: unknown;
   ext?: Record<string, unknown>;
+  /**
+   * Opaque correlation data echoed unchanged in responses. Capability-discovery
+   * storyboards send context.correlation_id and assert the response carries it
+   * back. Populated per-request by the caller (MCP handler / REST route) after
+   * getCapabilities returns; not part of the static capability set.
+   */
+  context?: Record<string, unknown>;
 };
 
 const STATIC_CAPABILITIES: AdcpCapabilities = {
   adcp: {
     major_versions: [2, 3],
+    // 24h replay window (recommended in the HEAD schema; min 3600, max 604800).
+    // Mutating tools (activate_signal) honour this — see activationRepo.
+    idempotency: { replay_ttl_seconds: 86400 },
   },
   supported_protocols: ["signals"],
   signals: {

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -261,7 +261,17 @@ async function callGetCapabilities(
         protocols = [rawSingle];
     }
     const caps = await getCapabilities(env.SIGNALS_CACHE, protocols);
-    return toolResult(JSON.stringify(caps, null, 2), caps);
+
+    // Echo back the request's context block. Capability-discovery storyboards
+    // send context.correlation_id and assert it round-trips. Per
+    // /schemas/core/context.json, context is opaque — we don't parse it, we
+    // copy it through unchanged.
+    const ctx = args["context"];
+    const response = ctx && typeof ctx === "object" && !Array.isArray(ctx)
+        ? { ...caps, context: ctx as Record<string, unknown> }
+        : caps;
+
+    return toolResult(JSON.stringify(response, null, 2), response);
 }
 
 async function callGetSignals(

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -77,6 +77,14 @@ export const ADCP_TOOLS: McpToolDefinition[] = [
                         "Provided for compatibility with clients that use the singular form.",
                     enum: [...PROTOCOL_ENUM],
                 },
+                context: {
+                    type: "object",
+                    description:
+                        "Opaque correlation data echoed unchanged in the response. " +
+                        "Use for tracing / session IDs / correlation IDs. Per the AdCP " +
+                        "context schema, contents are not parsed by the agent — they round-trip.",
+                    additionalProperties: true,
+                },
             },
         },
         outputSchema: {
@@ -85,12 +93,23 @@ export const ADCP_TOOLS: McpToolDefinition[] = [
             properties: {
                 adcp: {
                     type: "object",
-                    required: ["major_versions"],
+                    required: ["major_versions", "idempotency"],
                     properties: {
                         major_versions: {
                             type: "array",
                             items: { type: "integer", minimum: 1 },
                             minItems: 1,
+                        },
+                        idempotency: {
+                            type: "object",
+                            required: ["replay_ttl_seconds"],
+                            properties: {
+                                replay_ttl_seconds: {
+                                    type: "integer",
+                                    minimum: 3600,
+                                    maximum: 604800,
+                                },
+                            },
                         },
                     },
                     additionalProperties: true,
@@ -106,6 +125,7 @@ export const ADCP_TOOLS: McpToolDefinition[] = [
                 creative: { type: "object", additionalProperties: true },
                 brand: { type: "object", additionalProperties: true },
                 ext: { type: "object", additionalProperties: true },
+                context: { type: "object", additionalProperties: true },
                 extensions_supported: { type: "array", items: { type: "string" } },
                 last_updated: { type: "string" },
             },

--- a/src/routes/capabilities.ts
+++ b/src/routes/capabilities.ts
@@ -22,8 +22,18 @@ export async function handleGetCapabilities(
       : undefined;
 
     const caps = await getCapabilities(env.SIGNALS_CACHE, protocols);
+
+    // Echo back any context the caller passed. REST /capabilities is a GET,
+    // so we look for `correlation_id` in the query string (the most common
+    // field) and assemble a context object from it. Schema-wise this is an
+    // opaque pass-through — the field has no protocol semantics.
+    const correlationId = url.searchParams.get("correlation_id");
+    const response = correlationId
+      ? { ...caps, context: { correlation_id: correlationId } }
+      : caps;
+
     logger.info("capabilities_requested", { protocols });
-    return jsonResponse(caps);
+    return jsonResponse(response);
   } catch (err) {
     logger.error("capabilities_error", { error: String(err) });
     return errorResponse("INTERNAL_ERROR", "Failed to retrieve capabilities", 500);

--- a/tests/security.test.ts
+++ b/tests/security.test.ts
@@ -81,6 +81,28 @@ describe("MCP tool definitions — outputSchema", () => {
     expect(props.protocol?.type).toBe("string");
   });
 
+  it("get_adcp_capabilities inputSchema advertises `context` (opaque echo)", () => {
+    const schema = getToolByName("get_adcp_capabilities")!.inputSchema;
+    const props = schema.properties as Record<string, { type?: string }>;
+    expect(props.context?.type).toBe("object");
+  });
+
+  it("get_adcp_capabilities outputSchema requires adcp.idempotency.replay_ttl_seconds (HEAD schema)", () => {
+    const schema = getToolByName("get_adcp_capabilities")!.outputSchema!;
+    const adcp = (schema.properties as Record<string, any>).adcp;
+    expect(adcp.required).toContain("idempotency");
+    const idempotency = adcp.properties.idempotency;
+    expect(idempotency.required).toContain("replay_ttl_seconds");
+    expect(idempotency.properties.replay_ttl_seconds.minimum).toBe(3600);
+    expect(idempotency.properties.replay_ttl_seconds.maximum).toBe(604800);
+  });
+
+  it("get_adcp_capabilities outputSchema declares optional `context` for echo", () => {
+    const schema = getToolByName("get_adcp_capabilities")!.outputSchema!;
+    const props = schema.properties as Record<string, { type?: string }>;
+    expect(props.context?.type).toBe("object");
+  });
+
   it("activate_signal outputSchema requires task_id, status, signal_agent_segment_id", () => {
     const schema = getToolByName("activate_signal")!.outputSchema!;
     expect(schema.required).toEqual(
@@ -99,6 +121,42 @@ describe("MCP tool definitions — outputSchema", () => {
     for (const t of ADCP_TOOLS) {
       expect(getToolByName(t.name)).toBe(t);
     }
+  });
+});
+
+// ── getCapabilities runtime shape ─────────────────────────────────────────────
+// HEAD schema (per upstream PR #2315) requires adcp.idempotency in the response.
+// Pin it here so a future edit to STATIC_CAPABILITIES can't drop the field.
+
+import { getCapabilities } from "../src/domain/capabilityService";
+
+describe("getCapabilities runtime shape", () => {
+  function makeStaticKv(): KVNamespace {
+    const store = new Map<string, string>();
+    return {
+      async get(k: string) { return store.get(k) ?? null; },
+      async put(k: string, v: string) { store.set(k, v); },
+      async delete(k: string) { store.delete(k); },
+      async list() { return { keys: [], list_complete: true } as never; },
+      async getWithMetadata() { return { value: null, metadata: null } as never; },
+    } as unknown as KVNamespace;
+  }
+
+  it("includes adcp.idempotency.replay_ttl_seconds in spec range", async () => {
+    const caps = await getCapabilities(makeStaticKv());
+    expect(caps.adcp.idempotency).toBeDefined();
+    const ttl = caps.adcp.idempotency.replay_ttl_seconds;
+    expect(typeof ttl).toBe("number");
+    expect(ttl).toBeGreaterThanOrEqual(3600);
+    expect(ttl).toBeLessThanOrEqual(604800);
+  });
+
+  it("declares supported_protocols as a non-empty array of valid enum values", async () => {
+    const caps = await getCapabilities(makeStaticKv());
+    expect(Array.isArray(caps.supported_protocols)).toBe(true);
+    expect(caps.supported_protocols.length).toBeGreaterThan(0);
+    const allowed = ["media_buy", "signals", "governance", "sponsored_intelligence", "creative", "brand"];
+    for (const p of caps.supported_protocols) expect(allowed).toContain(p);
   });
 });
 


### PR DESCRIPTION
## Summary
The agenticadvertising.org evaluator runs the **HEAD** AdCP schema, not the rc.{1,2,3} tags our local AJV check used. Per the upstream [issue #2352 thread](https://github.com/adcontextprotocol/adcp/issues/2352), two real conformance gaps explain the persistent `capability_discovery` failures.

### Gap 1 — `adcp.idempotency` missing
Upstream PR #2315 made `adcp.idempotency` REQUIRED (alongside `major_versions`). The change landed without a re-tagged schema release, so rc.{1,2,3} validators don't catch its absence; the live evaluator runs HEAD and does. (Upstream issue #2366 tracks the missing schema tag.)

Fix: add `idempotency: { replay_ttl_seconds: 86400 }` to the `adcp` block. 24h is the spec-recommended value; range is 3600..604800. Our activation flow is already idempotent at the operation_id level which is what this declaration commits to.

### Gap 2 — `context` not echoed back
[`/schemas/core/context.json`](https://github.com/adcontextprotocol/adcp/blob/main/static/schemas/source/core/context.json) defines `context` as opaque correlation data that's "preserved and returned unchanged." Capability-discovery storyboards send `context.correlation_id` in the request and assert the response carries it back. Our handler dropped it.

Fix: read `args.context` (MCP) or `?correlation_id=` (REST) and merge into the response. No-op when absent. Pass-through — we don't parse it.

## Changes
- [src/domain/capabilityService.ts](src/domain/capabilityService.ts): static `adcp.idempotency` block; cache key bumped v6 → v7.
- [src/mcp/server.ts](src/mcp/server.ts) `callGetCapabilities`: echo `args.context` into both `content[].text` and `structuredContent`.
- [src/routes/capabilities.ts](src/routes/capabilities.ts): REST echoes `?correlation_id=` as `context.correlation_id`.
- [src/mcp/tools.ts](src/mcp/tools.ts): `inputSchema` advertises `context`; `outputSchema` requires `adcp.idempotency.replay_ttl_seconds` (3600..604800) and declares optional `context`.

## Tests
- 5 new unit tests in [tests/security.test.ts](tests/security.test.ts) pin the contract (input/output schema shape + runtime values).
- 4 new live checks in [scripts/test-live.sh](scripts/test-live.sh) — REST + MCP, idempotency + context-echo.
- Full unit suite: **137 passed | 0 failed | 25 skipped** (was 132 / 0 / 25).
- Type-check: zero new errors.

## Test plan (live, after merge + deploy)
- [ ] `npm run test:live` → expect **44/44** (new live checks pass)
- [ ] Manual: `curl https://adcp-signals-adaptor.evgeny-193.workers.dev/capabilities | jq .adcp.idempotency` → `{"replay_ttl_seconds": 86400}`
- [ ] Manual: MCP `tools/call get_adcp_capabilities` with `arguments: { context: { correlation_id: "x" } }` → response carries `context.correlation_id: "x"`
- [ ] Re-run agenticadvertising.org evaluator — capability_discovery should now PASS instead of failing silently

## Related upstream
- [adcontextprotocol/adcp#2364](https://github.com/adcontextprotocol/adcp/issues/2364) — runner-output contract (will give us actionable failure detail going forward)
- [adcontextprotocol/adcp#2365](https://github.com/adcontextprotocol/adcp/issues/2365) — populate signals protocol baseline (unblocks Signals SKIP)
- [adcontextprotocol/adcp#2366](https://github.com/adcontextprotocol/adcp/issues/2366) — release-hygiene for the schema-tag drift this PR works around

🤖 Generated with [Claude Code](https://claude.com/claude-code)