### PR TITLE
Sec-4 through Sec-8: remaining hardening bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,9 +128,11 @@ Pass criteria: thresholds are calibrated empirically from real `text-embedding-3
 
 Returns a 512×512 orthogonal rotation matrix mapping `openai-te3-small-d512-v1` → `ucp-space-v1.0`. Status is `"simulated"` — IAB Tech Lab has not yet published reference model vectors, so R ≈ I (identity). Endpoint shape is fully spec-compliant and will carry the real matrix on IAB publication. Requires auth.
 
+> **API key:** gated routes require `Authorization: Bearer $DEMO_API_KEY`. Export the value you provisioned via `wrangler secret put DEMO_API_KEY` into your shell before running the examples below — e.g. `export DEMO_API_KEY=...`. The key is a Worker secret, not a checked-in constant.
+
 ```bash
 curl https://adcp-signals-adaptor.evgeny-193.workers.dev/ucp/projector \
-  -H "Authorization: Bearer demo-key-adcp-signals-v1" \
+  -H "Authorization: Bearer $DEMO_API_KEY" \
   | jq '{from_space, to_space, status, anchor_count, signature}'
 ```
 
@@ -284,7 +286,7 @@ Every signal carries an `x_ucp` object — UCP HybridPayload per the AdCP-UCP Br
 
 ```bash
 curl https://adcp-signals-adaptor.evgeny-193.workers.dev/signals/sig_drama_viewers/embedding \
-  -H "Authorization: Bearer demo-key-adcp-signals-v1"
+  -H "Authorization: Bearer $DEMO_API_KEY"
 ```
 
 ---
@@ -293,7 +295,7 @@ curl https://adcp-signals-adaptor.evgeny-193.workers.dev/signals/sig_drama_viewe
 
 ```
 POST /signals/query
