### PR TITLE
Strict-types sweep round 2: -36 src errors + 2 real bug fixes

### DIFF
--- a/src/activations/adapters/linkedin/client.ts
+++ b/src/activations/adapters/linkedin/client.ts
@@ -55,7 +55,10 @@ export async function createCampaign(
     id,
     name: json.name ?? payload.name,
     status: json.status ?? 'DRAFT',
-    account: json.account ?? payload.account,
+    // payload.account is optional on the body (primary transport is the URL
+    // path); fall back to empty string so the response shape stays a string
+    // rather than `string | undefined`.
+    account: json.account ?? payload.account ?? '',
     targetingCriteria: json.targetingCriteria ?? payload.targetingCriteria,
   };
 }

--- a/src/domain/compositeScorer.ts
+++ b/src/domain/compositeScorer.ts
@@ -17,8 +17,43 @@
  *   Floor: 50K households (below this → "narrow" confidence tier).
  */
 
-import type { AudienceQueryNode, AudienceQueryLeaf, AudienceQueryBranch, AudienceQueryAST } from "./queryParser.js";
-import type { LeafResolution, ResolvedSignal, CatalogSignal } from "./queryResolver.js";
+import type { AudienceQueryNode, AudienceQueryLeaf, AudienceQueryBranch, AudienceQueryAST, TemporalScope } from "./queryParser.js";
+import type { CatalogSignal } from "./queryResolver.js";
+
+// LeafResolution + ResolvedSignal were previously imported from queryResolver
+// but were removed when QueryResolver was refactored to its current
+// resolveAST / ResolvedLeaf / LeafMatch shape. The CompositeScorer still
+// consumes the older nested shape, populated by adaptToLeafResolutions in
+// nlQueryHandler — these declarations describe what that adapter produces.
+//
+// The nested `signal` field is typed loosely because the adapter normalises
+// several sources of truth (D1 rows, CatalogSignal objects, stubs for unknown
+// IDs) into a minimal superset — tightening the type here would cascade
+// through 10+ call sites for no correctness benefit, since the scorer's
+// consumers (`topMatch.signal.coverage_percentage`, etc.) supply their own
+// defaults inline.
+export interface ResolvedSignal {
+  signal: {
+    signal_agent_segment_id: string;
+    name: string;
+    description?: string;
+    coverage_percentage: number;
+    estimated_audience_size: number;
+    iab_taxonomy_ids?: string[];
+    category?: string;
+    [key: string]: unknown;
+  };
+  match_score: number;
+  match_method: string;
+  is_exclusion: boolean;
+  temporal_scope?: TemporalScope;
+}
+
+export interface LeafResolution {
+  leaf: AudienceQueryLeaf;
+  matches: ResolvedSignal[];
+  is_exclusion: boolean;
+}
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
@@ -179,6 +214,7 @@ export class CompositeScorer {
     }
 
     const topMatch = resolution.matches[0];
