### PR TITLE
Sec-11: /capabilities ext.ucp now reports the real engine (pre-demo)

### DIFF
--- a/scripts/pre-demo-audit.mjs
+++ b/scripts/pre-demo-audit.mjs
@@ -1,0 +1,344 @@
+// scripts/pre-demo-audit.mjs
+// Ad-hoc pre-demo audit — exercises every demo-worthy flow end-to-end
+// against the live worker, reports a line per check.
+//
+// Usage:
+//   API_KEY=... node scripts/pre-demo-audit.mjs
+
+const BASE = process.env.BASE ?? 'https://adcp-signals-adaptor.evgeny-193.workers.dev';
+const KEY = process.env.API_KEY;
+if (!KEY) {
+  console.error('ERROR: API_KEY not set');
+  process.exit(2);
+}
+
+const results = [];
+function log(label, ok, detail = '') {
+  results.push({ label, ok, detail });
+  const mark = ok ? 'PASS' : 'FAIL';
+  const suffix = detail ? ` — ${detail}` : '';
+  console.log(`${mark.padEnd(4)} ${label}${suffix}`);
+}
+
+const auth = { Authorization: `Bearer ${KEY}` };
+const json = { 'Content-Type': 'application/json' };
+
+async function fetchJson(url, init = {}) {
+  const res = await fetch(url, init);
+  const text = await res.text();
+  let body;
+  try { body = JSON.parse(text); } catch { body = { _raw: text.slice(0, 200) }; }
+  return { status: res.status, body, raw: text };
+}
+
+// ── Core protocol ────────────────────────────────────────────────────────────
+
+async function checkHealth() {
+  const { status, body } = await fetchJson(`${BASE}/health`);
+  log('health', status === 200 && body.status === 'ok', `v=${body.version}`);
+}
+
+async function checkCapabilities() {
+  const { status, body } = await fetchJson(`${BASE}/capabilities?correlation_id=demo`);
+  log('capabilities — 200', status === 200);
+  log('capabilities — adcp.major_versions contains 3', Array.isArray(body.adcp?.major_versions) && body.adcp.major_versions.includes(3));
+  log('capabilities — adcp.idempotency.replay_ttl_seconds', typeof body.adcp?.idempotency?.replay_ttl_seconds === 'number');
+  log('capabilities — supported_protocols includes signals', body.supported_protocols?.includes('signals'));
+  log('capabilities — context correlation_id echo', body.context?.correlation_id === 'demo');
+  log('capabilities — ext.ucp present', !!body.ext?.ucp);
+  // Consistency check vs gts
+  const gts = await fetchJson(`${BASE}/ucp/gts`);
+  const capPhase = body.ext?.ucp?.phase;
+  const gtsPhase = gts.body.engine_phase;
+  log(
+    'capabilities — ext.ucp.phase matches gts engine_phase',
+    capPhase === gtsPhase,
+    `capabilities:${capPhase} vs gts:${gtsPhase}`,
+  );
+  const capSpaces = body.ext?.ucp?.supported_spaces ?? [];
+  const gtsSpace = gts.body.space_id;
+  log(
+    'capabilities — ext.ucp.supported_spaces contains gts.space_id',
+    capSpaces.includes(gtsSpace),
+    `capabilities:${JSON.stringify(capSpaces)} vs gts:${gtsSpace}`,
+  );
+}
+
+async function checkGts() {
+  const { status, body } = await fetchJson(`${BASE}/ucp/gts`);
+  log('ucp/gts — 200', status === 200);
+  log('ucp/gts — overall_pass true', body.overall_pass === true);
+  log('ucp/gts — pass_rate 1.0', body.pass_rate === 1);
+  log('ucp/gts — engine_phase llm-v1', body.engine_phase === 'llm-v1');
+  log('ucp/gts — 15 pairs', body.pairs?.length === 15);
+}
+
+async function checkProjector() {
+  const unauth = await fetchJson(`${BASE}/ucp/projector`);
+  log('ucp/projector — unauth 401', unauth.status === 401);
+  const authed = await fetchJson(`${BASE}/ucp/projector`, { headers: auth });
+  log('ucp/projector — authed 200', authed.status === 200);
+  log('ucp/projector — 512-row matrix', Array.isArray(authed.body.matrix) && authed.body.matrix.length === 512);
+  log('ucp/projector — status simulated', authed.body.status === 'simulated');
+}
+
+async function checkHandshake() {
+  for (const [name, spaces, expected] of [
+    ['direct_match', ['openai-te3-small-d512-v1'], 'direct_match'],
+    ['projector_required', ['bert-base-uncased-v1'], 'projector_required'],
+    ['legacy_fallback', [], 'legacy_fallback'],
+  ]) {
+    const { status, body } = await fetchJson(`${BASE}/ucp/simulate-handshake`, {
+      method: 'POST', headers: json,
+      body: JSON.stringify({ buyer_space_ids: spaces, buyer_ucp_version: expected === 'legacy_fallback' ? 'ucp-v0' : 'ucp-v1' }),
+    });
+    log(`handshake — ${name}`, status === 200 && body.outcome === expected);
+  }
+}
+
+// ── Search + search pagination sanity ────────────────────────────────────────
+
+async function checkSearch() {
+  const { status, body } = await fetchJson(`${BASE}/signals/search`, {
+    method: 'POST', headers: { ...auth, ...json },
+    body: JSON.stringify({ query: 'high income', limit: 3 }),
+  });
+  log('signals/search — 200', status === 200);
+  log('signals/search — results returned', body.signals?.length > 0);
+  log('signals/search — signal_agent_segment_id populated', !!body.signals?.[0]?.signal_agent_segment_id);
+  log('signals/search — totalCount and count consistent',
+    typeof body.totalCount === 'number' && typeof body.count === 'number' && body.count <= body.totalCount);
+  // destination post-filter correctness (Sec-7)
+  const destFiltered = await fetchJson(`${BASE}/signals/search`, {
+    method: 'POST', headers: { ...auth, ...json },
+    body: JSON.stringify({ query: 'income', destination: 'mock_dsp', limit: 2 }),
+  });
+  log('signals/search — destination filter returns results', destFiltered.body.signals?.length > 0);
+  log('signals/search — destination filter totalCount matches filtered set',
+    destFiltered.body.signals.every(s => s.deployments?.some(d => d.platform === 'mock_dsp')),
+    `destinations: ${destFiltered.body.signals.map(s => s.deployments?.map(d => d.platform).join(',')).join(' | ')}`,
+  );
+}
+
+// ── NL query ──────────────────────────────────────────────────────────────────
+
+async function checkNlQuery() {
+  const cases = [
+    'affluent families 35-44 who stream heavily',
+    'cord cutters who watch drama in the afternoon',
+    "soccer moms 35+ in Nashville who don't drink coffee",
+    'graduate educated adults who are not low income',
+  ];
+  for (const q of cases) {
+    const { status, body } = await fetchJson(`${BASE}/signals/query`, {
+      method: 'POST', headers: { ...auth, ...json },
+      body: JSON.stringify({ query: q, limit: 3 }),
+    });
+    const count = body.result?.matched_signals?.length ?? 0;
+    log(`nl-query — "${q.slice(0, 40)}..."`, status === 200 && body.success === true && count > 0, `${count} matches`);
+  }
+}
+
+// ── Concepts ──────────────────────────────────────────────────────────────────
+
+async function checkConcepts() {
+  const list = await fetchJson(`${BASE}/ucp/concepts`);
+  log('concepts — list 200', list.status === 200 && list.body.concepts?.length >= 15);
+  const byId = await fetchJson(`${BASE}/ucp/concepts/SOCCER_MOM_US`);
+  log('concepts — get SOCCER_MOM_US', byId.status === 200 && byId.body.concept_id === 'SOCCER_MOM_US');
+  const bySearch = await fetchJson(`${BASE}/ucp/concepts?q=afternoon+drama`);
+  log('concepts — search', bySearch.status === 200 && bySearch.body.concepts?.length > 0);
+  const seedUnauth = await fetchJson(`${BASE}/ucp/concepts/seed`, { method: 'POST' });
+  log('concepts/seed — unauth 401 (Sec-5 pin)', seedUnauth.status === 401);
+  const seedAuth = await fetchJson(`${BASE}/ucp/concepts/seed`, { method: 'POST', headers: auth });
+  log('concepts/seed — auth 200 with env.DEMO_API_KEY', seedAuth.status === 200);
+}
+
+// ── Embeddings ───────────────────────────────────────────────────────────────
+
+async function checkEmbeddings() {
+  const { status, body } = await fetchJson(`${BASE}/signals/sig_drama_viewers/embedding`, { headers: auth });
+  log('embedding — 200', status === 200);
+  log('embedding — 512-dim vector', Array.isArray(body.embedding?.vector) && body.embedding.vector.length === 512);
+  log('embedding — space_id openai-te3-small-d512-v1', body.embedding?.space_id === 'openai-te3-small-d512-v1');
+}
+
+// ── Activation end-to-end ────────────────────────────────────────────────────
+
+async function checkActivation() {
+  const submit = await fetchJson(`${BASE}/signals/activate`, {
+    method: 'POST', headers: { ...auth, ...json },
+    body: JSON.stringify({ signalId: 'sig_drama_viewers', destination: 'mock_dsp' }),
+  });
+  log('activation — submit 202 + task_id', submit.status === 202 && !!submit.body.task_id);
+  const taskId = submit.body.task_id;
+  await new Promise(r => setTimeout(r, 500));
+  const poll1 = await fetchJson(`${BASE}/operations/${taskId}`, { headers: auth });
+  log('activation — poll #1', poll1.status === 200 && ['working', 'completed'].includes(poll1.body.status));
+  await new Promise(r => setTimeout(r, 500));
+  const poll2 = await fetchJson(`${BASE}/operations/${taskId}`, { headers: auth });
+  log('activation — poll #2 completed', poll2.status === 200 && poll2.body.status === 'completed');
+  log('activation — deployments populated on completed',
+    Array.isArray(poll2.body.deployments) && poll2.body.deployments.length > 0);
+}
+
+// ── MCP ───────────────────────────────────────────────────────────────────────
+
+async function checkMcp() {
+  const init = await fetchJson(`${BASE}/mcp`, {
+    method: 'POST', headers: json,
+    body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'initialize', params: { protocolVersion: '2024-11-05', clientInfo: { name: 'audit', version: '1' } } }),
+  });
+  log('mcp — initialize (public)', init.status === 200 && !!init.body.result?.serverInfo?.name);
+  log('mcp — serverInfo.ucp.space_id matches real engine',
+    init.body.result?.serverInfo?.ucp?.space_id === 'openai-te3-small-d512-v1');
+
+  const tools = await fetchJson(`${BASE}/mcp`, {
+    method: 'POST', headers: json,
+    body: JSON.stringify({ jsonrpc: '2.0', id: 2, method: 'tools/list', params: {} }),
+  });
+  log('mcp — tools/list 8 tools', tools.body.result?.tools?.length === 8);
+  log('mcp — every tool has outputSchema', tools.body.result?.tools?.every(t => !!t.outputSchema));
+
+  const unauthCall = await fetchJson(`${BASE}/mcp`, {
+    method: 'POST', headers: json,
+    body: JSON.stringify({ jsonrpc: '2.0', id: 3, method: 'tools/call', params: { name: 'get_adcp_capabilities', arguments: {} } }),
+  });
+  log('mcp — tools/call unauth returns -32001', unauthCall.body.error?.code === -32001);
+
+  const authedCall = await fetchJson(`${BASE}/mcp`, {
+    method: 'POST', headers: { ...auth, ...json },
+    body: JSON.stringify({ jsonrpc: '2.0', id: 4, method: 'tools/call', params: { name: 'get_adcp_capabilities', arguments: {} } }),
+  });
+  log('mcp — tools/call authed has structuredContent',
+    !!authedCall.body.result?.structuredContent?.adcp);
+
+  const similar = await fetchJson(`${BASE}/mcp`, {
+    method: 'POST', headers: { ...auth, ...json },
+    body: JSON.stringify({
+      jsonrpc: '2.0', id: 5, method: 'tools/call',
+      params: { name: 'get_similar_signals', arguments: { signal_agent_segment_id: 'sig_drama_viewers', top_k: 3, min_similarity: 0.0 } },
+    }),
+  });
+  log('mcp — get_similar_signals min_similarity=0 returns results',
+    similar.body.result?.structuredContent?.results?.length > 0);
+
+  const nl = await fetchJson(`${BASE}/mcp`, {
+    method: 'POST', headers: { ...auth, ...json },
+    body: JSON.stringify({
+      jsonrpc: '2.0', id: 6, method: 'tools/call',
+      params: { name: 'query_signals_nl', arguments: { query: 'affluent streaming families', limit: 3 } },
+    }),
+  });
+  log('mcp — query_signals_nl via MCP', nl.body.result?.structuredContent?.success === true);
+
+  const concept = await fetchJson(`${BASE}/mcp`, {
+    method: 'POST', headers: { ...auth, ...json },
+    body: JSON.stringify({
+      jsonrpc: '2.0', id: 7, method: 'tools/call',
+      params: { name: 'get_concept', arguments: { concept_id: 'SOCCER_MOM_US' } },
+    }),
+  });
+  log('mcp — get_concept returns structuredContent',
+    concept.body.result?.structuredContent?.concept_id === 'SOCCER_MOM_US');
+}
+
+// ── Security-fix probes ──────────────────────────────────────────────────────
+
+async function checkSecurity() {
+  // Sec-1: LinkedIn route gating
+  const li = await Promise.all([
+    fetchJson(`${BASE}/auth/linkedin/init`),
+    fetchJson(`${BASE}/auth/linkedin/status`),
+    fetchJson(`${BASE}/auth/linkedin/callback?state=fabricated`),
+  ]);
+  log('linkedin/init unauth 401', li[0].status === 401);
+  log('linkedin/status unauth 401', li[1].status === 401);
+  log('linkedin/callback public + state-invalid HTML',
+    li[2].status === 200 && li[2].raw.includes('Invalid State'));
+  const liAuth = await fetchJson(`${BASE}/auth/linkedin/status`, { headers: auth });
+  log('linkedin/status authed 200', liAuth.status === 200);
+
+  // Sec-1 B: body-size cap
+  const bigBody = '"' + 'x'.repeat(1_100_000) + '"';
+  const big = await fetch(`${BASE}/mcp`, {
+    method: 'POST', headers: { 'Content-Type': 'application/json' }, body: bigBody,
+  });
+  const bigText = await big.text();
+  log('mcp — >1MB body rejected (-32600)', bigText.includes('-32600'));
+
+  // token-debug gone
+  const td = await fetchJson(`${BASE}/auth/linkedin/token-debug`);
+  log('token-debug — 401 (unauth path)', td.status === 401);
+}
+
+// ── CORS ──────────────────────────────────────────────────────────────────────
+
+async function checkCors() {
+  const res = await fetch(`${BASE}/mcp`, {
+    method: 'OPTIONS',
+    headers: {
+      Origin: 'https://example.com',
+      'Access-Control-Request-Method': 'POST',
+      'Access-Control-Request-Headers': 'Content-Type, Authorization, Mcp-Session-Id',
+    },
+  });
+  const allowHdr = (res.headers.get('access-control-allow-headers') ?? '').toLowerCase();
+  log('cors — Mcp-Session-Id in allow-headers', allowHdr.includes('mcp-session-id'));
+  log('cors — Authorization in allow-headers', allowHdr.includes('authorization'));
+  const expose = (res.headers.get('access-control-expose-headers') ?? '').toLowerCase();
+  log('cors — Mcp-Session-Id in expose-headers', expose.includes('mcp-session-id'));
+}
+
+// ── Error paths (fail loudly, don't leak) ────────────────────────────────────
+
+async function checkErrors() {
+  const notFound = await fetchJson(`${BASE}/does-not-exist`);
+  log('error — 404 with clean JSON',
+    notFound.status === 404 && typeof notFound.body.error === 'string' && !notFound.body.error.includes('stack'));
+  const badJson = await fetch(`${BASE}/signals/search`, {
+    method: 'POST', headers: { ...auth, ...json }, body: 'not json',
+  });
+  log('error — bad JSON body returns 4xx/5xx', badJson.status >= 400);
+  const activateMissing = await fetchJson(`${BASE}/signals/activate`, {
+    method: 'POST', headers: { ...auth, ...json },
+    body: JSON.stringify({}),
+  });
+  log('error — activate missing signalId returns 4xx',
+    activateMissing.status >= 400 && activateMissing.status < 500);
+  const opNotFound = await fetchJson(`${BASE}/operations/op_does_not_exist`, { headers: auth });
+  log('error — operation not found 404', opNotFound.status === 404);
+}
+
+// ── Run ───────────────────────────────────────────────────────────────────────
+
+(async () => {
+  try {
+    await checkHealth();
+    await checkCapabilities();
+    await checkGts();
+    await checkProjector();
+    await checkHandshake();
+    await checkSearch();
+    await checkNlQuery();
+    await checkConcepts();
+    await checkEmbeddings();
+    await checkActivation();
+    await checkMcp();
+    await checkSecurity();
+    await checkCors();
+    await checkErrors();
+  } catch (err) {
+    log('audit — fatal error', false, String(err));
+  }
+
+  const fails = results.filter(r => !r.ok);
+  console.log('\n' + '='.repeat(60));
+  console.log(`TOTAL: ${results.length} | PASS: ${results.length - fails.length} | FAIL: ${fails.length}`);
+  if (fails.length > 0) {
+    console.log('\nFAILURES:');
+    for (const f of fails) console.log(`  - ${f.label}${f.detail ? ` (${f.detail})` : ''}`);
+    process.exit(1);
+  }
+  process.exit(0);
+})();

