### PR TITLE
Sec-2: Outbound fetch hygiene (webhook 2xx gate, image guardrails)

### DIFF
--- a/src/activations/routes/linkedin.ts
+++ b/src/activations/routes/linkedin.ts
@@ -40,6 +40,7 @@ import { createFullCreative } from '../adapters/linkedin/creativeClient';
 import type { LinkedInEnv, LinkedInActivationRequest } from '../types/linkedin';
 import type { LinkedInAuthEnv } from '../auth/linkedin';
 import { getValidAccessToken } from '../auth/linkedin';
+import { fetchWithTimeout, readBoundedArrayBuffer, BoundedFetchError } from '../../utils/fetchWithLimits';
 
 export interface LinkedInRouteEnv extends LinkedInEnv, LinkedInAuthEnv {
   DEMO_API_KEY: string;
@@ -62,6 +63,26 @@ export interface LinkedInRouteRequest extends LinkedInActivationRequest {
 // Push src/assets/adcp-banner-1200x1000.jpg to your repo and this URL works automatically
 const DEFAULT_BANNER_URL =
   'https://raw.githubusercontent.com/EvgenyAndroid/adcp-signals-adaptor/master/src/assets/adcp-banner-1200x1000.jpg';
+
+// Image fetch guardrails. LinkedIn's own limits are 5 MB for images; we cap
+// below that so an attacker-controlled creative.image_url can't make the
+// worker download arbitrary data before LinkedIn's upload API rejects it.
+// Timeout is generous (15 s) because GitHub/CDN cold starts can be slow;
+// the worker's overall budget is 30 s.
+const IMAGE_FETCH_TIMEOUT_MS = 15_000;
+const IMAGE_MAX_BYTES = 5 * 1024 * 1024; // 5 MB
+const IMAGE_ALLOWED_MIMES = ['image/jpeg', 'image/png', 'image/gif'];
+
+// Only http(s) schemes — otherwise fetch() on Workers will happily resolve
+// data: / blob: / file: schemes that short-circuit the guardrails.
+function isFetchableImageUrl(raw: string): boolean {
+  try {
+    const u = new URL(raw);
+    return u.protocol === 'https:' || u.protocol === 'http:';
+  } catch {
+    return false;
+  }
+}
 
 export async function handleLinkedInActivate(
   request: Request,
@@ -108,15 +129,37 @@ export async function handleLinkedInActivate(
         try {
           const accessToken = await getValidAccessToken(env);
 
-          // Fetch banner image from GitHub (or custom URL if provided)
+          // Fetch banner image from GitHub (or custom URL if provided).
+          // The URL can be caller-supplied, so we gate it:
+          //   1. scheme allow-list (http/https only; no data: / file: / blob:)
+          //   2. 15 s timeout (cold CDN edges can be slow; the worker budget is 30 s)
+          //   3. 5 MB body cap, enforced both via Content-Length pre-check and
+          //      streaming read (some CDNs use chunked encoding with no length)
+          //   4. Content-Type allow-list (image/jpeg, image/png, image/gif)
           const imageUrl = body.creative?.image_url ?? DEFAULT_BANNER_URL;
-          const imageRes = await fetch(imageUrl);
+          if (!isFetchableImageUrl(imageUrl)) {
+            throw new Error(`Banner URL rejected (must be http/https): ${imageUrl}`);
+          }
+          const imageRes = await fetchWithTimeout(imageUrl, {
+            timeoutMs: IMAGE_FETCH_TIMEOUT_MS,
+          });
 
           if (!imageRes.ok) {
             throw new Error(`Banner fetch failed: ${imageUrl} → HTTP ${imageRes.status}`);
           }
 
-          const imageBytes = await imageRes.arrayBuffer();
+          let imageBytes: ArrayBuffer;
+          try {
+            imageBytes = await readBoundedArrayBuffer(imageRes, {
+              maxBytes: IMAGE_MAX_BYTES,
+              allowedContentTypes: IMAGE_ALLOWED_MIMES,
+            });
+          } catch (err) {
+            if (err instanceof BoundedFetchError) {
+              throw new Error(`Banner rejected (${err.reason}): ${err.message}`);
+            }
+            throw err;
+          }
 
           const creativeResult = await createFullCreative(
             imageBytes,

--- a/src/domain/activationService.ts
+++ b/src/domain/activationService.ts
@@ -25,6 +25,7 @@ import { getProposal, deleteProposal } from "../storage/proposalCache";
 import { operationId } from "../utils/ids";
 import type { Logger } from "../utils/logger";
 import type { CanonicalSignal } from "../types/signal";
+import { fetchWithTimeout } from "../utils/fetchWithLimits";
 
 export async function activateSignalService(
   db: DB,
@@ -189,7 +190,15 @@ function isValidWebhookUrl(raw: string): boolean {
 
 /**
  * Fire webhook with activation completion payload.
- * Non-fatal: logs error but doesn't throw.
+ *
+ * Non-fatal: logs and moves on. `markWebhookFired` is the "don't retry"
+ * receipt — we only set it when we have evidence the remote actually
+ * accepted the delivery, i.e. a 2xx response. Non-2xx leaves the DB flag
+ * clear so the next poll retries; prior versions marked fired regardless
+ * of status, which silently lost deliveries to e.g. a 500 on the receiver.
+ *
+ * Invalid URLs (non-https, unparseable) are still marked fired — retrying
+ * them just re-fails synchronously every poll with no possible recovery.
  */
 async function fireWebhook(
   db: DB,
@@ -209,41 +218,42 @@ async function fireWebhook(
     return;
   }
 
-  const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), WEBHOOK_TIMEOUT_MS);
+  const platformSegmentId = `${destination}_${signalId}`;
+  const payload = {
+    task_id: opId,
+    status: "completed",
+    signal_agent_segment_id: signalId,
+    deployments: [
+      {
+        type: "platform",
+        platform: destination,
+        is_live: true,
+        activation_key: { type: "segment_id", segment_id: platformSegmentId },
+        estimated_activation_duration_minutes: 0,
+      },
+    ],
+    completed_at: new Date().toISOString(),
+  };
 
   try {
-    const platformSegmentId = `${destination}_${signalId}`;
-    const payload = {
-      task_id: opId,
-      status: "completed",
-      signal_agent_segment_id: signalId,
-      deployments: [
-        {
-          type: "platform",
-          platform: destination,
-          is_live: true,
-          activation_key: { type: "segment_id", segment_id: platformSegmentId },
-          estimated_activation_duration_minutes: 0,
-        },
-      ],
-      completed_at: new Date().toISOString(),
-    };
-
-    const res = await fetch(webhookUrl, {
+    const res = await fetchWithTimeout(webhookUrl, {
       method: "POST",
       headers: { "Content-Type": "application/json", "User-Agent": "adcp-signals-adaptor/1.0" },
       body: JSON.stringify(payload),
-      signal: controller.signal,
+      timeoutMs: WEBHOOK_TIMEOUT_MS,
     });
 
-    await markWebhookFired(db, opId);
-    logger.info("webhook_fired", { operationId: opId, statusCode: res.status });
+    if (res.ok) {
+      await markWebhookFired(db, opId);
+      logger.info("webhook_fired", { operationId: opId, statusCode: res.status });
+    } else {
+      // Receiver rejected the delivery. Leave the flag clear so the next
+      // poll retries — don't burn the single attempt on a transient 5xx.
+      logger.warn("webhook_non_2xx", { operationId: opId, statusCode: res.status });
+    }
   } catch (err) {
+    // Network error or timeout — treat as retriable.
     logger.error("webhook_failed", { operationId: opId, error: String(err) });
-    // Non-fatal — caller can re-poll
-  } finally {
-    clearTimeout(timeout);
   }
 }
 

--- a/src/utils/fetchWithLimits.ts
+++ b/src/utils/fetchWithLimits.ts
@@ -1,0 +1,151 @@
+// src/utils/fetchWithLimits.ts
+//
+// Bounded outbound fetch helper — timeout, response size cap, optional MIME
+// allow-list. Used for outbound calls that talk to URLs the caller supplied
+// (webhook_url on activation, creative.image_url on LinkedIn activation)
+// where a remote can otherwise make the worker hang, download unbounded
+// data, or hand us the wrong content type.
+//
+// Not a substitute for full SSRF defence. The Cloudflare edge already blocks
+// worker egress to RFC1918 / loopback ranges, so the attacker-chosen URL
+// can't reach internal services. What this guards against is the outbound
+// side: a slow or oversized response chewing up worker CPU budget on a
+// paid-egress path.
+
+export interface FetchWithLimitsOptions extends RequestInit {
+  /** Hard timeout in milliseconds. Defaults to 5000. */
+  timeoutMs?: number;
+}
+
+/**
+ * fetch() with a per-request AbortController timeout.
+ *
+ * Callers can bring their own `signal` — we chain it so either the external
+ * cancellation or the timeout aborts the request.
+ */
+export async function fetchWithTimeout(
+  url: string,
+  opts: FetchWithLimitsOptions = {},
+): Promise<Response> {
+  const timeoutMs = opts.timeoutMs ?? 5000;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(new Error(`fetch timeout after ${timeoutMs}ms`)), timeoutMs);
+
+  // Chain caller's signal, if any, into our controller.
+  if (opts.signal) {
+    if (opts.signal.aborted) {
+      controller.abort(opts.signal.reason);
+    } else {
+      opts.signal.addEventListener("abort", () => controller.abort(opts.signal!.reason), { once: true });
+    }
+  }
+
+  try {
+    const { timeoutMs: _ignore, signal: _ignoreSignal, ...rest } = opts;
+    return await fetch(url, { ...rest, signal: controller.signal });
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export interface BoundedBufferOptions {
+  /** Hard cap on body bytes read. Rejects (throws) past this size. */
+  maxBytes: number;
+  /** Allow-listed content-type prefixes, e.g. ["image/jpeg", "image/png"]. Optional. */
+  allowedContentTypes?: string[];
+}
+
+export class BoundedFetchError extends Error {
+  constructor(
+    message: string,
+    public readonly reason: "size_exceeded" | "bad_content_type" | "missing_content_type",
+  ) {
+    super(message);
+    this.name = "BoundedFetchError";
+  }
+}
+
+/**
+ * Read an HTTP response into an ArrayBuffer, but refuse to load more than
+ * `maxBytes` and optionally require the Content-Type to start with one of
+ * `allowedContentTypes`.
+ *
+ * Two defences compose:
+ *   1. Content-Length pre-check — reject upfront without reading the body.
+ *   2. Streaming read with running byte count — catches servers that lie
+ *      about Content-Length (or omit it entirely, e.g. chunked transfer).
+ *
+ * On violation we cancel the body reader so we don't continue draining the
+ * socket. The caller gets a typed BoundedFetchError to distinguish size
+ * vs MIME problems from regular HTTP errors.
+ */
+export async function readBoundedArrayBuffer(
+  response: Response,
+  opts: BoundedBufferOptions,
+): Promise<ArrayBuffer> {
+  if (opts.allowedContentTypes && opts.allowedContentTypes.length > 0) {
+    const ct = response.headers.get("content-type")?.toLowerCase() ?? "";
+    if (!ct) {
+      throw new BoundedFetchError(
+        `Response has no Content-Type (expected one of: ${opts.allowedContentTypes.join(", ")})`,
+        "missing_content_type",
+      );
+    }
+    const allowed = opts.allowedContentTypes.some((a) => ct.startsWith(a.toLowerCase()));
+    if (!allowed) {
+      throw new BoundedFetchError(
+        `Unexpected Content-Type "${ct}" (expected one of: ${opts.allowedContentTypes.join(", ")})`,
+        "bad_content_type",
+      );
+    }
+  }
+
+  // Pre-check on Content-Length if the server supplied one.
+  const lenHeader = response.headers.get("content-length");
+  if (lenHeader) {
+    const len = Number(lenHeader);
+    if (Number.isFinite(len) && len > opts.maxBytes) {
+      throw new BoundedFetchError(
+        `Response size ${len} exceeds limit ${opts.maxBytes}`,
+        "size_exceeded",
+      );
+    }
+  }
+
+  // Stream the body. If the server lied about Content-Length (or omitted it,
+  // which is legal for chunked encoding), we still catch oversize here.
+  if (!response.body) {
+    return new ArrayBuffer(0);
+  }
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (!value) continue;
+      total += value.byteLength;
+      if (total > opts.maxBytes) {
+        // Best-effort cancel so we don't keep draining the socket.
+        await reader.cancel().catch(() => undefined);
+        throw new BoundedFetchError(
+          `Response body exceeds limit ${opts.maxBytes} (read ${total} bytes)`,
+          "size_exceeded",
+        );
+      }
+      chunks.push(value);
+    }
+  } finally {
+    // releaseLock can throw if the reader is already canceled; ignore.
+    try { reader.releaseLock(); } catch { /* ignore */ }
+  }
+
+  const out = new Uint8Array(total);
+  let offset = 0;
+  for (const c of chunks) {
+    out.set(c, offset);
+    offset += c.byteLength;
+  }
+  return out.buffer;
+}

--- a/tests/fetchWithLimits.test.ts
+++ b/tests/fetchWithLimits.test.ts
@@ -1,0 +1,193 @@
+// tests/fetchWithLimits.test.ts
+// Unit tests for the bounded outbound fetch helpers introduced in Sec-2.
+//
+// We don't hit the network — the tests construct in-memory Response objects
+// with ReadableStream bodies and feed them through readBoundedArrayBuffer.
+// fetchWithTimeout is tested against a mocked global fetch.
+
+import { describe, it, expect, vi, afterEach } from "vitest";
+import {
+  fetchWithTimeout,
+  readBoundedArrayBuffer,
+  BoundedFetchError,
+} from "../src/utils/fetchWithLimits";
+
+function streamOf(chunks: Uint8Array[]): ReadableStream<Uint8Array> {
+  let i = 0;
+  return new ReadableStream<Uint8Array>({
+    pull(controller) {
+      if (i < chunks.length) {
+        controller.enqueue(chunks[i++]);
+      } else {
+        controller.close();
+      }
+    },
+  });
+}
+
+function responseWith(
+  body: ReadableStream<Uint8Array> | ArrayBuffer | string | null,
+  init: ResponseInit & { headers?: Record<string, string> } = {},
+): Response {
+  return new Response(body as BodyInit | null, init);
+}
+
+describe("readBoundedArrayBuffer", () => {
+  it("reads a small body within the cap", async () => {
+    const bytes = new Uint8Array([1, 2, 3, 4, 5]);
+    const res = responseWith(streamOf([bytes]), {
+      headers: { "content-type": "image/jpeg", "content-length": String(bytes.length) },
+    });
+    const buf = await readBoundedArrayBuffer(res, { maxBytes: 100 });
+    expect(new Uint8Array(buf)).toEqual(bytes);
+  });
+
+  it("rejects upfront when Content-Length exceeds maxBytes", async () => {
+    const res = responseWith(streamOf([new Uint8Array(10)]), {
+      headers: { "content-type": "image/jpeg", "content-length": "999999" },
+    });
+    await expect(
+      readBoundedArrayBuffer(res, { maxBytes: 100 }),
+    ).rejects.toMatchObject({
+      name: "BoundedFetchError",
+      reason: "size_exceeded",
+    });
+  });
+
+  it("catches servers that lie about Content-Length (streams past the cap)", async () => {
+    // Server says 10 bytes but sends 1000. The streaming counter catches it.
+    const big = new Uint8Array(1000);
+    const res = responseWith(streamOf([big]), {
+      headers: { "content-type": "image/jpeg", "content-length": "10" },
+    });
+    await expect(
+      readBoundedArrayBuffer(res, { maxBytes: 100 }),
+    ).rejects.toMatchObject({ reason: "size_exceeded" });
+  });
+
+  it("catches chunked-encoding responses with no Content-Length header", async () => {
+    const chunks = [new Uint8Array(60), new Uint8Array(60), new Uint8Array(60)];
+    const res = responseWith(streamOf(chunks), {
+      headers: { "content-type": "image/png" }, // no content-length
+    });
+    await expect(
+      readBoundedArrayBuffer(res, { maxBytes: 100 }),
+    ).rejects.toMatchObject({ reason: "size_exceeded" });
+  });
+
+  it("enforces Content-Type allow-list (exact prefix match)", async () => {
+    const res = responseWith(streamOf([new Uint8Array(5)]), {
+      headers: { "content-type": "application/octet-stream" },
+    });
+    await expect(
+      readBoundedArrayBuffer(res, {
+        maxBytes: 100,
+        allowedContentTypes: ["image/jpeg", "image/png"],
+      }),
+    ).rejects.toMatchObject({
+      reason: "bad_content_type",
+    });
+  });
+
+  it("allows content types with charset/parameter suffix", async () => {
+    const res = responseWith(streamOf([new Uint8Array(5)]), {
+      headers: { "content-type": "image/jpeg; charset=binary" },
+    });
+    const buf = await readBoundedArrayBuffer(res, {
+      maxBytes: 100,
+      allowedContentTypes: ["image/jpeg"],
+    });
+    expect(buf.byteLength).toBe(5);
+  });
+
+  it("rejects missing Content-Type when an allow-list is provided", async () => {
+    const res = responseWith(streamOf([new Uint8Array(5)]), {
+      headers: {},
+    });
+    await expect(
+      readBoundedArrayBuffer(res, {
+        maxBytes: 100,
+        allowedContentTypes: ["image/jpeg"],
+      }),
+    ).rejects.toMatchObject({ reason: "missing_content_type" });
+  });
+
+  it("handles an empty body cleanly", async () => {
+    const res = responseWith(null, { headers: { "content-type": "image/jpeg" } });
+    const buf = await readBoundedArrayBuffer(res, {
+      maxBytes: 100,
+      allowedContentTypes: ["image/jpeg"],
+    });
+    expect(buf.byteLength).toBe(0);
+  });
+});
+
+describe("fetchWithTimeout", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns the response when fetch resolves within the timeout", async () => {
+    const expected = new Response("hello");
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(expected);
+    const res = await fetchWithTimeout("https://example.com/", { timeoutMs: 5000 });
+    expect(await res.text()).toBe("hello");
+    // Verify the upstream fetch received our signal
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "https://example.com/",
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+  });
+
+  it("aborts and propagates when the timer expires before fetch resolves", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(
+      (_url, init) =>
+        new Promise((_resolve, reject) => {
+          const signal = (init as RequestInit).signal;
+          signal?.addEventListener("abort", () => {
+            reject(signal.reason ?? new Error("aborted"));
+          });
+        }),
+    );
+    await expect(
+      fetchWithTimeout("https://example.com/", { timeoutMs: 20 }),
+    ).rejects.toThrow(/timeout after 20ms/);
+  });
+
+  it("honours a caller-supplied signal that is already aborted", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation((_url, init) => {
+      const signal = (init as RequestInit).signal!;
+      if (signal.aborted) {
+        return Promise.reject(signal.reason ?? new Error("aborted"));
+      }
+      return new Promise((_r, reject) => {
+        signal.addEventListener("abort", () => reject(signal.reason));
+      });
+    });
+    const ac = new AbortController();
+    ac.abort(new Error("caller cancelled"));
+    await expect(
+      fetchWithTimeout("https://example.com/", { timeoutMs: 5000, signal: ac.signal }),
+    ).rejects.toThrow(/caller cancelled/);
+    expect(fetchSpy).toHaveBeenCalled();
+  });
+
+  it("does not leak the timer into the returned promise on success", async () => {
+    // Regression for clearTimeout in finally. If we forgot it, this test
+    // would hang — the event loop wouldn't exit until 10_000 ms elapsed.
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response("ok"));
+    const start = Date.now();
+    await fetchWithTimeout("https://example.com/", { timeoutMs: 10_000 });
+    const elapsed = Date.now() - start;
+    expect(elapsed).toBeLessThan(200);
+  });
+});
+
+describe("BoundedFetchError", () => {
+  it("preserves reason on the typed error", () => {
+    const err = new BoundedFetchError("too big", "size_exceeded");
+    expect(err.name).toBe("BoundedFetchError");
+    expect(err.reason).toBe("size_exceeded");
+    expect(err.message).toBe("too big");
+  });
+});

--- a/tests/webhook.test.ts
+++ b/tests/webhook.test.ts
@@ -1,0 +1,180 @@
+// tests/webhook.test.ts
+// Sec-2: the activation webhook now marks `webhook_fired` only when the
+// receiver returns 2xx. Prior behavior marked fired regardless of status,
+// which silently dropped deliveries to a 500 (the next poll would not
+// retry). The tests mock activationRepo so we can assert markWebhookFired
+// is / isn't called based on the outbound Response status.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// vi.mock() must be hoisted before any imports of the module under test.
+// We stub the entire activationRepo module — the service layer is the unit
+// we're testing, and the repo is irrelevant to the 2xx-gate logic.
+vi.mock("../src/storage/activationRepo", () => ({
+  findOperationById: vi.fn(),
+  updateJobStatus: vi.fn(async () => {}),
+  markWebhookFired: vi.fn(async () => {}),
+  createActivationJob: vi.fn(),
+  appendEvent: vi.fn(),
+  listJobsBySignal: vi.fn(),
+}));
+
+import { getOperationService } from "../src/domain/activationService";
+import {
+  findOperationById,
+  updateJobStatus,
+  markWebhookFired,
+} from "../src/storage/activationRepo";
+import { createLogger } from "../src/utils/logger";
+
+const mockFindOperation = vi.mocked(findOperationById);
+const mockUpdateStatus = vi.mocked(updateJobStatus);
+const mockMarkFired = vi.mocked(markWebhookFired);
+
+// Minimal DB stub — the service never touches it directly on a completed
+// op because updateJobStatus is mocked out at the module layer.
+const db = {} as unknown as import("../src/storage/db").DB;
+const logger = createLogger("test-webhook");
+
+function completedOpWithWebhook(webhookUrl: string) {
+  return {
+    operationId: "op_test_1",
+    signalId: "sig_drama_viewers",
+    destination: "mock_dsp",
+    status: "working" as const, // lazy state machine will advance to completed on poll
+    webhookUrl,
+    webhookFired: false,
+    submittedAt: "2026-04-19T00:00:00Z",
+    updatedAt: "2026-04-19T00:00:00Z",
+  };
+}
+
+describe("webhook 2xx gate", () => {
+  beforeEach(() => {
+    mockFindOperation.mockReset();
+    mockUpdateStatus.mockReset().mockResolvedValue(undefined);
+    mockMarkFired.mockReset().mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("marks fired on 2xx", async () => {
+    mockFindOperation.mockResolvedValue(completedOpWithWebhook("https://example.com/hook"));
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(null, { status: 200 }),
+    );
+
+    await getOperationService(db, "op_test_1", logger);
+
+    expect(mockMarkFired).toHaveBeenCalledWith(db, "op_test_1");
+    expect(mockMarkFired).toHaveBeenCalledTimes(1);
+  });
+
+  it("marks fired on 204", async () => {
+    mockFindOperation.mockResolvedValue(completedOpWithWebhook("https://example.com/hook"));
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(null, { status: 204 }));
+
+    await getOperationService(db, "op_test_1", logger);
+
+    expect(mockMarkFired).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT mark fired on 4xx", async () => {
+    mockFindOperation.mockResolvedValue(completedOpWithWebhook("https://example.com/hook"));
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("bad request", { status: 400 }),
+    );
+
+    await getOperationService(db, "op_test_1", logger);
+
+    expect(mockMarkFired).not.toHaveBeenCalled();
+  });
+
+  it("does NOT mark fired on 5xx (so next poll retries)", async () => {
+    mockFindOperation.mockResolvedValue(completedOpWithWebhook("https://example.com/hook"));
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("server error", { status: 500 }),
+    );
+
+    await getOperationService(db, "op_test_1", logger);
+
+    expect(mockMarkFired).not.toHaveBeenCalled();
+  });
+
+  it("does NOT mark fired on a network error / timeout", async () => {
+    mockFindOperation.mockResolvedValue(completedOpWithWebhook("https://example.com/hook"));
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("network down"));
+
+    await getOperationService(db, "op_test_1", logger);
+
+    expect(mockMarkFired).not.toHaveBeenCalled();
+  });
+
+  it("marks fired (no retry) on an invalid webhook URL — scheme check", async () => {
+    mockFindOperation.mockResolvedValue(completedOpWithWebhook("http://example.com/hook"));
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+
+    await getOperationService(db, "op_test_1", logger);
+
+    // Invalid URL is terminally bad — retrying won't help. Mark fired so
+    // we don't redo the rejection on every poll.
+    expect(mockMarkFired).toHaveBeenCalledTimes(1);
+    // And we must NOT have actually dispatched the request.
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("marks fired (no retry) on an unparseable webhook URL", async () => {
+    mockFindOperation.mockResolvedValue(completedOpWithWebhook("not a url"));
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+
+    await getOperationService(db, "op_test_1", logger);
+
+    expect(mockMarkFired).toHaveBeenCalledTimes(1);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("completed op without a webhook_url does not touch fetch or markFired", async () => {
+    mockFindOperation.mockResolvedValue({
+      ...completedOpWithWebhook("https://example.com/hook"),
+      webhookUrl: undefined as unknown as string,
+    });
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+
+    await getOperationService(db, "op_test_1", logger);
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(mockMarkFired).not.toHaveBeenCalled();
+  });
+
+  it("already-fired webhook does not fire again", async () => {
+    mockFindOperation.mockResolvedValue({
+      ...completedOpWithWebhook("https://example.com/hook"),
+      webhookFired: true,
+    });
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+
+    await getOperationService(db, "op_test_1", logger);
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(mockMarkFired).not.toHaveBeenCalled();
+  });
+
+  it("webhook fetch runs with an AbortController timeout signal", async () => {
+    mockFindOperation.mockResolvedValue(completedOpWithWebhook("https://example.com/hook"));
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(null, { status: 200 }),
+    );
+
+    await getOperationService(db, "op_test_1", logger);
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "https://example.com/hook",
+      expect.objectContaining({
+        method: "POST",
+        signal: expect.any(AbortSignal),
+      }),
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Two findings from the static security review on outbound network calls:

- **#6** — Activation webhook only marks `webhook_fired` on **2xx**. Previously the flag was set regardless of status, so a receiver returning 500 (transient) had its delivery silently dropped — the next poll would see \`webhookFired = true\` and never retry. The flag was a "don't retry" receipt, but we treated it as "we tried."
- **#7** — LinkedIn `creative.image_url` fetch is now bounded: scheme allow-list (http/https only — blocks \`data:\`/\`file:\`/\`blob:\`), 15 s timeout, 5 MB cap (Content-Length pre-check **and** streaming byte counter for chunked encoding), Content-Type allow-list (image/jpeg, image/png, image/gif).

## New helper — `src/utils/fetchWithLimits.ts`

- \`fetchWithTimeout(url, opts)\` — fetch + AbortController, chains caller's signal so external cancellation also aborts. Releases the timer on both resolve and reject paths.
- \`readBoundedArrayBuffer(response, opts)\` — streams the body with a byte counter, refuses past \`maxBytes\`, optionally enforces a Content-Type allow-list. Cancels the body reader on overflow so we don't keep draining the socket.
- \`BoundedFetchError\` with typed \`reason\` for caller decision logic.

## Webhook lifecycle (table)

| Outcome | markFired? | Why |
|---|---|---|
| 2xx | yes | Receiver acknowledged |
| 4xx / 5xx | **no** | Receiver rejected — next poll retries |
| Network error / timeout | **no** | Likely transient — next poll retries |
| Invalid URL (non-https / unparseable) | yes | Terminal — retrying just re-fails synchronously |

## Out of scope

Other outbound fetches (OpenAI, Anthropic, LinkedIn API) are unchanged. They're authenticated to known internal services where the remote isn't attacker-chosen, so retrofitting them is scope creep on this PR.

## Testing

- Unit: **177 passed / 12 skipped** (+23 new — 13 fetch-helper + 10 webhook).
- Type-check: 0 new errors.
- Live runner: no changes needed — webhook only fires when caller supplies \`webhook_url\`; image fetch only runs when \`with_creative=true\` (operator path).

## Test plan

- [x] \`npx vitest run\` → 177 pass
- [x] \`npx tsc --noEmit\` → no new errors
- [ ] Merge + deploy + \`bash scripts/test-live.sh\` against live worker (full pre-existing suite still green)
- [ ] Smoke test: send activation with \`webhook_url\` pointing at a 500-returning endpoint, confirm \`webhook_fired\` stays \`0\` and next poll re-fires
- [ ] Smoke test: \`with_creative=true\` with a 10 MB \`image_url\` returns \`Banner rejected (size_exceeded)\` warning, campaign still created

🤖 Generated with [Claude Code](https://claude.com/claude-code)