+    if (!topMatch) return emptyNode(leaf.confidence * 0.3);
     const size = Math.round(topMatch.signal.coverage_percentage * US_ADULT_BASELINE);
     return {
       signals: resolution.matches,
@@ -262,7 +298,11 @@ export class CompositeScorer {
   private scoreNOT(branch: AudienceQueryBranch): AudienceNode {
     // NOT nodes flip the match into exclude_signals; we score the child
     // but return it in exclude_signals rather than signals.
-    const child = this.scoreNode(branch.children[0]);
+    const firstChild = branch.children[0];
+    if (!firstChild) {
+      return { signals: [], estimated_size: US_ADULT_BASELINE, confidence: 0, exclude_signals: [] };
+    }
+    const child = this.scoreNode(firstChild);
     const invertedSize = US_ADULT_BASELINE - child.estimated_size;
     return {
       signals: [],
@@ -330,7 +370,7 @@ export function buildResolutionMap(resolutions: LeafResolution[]): Map<string, L
     const key = `${r.leaf.dimension}::${r.leaf.value}`;
     // Keep highest-confidence resolution if same key appears twice (archetype expansion)
     const existing = map.get(key);
-    if (!existing || r.matches[0]?.match_score > (existing.matches[0]?.match_score ?? 0)) {
+    if (!existing || (r.matches[0]?.match_score ?? 0) > (existing.matches[0]?.match_score ?? 0)) {
       map.set(key, r);
     }
   }

--- a/src/domain/embeddingStore.ts
+++ b/src/domain/embeddingStore.ts
@@ -221,9 +221,13 @@ export function cosineSimilarity(a: number[], b: number[]): number {
   if (a.length !== b.length) throw new Error(`Dimension mismatch: ${a.length} vs ${b.length}`);
   let dot = 0, normA = 0, normB = 0;
   for (let i = 0; i < a.length; i++) {
-    dot   += a[i] * b[i];
-    normA += a[i] * a[i];
-    normB += b[i] * b[i];
+    // Local copies to satisfy noUncheckedIndexedAccess. The length-equality
+    // check above guarantees both indices are in bounds.
+    const ai = a[i] ?? 0;
+    const bi = b[i] ?? 0;
+    dot   += ai * bi;
+    normA += ai * ai;
+    normB += bi * bi;
   }
   const denom = Math.sqrt(normA) * Math.sqrt(normB);
   return denom === 0 ? 0 : dot / denom;

--- a/src/domain/semanticResolver.ts
+++ b/src/domain/semanticResolver.ts
@@ -28,6 +28,15 @@ export interface CatalogSignalForSemantic {
   description?: string;
   category?: string;
   taxonomy_id?: string;
+  // D1 wire-name alias. Production catalog rows carry both — semanticResolver
+  // uses `id` exclusively, but the object shape passed through the pipeline
+  // mirrors the D1 row. Declared here so consumers don't need to cast.
+  signal_agent_segment_id?: string;
+  category_type?: string;
+  estimated_audience_size?: number;
+  coverage_percentage?: number;
+  iab_taxonomy_ids?: string[];
+  rules?: Array<{ dimension: string; operator: string; value: string | number | string[] }>;
 }
 
 export interface SemanticMatch {
@@ -87,7 +96,9 @@ export function buildSignalSemanticText(signal: CatalogSignalForSemantic): strin
 export function cosineSimilarity(a: number[], b: number[]): number {
   if (a.length !== b.length || a.length === 0) return 0;
   let dot = 0;
-  for (let i = 0; i < a.length; i++) dot += a[i] * b[i];
+  // Length-check above guarantees both indices in bounds; the `?? 0`
+  // satisfies noUncheckedIndexedAccess without changing the math.
+  for (let i = 0; i < a.length; i++) dot += (a[i] ?? 0) * (b[i] ?? 0);
   // Clamp to [-1, 1] to handle float rounding
   return Math.max(-1, Math.min(1, dot));
 }
@@ -137,13 +148,17 @@ export class SemanticResolver {
     ]);
 
     const matches: SemanticMatch[] = [];
+    if (!queryVec) return matches; // engine yielded no vector — skip scoring
     for (let i = 0; i < catalog.length; i++) {
-      const score = cosineSimilarity(queryVec, candidateVecs[i]);
+      const candidate = catalog[i];
+      const candidateVec = candidateVecs[i];
+      if (!candidate || !candidateVec) continue; // shouldn't happen; index guard
+      const score = cosineSimilarity(queryVec, candidateVec);
       if (score >= this.minScore) {
         matches.push({
-          signalId: catalog[i].id,
-          signalName: catalog[i].name,
-          score: Math.max(0, score), // clamp negatives to 0 for scoring
+          signalId: candidate.id,
+          signalName: candidate.name,
+          score: Math.max(0, score),
           match_method: 'embedding_similarity',
         });
       }

--- a/src/domain/signalService.ts
+++ b/src/domain/signalService.ts
@@ -61,11 +61,14 @@ export async function searchSignalsService(
     req.brief ? rankByRelevance(signals, req.brief).slice(0, limit) : signals
   );
 
-  // Filter deployments by requested destinations array
-  if (req.destinations && req.destinations.length > 0) {
-    const requestedPlatforms = req.destinations
-      .filter((d) => d.type === "platform" && d.platform)
-      .map((d) => d.platform as string);
+  // Filter deployments by requested platforms. The request field is
+  // `deployments` on SearchSignalsRequest (not `destinations` — that was
+  // a typo from an earlier iteration that made this entire filter a silent
+  // no-op because the property didn't exist).
+  if (req.deployments && req.deployments.length > 0) {
+    const requestedPlatforms = req.deployments
+      .filter((d: { type: string; platform?: string }) => d.type === "platform" && d.platform)
+      .map((d: { platform?: string }) => d.platform as string);
     if (requestedPlatforms.length > 0) {
       summaries = summaries
         .map((s) => ({
@@ -360,15 +363,23 @@ export async function getAllSignalsForCatalog(db: DB): Promise<CatalogSignal[]> 
   const { signals } = await searchSignals(db, { limit: 500, offset: 0 });
 
   return signals.map((s): CatalogSignal => ({
+    // CatalogSignal's typed field is `id` (see semanticResolver's
+    // CatalogSignalForSemantic); production code reads signal.id throughout
+    // the resolver/scorer. We set both `id` (spec-aligned) and
+    // `signal_agent_segment_id` (D1 wire-name) so consumers reading either
+    // — including the nlQueryHandler catalog-map builder that checks both —
+    // see the same value.
+    id: s.signalId,
     signal_agent_segment_id: s.signalId,
     name: s.name,
+    category: s.categoryType,
     category_type: s.categoryType,
     estimated_audience_size: s.estimatedAudienceSize ?? 0,
     coverage_percentage: s.estimatedAudienceSize
       ? s.estimatedAudienceSize / TOTAL_ADDRESSABLE
       : 0,
     description: s.description,
-    iab_taxonomy_ids: s.taxonomyId ? [s.taxonomyId] : undefined,
+    ...(s.externalTaxonomyId ? { iab_taxonomy_ids: [s.externalTaxonomyId] } : {}),
     rules: inferRulesFromSignalId(s.signalId),
   }));
 }

--- a/src/routes/getProjector.ts
+++ b/src/routes/getProjector.ts
@@ -82,7 +82,8 @@ const ANCHOR_CLUSTERS: Array<{ anchor_id: string; signal_ids: string[] }> = [
 // ─── Math helpers ─────────────────────────────────────────────────────────────
 
 function add(a: number[], b: number[]): number[] {
-  return a.map((v, i) => v + b[i]);
+  // Caller guarantees equal length; `?? 0` satisfies noUncheckedIndexedAccess.
+  return a.map((v, i) => v + (b[i] ?? 0));
 }
 
 function scale(v: number[], s: number): number[] {
@@ -106,12 +107,18 @@ function computeCentroid(vectors: number[][]): number[] {
  */
 function crossCovariance(A: number[][], B: number[][]): number[][] {
   const n = A.length;
-  const d = A[0].length;
+  if (n === 0) return [];
+  const d = A[0]!.length;
   const H: number[][] = Array.from({ length: d }, () => new Array(d).fill(0));
   for (let i = 0; i < n; i++) {
+    const ai = A[i];
+    const bi = B[i];
+    if (!ai || !bi) continue;
     for (let r = 0; r < d; r++) {
+      const ar = ai[r] ?? 0;
+      const hr = H[r]!;
       for (let c = 0; c < d; c++) {
-        H[r][c] += A[i][r] * B[i][c];
+        hr[c] = (hr[c] ?? 0) + ar * (bi[c] ?? 0);
       }
     }
   }
@@ -213,9 +220,11 @@ export function applyProjector(matrix: number[][], vec: number[]): number[] {
   const dim = vec.length;
   const out = new Array(dim).fill(0);
   for (let r = 0; r < dim; r++) {
+    const row = matrix[r];
+    if (!row) continue;
     let sum = 0;
     for (let c = 0; c < dim; c++) {
-      sum += matrix[r][c] * vec[c];
+      sum += (row[c] ?? 0) * (vec[c] ?? 0);
     }
     out[r] = sum;
   }

--- a/src/types/ucp.ts
+++ b/src/types/ucp.ts
@@ -117,6 +117,10 @@ export interface UcpCapabilityDeclaration {
     embedding_endpoint_template: string;       // "/signals/{signal_id}/embedding"
     similarity_search: boolean;      // true when get_similar_signals tool present
     phase: UcpEmbeddingPhase;
+    // Optional: GTS (Golden Test Set) version advertised by /ucp/gts so
+    // capability_discovery responses can declare which GTS pair set they
+    // align with.
+    gts_version?: string;
 }
 
 // ── Similarity Search ─────────────────────────────────────────────────────────

--- a/src/ucp/embeddingEngine.ts
+++ b/src/ucp/embeddingEngine.ts
@@ -167,7 +167,11 @@ export class LlmEmbeddingEngine implements EmbeddingEngine {
     try {
       const store = await getEmbeddingStore();
       const stored = store.getSignalEmbedding(signalId);
-      if (stored && stored.phase === 'llm-v1') {
+      // embeddingStore's SignalEmbedding doesn't carry a `phase` field —
+      // by construction the static store only holds llm-v1 vectors
+      // (generated once via scripts/embed-signals.html with te3-small).
+      // A non-empty return here means we have a real vector.
+      if (stored && stored.vector.length > 0) {
         return stored.vector;
       }
     } catch {

--- a/src/ucp/vacDeclaration.ts
+++ b/src/ucp/vacDeclaration.ts
@@ -30,7 +30,10 @@ export const DIM_SLOTS = {
 
 // ── VAC declaration factory ───────────────────────────────────────────────────
 
-export function buildVacDeclaration(signalId: string): UcpEmbeddingDeclaration {
+export function buildVacDeclaration(
+  signalId: string,
+  phase: UcpEmbeddingDeclaration["phase"] = "pseudo-v1",
+): UcpEmbeddingDeclaration {
   return {
     model_id: UCP_MODEL_ID,
     model_family: UCP_MODEL_FAMILY,
@@ -39,7 +42,7 @@ export function buildVacDeclaration(signalId: string): UcpEmbeddingDeclaration {
     encoding: "float32",
     normalization: "l2",
     distance_metric: "cosine",
-    phase: "pseudo-v1",
+    phase,
     vector_endpoint: `/signals/${signalId}/embedding`,
   };
 }


### PR DESCRIPTION
## Summary
Continues PR #10's sweep. Drops src/ TS errors **89 → 53 (−36, ~40%)**. Two real bugs fixed along the way.

## Real bugs

### 🐛 `req.destinations` was a silent no-op (signalService.ts)
The deployment-platform filter on `/signals/search` read `req.destinations`. The `SearchSignalsRequest` interface declares `deployments` (not `destinations`). Live consequence: passing `deployments: [{type:"platform", platform:"mock_dsp"}]` did NOT filter signals by platform. Fixed.

### 🐛 `s.taxonomyId` returned undefined (signalService.ts)
`CanonicalSignal` field is `externalTaxonomyId`. The catalog row's `iab_taxonomy_ids` was always undefined → dropped from JSON. Catalog signals lost their taxonomy pointers in the NLAQ pipeline. Fixed.

### Catalog-shape alignment
`semanticResolver` reads `signal.id`; `getAllSignalsForCatalog` was emitting `signal_agent_segment_id`. Mismatch — every catalog signal id was undefined inside the resolver. Now both fields are populated; `CatalogSignalForSemantic` widened to declare what production rows carry.

## Mechanical fixes
- **getProjector.ts** matrix math: 11 noUncheckedIndexedAccess errors cleared via `arr[i] ?? 0` (math unchanged; length-equality preconditions guarantee in-bounds).
- **embeddingStore.ts / semanticResolver.ts** cosineSimilarity: same treatment.
- **compositeScorer.ts**: declare `LeafResolution` + `ResolvedSignal` locally (were imported from `queryResolver` but removed when the resolver was refactored). `TemporalScope` imported from `queryParser`. Null-guards for `branch.children[0]` and `resolution.matches[0]`.
- **types/ucp.ts**: add `gts_version?: string` to `UcpCapabilityDeclaration`.
- **vacDeclaration.ts**: `buildVacDeclaration` accepts optional `phase` arg matching the existing two-arg caller.
- **embeddingEngine.ts**: drop reference to non-existent `phase` on static `SignalEmbedding`.
- **linkedin/client.ts**: `account` falls back to `''` so response stays a string.

## Tests
- Vitest: **137 / 0 / 25** (unchanged)
- Type-check: **53 src errors** (was 89 on master, −36). Zero new errors.

## Deferred
- `src/domain/queryResolver.test.ts` (37 errors) — misplaced test file with API drift like #11 had; same kind of alignment work, separate follow-up.
- `src/mcp/server.ts` (3 errors) — `callGetSimilarSignals` dead-API; **fixed in PR #14**, clears on co-merge.
- `exactOptionalPropertyTypes` drift in route↔service request literals (signalService:47, mcp/server:297/335, routes/searchSignals:23, signalModel:51, signalRepo:55) — needs cascading type changes; focused PR later.

## Test plan
- [ ] CI green
- [ ] After merge + deploy: `npm run test:live` still 40/40 (no API surface changes)
- [ ] Manual: `POST /signals/search {"deployments":[{"type":"platform","platform":"mock_dsp"}]}` actually filters now (was silent no-op)

🤖 Generated with [Claude Code](https://claude.com/claude-code)