-Authorization: Bearer demo-key-adcp-signals-v1
+Authorization: Bearer $DEMO_API_KEY
 Content-Type: application/json
 
 {
@@ -519,7 +521,7 @@ npm run dev
 
 # Seed concept registry
 curl -X POST http://localhost:8787/ucp/concepts/seed \
-  -H "Authorization: Bearer demo-key-adcp-signals-v1"
+  -H "Authorization: Bearer $DEMO_API_KEY"
 ```
 
 ## Deploying

--- a/curl-tests.cmd
+++ b/curl-tests.cmd
@@ -1,7 +1,15 @@
 :: ============================================================
 :: AdCP Signals Adaptor — Windows curl test commands
 :: Base URL: https://adcp-signals-adaptor.evgeny-193.workers.dev
-:: API Key:  demo-key-adcp-signals-v1
+::
+:: Usage:
+::   set DEMO_API_KEY=<the-key-you-provisioned-via-wrangler-secret>
+::   curl-tests.cmd
+::
+:: The API key is a Worker secret. Export it into this shell before
+:: running any of the gated calls below. Do NOT hardcode it here —
+:: prior revisions shipped the value in-tree, which made the "secret"
+:: effectively public.
 :: ============================================================
 
 
@@ -37,43 +45,43 @@ curl https://adcp-signals-adaptor.evgeny-193.workers.dev/ucp/gts
 :: ── UCP PHASE 2b — PROJECTOR (auth required) ────────────────
 
 :: Projector matrix (512x512 — large response)
-curl https://adcp-signals-adaptor.evgeny-193.workers.dev/ucp/projector -H "Authorization: Bearer demo-key-adcp-signals-v1"
+curl https://adcp-signals-adaptor.evgeny-193.workers.dev/ucp/projector -H "Authorization: Bearer %DEMO_API_KEY%"
 
 
 :: ── SIGNALS — SEARCH (auth required) ─────────────────────────
 
 :: Search by brief
-curl -X POST https://adcp-signals-adaptor.evgeny-193.workers.dev/signals/search -H "Authorization: Bearer demo-key-adcp-signals-v1" -H "Content-Type: application/json" -d "{\"query\":\"high income households\",\"limit\":5}"
+curl -X POST https://adcp-signals-adaptor.evgeny-193.workers.dev/signals/search -H "Authorization: Bearer %DEMO_API_KEY%" -H "Content-Type: application/json" -d "{\"query\":\"high income households\",\"limit\":5}"
 
 :: Search by category
-curl -X POST https://adcp-signals-adaptor.evgeny-193.workers.dev/signals/search -H "Authorization: Bearer demo-key-adcp-signals-v1" -H "Content-Type: application/json" -d "{\"categoryType\":\"demographic\",\"limit\":10}"
+curl -X POST https://adcp-signals-adaptor.evgeny-193.workers.dev/signals/search -H "Authorization: Bearer %DEMO_API_KEY%" -H "Content-Type: application/json" -d "{\"categoryType\":\"demographic\",\"limit\":10}"
 
 
 :: ── SIGNALS — NL QUERY (auth required) ───────────────────────
 
 :: Simple query — should hit medium confidence
-curl -X POST https://adcp-signals-adaptor.evgeny-193.workers.dev/signals/query -H "Authorization: Bearer demo-key-adcp-signals-v1" -H "Content-Type: application/json" -d "{\"query\":\"affluent families 35-44 who stream heavily\",\"limit\":5}"
+curl -X POST https://adcp-signals-adaptor.evgeny-193.workers.dev/signals/query -H "Authorization: Bearer %DEMO_API_KEY%" -H "Content-Type: application/json" -d "{\"query\":\"affluent families 35-44 who stream heavily\",\"limit\":5}"
 
 :: Archetype query — cord_cutter
-curl -X POST https://adcp-signals-adaptor.evgeny-193.workers.dev/signals/query -H "Authorization: Bearer demo-key-adcp-signals-v1" -H "Content-Type: application/json" -d "{\"query\":\"streaming heavy watchers cord cutters\",\"limit\":5}"
+curl -X POST https://adcp-signals-adaptor.evgeny-193.workers.dev/signals/query -H "Authorization: Bearer %DEMO_API_KEY%" -H "Content-Type: application/json" -d "{\"query\":\"streaming heavy watchers cord cutters\",\"limit\":5}"
 
 :: Complex query — multiple dimensions, expect narrow tier
-curl -X POST https://adcp-signals-adaptor.evgeny-193.workers.dev/signals/query -H "Authorization: Bearer demo-key-adcp-signals-v1" -H "Content-Type: application/json" -d "{\"query\":\"soccer moms 35+ in Nashville who don't drink coffee but watch Desperate Housewives in the afternoon\",\"limit\":10}"
+curl -X POST https://adcp-signals-adaptor.evgeny-193.workers.dev/signals/query -H "Authorization: Bearer %DEMO_API_KEY%" -H "Content-Type: application/json" -d "{\"query\":\"soccer moms 35+ in Nashville who don't drink coffee but watch Desperate Housewives in the afternoon\",\"limit\":10}"
 
 :: Negation query
-curl -X POST https://adcp-signals-adaptor.evgeny-193.workers.dev/signals/query -H "Authorization: Bearer demo-key-adcp-signals-v1" -H "Content-Type: application/json" -d "{\"query\":\"graduate educated adults who are not low income\",\"limit\":5}"
+curl -X POST https://adcp-signals-adaptor.evgeny-193.workers.dev/signals/query -H "Authorization: Bearer %DEMO_API_KEY%" -H "Content-Type: application/json" -d "{\"query\":\"graduate educated adults who are not low income\",\"limit\":5}"
 
 
 :: ── EMBEDDINGS (auth required) ────────────────────────────────
 
 :: Real v1 vector — drama viewers
-curl https://adcp-signals-adaptor.evgeny-193.workers.dev/signals/sig_drama_viewers/embedding -H "Authorization: Bearer demo-key-adcp-signals-v1"
+curl https://adcp-signals-adaptor.evgeny-193.workers.dev/signals/sig_drama_viewers/embedding -H "Authorization: Bearer %DEMO_API_KEY%"
 
 :: Real v1 vector — high income
-curl https://adcp-signals-adaptor.evgeny-193.workers.dev/signals/sig_high_income_households/embedding -H "Authorization: Bearer demo-key-adcp-signals-v1"
+curl https://adcp-signals-adaptor.evgeny-193.workers.dev/signals/sig_high_income_households/embedding -H "Authorization: Bearer %DEMO_API_KEY%"
 
 :: Pseudo-v1 fallback — dynamic signal (will return pseudo-v1 phase)
-curl https://adcp-signals-adaptor.evgeny-193.workers.dev/signals/sig_dyn_high_income_150k_70ea9fdf/embedding -H "Authorization: Bearer demo-key-adcp-signals-v1"
+curl https://adcp-signals-adaptor.evgeny-193.workers.dev/signals/sig_dyn_high_income_150k_70ea9fdf/embedding -H "Authorization: Bearer %DEMO_API_KEY%"
 
 
 :: ── CONCEPT REGISTRY (public) ────────────────────────────────
@@ -97,16 +105,16 @@ curl "https://adcp-signals-adaptor.evgeny-193.workers.dev/ucp/concepts?category=
 curl "https://adcp-signals-adaptor.evgeny-193.workers.dev/ucp/concepts?category=purchase_intent"
 
 :: Seed concept registry (auth required)
-curl -X POST https://adcp-signals-adaptor.evgeny-193.workers.dev/ucp/concepts/seed -H "Authorization: Bearer demo-key-adcp-signals-v1"
+curl -X POST https://adcp-signals-adaptor.evgeny-193.workers.dev/ucp/concepts/seed -H "Authorization: Bearer %DEMO_API_KEY%"
 
 
 :: ── ACTIVATION (auth required) ────────────────────────────────
 
 :: Activate a signal
-curl -X POST https://adcp-signals-adaptor.evgeny-193.workers.dev/signals/activate -H "Authorization: Bearer demo-key-adcp-signals-v1" -H "Content-Type: application/json" -d "{\"signalId\":\"sig_drama_viewers\",\"destination\":\"mock_dsp\"}"
+curl -X POST https://adcp-signals-adaptor.evgeny-193.workers.dev/signals/activate -H "Authorization: Bearer %DEMO_API_KEY%" -H "Content-Type: application/json" -d "{\"signalId\":\"sig_drama_viewers\",\"destination\":\"mock_dsp\"}"
 
 :: Poll activation status (replace TASK_ID with value from activate response)
-curl https://adcp-signals-adaptor.evgeny-193.workers.dev/operations/TASK_ID -H "Authorization: Bearer demo-key-adcp-signals-v1"
+curl https://adcp-signals-adaptor.evgeny-193.workers.dev/operations/TASK_ID -H "Authorization: Bearer %DEMO_API_KEY%"
 
 
 :: ── MCP (public) ──────────────────────────────────────────────
@@ -121,7 +129,7 @@ curl -X POST https://adcp-signals-adaptor.evgeny-193.workers.dev/mcp -H "Content
 curl -X POST https://adcp-signals-adaptor.evgeny-193.workers.dev/mcp -H "Content-Type: application/json" -d "{\"jsonrpc\":\"2.0\",\"id\":3,\"method\":\"tools/call\",\"params\":{\"name\":\"get_adcp_capabilities\",\"arguments\":{}}}"
 
 :: MCP query_signals_nl
-curl -X POST https://adcp-signals-adaptor.evgeny-193.workers.dev/mcp -H "Authorization: Bearer demo-key-adcp-signals-v1" -H "Content-Type: application/json" -d "{\"jsonrpc\":\"2.0\",\"id\":4,\"method\":\"tools/call\",\"params\":{\"name\":\"query_signals_nl\",\"arguments\":{\"query\":\"affluent streaming families\",\"limit\":5}}}"
+curl -X POST https://adcp-signals-adaptor.evgeny-193.workers.dev/mcp -H "Authorization: Bearer %DEMO_API_KEY%" -H "Content-Type: application/json" -d "{\"jsonrpc\":\"2.0\",\"id\":4,\"method\":\"tools/call\",\"params\":{\"name\":\"query_signals_nl\",\"arguments\":{\"query\":\"affluent streaming families\",\"limit\":5}}}"
 
 :: MCP get_concept
 curl -X POST https://adcp-signals-adaptor.evgeny-193.workers.dev/mcp -H "Content-Type: application/json" -d "{\"jsonrpc\":\"2.0\",\"id\":5,\"method\":\"tools/call\",\"params\":{\"name\":\"get_concept\",\"arguments\":{\"concept_id\":\"SOCCER_MOM_US\"}}}"

--- a/scripts/test-live.sh
+++ b/scripts/test-live.sh
@@ -12,7 +12,14 @@
 set -u
 
 BASE="${BASE:-https://adcp-signals-adaptor.evgeny-193.workers.dev}"
-KEY="${API_KEY:-demo-key-adcp-signals-v1}"
+# API_KEY must be provided via the environment. Previously this script
+# defaulted to the demo value, which meant the "secret" was effectively
+# published in-tree. Fail loudly if the operator forgot to export it.
+if [ -z "${API_KEY:-}" ]; then
+  echo "ERROR: API_KEY is not set. Run: export API_KEY=<your-DEMO_API_KEY-secret>" >&2
+  exit 2
+fi
+KEY="$API_KEY"
 
 PASS=0
 FAIL=0

--- a/scripts/test-live.sh
+++ b/scripts/test-live.sh
@@ -185,15 +185,29 @@ fi
 echo ""
 echo "=== AUTH SURFACE ==="
 run "token-debug should be gone"          401 ''  "$BASE/auth/linkedin/token-debug"
-# Sec-1 Finding #2: OAuth routes are no longer public. An unauth'd caller
-# can no longer initiate the flow (DoS on shared LinkedIn tokens), hit the
-# callback (overwriting tokens), or read /status (which leaked a token
-# preview + scope + ad account ID).
+# /init and /status are DEMO_API_KEY gated. /init is the load-bearing
+# defense — it's the only route that can issue a state UUID, so an
+# unauth'd caller cannot start a flow whose callback we'd later accept.
 run "linkedin init requires auth"         401 ''  "$BASE/auth/linkedin/init"
-run "linkedin callback requires auth"     401 ''  "$BASE/auth/linkedin/callback?state=fabricated"
 run "linkedin status requires auth"       401 ''  "$BASE/auth/linkedin/status"
-# With a valid API key, /status is reachable (the operator path).
 run "linkedin status with auth reachable" 200 ''  -H "Authorization: Bearer $KEY" "$BASE/auth/linkedin/status"
+# /callback is intentionally public: LinkedIn's 302 back to the worker
+# carries only the OAuth state param, no bearer. The state mechanism
+# (single-use UUID in KV, issued on /init, consumed on /callback) is the
+# defense. A fabricated state must be rejected with the "Invalid State"
+# HTML page rather than proceeding to token exchange.
+run "linkedin callback fabricated state → Invalid State" 200 '' \
+    "$BASE/auth/linkedin/callback?state=fabricated-by-attacker"
+# Additional correctness check — response body is the Invalid State page,
+# not some generic success. Shell-side since the body is HTML, not JSON.
+CB_BODY=$(curl -s "$BASE/auth/linkedin/callback?state=fabricated-by-attacker")
+if printf '%s' "$CB_BODY" | grep -q 'Invalid State'; then
+  PASS=$((PASS + 1))
+  printf 'PASS %-46s %s\n' "linkedin callback rejects fabricated state body" "(Invalid State)"
+else
+  FAIL=$((FAIL + 1)); FAILS+=("linkedin callback body check")
+  printf 'FAIL %-46s %s\n' "linkedin callback rejects fabricated state body" "(unexpected body)"
+fi
 # Sec-1 Finding B: oversized MCP bodies rejected pre-parse via Content-Length
 # header check. We generate the body as a file (argv doesn't fit 1.1MB on
 # Windows git-bash) and let curl set Content-Length itself.

--- a/src/activations/adapters/linkedin/client.ts
+++ b/src/activations/adapters/linkedin/client.ts
@@ -9,9 +9,14 @@
  */
 
 import type { LinkedInCampaignPayload, LinkedInCampaignResponse } from '../../types/linkedin';
+import { fetchWithTimeout } from '../../../utils/fetchWithLimits';
 
 const BASE = 'https://api.linkedin.com/rest';
 const LI_VERSION = '202503';
+
+// LinkedIn's ad-platform endpoints target ~p99 <3s; 10s is generous cover
+// for tail latency while staying well under the 30s Worker CPU budget.
+const LI_API_TIMEOUT_MS = 10_000;
 
 const DEFAULT_HEADERS = (token: string) => ({
   'Authorization': `Bearer ${token}`,
@@ -29,10 +34,11 @@ export async function createCampaign(
 ): Promise<LinkedInCampaignResponse> {
   const url = `${BASE}/adAccounts/${adAccountId}/adCampaigns`;
 
-  const res = await fetch(url, {
+  const res = await fetchWithTimeout(url, {
     method: 'POST',
     headers: DEFAULT_HEADERS(accessToken),
     body: JSON.stringify(payload),
+    timeoutMs: LI_API_TIMEOUT_MS,
   });
 
   if (!res.ok) {
@@ -68,8 +74,9 @@ export async function getCampaign(
   accessToken: string,
   adAccountId: string,
 ): Promise<LinkedInCampaignResponse> {
-  const res = await fetch(`${BASE}/adAccounts/${adAccountId}/adCampaigns/${campaignId}`, {
+  const res = await fetchWithTimeout(`${BASE}/adAccounts/${adAccountId}/adCampaigns/${campaignId}`, {
     headers: DEFAULT_HEADERS(accessToken),
+    timeoutMs: LI_API_TIMEOUT_MS,
   });
 
   if (!res.ok) {
@@ -89,8 +96,9 @@ export async function listCampaignGroups(
   // Simple search without status filter — LinkedIn rejects search.status.values[] param
   const url = `${BASE}/adAccounts/${adAccountId}/adCampaignGroups?q=search&count=10`;
 
-  const res = await fetch(url, {
+  const res = await fetchWithTimeout(url, {
     headers: DEFAULT_HEADERS(accessToken),
+    timeoutMs: LI_API_TIMEOUT_MS,
   });
 
   if (!res.ok) {
@@ -109,7 +117,7 @@ export async function createCampaignGroup(
 ): Promise<string> {
   const url = `${BASE}/adAccounts/${adAccountId}/adCampaignGroups`;
 
-  const res = await fetch(url, {
+  const res = await fetchWithTimeout(url, {
     method: 'POST',
     headers: DEFAULT_HEADERS(accessToken),
     body: JSON.stringify({
@@ -118,6 +126,7 @@ export async function createCampaignGroup(
       status: 'ACTIVE',
       runSchedule: { start: Date.now() },
     }),
+    timeoutMs: LI_API_TIMEOUT_MS,
   });
 
   if (!res.ok) {
@@ -137,8 +146,9 @@ export async function validateToken(
   accessToken: string,
 ): Promise<{ valid: boolean; sub?: string; name?: string }> {
   try {
-    const res = await fetch('https://api.linkedin.com/v2/userinfo', {
+    const res = await fetchWithTimeout('https://api.linkedin.com/v2/userinfo', {
       headers: { 'Authorization': `Bearer ${accessToken}` },
+      timeoutMs: LI_API_TIMEOUT_MS,
     });
     if (!res.ok) return { valid: false };
     const json = await res.json() as { sub?: string; name?: string };

--- a/src/activations/adapters/linkedin/creativeClient.ts
+++ b/src/activations/adapters/linkedin/creativeClient.ts
@@ -32,9 +32,16 @@
  */
 
 import { LinkedInApiError } from './client';
+import { fetchWithTimeout } from '../../../utils/fetchWithLimits';
 
 const BASE = 'https://api.linkedin.com/rest';
 const LI_VERSION = '202503';
+
+// LinkedIn's creative endpoints can be slower than the ad-platform ones
+// (image upload crosses a different pipeline). 20s here covers slow uploads
+// of the 5MB max-size banner; the 5MB size cap lives in the route layer.
+const LI_API_TIMEOUT_MS = 10_000;
+const LI_UPLOAD_TIMEOUT_MS = 20_000;
 
 const DEFAULT_HEADERS = (token: string) => ({
   'Authorization': `Bearer ${token}`,
@@ -93,12 +100,13 @@ export async function uploadImage(
   const owner = organizationUrn ?? `urn:li:sponsoredAccount:${adAccountId}`;
 
   // Initialize upload — get pre-signed uploadUrl + imageUrn
-  const initRes = await fetch(`${BASE}/images?action=initializeUpload`, {
+  const initRes = await fetchWithTimeout(`${BASE}/images?action=initializeUpload`, {
     method: 'POST',
     headers: DEFAULT_HEADERS(accessToken),
     body: JSON.stringify({
       initializeUploadRequest: { owner },
     }),
+    timeoutMs: LI_API_TIMEOUT_MS,
   });
 
   if (!initRes.ok) {
@@ -113,13 +121,14 @@ export async function uploadImage(
   const { uploadUrl, image: imageUrn } = initData.value;
 
   // PUT raw bytes to pre-signed URL — no LinkedIn-Version header on this one
-  const uploadRes = await fetch(uploadUrl, {
+  const uploadRes = await fetchWithTimeout(uploadUrl, {
     method: 'PUT',
     headers: {
       'Authorization': `Bearer ${accessToken}`,
       'Content-Type': 'image/jpeg',
     },
     body: imageBytes,
+    timeoutMs: LI_UPLOAD_TIMEOUT_MS,
   });
 
   if (!uploadRes.ok) {
@@ -170,10 +179,11 @@ export async function createDarkPost(
     isReshareDisabledByAuthor: true,
   };
 
-  const res = await fetch(`${BASE}/posts`, {
+  const res = await fetchWithTimeout(`${BASE}/posts`, {
     method: 'POST',
     headers: DEFAULT_HEADERS(accessToken),
     body: JSON.stringify(body),
+    timeoutMs: LI_API_TIMEOUT_MS,
   });
 
   if (!res.ok) {
@@ -208,10 +218,11 @@ export async function createAdCreative(
     },
   };
 
-  const res = await fetch(`${BASE}/adCreatives`, {
+  const res = await fetchWithTimeout(`${BASE}/adCreatives`, {
     method: 'POST',
     headers: DEFAULT_HEADERS(accessToken),
     body: JSON.stringify(body),
+    timeoutMs: LI_API_TIMEOUT_MS,
   });
 
   const resText = await res.text();

--- a/src/activations/auth/linkedin.ts
+++ b/src/activations/auth/linkedin.ts
@@ -35,6 +35,8 @@
  *   id = "e17c4c99b649460a92016e1257436f22"
  */
 
+import { encryptIfConfigured, decryptIfNeeded } from '../../utils/tokenCrypto';
+
 const LI_AUTH_URL  = 'https://www.linkedin.com/oauth/v2/authorization';
 const LI_TOKEN_URL = 'https://www.linkedin.com/oauth/v2/accessToken';
 
@@ -63,6 +65,9 @@ export interface LinkedInAuthEnv {
   LINKEDIN_REDIRECT_URI: string;
   LINKEDIN_AD_ACCOUNT_ID: string;
   SIGNALS_CACHE: KVNamespace;
+  // Optional: when set, access/refresh tokens are AES-GCM encrypted at rest.
+  // Unset ⇒ plaintext storage (legacy; reads transparently handle both).
+  TOKEN_ENCRYPTION_KEY?: string;
 }
 
 // ─── Token shape ──────────────────────────────────────────────────────────────
@@ -176,7 +181,7 @@ export async function handleLinkedInAuthCallback(
     `);
   }
 