--- a/src/domain/capabilityService.ts
+++ b/src/domain/capabilityService.ts
@@ -10,10 +10,13 @@
 // Cache key bumped to v6 for the v3-conformant shape (ucp moved to ext)
 // then v7 for the HEAD-schema-conformant shape (adds adcp.idempotency).
 
-const CACHE_KEY = "adcp_capabilities_v7";
+// Cache key bumped to v8 — the ext.ucp block is now engine-aware, so any
+// v7 cache entry written under the old static pseudo-declaring
+// UCP_CAPABILITY needs to be invalidated on next deploy.
+const CACHE_KEY = "adcp_capabilities_v8";
 const CACHE_TTL_SECONDS = 3600;
 
-import { UCP_CAPABILITY } from "../ucp/vacDeclaration";
+import { buildUcpCapability, type UcpCapabilityEnv } from "../ucp/vacDeclaration";
 
 const VALID_PROTOCOLS = new Set([
   "media_buy",
@@ -53,60 +56,49 @@ type AdcpCapabilities = {
   context?: Record<string, unknown>;
 };
 
-const STATIC_CAPABILITIES: AdcpCapabilities = {
-  adcp: {
-    major_versions: [2, 3],
-    // 24h replay window (recommended in the HEAD schema; min 3600, max 604800).
-    // Mutating tools (activate_signal) honour this — see activationRepo.
-    idempotency: { replay_ttl_seconds: 86400 },
-  },
-  supported_protocols: ["signals"],
-  signals: {
-    signal_categories: [
-      "demographic",
-      "interest",
-      "purchase_intent",
-      "geo",
-      "composite",
-    ],
-    dynamic_segment_generation: true,
-    activation_mode: "async",
-    provider: "AdCP Signals Adaptor - Demo Provider (Evgeny)",
-    destinations: [
-      {
-        id: "mock_dsp",
-        name: "Mock DSP",
-        type: "dsp",
-        activation_supported: true,
-      },
-      {
-        id: "mock_cleanroom",
-        name: "Mock Clean Room",
-        type: "cleanroom",
-        activation_supported: true,
-      },
-      {
-        id: "mock_cdp",
-        name: "Mock CDP",
-        type: "cdp",
-        activation_supported: true,
-      },
-      {
-        id: "mock_measurement",
-        name: "Mock Measurement Platform",
-        type: "measurement",
-        activation_supported: false,
-      },
-    ],
-    limits: {
-      max_signals_per_request: 100,
-      max_rules_per_segment: 6,
+// Protocol + provider metadata is static; only the ext.ucp block varies
+// by engine env. Build the full capability object per-request (cheap — it's
+// all constant-time), and cache it in KV so we don't rebuild on every call.
+function buildStaticCapabilities(env: UcpCapabilityEnv): AdcpCapabilities {
+  return {
+    adcp: {
+      major_versions: [2, 3],
+      // 24h replay window (recommended in the HEAD schema; min 3600, max 604800).
+      // Mutating tools (activate_signal) honour this — see activationRepo.
+      idempotency: { replay_ttl_seconds: 86400 },
     },
-  },
-  ext: {
-    ucp: UCP_CAPABILITY,
-  },
-};
+    supported_protocols: ["signals"],
+    signals: {
+      signal_categories: [
+        "demographic",
+        "interest",
+        "purchase_intent",
+        "geo",
+        "composite",
+      ],
+      dynamic_segment_generation: true,
+      activation_mode: "async",
+      provider: "AdCP Signals Adaptor - Demo Provider (Evgeny)",
+      destinations: [
+        { id: "mock_dsp",         name: "Mock DSP",                   type: "dsp",         activation_supported: true  },
+        { id: "mock_cleanroom",   name: "Mock Clean Room",            type: "cleanroom",   activation_supported: true  },
+        { id: "mock_cdp",         name: "Mock CDP",                   type: "cdp",         activation_supported: true  },
+        { id: "mock_measurement", name: "Mock Measurement Platform",  type: "measurement", activation_supported: false },
+      ],
+      limits: {
+        max_signals_per_request: 100,
+        max_rules_per_segment: 6,
+      },
+    },
+    ext: {
+      // ext.ucp now mirrors the real engine. Previously this was a static
+      // UCP_CAPABILITY constant that always declared the pseudo bridge,
+      // so /capabilities contradicted /ucp/gts and /mcp serverInfo.ucp
+      // on any deployment where EMBEDDING_ENGINE=llm.
+      ucp: buildUcpCapability(env),
+    },
+  };
+}
 
 // Per-protocol block keys that may appear at top level.
 const PROTOCOL_BLOCK_KEYS = [
@@ -128,6 +120,7 @@ const PROTOCOL_BLOCK_KEYS = [
 export async function getCapabilities(
   kv: KVNamespace,
   protocols?: string[],
+  env?: UcpCapabilityEnv,
 ): Promise<AdcpCapabilities> {
   let full: AdcpCapabilities | null = null;
   try {
@@ -136,9 +129,12 @@ export async function getCapabilities(
   } catch { /* cache miss */ }
 
   if (!full) {
-    full = STATIC_CAPABILITIES;
+    // env is optional for backwards compat with test shims; default to an
+    // empty object which makes buildUcpCapability fall through to the
+    // pseudo declaration (correct for tests that don't set EMBEDDING_ENGINE).
+    full = buildStaticCapabilities(env ?? {});
     try {
-      await kv.put(CACHE_KEY, JSON.stringify(STATIC_CAPABILITIES), {
+      await kv.put(CACHE_KEY, JSON.stringify(full), {
         expirationTtl: CACHE_TTL_SECONDS,
       });
     } catch { /* non-fatal */ }

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -310,7 +310,10 @@ async function callGetCapabilities(
     } else if (typeof rawSingle === "string" && rawSingle.length > 0) {
         protocols = [rawSingle];
     }
-    const caps = await getCapabilities(env.SIGNALS_CACHE, protocols);
+    const caps = await getCapabilities(env.SIGNALS_CACHE, protocols, {
+        ...(env.EMBEDDING_ENGINE !== undefined ? { EMBEDDING_ENGINE: env.EMBEDDING_ENGINE } : {}),
+        ...(env.OPENAI_API_KEY    !== undefined ? { OPENAI_API_KEY:    env.OPENAI_API_KEY    } : {}),
+    });
 
     // Echo back the request's context block. Capability-discovery storyboards
     // send context.correlation_id and assert it round-trips. Per

--- a/src/routes/capabilities.ts
+++ b/src/routes/capabilities.ts
@@ -21,7 +21,10 @@ export async function handleGetCapabilities(
       ? raw.split(",").map((s) => s.trim()).filter(Boolean)
       : undefined;
 
-    const caps = await getCapabilities(env.SIGNALS_CACHE, protocols);
+    const caps = await getCapabilities(env.SIGNALS_CACHE, protocols, {
+      ...(env.EMBEDDING_ENGINE !== undefined ? { EMBEDDING_ENGINE: env.EMBEDDING_ENGINE } : {}),
+      ...(env.OPENAI_API_KEY    !== undefined ? { OPENAI_API_KEY:    env.OPENAI_API_KEY    } : {}),
+    });
 
     // Echo back any context the caller passed. REST /capabilities is a GET,
     // so we look for `correlation_id` in the query string (the most common

--- a/src/ucp/vacDeclaration.ts
+++ b/src/ucp/vacDeclaration.ts
@@ -6,9 +6,17 @@ import type { UcpEmbeddingDeclaration, UcpCapabilityDeclaration } from "../types
 
 // ── Model constants ───────────────────────────────────────────────────────────
 
+// Pseudo bridge (hash-based, deterministic, no external deps).
 export const UCP_MODEL_ID = "adcp-ucp-bridge-pseudo-v1.0";
 export const UCP_MODEL_FAMILY = "adcp-bridge/deterministic-taxonomy-v1";
 export const UCP_SPACE_ID = "adcp-bridge-space-v1.0";
+
+// Real LLM engine (OpenAI text-embedding-3-small 512-dim). Must stay in sync
+// with LlmEmbeddingEngine.spaceId in src/ucp/embeddingEngine.ts — that class
+// is what /ucp/gts, /signals/*/embedding, and /mcp serverInfo.ucp all report
+// against when EMBEDDING_ENGINE=llm + OPENAI_API_KEY is set.
+export const LLM_SPACE_ID = "openai-te3-small-d512-v1";
+
 export const UCP_DIMENSIONS = 512;
 export const UCP_GTS_VERSION = "adcp-gts-v1.0";
 
@@ -48,7 +56,43 @@ export function buildVacDeclaration(
 }
 
 // ── Capability declaration (for get_adcp_capabilities) ───────────────────────
+//
+// Historically this was a static `UCP_CAPABILITY` constant that always
+// declared the pseudo bridge. That was a lie on any deployment where
+// EMBEDDING_ENGINE=llm + OPENAI_API_KEY is set — /capabilities said
+// pseudo-v1 / adcp-bridge-space-v1.0 while every other surface
+// (/ucp/gts, /signals/*/embedding, /mcp serverInfo.ucp) correctly reported
+// the LLM engine. A buyer agent reading /capabilities to decide
+// interop would get the wrong answer.
+//
+// buildUcpCapability(env) now uses the SAME switch that createEmbeddingEngine
+// uses in embeddingEngine.ts, so the declaration in /capabilities matches
+// what the service will actually produce at runtime.
 
+export interface UcpCapabilityEnv {
+  EMBEDDING_ENGINE?: string;
+  OPENAI_API_KEY?: string;
+}
+
+export function buildUcpCapability(env: UcpCapabilityEnv): UcpCapabilityDeclaration {
+  const isLlm = env.EMBEDDING_ENGINE === "llm" && !!env.OPENAI_API_KEY;
+  return {
+    supported_spaces: [isLlm ? LLM_SPACE_ID : UCP_SPACE_ID],
+    supported_encodings: ["float32"],
+    dimensions: [UCP_DIMENSIONS],
+    embedding_endpoint_template: "/signals/{signal_id}/embedding",
+    similarity_search: true,
+    phase: isLlm ? "llm-v1" : "pseudo-v1",
+    gts_version: UCP_GTS_VERSION,
+  };
+}
+
+/**
+ * @deprecated Static export kept for callers that don't yet thread env
+ * through. New callers must use buildUcpCapability(env) to get an
+ * engine-accurate declaration. This constant always reports the pseudo
+ * bridge, which is usually WRONG on prod deployments.
+ */
 export const UCP_CAPABILITY: UcpCapabilityDeclaration = {
   supported_spaces: [UCP_SPACE_ID],
   supported_encodings: ["float32"],

--- a/tests/security.test.ts
+++ b/tests/security.test.ts
@@ -191,6 +191,50 @@ describe("getCapabilities runtime shape", () => {
     const allowed = ["media_buy", "signals", "governance", "sponsored_intelligence", "creative", "brand"];
     for (const p of caps.supported_protocols) expect(allowed).toContain(p);
   });
+
+  // Sec-11: ext.ucp must match the engine env the worker is actually running.
+  // Regression pin for the prior bug where /capabilities always declared the
+  // pseudo bridge even on LLM deployments.
+
+  it("ext.ucp declares openai-te3-small-d512-v1 when EMBEDDING_ENGINE=llm + OPENAI_API_KEY set", async () => {
+    const caps = await getCapabilities(makeStaticKv(), undefined, {
+      EMBEDDING_ENGINE: "llm",
+      OPENAI_API_KEY: "sk-test",
+    });
+    const ucp = (caps.ext as any).ucp;
+    expect(ucp.phase).toBe("llm-v1");
+    expect(ucp.supported_spaces).toEqual(["openai-te3-small-d512-v1"]);
+  });
+
+  it("ext.ucp declares the pseudo bridge when EMBEDDING_ENGINE is unset", async () => {
+    const caps = await getCapabilities(makeStaticKv(), undefined, {});
+    const ucp = (caps.ext as any).ucp;
+    expect(ucp.phase).toBe("pseudo-v1");
+    expect(ucp.supported_spaces).toEqual(["adcp-bridge-space-v1.0"]);
+  });
+
+  it("ext.ucp falls back to pseudo when EMBEDDING_ENGINE=llm but OPENAI_API_KEY is missing", async () => {
+    // Same mode-selection semantics as createEmbeddingEngine — no key, no LLM.
+    const caps = await getCapabilities(makeStaticKv(), undefined, {
+      EMBEDDING_ENGINE: "llm",
+    });
+    const ucp = (caps.ext as any).ucp;
+    expect(ucp.phase).toBe("pseudo-v1");
+  });
+
+  it("cache segregates per engine env via the v8 key bump (no cross-contamination)", async () => {
+    // Two sequential calls with different envs must not see each other's
+    // cached declaration. The cache key is global to the deployment; the
+    // test here guards the "cache holds whatever was written first" case
+    // by using fresh KV per call — which is what a new deploy looks like.
+    const capsLlm = await getCapabilities(makeStaticKv(), undefined, {
+      EMBEDDING_ENGINE: "llm",
+      OPENAI_API_KEY: "sk-test",
+    });
+    const capsPseudo = await getCapabilities(makeStaticKv(), undefined, {});
+    expect((capsLlm.ext as any).ucp.phase).toBe("llm-v1");
+    expect((capsPseudo.ext as any).ucp.phase).toBe("pseudo-v1");
+  });
 });
 
 // ── CORS headers ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
Pre-demo audit finding. Before this fix, `/capabilities.ext.ucp` returned `phase: pseudo-v1` / `supported_spaces: [adcp-bridge-space-v1.0]` — the pseudo bridge — while every other surface correctly reported the LLM engine (`llm-v1` / `openai-te3-small-d512-v1`). A buyer agent or evaluator reading `/capabilities` to decide interop would get the wrong answer.

**Fix**: new `buildUcpCapability(env)` factory in [src/ucp/vacDeclaration.ts](src/ucp/vacDeclaration.ts) uses the same switch as `createEmbeddingEngine`. `capabilityService` threads env through and caches under a bumped key (`adcp_capabilities_v8`) so the old pseudo-declaring entry gets evicted.

**Tests**: +4 cases in [tests/security.test.ts](tests/security.test.ts) — LLM env, unset env, LLM-but-no-key fallback, cross-env cache isolation.

Type-check: baseline 95. Unit tests: 244 pass.