### PR TITLE
Sec-10 follow-up (II): wording nits (SQLite serialization + operator-facing messages)

### DIFF
--- a/src/activations/auth/linkedin.ts
+++ b/src/activations/auth/linkedin.ts
@@ -3,12 +3,15 @@
  *
  * LinkedIn OAuth 2.0 Authorization Code flow with automatic token refresh.
  *
- * SETUP (one-time, in browser):
- *   1. Visit: GET /auth/linkedin/init
- *   2. LinkedIn login page appears — authorize the app
- *   3. LinkedIn redirects to: GET /auth/linkedin/callback?code=XXX
- *   4. Worker exchanges code for access_token + refresh_token
- *   5. Both tokens stored in KV — never needed manually again
+ * SETUP (one-time, operator-driven):
+ *   1. Call `GET /auth/linkedin/init` with your API key
+ *      (Authorization: Bearer $DEMO_API_KEY). The HTML response
+ *      contains a one-click LinkedIn authorize link.
+ *   2. Click through to LinkedIn; authorize the app.
+ *   3. LinkedIn redirects to `GET /auth/linkedin/callback?code=XXX`
+ *      (public by design — state-consumed-once is the defense).
+ *   4. Worker exchanges the code for access_token + refresh_token.
+ *   5. Both tokens stored in KV — never needed manually again.
  *
  * ALL SUBSEQUENT CALLS (fully automated, server-to-server):
  *   - Worker reads access_token from KV
@@ -272,9 +275,9 @@ export async function handleLinkedInAuthCallback(
  * public /callback route. Under the previous KV implementation
  * (`kv.get` → `kv.delete`) two near-simultaneous callbacks could both see
  * the state before either deletion landed, yielding a TOCTOU replay. With
- * D1, SQLite serializes row-level writes — the DELETE that matches a row
- * is the only one that sees it; any concurrent DELETE on the same primary
- * key returns zero rows. Strictly single-use.
+ * D1, SQLite serializes writes — only one DELETE can consume the state;
+ * any concurrent DELETE on the same primary key returns zero rows.
+ * Strictly single-use.
  *
  * The WHERE clause includes an expiry check so a DB with stale rows (after
  * a clock rewind or a missed cleanup) can't be induced to accept something
@@ -309,7 +312,7 @@ export async function handleLinkedInAuthStatus(
   if (!accessToken || !refreshToken) {
     return json({
       configured: false,
-      message: 'No LinkedIn tokens found. Visit /auth/linkedin/init to authorize.',
+      message: 'No LinkedIn tokens found. Call `GET /auth/linkedin/init` with your API key to start the flow.',
     });
   }
 
@@ -351,7 +354,7 @@ export async function getValidAccessToken(env: LinkedInAuthEnv): Promise<string>
   ]);
 
   if (!accessToken || !refreshToken) {
-    throw new Error('LinkedIn not authorized. Visit /auth/linkedin/init to complete setup.');
+    throw new Error('LinkedIn not authorized. Call `GET /auth/linkedin/init` with your API key to complete setup.');
   }
 
   const needsRefresh = !expiresAt

--- a/src/index.ts
+++ b/src/index.ts
@@ -86,8 +86,8 @@ export default {
         // /init writes a random UUID to the `oauth_state` D1 table, and
         // /callback consumes it atomically via
         // `DELETE ... WHERE state = ? AND expires_at > ? RETURNING state`
-        // — SQLite serializes the row-level write, so exactly one DELETE
-        // matches a given state. An attacker can't forge a valid state
+        // — SQLite serializes writes, so only one DELETE can consume a
+        // given state. An attacker can't forge a valid state
         // without first coaxing a legitimate operator to hit /init —
         // which /init's auth gate prevents.
         //


### PR DESCRIPTION
Two comments/strings-only nits from the reviewer. No runtime change.

- 'row-level' wording in src/index.ts + src/activations/auth/linkedin.ts replaced with 'SQLite serializes writes, so only one DELETE can consume a given state' — closer to the actual semantics.
- Three operator-facing strings saying 'Visit /auth/linkedin/init' updated to 'Call `GET /auth/linkedin/init` with your API key'. The route is DEMO_API_KEY-gated; naive browser nav returns 401, so the old phrasing was misleading.

Type-check clean. 240 unit tests pass. Live suite unchanged (will re-run post-deploy).