-  await storeTokens(tokenSet, env.SIGNALS_CACHE);
+  await storeTokens(tokenSet, env.SIGNALS_CACHE, env.TOKEN_ENCRYPTION_KEY);
 
   return htmlResponse('Authorization Successful ✓', `
     <p style="color:#00ff88; font-size: 20px;">✓ LinkedIn authorization complete.</p>
@@ -208,11 +213,16 @@ async function consumeOAuthState(state: string, kv: KVNamespace): Promise<boolea
 export async function handleLinkedInAuthStatus(
   env: LinkedInAuthEnv,
 ): Promise<Response> {
-  const [accessToken, refreshToken, expiresAt, metaRaw] = await Promise.all([
+  const [rawAccess, rawRefresh, expiresAt, metaRaw] = await Promise.all([
     env.SIGNALS_CACHE.get(KV_ACCESS_TOKEN),
     env.SIGNALS_CACHE.get(KV_REFRESH_TOKEN),
     env.SIGNALS_CACHE.get(KV_TOKEN_EXPIRES),
     env.SIGNALS_CACHE.get(KV_TOKEN_META),
+  ]);
+
+  const [accessToken, refreshToken] = await Promise.all([
+    decryptIfNeeded(rawAccess,  env.TOKEN_ENCRYPTION_KEY),
+    decryptIfNeeded(rawRefresh, env.TOKEN_ENCRYPTION_KEY),
   ]);
 
   if (!accessToken || !refreshToken) {
@@ -248,10 +258,15 @@ export async function handleLinkedInAuthStatus(
 // ─── Token manager ────────────────────────────────────────────────────────────
 
 export async function getValidAccessToken(env: LinkedInAuthEnv): Promise<string> {
-  const [accessToken, refreshToken, expiresAt] = await Promise.all([
+  const [rawAccess, rawRefresh, expiresAt] = await Promise.all([
     env.SIGNALS_CACHE.get(KV_ACCESS_TOKEN),
     env.SIGNALS_CACHE.get(KV_REFRESH_TOKEN),
     env.SIGNALS_CACHE.get(KV_TOKEN_EXPIRES),
+  ]);
+
+  const [accessToken, refreshToken] = await Promise.all([
+    decryptIfNeeded(rawAccess,  env.TOKEN_ENCRYPTION_KEY),
+    decryptIfNeeded(rawRefresh, env.TOKEN_ENCRYPTION_KEY),
   ]);
 
   if (!accessToken || !refreshToken) {
@@ -264,7 +279,7 @@ export async function getValidAccessToken(env: LinkedInAuthEnv): Promise<string>
   if (!needsRefresh) return accessToken;
 
   const newTokenSet = await refreshAccessToken(refreshToken, env);
-  await storeTokens(newTokenSet, env.SIGNALS_CACHE);
+  await storeTokens(newTokenSet, env.SIGNALS_CACHE, env.TOKEN_ENCRYPTION_KEY);
   return newTokenSet.access_token;
 }
 
@@ -356,13 +371,25 @@ async function refreshAccessToken(
 
 // ─── KV storage ───────────────────────────────────────────────────────────────
 
-async function storeTokens(tokenSet: LinkedInTokenSet, kv: KVNamespace): Promise<void> {
+async function storeTokens(
+  tokenSet: LinkedInTokenSet,
+  kv: KVNamespace,
+  encryptionKey?: string,
+): Promise<void> {
   const ttl90Days   = 90  * 24 * 60 * 60;
   const ttl12Months = 365 * 24 * 60 * 60;
 
+  // Tokens are the secrets at risk. `expires_at` and `token_meta` are
+  // non-sensitive timestamps/scopes, stored plaintext so /status etc. can
+  // read them without the encryption key.
+  const [encryptedAccess, encryptedRefresh] = await Promise.all([
+    encryptIfConfigured(tokenSet.access_token,  encryptionKey),
+    encryptIfConfigured(tokenSet.refresh_token, encryptionKey),
+  ]);
+
   await Promise.all([
-    kv.put(KV_ACCESS_TOKEN,  tokenSet.access_token,  { expirationTtl: ttl90Days }),
-    kv.put(KV_REFRESH_TOKEN, tokenSet.refresh_token, { expirationTtl: ttl12Months }),
+    kv.put(KV_ACCESS_TOKEN,  encryptedAccess,  { expirationTtl: ttl90Days }),
+    kv.put(KV_REFRESH_TOKEN, encryptedRefresh, { expirationTtl: ttl12Months }),
     kv.put(KV_TOKEN_EXPIRES, tokenSet.expires_at),
     kv.put(KV_TOKEN_META, JSON.stringify({
       scope:       tokenSet.scope,

--- a/src/activations/auth/linkedin.ts
+++ b/src/activations/auth/linkedin.ts
@@ -36,6 +36,7 @@
  */
 
 import { encryptIfConfigured, decryptIfNeeded } from '../../utils/tokenCrypto';
+import { fetchWithTimeout } from '../../utils/fetchWithLimits';
 
 const LI_AUTH_URL  = 'https://www.linkedin.com/oauth/v2/authorization';
 const LI_TOKEN_URL = 'https://www.linkedin.com/oauth/v2/accessToken';
@@ -297,10 +298,11 @@ async function exchangeCodeForTokens(
     redirect_uri: env.LINKEDIN_REDIRECT_URI,
   });
 
-  const res = await fetch(LI_TOKEN_URL, {
+  const res = await fetchWithTimeout(LI_TOKEN_URL, {
     method: 'POST',
     headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
     body: body.toString(),
+    timeoutMs: 15_000,
   });
 
   if (!res.ok) {
@@ -342,10 +344,11 @@ async function refreshAccessToken(
     client_secret: env.LINKEDIN_CLIENT_SECRET,
   });
 
-  const res = await fetch(LI_TOKEN_URL, {
+  const res = await fetchWithTimeout(LI_TOKEN_URL, {
     method: 'POST',
     headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
     body: body.toString(),
+    timeoutMs: 15_000,
   });
 
   if (!res.ok) {

--- a/src/activations/auth/linkedin.ts
+++ b/src/activations/auth/linkedin.ts
@@ -146,6 +146,22 @@ export async function handleLinkedInAuthCallback(
   // returned an error or a code. Provider-supplied values are escaped
   // below because the error path still renders them.
   if (!state || !(await consumeOAuthState(state, env.SIGNALS_CACHE))) {
+    // Observability: log unknown/expired/replayed state so a spike —
+    // typically a sign of abuse or a misconfigured relay — is visible in
+    // `wrangler tail`. The route is public (provider redirects carry no
+    // bearer), so the state machine is the only defense; a spike here is
+    // where we'd see it first. Log structure matches createLogger output.
+    console.warn(JSON.stringify({
+      level: 'warn',
+      event: 'linkedin_callback_invalid_state',
+      ts: new Date().toISOString(),
+      // Don't log the state value — that's the thing someone trying to
+      // replay would be leaking. Log presence only.
+      state_present: !!state,
+      has_code: !!code,
+      has_error: !!error,
+      ua: request.headers.get('user-agent') ?? null,
+    }));
     return htmlResponse('Invalid State', `
       <p style="color:#ef4444">OAuth state missing, expired, or already used.</p>
       <p>This protects against CSRF. Start the flow fresh.</p>

--- a/src/domain/conceptHandler.ts
+++ b/src/domain/conceptHandler.ts
@@ -23,6 +23,7 @@ import {
   CONCEPT_REGISTRY,
 } from "./conceptRegistry.js";
 import type { ConceptEntry } from "./conceptRegistry.js";
+import { requireAuth } from "../routes/shared";
 
 // ─── Env interface (matches wrangler.toml bindings) ──────────────────────────
 
@@ -30,6 +31,12 @@ interface Env {
   SIGNALS_CACHE: KVNamespace;
   DB: D1Database;
   ANTHROPIC_API_KEY?: string;
+  // DEMO_API_KEY is plumbed through so /ucp/concepts/seed uses the same
+  // shared secret as every other gated route. Previously this route had a
+  // hardcoded string literal that bypassed env.DEMO_API_KEY entirely —
+  // meaning rotating the secret via `wrangler secret put` silently broke
+  // the seed route. Now unified.
+  DEMO_API_KEY: string;
 }
 
 // ─── Response helpers ─────────────────────────────────────────────────────────
@@ -59,10 +66,16 @@ export async function handleConceptRoute(
 ): Promise<Response> {
   const url = new URL(request.url);
 
-  // POST /ucp/concepts/seed — re-seed KV (auth required)
+  // POST /ucp/concepts/seed — re-seed KV (auth required).
+  //
+  // Note: /ucp/concepts is in publicPaths at the top-level, so the seed
+  // sub-path bypasses the global auth gate. The check below is the actual
+  // defense. requireAuth does a constant-time compare against the active
+  // env.DEMO_API_KEY secret — rotating the secret via `wrangler secret put`
+  // automatically applies here. A previous hardcoded-string check is the
+  // reason we're re-doing this.
   if (pathname === "/ucp/concepts/seed" && request.method === "POST") {
-    const auth = request.headers.get("Authorization");
-    if (auth !== "Bearer demo-key-adcp-signals-v1") {
+    if (!requireAuth(request, env.DEMO_API_KEY)) {
       return json({ error: "Unauthorized" }, 401);
     }
     const count = await seedConceptsToKV(env.SIGNALS_CACHE);

--- a/src/domain/queryParser.ts
+++ b/src/domain/queryParser.ts
@@ -13,6 +13,8 @@
  *   - Title-level content affinity ("Desperate Housewives" → drama + audience embedding hint)
  */
 
+import { fetchWithTimeout } from "../utils/fetchWithLimits";
+
 // ─── Types ────────────────────────────────────────────────────────────────────
 
 export type Dimension =
@@ -163,10 +165,13 @@ export async function parseNLQuery(
 
   let raw: string;
   try {
-    const resp = await fetch("https://api.anthropic.com/v1/messages", {
+    // 30s timeout — Claude message-completions can take 15–20s on long
+    // prompts; we want to abort rather than eat the Worker's 30s CPU budget.
+    const resp = await fetchWithTimeout("https://api.anthropic.com/v1/messages", {
       method: "POST",
       headers,
       body: JSON.stringify(body),
+      timeoutMs: 30_000,
     });
 
     if (!resp.ok) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -70,18 +70,24 @@ export default {
         // (initialize, tools/list, ping) stay reachable, paid-egress /
         // state-changing tools do not.
         //
-        // /auth/linkedin/{init,callback,status} are NOT public. Earlier
-        // iterations made them public "so OAuth works without a token";
-        // that let any internet user complete the OAuth flow and overwrite
-        // the worker's shared LinkedIn tokens (a DoS on the integration),
-        // and the /status route leaked a 12-char token preview + scope +
-        // ad account ID to anyone. Now gated by the DEMO_API_KEY — this
-        // is a demo, so an admin-initiated one-time bootstrap is the right
-        // trust model. LinkedIn's redirect back to /callback carries the
-        // API key via the original /init request's setup link (the operator
-        // opens /auth/linkedin/init in an auth'd browser tab; the subsequent
-        // redirect inherits the Authorization header via a cookie or a
-        // browser-extension, depending on how the operator drives the flow).
+        // /auth/linkedin/init and /auth/linkedin/status are DEMO_API_KEY
+        // gated (not listed here). `init` gating is the load-bearing
+        // defense: it's the only path that can issue a state UUID, so
+        // an unauth'd attacker cannot start a flow whose callback we
+        // would later accept. `status` gating prevents a token preview
+        // + scope leak to any passerby.
+        //
+        // /auth/linkedin/callback is public. LinkedIn's 302 back to the
+        // worker is a cross-origin top-level navigation — it carries the
+        // OAuth `state` query param and nothing else. A bearer token on
+        // that request is architecturally impossible without a cookie or
+        // signed bootstrap layer, which we don't have. The defense for
+        // this route is the OAuth state machine, already implemented in
+        // auth/linkedin.ts: /init writes a random UUID to KV, /callback
+        // accepts the returned state only if it matches a live KV entry,
+        // and the entry is deleted on first use (single-use). An attacker
+        // can't forge a valid state without first coaxing a legitimate
+        // operator to hit /init — which /init's auth gate prevents.
         const publicPaths = [
             "/capabilities",
             "/health",
@@ -89,6 +95,7 @@ export default {
             "/ucp/concepts",
             "/ucp/gts",
             "/ucp/simulate-handshake",
+            "/auth/linkedin/callback",
         ];
         const isPublic = publicPaths.some((p) => path === p || path.startsWith(p + "/"));
 

--- a/src/storage/signalRepo.ts
+++ b/src/storage/signalRepo.ts
@@ -155,10 +155,27 @@ export async function searchSignals(
     conditions.push("s.activation_supported = ?");
     params.push(opts.activationSupported ? 1 : 0);
   }
+  // Destination filter is now SQL-side via json_each on the destinations
+  // JSON-array column. Previously this ran as a post-filter in memory AFTER
+  // COUNT(*) was computed, which meant totalCount overcounted by the number
+  // of rows that matched the other filters but not the destination. It
+  // also meant `LIMIT ? OFFSET ?` applied to the unfiltered set, so pagers
+  // could see short/empty pages in the middle of a scan.
+  //
+  // D1 runs SQLite, which ships with the json1 extension. `json_each(col)`
+  // expands the JSON array into a one-row-per-element virtual table so the
+  // EXISTS correlates row-by-row, using the same bound param.
+  if (opts.destination) {
+    conditions.push(
+      "EXISTS (SELECT 1 FROM json_each(s.destinations) WHERE json_each.value = ?)"
+    );
+    params.push(opts.destination);
+  }
 
   const where = conditions.length > 0 ? `WHERE ${conditions.join(" AND ")}` : "";
 
-  // Count query
+  // Count query — includes the destination filter, so totalCount now matches
+  // what the paginated result set actually enumerates.
   const countRow = await queryFirst<{ total: number }>(
     db,
     `SELECT COUNT(*) as total FROM signals s ${where}`,
@@ -166,19 +183,13 @@ export async function searchSignals(
   );
   const totalCount = countRow?.total ?? 0;
 
-  // Data query - destination filtering done in-memory (JSON column)
   const rows = await queryAll<SignalRow>(
     db,
     `SELECT s.* FROM signals s ${where} ORDER BY s.name ASC LIMIT ? OFFSET ?`,
     [...params, opts.limit, opts.offset]
   );
 
-  let signals = rows.map((r) => rowToSignal(r));
-
-  // Post-filter by destination
-  if (opts.destination) {
-    signals = signals.filter((s) => s.destinations.includes(opts.destination!));
-  }
+  const signals = rows.map((r) => rowToSignal(r));
 
   return { signals, totalCount };
 }

--- a/src/types/env.ts
+++ b/src/types/env.ts
@@ -31,4 +31,11 @@ export interface Env {
   // deliveries (backwards-compatible). Provision via:
   //   wrangler secret put WEBHOOK_SIGNING_SECRET
   WEBHOOK_SIGNING_SECRET?: string;
+
+  // Optional — when set, LinkedIn access/refresh tokens stored in KV are
+  // AES-GCM encrypted at rest. Unset ⇒ tokens stored plaintext (legacy,
+  // backwards-compatible during rollout). Reads auto-detect the enc:v1:
+  // prefix and decrypt; plaintext values are returned unchanged. Provision:
+  //   wrangler secret put TOKEN_ENCRYPTION_KEY
+  TOKEN_ENCRYPTION_KEY?: string;
 }

--- a/src/ucp/embeddingEngine.ts
+++ b/src/ucp/embeddingEngine.ts
@@ -21,6 +21,7 @@
 // is always assignable to UcpEmbeddingDeclaration.phase without casting.
 export type { UcpEmbeddingPhase as EmbeddingPhase } from "../types/ucp";
 import type { UcpEmbeddingPhase } from "../types/ucp";
+import { fetchWithTimeout } from "../utils/fetchWithLimits";
 
 export interface SignalEmbedding {
   model_id: string;
@@ -138,7 +139,9 @@ export class LlmEmbeddingEngine implements EmbeddingEngine {
   }
 
   private async callOpenAI(text: string): Promise<number[]> {
-    const res = await fetch('https://api.openai.com/v1/embeddings', {
+    // 15s timeout — OpenAI embeddings typically return in <1s; a 15s cap
+    // is generous for p99 while still well under the Worker CPU budget.
+    const res = await fetchWithTimeout('https://api.openai.com/v1/embeddings', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -149,6 +152,7 @@ export class LlmEmbeddingEngine implements EmbeddingEngine {
         input: text,
         dimensions: 512,
       }),
+      timeoutMs: 15_000,
     });
     if (!res.ok) {
       const err = await res.text();

--- a/src/utils/tokenCrypto.ts
+++ b/src/utils/tokenCrypto.ts
@@ -1,0 +1,148 @@
+// src/utils/tokenCrypto.ts
+//
+// AES-GCM envelope encryption for secrets stored in KV at rest.
+//
+// Threat model: a KV dump (misconfigured binding, a compromised dashboard
+// session, a read-only dev binding accidentally bound to prod) would
+// otherwise expose the LinkedIn access/refresh tokens in plaintext. We
+// can't keep a KV binding from being readable, but we can make what's
+// inside useless without the Worker secret.
+//
+// Format on disk:
+//   "enc:v1:" + base64url(iv || ciphertext)
+//
+// * `enc:v1:` prefix — lets the reader distinguish encrypted values from
+//   legacy plaintext written before this helper shipped, and lets us rotate
+//   the scheme (enc:v2:…) without ambiguity.
+// * iv — 12 random bytes, required by AES-GCM, generated per write.
+// * ciphertext — includes the 128-bit auth tag appended by Web Crypto's
+//   AES-GCM implementation, so we don't store a separate tag.
+//
+// The caller passes a raw passphrase (env.TOKEN_ENCRYPTION_KEY). We derive
+// a 256-bit AES key via SHA-256 so operators can `wrangler secret put`
+// any string they like rather than having to produce 32 raw bytes.
+
+const PREFIX = "enc:v1:";
+
+declare const crypto: Crypto;
+
+/**
+ * Returns true if `raw` looks like a value previously written by
+ * `encryptToken`. Anything else is assumed to be legacy plaintext.
+ */
+export function isEncrypted(raw: string | null | undefined): boolean {
+  return !!raw && raw.startsWith(PREFIX);
+}
+
+async function deriveKey(passphrase: string): Promise<CryptoKey> {
+  const digest = await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(passphrase),
+  );
+  return crypto.subtle.importKey(
+    "raw",
+    digest,
+    { name: "AES-GCM", length: 256 },
+    false,
+    ["encrypt", "decrypt"],
+  );
+}
+
+export async function encryptToken(plaintext: string, passphrase: string): Promise<string> {
+  const key = await deriveKey(passphrase);
+  const iv = crypto.getRandomValues(new Uint8Array(12));
+  const ciphertext = new Uint8Array(
+    await crypto.subtle.encrypt(
+      { name: "AES-GCM", iv },
+      key,
+      new TextEncoder().encode(plaintext),
+    ),
+  );
+
+  const combined = new Uint8Array(iv.length + ciphertext.length);
+  combined.set(iv, 0);
+  combined.set(ciphertext, iv.length);
+
+  return PREFIX + bytesToBase64Url(combined);
+}
+
+/**
+ * Decrypt a value produced by `encryptToken`. Throws if the value isn't
+ * encrypted, if the passphrase is wrong, or if the ciphertext is tampered
+ * (AES-GCM integrity check fails).
+ */
+export async function decryptToken(encrypted: string, passphrase: string): Promise<string> {
+  if (!isEncrypted(encrypted)) {
+    throw new Error("Value is not enc:v1: — cannot decrypt");
+  }
+  const combined = base64UrlToBytes(encrypted.slice(PREFIX.length));
+  if (combined.length < 13) {
+    // 12-byte IV + at least one byte of ciphertext (plus tag)
+    throw new Error("Encrypted payload truncated");
+  }
+  const iv = combined.slice(0, 12);
+  const ciphertext = combined.slice(12);
+
+  const key = await deriveKey(passphrase);
+  const plainBuf = await crypto.subtle.decrypt(
+    { name: "AES-GCM", iv },
+    key,
+    ciphertext,
+  );
+  return new TextDecoder().decode(plainBuf);
+}
+
+/**
+ * Convenience read: decrypt an enc:v1: value, or return a legacy plaintext
+ * value unchanged. Used during the one-time migration window where KV may
+ * contain values written before the encryption patch landed.
+ *
+ * Pass `null`/`undefined` through unchanged so callers can keep their
+ * existing null-checks.
+ */
+export async function decryptIfNeeded(
+  raw: string | null | undefined,
+  passphrase: string | undefined,
+): Promise<string | null> {
+  if (raw == null || raw === "") return null;
+  if (!isEncrypted(raw)) return raw; // legacy plaintext — return as-is
+  if (!passphrase) {
+    throw new Error(
+      "KV value is encrypted but TOKEN_ENCRYPTION_KEY is not configured",
+    );
+  }
+  return decryptToken(raw, passphrase);
+}
+
+/**
+ * Convenience write: encrypt when a passphrase is configured, otherwise
+ * write plaintext. Pairing with `decryptIfNeeded` means the feature is
+ * opt-in via `wrangler secret put TOKEN_ENCRYPTION_KEY` — unset ⇒ legacy
+ * behavior.
+ */
+export async function encryptIfConfigured(
+  plaintext: string,
+  passphrase: string | undefined,
+): Promise<string> {
+  if (!passphrase) return plaintext;
+  return encryptToken(plaintext, passphrase);
+}
+
+// ─── base64url (standard base64 minus padding, URL-safe charset) ─────────────
+
+function bytesToBase64Url(bytes: Uint8Array): string {
+  let bin = "";
+  for (let i = 0; i < bytes.length; i++) bin += String.fromCharCode(bytes[i]!);
+  const b64 = btoa(bin);
+  return b64.replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+function base64UrlToBytes(b64url: string): Uint8Array {
+  // Restore padding and standard alphabet
+  const pad = b64url.length % 4 === 0 ? "" : "=".repeat(4 - (b64url.length % 4));
+  const b64 = b64url.replace(/-/g, "+").replace(/_/g, "/") + pad;
+  const bin = atob(b64);
+  const out = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
+  return out;
+}

--- a/tests/conceptHandler-auth.test.ts
+++ b/tests/conceptHandler-auth.test.ts
@@ -1,0 +1,96 @@
+// tests/conceptHandler-auth.test.ts
+// Sec-5: /ucp/concepts/seed now authenticates via requireAuth(request, env.DEMO_API_KEY).
+// Previously the route hardcoded a string literal, so rotating the secret
+// via `wrangler secret put DEMO_API_KEY` silently broke the route.
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Stub the registry's KV writer — we only care about the auth check here.
+vi.mock("../src/domain/conceptRegistry.js", async () => {
+  const actual = await vi.importActual<typeof import("../src/domain/conceptRegistry.js")>(
+    "../src/domain/conceptRegistry.js",
+  );
+  return {
+    ...actual,
+    seedConceptsToKV: vi.fn(async () => 42),
+  };
+});
+
+import { handleConceptRoute } from "../src/domain/conceptHandler";
+
+function makeEnv(demoApiKey: string) {
+  return {
+    SIGNALS_CACHE: {
+      async put() {},
+      async get() { return null; },
+      async delete() {},
+    } as unknown as KVNamespace,
+    DB: {} as unknown as D1Database,
+    DEMO_API_KEY: demoApiKey,
+  };
+}
+
+function seedRequest(authHeader?: string): Request {
+  const headers = new Headers();
+  if (authHeader) headers.set("Authorization", authHeader);
+  return new Request("https://example.com/ucp/concepts/seed", {
+    method: "POST",
+    headers,
+  });
+}
+
+describe("/ucp/concepts/seed auth — uses env.DEMO_API_KEY", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("401 without Authorization header", async () => {
+    const env = makeEnv("secret-value-A");
+    const res = await handleConceptRoute(seedRequest(), env, "/ucp/concepts/seed");
+    expect(res.status).toBe(401);
+  });
+
+  it("401 with wrong key", async () => {
+    const env = makeEnv("secret-value-A");
+    const res = await handleConceptRoute(
+      seedRequest("Bearer wrong-value"),
+      env,
+      "/ucp/concepts/seed",
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("200 with the key matching env.DEMO_API_KEY", async () => {
+    const env = makeEnv("secret-value-A");
+    const res = await handleConceptRoute(
+      seedRequest("Bearer secret-value-A"),
+      env,
+      "/ucp/concepts/seed",
+    );
+    expect(res.status).toBe(200);
+  });
+
+  it("pins the rotation behavior: changing env.DEMO_API_KEY changes which key works", async () => {
+    // Same Authorization header, two different env.DEMO_API_KEY values.
+    // Regression for the old hardcoded-string bug: if the auth check were
+    // still comparing against a literal, rotating the env secret wouldn't
+    // change the outcome here.
+    const req = seedRequest("Bearer rotated-value-B");
+
+    const envOld = makeEnv("secret-value-A");
+    const resOld = await handleConceptRoute(req, envOld, "/ucp/concepts/seed");
+    expect(resOld.status).toBe(401); // old key doesn't match
+
+    const envNew = makeEnv("rotated-value-B");
+    const resNew = await handleConceptRoute(req, envNew, "/ucp/concepts/seed");
+    expect(resNew.status).toBe(200); // rotated key now accepted
+  });
+
+  it("accepts ApiKey scheme too (matches requireAuth semantics)", async () => {
+    const env = makeEnv("secret-value-A");
+    const res = await handleConceptRoute(
+      seedRequest("ApiKey secret-value-A"),
+      env,
+      "/ucp/concepts/seed",
+    );
+    expect(res.status).toBe(200);
+  });
+});

--- a/tests/security.test.ts
+++ b/tests/security.test.ts
@@ -256,7 +256,10 @@ describe("constantTimeEqual", () => {
 // ── requireAuth ───────────────────────────────────────────────────────────────
 
 describe("requireAuth", () => {
-  const KEY = "demo-key-adcp-signals-v1";
+  // Test fixture only — the real demo key is a Worker secret, not a
+  // checked-in constant. Using an obviously-labeled value so no one greps
+  // the repo and mistakes this for the production key.
+  const KEY = "fixture-api-key-for-requireAuth-tests";
 
   function req(authHeader?: string): Request {
     const headers = new Headers();

--- a/tests/signalRepo-count.test.ts
+++ b/tests/signalRepo-count.test.ts
@@ -1,0 +1,145 @@
+// tests/signalRepo-count.test.ts
+// Sec-7: searchSignals must apply the destination filter in SQL so the
+// COUNT(*) and the paginated data query see the same row set — otherwise
+// totalCount overcounts and callers paginate into empty pages.
+//
+// We can't run real D1/SQLite in this test setup, so the test intercepts
+// every prepare/bind/first/all call, records SQL + params, and asserts:
+//   (a) the COUNT and the data query carry identical WHERE clauses
+//   (b) destination is bound as a SQL param (not grep-and-substituted)
+//   (c) the WHERE clause uses json_each on the destinations column — the
+//       only shape D1 supports for JSON-array membership without a full
+//       column rewrite.
+//
+// A complementary correctness check runs against the live worker in
+// scripts/test-live.sh.
+
+import { describe, it, expect } from "vitest";
+import { searchSignals } from "../src/storage/signalRepo";
+
+interface Call {
+  sql: string;
+  params: unknown[];
+}
+
+function makeRecordingDb(countTotal: number, rowResults: unknown[]): {
+  db: D1Database;
+  calls: Call[];
+} {
+  const calls: Call[] = [];
+  const db = {
+    prepare(sql: string) {
+      let bound: unknown[] = [];
+      return {
+        bind(...args: unknown[]) {
+          bound = args;
+          return this;
+        },
+        async first<T>() {
+          calls.push({ sql, params: bound });
+          if (sql.toUpperCase().includes("COUNT(*)")) {
+            return { total: countTotal } as unknown as T;
+          }
+          return null as unknown as T;
+        },
+        async all<T>() {
+          calls.push({ sql, params: bound });
+          return { results: rowResults as T[] };
+        },
+        async run() {
+          calls.push({ sql, params: bound });
+          return { success: true, meta: {} } as unknown as D1Result;
+        },
+      };
+    },
+  } as unknown as D1Database;
+  return { db, calls };
+}
+
+// Pull the WHERE clause out of a query so the count and data queries can be
+// compared structurally rather than by string-equality (the data query
+// adds a trailing ORDER BY / LIMIT).
+function extractWhere(sql: string): string {
+  const m = sql.match(/WHERE\s+(.*?)(?:\s+ORDER BY|\s*$)/i);
+  return m ? m[1]!.trim() : "";
+}
+
+describe("searchSignals — totalCount vs destination filter", () => {
+  it("no destination: count and data queries share WHERE, no json_each", async () => {
+    const { db, calls } = makeRecordingDb(42, []);
+    const out = await searchSignals(db, {
+      categoryType: "demographic",
+      limit: 10,
+      offset: 0,
+    });
+    expect(out.totalCount).toBe(42);
+
+    const countCall = calls.find((c) => c.sql.toUpperCase().includes("COUNT(*)"));
+    const dataCall = calls.find((c) => !c.sql.toUpperCase().includes("COUNT(*)"));
+    expect(countCall).toBeDefined();
+    expect(dataCall).toBeDefined();
+    expect(extractWhere(countCall!.sql)).toBe(extractWhere(dataCall!.sql));
+    expect(countCall!.sql.toLowerCase()).not.toContain("json_each");
+  });
+
+  it("destination set: WHERE clause includes json_each on destinations", async () => {
+    const { db, calls } = makeRecordingDb(5, []);
+    await searchSignals(db, {
+      destination: "mock_dsp",
+      limit: 10,
+      offset: 0,
+    });
+
+    const countCall = calls.find((c) => c.sql.toUpperCase().includes("COUNT(*)"));
+    const dataCall = calls.find((c) => !c.sql.toUpperCase().includes("COUNT(*)"));
+    expect(countCall).toBeDefined();
+    expect(dataCall).toBeDefined();
+
+    // Both queries carry the SAME WHERE clause — this is the pin for the
+    // totalCount/data-set mismatch bug.
+    expect(extractWhere(countCall!.sql)).toBe(extractWhere(dataCall!.sql));
+
+    // json_each membership check is present.
+    expect(countCall!.sql.toLowerCase()).toContain("json_each(s.destinations)");
+
+    // Destination is bound as a SQL param, not interpolated into the text.
+    expect(countCall!.params).toContain("mock_dsp");
+    expect(dataCall!.params).toContain("mock_dsp");
+
+    // Sanity: the raw destination string isn't concatenated into the SQL
+    // (regression guard against a future edit that might swap json_each for
+    // a LIKE '%"dst"%' string-match).
+    expect(countCall!.sql).not.toContain('"mock_dsp"');
+  });
+
+  it("returns totalCount unchanged from the count query (no post-filter)", async () => {
+    // With the old in-memory post-filter, totalCount would come from the
+    // unfiltered count while .signals came from the filtered set.
+    // After the fix, the count reflects the destination filter — so the
+    // number our mock DB returns is exactly what the caller sees.
+    const { db } = makeRecordingDb(7, []);
+    const out = await searchSignals(db, {
+      destination: "mock_dsp",
+      limit: 10,
+      offset: 0,
+    });
+    expect(out.totalCount).toBe(7);
+  });
+
+  it("query + destination: both LIKE params and the destination are bound", async () => {
+    const { db, calls } = makeRecordingDb(3, []);
+    await searchSignals(db, {
+      query: "high income",
+      destination: "mock_dsp",
+      limit: 10,
+      offset: 0,
+    });
+
+    const countCall = calls.find((c) => c.sql.toUpperCase().includes("COUNT(*)"));
+    // LIKE params: two entries of "%high income%"
+    const likeParams = countCall!.params.filter((p) => p === "%high income%");
+    expect(likeParams.length).toBe(2);
+    // Destination bound separately
+    expect(countCall!.params).toContain("mock_dsp");
+  });
+});

--- a/tests/tokenCrypto.test.ts
+++ b/tests/tokenCrypto.test.ts
@@ -1,0 +1,136 @@
+// tests/tokenCrypto.test.ts
+// Sec-4: AES-GCM envelope encryption for secrets stored in KV at rest.
+
+import { describe, it, expect } from "vitest";
+import {
+  encryptToken,
+  decryptToken,
+  isEncrypted,
+  encryptIfConfigured,
+  decryptIfNeeded,
+} from "../src/utils/tokenCrypto";
+
+describe("tokenCrypto round-trip", () => {
+  const passphrase = "demo-passphrase-not-a-production-value";
+
+  it("encrypts and decrypts a string correctly", async () => {
+    const enc = await encryptToken("hello world", passphrase);
+    expect(isEncrypted(enc)).toBe(true);
+    expect(enc.startsWith("enc:v1:")).toBe(true);
+    const dec = await decryptToken(enc, passphrase);
+    expect(dec).toBe("hello world");
+  });
+
+  it("produces different ciphertext each call (fresh IV)", async () => {
+    const a = await encryptToken("same plaintext", passphrase);
+    const b = await encryptToken("same plaintext", passphrase);
+    expect(a).not.toBe(b);
+    // …but both decrypt to the same value
+    expect(await decryptToken(a, passphrase)).toBe("same plaintext");
+    expect(await decryptToken(b, passphrase)).toBe("same plaintext");
+  });
+
+  it("decrypt with wrong passphrase throws (auth tag fails)", async () => {
+    const enc = await encryptToken("secret", passphrase);
+    await expect(decryptToken(enc, "wrong-passphrase")).rejects.toThrow();
+  });
+
+  it("tampering the ciphertext throws on decrypt (integrity check)", async () => {
+    const enc = await encryptToken("secret", passphrase);
+    // Flip a byte in the middle of the base64url payload.
+    const body = enc.slice("enc:v1:".length);
+    const flipIdx = Math.floor(body.length / 2);
+    const flipped =
+      body.slice(0, flipIdx) +
+      (body[flipIdx] === "A" ? "B" : "A") +
+      body.slice(flipIdx + 1);
+    await expect(decryptToken("enc:v1:" + flipped, passphrase)).rejects.toThrow();
+  });
+
+  it("handles long tokens (LinkedIn access tokens are ~400 chars)", async () => {
+    const long = "A".repeat(512);
+    const enc = await encryptToken(long, passphrase);
+    const dec = await decryptToken(enc, passphrase);
+    expect(dec).toBe(long);
+    expect(dec.length).toBe(512);
+  });
+
+  it("handles unicode cleanly", async () => {
+    const input = "grüße — 日本語 — 🎯";
+    const enc = await encryptToken(input, passphrase);
+    expect(await decryptToken(enc, passphrase)).toBe(input);
+  });
+
+  it("rejects non-enc prefix on decrypt", async () => {
+    await expect(decryptToken("plaintext-lookalike", passphrase)).rejects.toThrow(
+      /not enc:v1:/,
+    );
+  });
+
+  it("rejects truncated payload", async () => {
+    await expect(decryptToken("enc:v1:AA", passphrase)).rejects.toThrow(/truncated/);
+  });
+});
+
+describe("isEncrypted", () => {
+  it("true for enc:v1: prefixed values", async () => {
+    const enc = await encryptToken("x", "p");
+    expect(isEncrypted(enc)).toBe(true);
+  });
+
+  it("false for plaintext", () => {
+    expect(isEncrypted("AQW12345-plain-linkedin-access-token")).toBe(false);
+    expect(isEncrypted("")).toBe(false);
+    expect(isEncrypted(null)).toBe(false);
+    expect(isEncrypted(undefined)).toBe(false);
+  });
+
+  it("false for a near-match prefix (case-sensitive / version-sensitive)", () => {
+    expect(isEncrypted("ENC:V1:abc")).toBe(false);
+    expect(isEncrypted("enc:v2:abc")).toBe(false);
+  });
+});
+
+describe("encryptIfConfigured / decryptIfNeeded (opt-in wrappers)", () => {
+  const passphrase = "config-passphrase";
+
+  it("no passphrase ⇒ pass-through plaintext on write", async () => {
+    const out = await encryptIfConfigured("raw-token", undefined);
+    expect(out).toBe("raw-token");
+    expect(isEncrypted(out)).toBe(false);
+  });
+
+  it("passphrase ⇒ encrypts on write", async () => {
+    const out = await encryptIfConfigured("raw-token", passphrase);
+    expect(isEncrypted(out)).toBe(true);
+    expect(await decryptToken(out, passphrase)).toBe("raw-token");
+  });
+
+  it("read plaintext returns it unchanged (legacy migration)", async () => {
+    const out = await decryptIfNeeded("legacy-plaintext-token", passphrase);
+    expect(out).toBe("legacy-plaintext-token");
+  });
+
+  it("read plaintext without a passphrase returns it unchanged", async () => {
+    const out = await decryptIfNeeded("legacy-plaintext-token", undefined);
+    expect(out).toBe("legacy-plaintext-token");
+  });
+
+  it("read encrypted value with no passphrase configured throws", async () => {
+    const enc = await encryptToken("x", passphrase);
+    await expect(decryptIfNeeded(enc, undefined)).rejects.toThrow(
+      /encrypted but TOKEN_ENCRYPTION_KEY is not configured/,
+    );
+  });
+
+  it("read encrypted with wrong passphrase throws (via AES-GCM)", async () => {
+    const enc = await encryptToken("x", passphrase);
+    await expect(decryptIfNeeded(enc, "other")).rejects.toThrow();
+  });
+
+  it("null/empty/undefined read returns null", async () => {
+    expect(await decryptIfNeeded(null, passphrase)).toBe(null);
+    expect(await decryptIfNeeded(undefined, passphrase)).toBe(null);
+    expect(await decryptIfNeeded("", passphrase)).toBe(null);
+  });
+});


### PR DESCRIPTION
Bundled follow-up to the OpenAI review pass. Closes the five Open/Partial items that remained after [#19](https://github.com/EvgenyAndroid/adcp-signals-adaptor/pull/19), [#20](https://github.com/EvgenyAndroid/adcp-signals-adaptor/pull/20), [#21](https://github.com/EvgenyAndroid/adcp-signals-adaptor/pull/21).

## Commits (review one at a time)

| Commit | What | Review priority |
|---|---|---|
| Sec-4 | AES-GCM encryption for LinkedIn tokens at rest | High — data-at-rest |
| Sec-5 | DEMO_API_KEY unification (conceptHandler + docs scrub) | **Highest — the hardcoded string check was actively misleading** |
| Sec-6 | fetchWithTimeout across all outbound providers | Medium — DoS hardening |
| Sec-7 | SQL-side destination filter so totalCount matches | High — correctness |
| Sec-8 | OAuth callback Option A (public, state is the defense) | High — unbreaks the flow |

## The five items this closes

1. **Sec-4** — Plaintext LinkedIn tokens in KV. New [src/utils/tokenCrypto.ts](src/utils/tokenCrypto.ts) provides envelope AES-GCM encryption (`enc:v1:` prefix, 12-byte random IV per write, 128-bit auth tag, SHA-256 passphrase → 256-bit AES key). Opt-in via `wrangler secret put TOKEN_ENCRYPTION_KEY`; unset = legacy plaintext (backwards-compatible rollout). Reads auto-detect the prefix so legacy tokens work until the next refresh naturally encrypts them.

2. **Sec-5** — DEMO_API_KEY remediation. The sharpest sub-item: [src/domain/conceptHandler.ts:65](src/domain/conceptHandler.ts:65) had `if (auth !== "Bearer demo-key-adcp-signals-v1")` — a literal string check that bypassed `env.DEMO_API_KEY`. Rotating the secret silently broke `/ucp/concepts/seed`. Now uses `requireAuth(request, env.DEMO_API_KEY)`. Also scrubbed published demo value from README (5 sites), curl-tests.cmd (18 sites), and test-live.sh (removed default fallback → fails loudly if `API_KEY` not exported).

3. **Sec-6** — Timeout coverage. Every outbound `await fetch()` in `src/` other than the one inside `fetchWithTimeout` itself now uses `fetchWithTimeout`. Providers covered: Anthropic (30s), OpenAI (15s), LinkedIn OAuth (15s), LinkedIn ad-platform (10s), LinkedIn image upload (20s).

4. **Sec-7** — `totalCount` pagination. [src/storage/signalRepo.ts](src/storage/signalRepo.ts) — destination filter moved from an in-memory post-filter into the SQL `WHERE` clause via `json_each(s.destinations)`. COUNT and data queries now share the same clause, so `totalCount` exactly matches the enumerable result set.

5. **Sec-8** — OAuth callback Option A. `/auth/linkedin/callback` restored to `publicPaths`. The OAuth state machine (single-use UUID in KV, issued by gated `/init`, consumed once on `/callback`) is the defense. Added observability log on unknown-state rejection. Updated [scripts/test-live.sh](scripts/test-live.sh) accordingly — fabricated-state callback now asserts 200 + "Invalid State" HTML body (the pin: state is the actual gate).

## Test coverage added

| File | New tests | What |
|---|---|---|
| [tests/tokenCrypto.test.ts](tests/tokenCrypto.test.ts) | +18 | Round-trip, fresh IV per write, wrong passphrase throws, byte-level tamper detection, long tokens, unicode, opt-in wrapper behavior (plaintext pass-through, legacy migration, missing-key error) |
| [tests/conceptHandler-auth.test.ts](tests/conceptHandler-auth.test.ts) | +5 | 401 without header, 401 wrong key, 200 matching env, **rotation pin** (same request, two env values, two outcomes — regression guard for the hardcoded-string bug), ApiKey scheme |
| [tests/signalRepo-count.test.ts](tests/signalRepo-count.test.ts) | +4 | No-destination path carries same WHERE; destination set uses `json_each(s.destinations)`; destination bound as param (not string-substituted); LIKE + destination params coexist |

## Verification

- Type-check: 0 new errors (baseline 95)
- Unit tests: **230 passed / 12 skipped** (+27)
- Live tests pending (will run against the deployed worker after merge)

## Deployment notes

Before deploy:

```bash
# Optional — enables AES-GCM encryption of LinkedIn tokens at rest.
# Skip if you're fine with plaintext storage for the demo.
wrangler secret put TOKEN_ENCRYPTION_KEY

# Required BEFORE this deploy if you want to rotate the demo key at the
# same time. Paste any new value; nothing in-tree references the old one.
# Callers (you, the runner, anyone following the README) need to update
# their local DEMO_API_KEY shell export to match.
wrangler secret put DEMO_API_KEY   # only if rotating
```

The existing `DEMO_API_KEY` secret keeps working as-is; nothing in this PR forces a rotation. Recommended: rotate separately once published demo value is scrubbed from everywhere (this PR scrubs in-tree; your own bookmarks, dashboards, and any external doc still need a sweep).

## Test plan

- [x] `npx vitest run` — 230 pass
- [x] `npx tsc --noEmit` — no new errors
- [ ] Merge + deploy
- [ ] `bash scripts/test-live.sh` against live worker (all 51+ pre-existing pass, plus the new callback-state body assertion)
- [ ] Smoke test: do a full `/auth/linkedin/init` → LinkedIn authorize → `/callback` → token exchange round-trip to verify Sec-8 restored the flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)