### PR TITLE
Sec-12: AdCP signals storyboard baseline conformance

### DIFF
--- a/src/domain/activationService.ts
+++ b/src/domain/activationService.ts
@@ -65,7 +65,12 @@ export async function activateSignalService(
   if (!signal.activationSupported) {
     throw new ValidationError(`Signal ${req.signalId} does not support activation`);
   }
-  if (!signal.destinations.includes(req.destination)) {
+  // Platform destinations are gated by the signal's destinations whitelist
+  // (mock_dsp, mock_cleanroom, etc.). Agent destinations are SA URLs that
+  // aren't in that whitelist by design — every signal MUST accept agent
+  // activation per the signals spec, so we skip the membership check
+  // when the caller declared destinationType = "agent".
+  if (req.destinationType !== "agent" && !signal.destinations.includes(req.destination)) {
     throw new ValidationError(
       `Signal ${req.signalId} is not available for destination '${req.destination}'`
     );

--- a/src/mappers/signalMapper.ts
+++ b/src/mappers/signalMapper.ts
@@ -20,6 +20,12 @@ const PROVIDER_EMAIL = "evgeny@samba.tv";
 const PRIVACY_POLICY_URL = `https://${PROVIDER_DOMAIN}/privacy`;
 const TOTAL_ADDRESSABLE = 240_000_000;
 
+// Self-identifying agent URL for signal_id.agent_url (per
+// /schemas/core/signal-id.json agent-variant). Hardcoded to the deployed
+// MCP endpoint; matches the worker we ship from. If we ever need this to be
+// per-deployment dynamic (staging vs prod), thread it through env.
+const SELF_AGENT_URL = `https://${PROVIDER_DOMAIN}/mcp`;
+
 const DESTINATION_PLATFORM_MAP: Record<string, { activationSupported: boolean }> = {
   mock_dsp:         { activationSupported: true },
   mock_cleanroom:   { activationSupported: true },
@@ -244,6 +250,10 @@ export function toSignalSummary(signal: CanonicalSignal): SignalSummary {
   const pricingCurrency = signal.pricing?.currency ?? "USD";
   const pricingOptionId = `opt-${signal.pricing?.model ?? "none"}-${signal.signalId}`.slice(0, 64);
 
+  // pricing_options is schema-required with minItems: 1. Emit a default
+  // sentinel option for signals that lack explicit pricing — buyers can
+  // still reference its pricing_option_id from the storyboard's
+  // context_outputs even when the signal is "free / contact for pricing".
   const pricingOptions = signal.pricing
     ? [
         {
@@ -254,9 +264,26 @@ export function toSignalSummary(signal: CanonicalSignal): SignalSummary {
           is_fixed: true,
         },
       ]
-    : [];
+    : [
+        {
+          pricing_option_id: `opt-default-${signal.signalId}`.slice(0, 64),
+          pricing_model: "cpm",
+          rate: 0,
+          currency: pricingCurrency,
+          is_fixed: false,
+        },
+      ];
 
   return {
+    // Universal signal_id required by the AdCP signals storyboard baseline.
+    // We're an agent-native signals service (no upstream data-provider
+    // catalog), so source is always "agent". The internal signalId already
+    // matches the schema's `^[a-zA-Z0-9_-]+$` pattern.
+    signal_id: {
+      source: "agent" as const,
+      agent_url: SELF_AGENT_URL,
+      id: signal.signalId,
+    },
     signal_agent_segment_id: signal.signalId,
     name: signal.name,
     description: signal.description,

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -350,7 +350,17 @@ async function callGetSignals(
 
     const db = getDb(env);
     const result = await searchSignalsService(db, env.SIGNALS_CACHE, req);
-    return toolResult(JSON.stringify(result, null, 2), result);
+
+    // Echo back the request's context block. Signals storyboard validates
+    // `context.correlation_id` round-trips. Per /schemas/core/context.json,
+    // context is opaque — copy through unchanged. Same pattern as
+    // get_adcp_capabilities.
+    const ctx = args["context"];
+    const response = ctx && typeof ctx === "object" && !Array.isArray(ctx)
+        ? { ...result, context: ctx as Record<string, unknown> }
+        : result;
+
+    return toolResult(JSON.stringify(response, null, 2), response);
 }
 
 async function callActivateSignal(
@@ -358,10 +368,26 @@ async function callActivateSignal(
     env: Env,
     logger: Logger
 ): Promise<unknown> {
-    const raw = args["deliver_to"] ?? args["deployments"];
-    const destination = Array.isArray(raw)
-        ? ((raw[0] as Record<string, unknown>)?.["platform"] as string ?? "mock_dsp")
-        : (args["destination"] as string ?? "mock_dsp");
+    // Accept three request shapes for the destinations payload:
+    //   - args.destinations  (current AdCP signals storyboard / HEAD spec)
+    //   - args.deliver_to    (legacy AdCP shape we shipped earlier)
+    //   - args.deployments   (older alias)
+    // Falls back to a singleton platform=mock_dsp record if none of these
+    // are populated, so unsophisticated demo callers still get a response.
+    const raw = args["destinations"] ?? args["deliver_to"] ?? args["deployments"];
+    const firstEntry = Array.isArray(raw) ? (raw[0] as Record<string, unknown>) : undefined;
+    const firstType = firstEntry?.["type"] as string | undefined;
+    // Pull destination name for the activation-job DB write — for an agent
+    // destination that's the agent_url; for a platform destination it's the
+    // platform name. Falls back to mock_dsp only when neither is supplied.
+    const destination = (firstEntry?.["agent_url"] as string)
+        ?? (firstEntry?.["platform"] as string)
+        ?? (args["destination"] as string)
+        ?? "mock_dsp";
+    // Track agent vs platform so the service can skip the destinations-
+    // whitelist check for agent activations (every signal MUST accept
+    // type=agent per the AdCP signals spec).
+    const destinationType: "platform" | "agent" = firstType === "agent" ? "agent" : "platform";
 
     const resolvedDestination = destination;
     const signalId = (args["signal_agent_segment_id"] ?? args["signalId"]) as string;
@@ -373,6 +399,7 @@ async function callActivateSignal(
     const req = {
         signalId,
         destination: resolvedDestination,
+        destinationType,
         accountId: args["accountId"] as string | undefined,
         campaignId: args["campaignId"] as string | undefined,
         notes: args["notes"] as string | undefined,
@@ -414,6 +441,13 @@ async function callActivateSignal(
             };
         });
 
+        // Echo back request context — signals storyboard validates
+        // `context.correlation_id` round-trips on activate_signal too.
+        const ctx = args["context"];
+        const contextEcho = ctx && typeof ctx === "object" && !Array.isArray(ctx)
+            ? { context: ctx as Record<string, unknown> }
+            : {};
+
         const specResponse = {
             task_id: result.task_id,
             status: "pending",
@@ -421,6 +455,7 @@ async function callActivateSignal(
             deployments: responseDeployments,
             ...(webhookUrl ? { webhook_url: webhookUrl } : {}),
             ...(pricingOptionId ? { pricing_option_id: pricingOptionId } : {}),
+            ...contextEcho,
         };
 
         return toolResult(JSON.stringify(specResponse, null, 2), specResponse);

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -79,7 +79,26 @@ export interface CustomSignalProposal {
 }
 
 // AdCP Signals spec-compliant signal object
+/**
+ * Universal signal identifier per /schemas/core/signal-id.json.
+ * Discriminated by `source`. We're a self-contained signals agent (not a
+ * data-provider catalog mirror), so every signal we expose is the `agent`
+ * variant — schema requires `source`, `agent_url`, `id`.
+ */
+export interface SignalIdAgent {
+  source: "agent";
+  agent_url: string;
+  id: string;
+}
+
 export interface SignalSummary {
+  /**
+   * Universal signal identifier — required by the AdCP signals storyboard
+   * baseline (validates `signals[0].signal_id.source` is present). Carries
+   * the source discriminator buyers use to know whether the ID resolves to
+   * an external catalog or is agent-native.
+   */
+  signal_id: SignalIdAgent;
   signal_agent_segment_id: string;
   name: string;
   description: string;
@@ -122,6 +141,15 @@ export interface SignalDeployment {
 export interface ActivateSignalRequest {
   signalId: string;
   destination: string;
+  /**
+   * Destination kind. Defaults to "platform" (the legacy behaviour and the
+   * shape every existing test exercises). When set to "agent", the
+   * destination is a sales-agent URL — those aren't in the signal's
+   * destinations whitelist (which enumerates downstream platforms only),
+   * so the service skips the membership check. Per AdCP signals spec
+   * docs/signals/specification.mdx:186, signal agents MUST accept both.
+   */
+  destinationType?: "platform" | "agent";
   accountId?: string;
   campaignId?: string;
   notes?: string;

--- a/storyboard_report_capability_discovery.json
+++ b/storyboard_report_capability_discovery.json
@@ -1,0 +1,438 @@
+{
+  "agent_url": "https://adcp-signals-adaptor.evgeny-193.workers.dev/mcp",
+  "agent_profile": {
+    "name": "E2E Test Client",
+    "tools": [
+      "get_adcp_capabilities",
+      "get_signals",
+      "activate_signal",
+      "get_operation_status",
+      "get_similar_signals",
+      "query_signals_nl",
+      "get_concept",
+      "search_concepts"
+    ],
+    "adcp_version": "v3",
+    "supported_protocols": [
+      "signals"
+    ],
+    "supports_governance": false,
+    "supports_si": false
+  },
+  "overall_status": "passing",
+  "tracks": [
+    {
+      "track": "core",
+      "status": "pass",
+      "label": "Core Protocol",
+      "scenarios": [
+        {
+          "agent_url": "https://adcp-signals-adaptor.evgeny-193.workers.dev/mcp",
+          "scenario": "capability_discovery/protocol_discovery",
+          "overall_passed": true,
+          "steps": [
+            {
+              "step": "Discover agent capabilities",
+              "task": "get_adcp_capabilities",
+              "passed": true,
+              "duration_ms": 53,
+              "details": "✓ Response matches get-adcp-capabilities-response.json schema; ✓ Agent declares supported protocol versions; ✓ Agent declares which protocol domains it supports; ✓ Response echoes back the context object; ✓ Context correlation_id returned unchanged",
+              "observation_data": {
+                "adcp": {
+                  "major_versions": [
+                    2,
+                    3
+                  ],
+                  "idempotency": {
+                    "replay_ttl_seconds": 86400
+                  }
+                },
+                "supported_protocols": [
+                  "signals"
+                ],
+                "signals": {
+                  "signal_categories": [
+                    "demographic",
+                    "interest",
+                    "purchase_intent",
+                    "geo",
+                    "composite"
+                  ],
+                  "dynamic_segment_generation": true,
+                  "activation_mode": "async",
+                  "provider": "AdCP Signals Adaptor - Demo Provider (Evgeny)",
+                  "destinations": [
+                    {
+                      "id": "mock_dsp",
+                      "name": "Mock DSP",
+                      "type": "dsp",
+                      "activation_supported": true
+                    },
+                    {
+                      "id": "mock_cleanroom",
+                      "name": "Mock Clean Room",
+                      "type": "cleanroom",
+                      "activation_supported": true
+                    },
+                    {
+                      "id": "mock_cdp",
+                      "name": "Mock CDP",
+                      "type": "cdp",
+                      "activation_supported": true
+                    },
+                    {
+                      "id": "mock_measurement",
+                      "name": "Mock Measurement Platform",
+                      "type": "measurement",
+                      "activation_supported": false
+                    }
+                  ],
+                  "limits": {
+                    "max_signals_per_request": 100,
+                    "max_rules_per_segment": 6
+                  }
+                },
+                "context": {
+                  "correlation_id": "capability_discovery--get_capabilities"
+                },
+                "ext": {
+                  "ucp": {
+                    "supported_spaces": [
+                      "openai-te3-small-d512-v1"
+                    ],
+                    "supported_encodings": [
+                      "float32"
+                    ],
+                    "dimensions": [
+                      512
+                    ],
+                    "embedding_endpoint_template": "/signals/{signal_id}/embedding",
+                    "similarity_search": true,
+                    "phase": "llm-v1",
+                    "gts_version": "adcp-gts-v1.0"
+                  }
+                },
+                "_message": "{\n  \"adcp\": {\n    \"major_versions\": [\n      2,\n      3\n    ],\n    \"idempotency\": {\n      \"replay_ttl_seconds\": 86400\n    }\n  },\n  \"supported_protocols\": [\n    \"signals\"\n  ],\n  \"signals\": {\n    \"signal_categories\": [\n      \"demographic\",\n      \"interest\",\n      \"purchase_intent\",\n      \"geo\",\n      \"composite\"\n    ],\n    \"dynamic_segment_generation\": true,\n    \"activation_mode\": \"async\",\n    \"provider\": \"AdCP Signals Adaptor - Demo Provider (Evgeny)\",\n    \"destinations\": [\n      {\n        \"id\": \"mock_dsp\",\n        \"name\": \"Mock DSP\",\n        \"type\": \"dsp\",\n        \"activation_supported\": true\n      },\n      {\n        \"id\": \"mock_cleanroom\",\n        \"name\": \"Mock Clean Room\",\n        \"type\": \"cleanroom\",\n        \"activation_supported\": true\n      },\n      {\n        \"id\": \"mock_cdp\",\n        \"name\": \"Mock CDP\",\n        \"type\": \"cdp\",\n        \"activation_supported\": true\n      },\n      {\n        \"id\": \"mock_measurement\",\n        \"name\": \"Mock Measurement Platform\",\n        \"type\": \"measurement\",\n        \"activation_supported\": false\n      }\n    ],\n    \"limits\": {\n      \"max_signals_per_request\": 100,\n      \"max_rules_per_segment\": 6\n    }\n  },\n  \"ext\": {\n    \"ucp\": {\n      \"supported_spaces\": [\n        \"openai-te3-small-d512-v1\"\n      ],\n      \"supported_encodings\": [\n        \"float32\"\n      ],\n      \"dimensions\": [\n        512\n      ],\n      \"embedding_endpoint_template\": \"/signals/{signal_id}/embedding\",\n      \"similarity_search\": true,\n      \"phase\": \"llm-v1\",\n      \"gts_version\": \"adcp-gts-v1.0\"\n    }\n  },\n  \"context\": {\n    \"correlation_id\": \"capability_discovery--get_capabilities\"\n  }\n}"
+              }
+            },
+            {
+              "step": "Discover capabilities filtered by protocol",
+              "task": "get_adcp_capabilities",
+              "passed": true,
+              "duration_ms": 42,
+              "details": "✓ Response matches get-adcp-capabilities-response.json schema; ✓ Response echoes back the context object; ✓ Context correlation_id returned unchanged",
+              "observation_data": {
+                "adcp": {
+                  "major_versions": [
+                    2,
+                    3
+                  ],
+                  "idempotency": {
+                    "replay_ttl_seconds": 86400
+                  }
+                },
+                "supported_protocols": [
+                  "signals"
+                ],
+                "signals": {
+                  "signal_categories": [
+                    "demographic",
+                    "interest",
+                    "purchase_intent",
+                    "geo",
+                    "composite"
+                  ],
+                  "dynamic_segment_generation": true,
+                  "activation_mode": "async",
+                  "provider": "AdCP Signals Adaptor - Demo Provider (Evgeny)",
+                  "destinations": [
+                    {
+                      "id": "mock_dsp",
+                      "name": "Mock DSP",
+                      "type": "dsp",
+                      "activation_supported": true
+                    },
+                    {
+                      "id": "mock_cleanroom",
+                      "name": "Mock Clean Room",
+                      "type": "cleanroom",
+                      "activation_supported": true
+                    },
+                    {
+                      "id": "mock_cdp",
+                      "name": "Mock CDP",
+                      "type": "cdp",
+                      "activation_supported": true
+                    },
+                    {
+                      "id": "mock_measurement",
+                      "name": "Mock Measurement Platform",
+                      "type": "measurement",
+                      "activation_supported": false
+                    }
+                  ],
+                  "limits": {
+                    "max_signals_per_request": 100,
+                    "max_rules_per_segment": 6
+                  }
+                },
+                "context": {
+                  "correlation_id": "capability_discovery--get_capabilities_filtered"
+                },
+                "ext": {
+                  "ucp": {
+                    "supported_spaces": [
+                      "openai-te3-small-d512-v1"
+                    ],
+                    "supported_encodings": [
+                      "float32"
+                    ],
+                    "dimensions": [
+                      512
+                    ],
+                    "embedding_endpoint_template": "/signals/{signal_id}/embedding",
+                    "similarity_search": true,
+                    "phase": "llm-v1",
+                    "gts_version": "adcp-gts-v1.0"
+                  }
+                },
+                "_message": "{\n  \"adcp\": {\n    \"major_versions\": [\n      2,\n      3\n    ],\n    \"idempotency\": {\n      \"replay_ttl_seconds\": 86400\n    }\n  },\n  \"supported_protocols\": [\n    \"signals\"\n  ],\n  \"signals\": {\n    \"signal_categories\": [\n      \"demographic\",\n      \"interest\",\n      \"purchase_intent\",\n      \"geo\",\n      \"composite\"\n    ],\n    \"dynamic_segment_generation\": true,\n    \"activation_mode\": \"async\",\n    \"provider\": \"AdCP Signals Adaptor - Demo Provider (Evgeny)\",\n    \"destinations\": [\n      {\n        \"id\": \"mock_dsp\",\n        \"name\": \"Mock DSP\",\n        \"type\": \"dsp\",\n        \"activation_supported\": true\n      },\n      {\n        \"id\": \"mock_cleanroom\",\n        \"name\": \"Mock Clean Room\",\n        \"type\": \"cleanroom\",\n        \"activation_supported\": true\n      },\n      {\n        \"id\": \"mock_cdp\",\n        \"name\": \"Mock CDP\",\n        \"type\": \"cdp\",\n        \"activation_supported\": true\n      },\n      {\n        \"id\": \"mock_measurement\",\n        \"name\": \"Mock Measurement Platform\",\n        \"type\": \"measurement\",\n        \"activation_supported\": false\n      }\n    ],\n    \"limits\": {\n      \"max_signals_per_request\": 100,\n      \"max_rules_per_segment\": 6\n    }\n  },\n  \"ext\": {\n    \"ucp\": {\n      \"supported_spaces\": [\n        \"openai-te3-small-d512-v1\"\n      ],\n      \"supported_encodings\": [\n        \"float32\"\n      ],\n      \"dimensions\": [\n        512\n      ],\n      \"embedding_endpoint_template\": \"/signals/{signal_id}/embedding\",\n      \"similarity_search\": true,\n      \"phase\": \"llm-v1\",\n      \"gts_version\": \"adcp-gts-v1.0\"\n    }\n  },\n  \"context\": {\n    \"correlation_id\": \"capability_discovery--get_capabilities_filtered\"\n  }\n}"
+              }
+            }
+          ],
+          "summary": "Protocol and capability discovery: all steps passed",
+          "total_duration_ms": 98,
+          "tested_at": "2026-04-19T11:19:59.967Z"
+        }
+      ],
+      "skipped_scenarios": [],
+      "observations": [],
+      "duration_ms": 98,
+      "mode": "observational"
+    }
+  ],
+  "tested_tracks": [
+    {
+      "track": "core",
+      "status": "pass",
+      "label": "Core Protocol",
+      "scenarios": [
+        {
+          "agent_url": "https://adcp-signals-adaptor.evgeny-193.workers.dev/mcp",
+          "scenario": "capability_discovery/protocol_discovery",
+          "overall_passed": true,
+          "steps": [
+            {
+              "step": "Discover agent capabilities",
+              "task": "get_adcp_capabilities",
+              "passed": true,
+              "duration_ms": 53,
+              "details": "✓ Response matches get-adcp-capabilities-response.json schema; ✓ Agent declares supported protocol versions; ✓ Agent declares which protocol domains it supports; ✓ Response echoes back the context object; ✓ Context correlation_id returned unchanged",
+              "observation_data": {
+                "adcp": {
+                  "major_versions": [
+                    2,
+                    3
+                  ],
+                  "idempotency": {
+                    "replay_ttl_seconds": 86400
+                  }
+                },
+                "supported_protocols": [
+                  "signals"
+                ],
+                "signals": {
+                  "signal_categories": [
+                    "demographic",
+                    "interest",
+                    "purchase_intent",
+                    "geo",
+                    "composite"
+                  ],
+                  "dynamic_segment_generation": true,
+                  "activation_mode": "async",
+                  "provider": "AdCP Signals Adaptor - Demo Provider (Evgeny)",
+                  "destinations": [
+                    {
+                      "id": "mock_dsp",
+                      "name": "Mock DSP",
+                      "type": "dsp",
+                      "activation_supported": true
+                    },
+                    {
+                      "id": "mock_cleanroom",
+                      "name": "Mock Clean Room",
+                      "type": "cleanroom",
+                      "activation_supported": true
+                    },
+                    {
+                      "id": "mock_cdp",
+                      "name": "Mock CDP",
+                      "type": "cdp",
+                      "activation_supported": true
+                    },
+                    {
+                      "id": "mock_measurement",
+                      "name": "Mock Measurement Platform",
+                      "type": "measurement",
+                      "activation_supported": false
+                    }
+                  ],
+                  "limits": {
+                    "max_signals_per_request": 100,
+                    "max_rules_per_segment": 6
+                  }
+                },
+                "context": {
+                  "correlation_id": "capability_discovery--get_capabilities"
+                },
+                "ext": {
+                  "ucp": {
+                    "supported_spaces": [
+                      "openai-te3-small-d512-v1"
+                    ],
+                    "supported_encodings": [
+                      "float32"
+                    ],
+                    "dimensions": [
+                      512
+                    ],
+                    "embedding_endpoint_template": "/signals/{signal_id}/embedding",
+                    "similarity_search": true,
+                    "phase": "llm-v1",
+                    "gts_version": "adcp-gts-v1.0"
+                  }
+                },
+                "_message": "{\n  \"adcp\": {\n    \"major_versions\": [\n      2,\n      3\n    ],\n    \"idempotency\": {\n      \"replay_ttl_seconds\": 86400\n    }\n  },\n  \"supported_protocols\": [\n    \"signals\"\n  ],\n  \"signals\": {\n    \"signal_categories\": [\n      \"demographic\",\n      \"interest\",\n      \"purchase_intent\",\n      \"geo\",\n      \"composite\"\n    ],\n    \"dynamic_segment_generation\": true,\n    \"activation_mode\": \"async\",\n    \"provider\": \"AdCP Signals Adaptor - Demo Provider (Evgeny)\",\n    \"destinations\": [\n      {\n        \"id\": \"mock_dsp\",\n        \"name\": \"Mock DSP\",\n        \"type\": \"dsp\",\n        \"activation_supported\": true\n      },\n      {\n        \"id\": \"mock_cleanroom\",\n        \"name\": \"Mock Clean Room\",\n        \"type\": \"cleanroom\",\n        \"activation_supported\": true\n      },\n      {\n        \"id\": \"mock_cdp\",\n        \"name\": \"Mock CDP\",\n        \"type\": \"cdp\",\n        \"activation_supported\": true\n      },\n      {\n        \"id\": \"mock_measurement\",\n        \"name\": \"Mock Measurement Platform\",\n        \"type\": \"measurement\",\n        \"activation_supported\": false\n      }\n    ],\n    \"limits\": {\n      \"max_signals_per_request\": 100,\n      \"max_rules_per_segment\": 6\n    }\n  },\n  \"ext\": {\n    \"ucp\": {\n      \"supported_spaces\": [\n        \"openai-te3-small-d512-v1\"\n      ],\n      \"supported_encodings\": [\n        \"float32\"\n      ],\n      \"dimensions\": [\n        512\n      ],\n      \"embedding_endpoint_template\": \"/signals/{signal_id}/embedding\",\n      \"similarity_search\": true,\n      \"phase\": \"llm-v1\",\n      \"gts_version\": \"adcp-gts-v1.0\"\n    }\n  },\n  \"context\": {\n    \"correlation_id\": \"capability_discovery--get_capabilities\"\n  }\n}"
+              }
+            },
+            {
+              "step": "Discover capabilities filtered by protocol",
+              "task": "get_adcp_capabilities",
+              "passed": true,
+              "duration_ms": 42,
+              "details": "✓ Response matches get-adcp-capabilities-response.json schema; ✓ Response echoes back the context object; ✓ Context correlation_id returned unchanged",
+              "observation_data": {
+                "adcp": {
+                  "major_versions": [
+                    2,
+                    3
+                  ],
+                  "idempotency": {
+                    "replay_ttl_seconds": 86400
+                  }
+                },
+                "supported_protocols": [
+                  "signals"
+                ],
+                "signals": {
+                  "signal_categories": [
+                    "demographic",
+                    "interest",
+                    "purchase_intent",
+                    "geo",
+                    "composite"
+                  ],
+                  "dynamic_segment_generation": true,
+                  "activation_mode": "async",
+                  "provider": "AdCP Signals Adaptor - Demo Provider (Evgeny)",
+                  "destinations": [
+                    {
+                      "id": "mock_dsp",
+                      "name": "Mock DSP",
+                      "type": "dsp",
+                      "activation_supported": true
+                    },
+                    {
+                      "id": "mock_cleanroom",
+                      "name": "Mock Clean Room",
+                      "type": "cleanroom",
+                      "activation_supported": true
+                    },
+                    {
+                      "id": "mock_cdp",
+                      "name": "Mock CDP",
+                      "type": "cdp",
+                      "activation_supported": true
+                    },
+                    {
+                      "id": "mock_measurement",
+                      "name": "Mock Measurement Platform",
+                      "type": "measurement",
+                      "activation_supported": false
+                    }
+                  ],
+                  "limits": {
+                    "max_signals_per_request": 100,
+                    "max_rules_per_segment": 6
+                  }
+                },
+                "context": {
+                  "correlation_id": "capability_discovery--get_capabilities_filtered"
+                },
+                "ext": {
+                  "ucp": {
+                    "supported_spaces": [
+                      "openai-te3-small-d512-v1"
+                    ],
+                    "supported_encodings": [
+                      "float32"
+                    ],
+                    "dimensions": [
+                      512
+                    ],
+                    "embedding_endpoint_template": "/signals/{signal_id}/embedding",
+                    "similarity_search": true,
+                    "phase": "llm-v1",
+                    "gts_version": "adcp-gts-v1.0"
+                  }
+                },
+                "_message": "{\n  \"adcp\": {\n    \"major_versions\": [\n      2,\n      3\n    ],\n    \"idempotency\": {\n      \"replay_ttl_seconds\": 86400\n    }\n  },\n  \"supported_protocols\": [\n    \"signals\"\n  ],\n  \"signals\": {\n    \"signal_categories\": [\n      \"demographic\",\n      \"interest\",\n      \"purchase_intent\",\n      \"geo\",\n      \"composite\"\n    ],\n    \"dynamic_segment_generation\": true,\n    \"activation_mode\": \"async\",\n    \"provider\": \"AdCP Signals Adaptor - Demo Provider (Evgeny)\",\n    \"destinations\": [\n      {\n        \"id\": \"mock_dsp\",\n        \"name\": \"Mock DSP\",\n        \"type\": \"dsp\",\n        \"activation_supported\": true\n      },\n      {\n        \"id\": \"mock_cleanroom\",\n        \"name\": \"Mock Clean Room\",\n        \"type\": \"cleanroom\",\n        \"activation_supported\": true\n      },\n      {\n        \"id\": \"mock_cdp\",\n        \"name\": \"Mock CDP\",\n        \"type\": \"cdp\",\n        \"activation_supported\": true\n      },\n      {\n        \"id\": \"mock_measurement\",\n        \"name\": \"Mock Measurement Platform\",\n        \"type\": \"measurement\",\n        \"activation_supported\": false\n      }\n    ],\n    \"limits\": {\n      \"max_signals_per_request\": 100,\n      \"max_rules_per_segment\": 6\n    }\n  },\n  \"ext\": {\n    \"ucp\": {\n      \"supported_spaces\": [\n        \"openai-te3-small-d512-v1\"\n      ],\n      \"supported_encodings\": [\n        \"float32\"\n      ],\n      \"dimensions\": [\n        512\n      ],\n      \"embedding_endpoint_template\": \"/signals/{signal_id}/embedding\",\n      \"similarity_search\": true,\n      \"phase\": \"llm-v1\",\n      \"gts_version\": \"adcp-gts-v1.0\"\n    }\n  },\n  \"context\": {\n    \"correlation_id\": \"capability_discovery--get_capabilities_filtered\"\n  }\n}"
+              }
+            }
+          ],
+          "summary": "Protocol and capability discovery: all steps passed",
+          "total_duration_ms": 98,
+          "tested_at": "2026-04-19T11:19:59.967Z"
+        }
+      ],
+      "skipped_scenarios": [],
+      "observations": [],
+      "duration_ms": 98,
+      "mode": "observational"
+    }
+  ],
+  "skipped_tracks": [],
+  "summary": {
+    "tracks_passed": 1,
+    "tracks_failed": 0,
+    "tracks_skipped": 0,
+    "tracks_partial": 0,
+    "headline": "All 1 track(s) pass"
+  },
+  "observations": [
+    {
+      "category": "tool_discovery",
+      "severity": "info",
+      "message": "Discovered 8 tools: [get_adcp_capabilities, get_signals, activate_signal, get_operation_status, get_similar_signals, query_signals_nl, get_concept, search_concepts]",
+      "evidence": {
+        "tools": [
+          "get_adcp_capabilities",
+          "get_signals",
+          "activate_signal",
+          "get_operation_status",
+          "get_similar_signals",
+          "query_signals_nl",
+          "get_concept",
+          "search_concepts"
+        ]
+      }
+    }
+  ],
+  "storyboards_executed": [
+    "capability_discovery"
+  ],
+  "controller_detected": false,
+  "tested_at": "2026-04-19T11:19:59.969Z",
+  "total_duration_ms": 2018
+}

--- a/storyboard_report_full.json
+++ b/storyboard_report_full.json
@@ -1,0 +1,2098 @@
+{
+  "agent_url": "https://adcp-signals-adaptor.evgeny-193.workers.dev/mcp",
+  "agent_profile": {
+    "name": "E2E Test Client",
+    "tools": [
+      "get_adcp_capabilities",
+      "get_signals",
+      "activate_signal",
+      "get_operation_status",
+      "get_similar_signals",
+      "query_signals_nl",
+      "get_concept",
+      "search_concepts"
+    ],
+    "adcp_version": "v3",
+    "supported_protocols": [
+      "signals"
+    ],
+    "supports_governance": false,
+    "supports_si": false
+  },
+  "overall_status": "passing",
+  "tracks": [
+    {
+      "track": "core",
+      "status": "pass",
+      "label": "Core Protocol",
+      "scenarios": [
+        {
+          "agent_url": "https://adcp-signals-adaptor.evgeny-193.workers.dev/mcp",
+          "scenario": "capability_discovery/protocol_discovery",
+          "overall_passed": true,
+          "steps": [
+            {
+              "step": "Discover agent capabilities",
+              "task": "get_adcp_capabilities",
+              "passed": true,
+              "duration_ms": 54,
+              "details": "✓ Response matches get-adcp-capabilities-response.json schema; ✓ Agent declares supported protocol versions; ✓ Agent declares which protocol domains it supports; ✓ Response echoes back the context object; ✓ Context correlation_id returned unchanged",
+              "observation_data": {
+                "adcp": {
+                  "major_versions": [
+                    2,
+                    3
+                  ],
+                  "idempotency": {
+                    "replay_ttl_seconds": 86400
+                  }
+                },
+                "supported_protocols": [
+                  "signals"
+                ],
+                "signals": {
+                  "signal_categories": [
+                    "demographic",
+                    "interest",
+                    "purchase_intent",
+                    "geo",
+                    "composite"
+                  ],
+                  "dynamic_segment_generation": true,
+                  "activation_mode": "async",
+                  "provider": "AdCP Signals Adaptor - Demo Provider (Evgeny)",
+                  "destinations": [
+                    {
+                      "id": "mock_dsp",
+                      "name": "Mock DSP",
+                      "type": "dsp",
+                      "activation_supported": true
+                    },
+                    {
+                      "id": "mock_cleanroom",
+                      "name": "Mock Clean Room",
+                      "type": "cleanroom",
+                      "activation_supported": true
+                    },
+                    {
+                      "id": "mock_cdp",
+                      "name": "Mock CDP",
+                      "type": "cdp",
+                      "activation_supported": true
+                    },
+                    {
+                      "id": "mock_measurement",
+                      "name": "Mock Measurement Platform",
+                      "type": "measurement",
+                      "activation_supported": false
+                    }
+                  ],
+                  "limits": {
+                    "max_signals_per_request": 100,
+                    "max_rules_per_segment": 6
+                  }
+                },
+                "context": {
+                  "correlation_id": "capability_discovery--get_capabilities"
+                },
+                "ext": {
+                  "ucp": {
+                    "supported_spaces": [
+                      "openai-te3-small-d512-v1"
+                    ],
+                    "supported_encodings": [
+                      "float32"
+                    ],
+                    "dimensions": [
+                      512
+                    ],
+                    "embedding_endpoint_template": "/signals/{signal_id}/embedding",
+                    "similarity_search": true,
+                    "phase": "llm-v1",
+                    "gts_version": "adcp-gts-v1.0"
+                  }
+                },
+                "_message": "{\n  \"adcp\": {\n    \"major_versions\": [\n      2,\n      3\n    ],\n    \"idempotency\": {\n      \"replay_ttl_seconds\": 86400\n    }\n  },\n  \"supported_protocols\": [\n    \"signals\"\n  ],\n  \"signals\": {\n    \"signal_categories\": [\n      \"demographic\",\n      \"interest\",\n      \"purchase_intent\",\n      \"geo\",\n      \"composite\"\n    ],\n    \"dynamic_segment_generation\": true,\n    \"activation_mode\": \"async\",\n    \"provider\": \"AdCP Signals Adaptor - Demo Provider (Evgeny)\",\n    \"destinations\": [\n      {\n        \"id\": \"mock_dsp\",\n        \"name\": \"Mock DSP\",\n        \"type\": \"dsp\",\n        \"activation_supported\": true\n      },\n      {\n        \"id\": \"mock_cleanroom\",\n        \"name\": \"Mock Clean Room\",\n        \"type\": \"cleanroom\",\n        \"activation_supported\": true\n      },\n      {\n        \"id\": \"mock_cdp\",\n        \"name\": \"Mock CDP\",\n        \"type\": \"cdp\",\n        \"activation_supported\": true\n      },\n      {\n        \"id\": \"mock_measurement\",\n        \"name\": \"Mock Measurement Platform\",\n        \"type\": \"measurement\",\n        \"activation_supported\": false\n      }\n    ],\n    \"limits\": {\n      \"max_signals_per_request\": 100,\n      \"max_rules_per_segment\": 6\n    }\n  },\n  \"ext\": {\n    \"ucp\": {\n      \"supported_spaces\": [\n        \"openai-te3-small-d512-v1\"\n      ],\n      \"supported_encodings\": [\n        \"float32\"\n      ],\n      \"dimensions\": [\n        512\n      ],\n      \"embedding_endpoint_template\": \"/signals/{signal_id}/embedding\",\n      \"similarity_search\": true,\n      \"phase\": \"llm-v1\",\n      \"gts_version\": \"adcp-gts-v1.0\"\n    }\n  },\n  \"context\": {\n    \"correlation_id\": \"capability_discovery--get_capabilities\"\n  }\n}"
+              }
+            },
+            {
+              "step": "Discover capabilities filtered by protocol",
+              "task": "get_adcp_capabilities",
+              "passed": true,
+              "duration_ms": 37,
+              "details": "✓ Response matches get-adcp-capabilities-response.json schema; ✓ Response echoes back the context object; ✓ Context correlation_id returned unchanged",
+              "observation_data": {
+                "adcp": {
+                  "major_versions": [
+                    2,
+                    3
+                  ],
+                  "idempotency": {
+                    "replay_ttl_seconds": 86400
+                  }
+                },
+                "supported_protocols": [
+                  "signals"
+                ],
+                "signals": {
+                  "signal_categories": [
+                    "demographic",
+                    "interest",
+                    "purchase_intent",
+                    "geo",
+                    "composite"
+                  ],
+                  "dynamic_segment_generation": true,
+                  "activation_mode": "async",
+                  "provider": "AdCP Signals Adaptor - Demo Provider (Evgeny)",
+                  "destinations": [
+                    {
+                      "id": "mock_dsp",
+                      "name": "Mock DSP",
+                      "type": "dsp",
+                      "activation_supported": true
+                    },
+                    {
+                      "id": "mock_cleanroom",
+                      "name": "Mock Clean Room",
+                      "type": "cleanroom",
+                      "activation_supported": true
+                    },
+                    {
+                      "id": "mock_cdp",
+                      "name": "Mock CDP",
+                      "type": "cdp",
+                      "activation_supported": true
+                    },
+                    {
+                      "id": "mock_measurement",
+                      "name": "Mock Measurement Platform",
+                      "type": "measurement",
+                      "activation_supported": false
+                    }
+                  ],
+                  "limits": {
+                    "max_signals_per_request": 100,
+                    "max_rules_per_segment": 6
+                  }
+                },
+                "context": {
+                  "correlation_id": "capability_discovery--get_capabilities_filtered"
+                },
+                "ext": {
+                  "ucp": {
+                    "supported_spaces": [
+                      "openai-te3-small-d512-v1"
+                    ],
+                    "supported_encodings": [
+                      "float32"
+                    ],
+                    "dimensions": [
+                      512
+                    ],
+                    "embedding_endpoint_template": "/signals/{signal_id}/embedding",
+                    "similarity_search": true,
+                    "phase": "llm-v1",
+                    "gts_version": "adcp-gts-v1.0"
+                  }
+                },
+                "_message": "{\n  \"adcp\": {\n    \"major_versions\": [\n      2,\n      3\n    ],\n    \"idempotency\": {\n      \"replay_ttl_seconds\": 86400\n    }\n  },\n  \"supported_protocols\": [\n    \"signals\"\n  ],\n  \"signals\": {\n    \"signal_categories\": [\n      \"demographic\",\n      \"interest\",\n      \"purchase_intent\",\n      \"geo\",\n      \"composite\"\n    ],\n    \"dynamic_segment_generation\": true,\n    \"activation_mode\": \"async\",\n    \"provider\": \"AdCP Signals Adaptor - Demo Provider (Evgeny)\",\n    \"destinations\": [\n      {\n        \"id\": \"mock_dsp\",\n        \"name\": \"Mock DSP\",\n        \"type\": \"dsp\",\n        \"activation_supported\": true\n      },\n      {\n        \"id\": \"mock_cleanroom\",\n        \"name\": \"Mock Clean Room\",\n        \"type\": \"cleanroom\",\n        \"activation_supported\": true\n      },\n      {\n        \"id\": \"mock_cdp\",\n        \"name\": \"Mock CDP\",\n        \"type\": \"cdp\",\n        \"activation_supported\": true\n      },\n      {\n        \"id\": \"mock_measurement\",\n        \"name\": \"Mock Measurement Platform\",\n        \"type\": \"measurement\",\n        \"activation_supported\": false\n      }\n    ],\n    \"limits\": {\n      \"max_signals_per_request\": 100,\n      \"max_rules_per_segment\": 6\n    }\n  },\n  \"ext\": {\n    \"ucp\": {\n      \"supported_spaces\": [\n        \"openai-te3-small-d512-v1\"\n      ],\n      \"supported_encodings\": [\n        \"float32\"\n      ],\n      \"dimensions\": [\n        512\n      ],\n      \"embedding_endpoint_template\": \"/signals/{signal_id}/embedding\",\n      \"similarity_search\": true,\n      \"phase\": \"llm-v1\",\n      \"gts_version\": \"adcp-gts-v1.0\"\n    }\n  },\n  \"context\": {\n    \"correlation_id\": \"capability_discovery--get_capabilities_filtered\"\n  }\n}"
+              }
+            }
+          ],
+          "summary": "Protocol and capability discovery: all steps passed",
+          "total_duration_ms": 96,
+          "tested_at": "2026-04-19T11:21:22.255Z"
+        },
+        {
+          "agent_url": "https://adcp-signals-adaptor.evgeny-193.workers.dev/mcp",
+          "scenario": "deterministic_testing/capability_discovery",
+          "overall_passed": true,
+          "steps": [
+            {
+              "step": "Check agent capabilities",
+              "task": "get_adcp_capabilities",
+              "passed": true,
+              "duration_ms": 36,
+              "details": "✓ Response matches get-adcp-capabilities-response.json schema; ✓ Agent declares supported protocols; ✓ Response echoes back the context object; ✓ Context correlation_id returned unchanged",
+              "observation_data": {
+                "adcp": {
+                  "major_versions": [
+                    2,
+                    3
+                  ],
+                  "idempotency": {
+                    "replay_ttl_seconds": 86400
+                  }
+                },
+                "supported_protocols": [
+                  "signals"
+                ],
+                "signals": {
+                  "signal_categories": [
+                    "demographic",
+                    "interest",
+                    "purchase_intent",
+                    "geo",
+                    "composite"
+                  ],
+                  "dynamic_segment_generation": true,
+                  "activation_mode": "async",
+                  "provider": "AdCP Signals Adaptor - Demo Provider (Evgeny)",
+                  "destinations": [
+                    {
+                      "id": "mock_dsp",
+                      "name": "Mock DSP",
+                      "type": "dsp",
+                      "activation_supported": true
+                    },
+                    {
+                      "id": "mock_cleanroom",
+                      "name": "Mock Clean Room",
+                      "type": "cleanroom",
+                      "activation_supported": true
+                    },
+                    {
+                      "id": "mock_cdp",
+                      "name": "Mock CDP",
+                      "type": "cdp",
+                      "activation_supported": true
+                    },
+                    {
+                      "id": "mock_measurement",
+                      "name": "Mock Measurement Platform",
+                      "type": "measurement",
+                      "activation_supported": false
+                    }
+                  ],
+                  "limits": {
+                    "max_signals_per_request": 100,
+                    "max_rules_per_segment": 6
+                  }
+                },
+                "context": {
+                  "correlation_id": "deterministic_testing--get_capabilities"
+                },
+                "ext": {
+                  "ucp": {
+                    "supported_spaces": [
+                      "openai-te3-small-d512-v1"
+                    ],
+                    "supported_encodings": [
+                      "float32"
+                    ],
+                    "dimensions": [
+                      512
+                    ],
+                    "embedding_endpoint_template": "/signals/{signal_id}/embedding",
+                    "similarity_search": true,
+                    "phase": "llm-v1",
+                    "gts_version": "adcp-gts-v1.0"
+                  }
+                },
+                "_message": "{\n  \"adcp\": {\n    \"major_versions\": [\n      2,\n      3\n    ],\n    \"idempotency\": {\n      \"replay_ttl_seconds\": 86400\n    }\n  },\n  \"supported_protocols\": [\n    \"signals\"\n  ],\n  \"signals\": {\n    \"signal_categories\": [\n      \"demographic\",\n      \"interest\",\n      \"purchase_intent\",\n      \"geo\",\n      \"composite\"\n    ],\n    \"dynamic_segment_generation\": true,\n    \"activation_mode\": \"async\",\n    \"provider\": \"AdCP Signals Adaptor - Demo Provider (Evgeny)\",\n    \"destinations\": [\n      {\n        \"id\": \"mock_dsp\",\n        \"name\": \"Mock DSP\",\n        \"type\": \"dsp\",\n        \"activation_supported\": true\n      },\n      {\n        \"id\": \"mock_cleanroom\",\n        \"name\": \"Mock Clean Room\",\n        \"type\": \"cleanroom\",\n        \"activation_supported\": true\n      },\n      {\n        \"id\": \"mock_cdp\",\n        \"name\": \"Mock CDP\",\n        \"type\": \"cdp\",\n        \"activation_supported\": true\n      },\n      {\n        \"id\": \"mock_measurement\",\n        \"name\": \"Mock Measurement Platform\",\n        \"type\": \"measurement\",\n        \"activation_supported\": false\n      }\n    ],\n    \"limits\": {\n      \"max_signals_per_request\": 100,\n      \"max_rules_per_segment\": 6\n    }\n  },\n  \"ext\": {\n    \"ucp\": {\n      \"supported_spaces\": [\n        \"openai-te3-small-d512-v1\"\n      ],\n      \"supported_encodings\": [\n        \"float32\"\n      ],\n      \"dimensions\": [\n        512\n      ],\n      \"embedding_endpoint_template\": \"/signals/{signal_id}/embedding\",\n      \"similarity_search\": true,\n      \"phase\": \"llm-v1\",\n      \"gts_version\": \"adcp-gts-v1.0\"\n    }\n  },\n  \"context\": {\n    \"correlation_id\": \"deterministic_testing--get_capabilities\"\n  }\n}"
+              }
+            }
+          ],
+          "summary": "Capability discovery: all steps passed",
+          "total_duration_ms": 36,
+          "tested_at": "2026-04-19T11:21:22.294Z"
+        },
+        {
+          "agent_url": "https://adcp-signals-adaptor.evgeny-193.workers.dev/mcp",
+          "scenario": "deterministic_testing/controller_validation",
+          "overall_passed": true,
+          "steps": [
+            {
+              "step": "List supported scenarios",
+              "task": "comply_test_controller",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Not testable: requires comply_test_controller harness"
+              ]
+            },
+            {
+              "step": "Unknown scenario returns error",
+              "task": "comply_test_controller",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Not testable: requires comply_test_controller harness"
+              ]
+            },
+            {
+              "step": "Missing params returns error",
+              "task": "comply_test_controller",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Not testable: requires comply_test_controller harness"
+              ]
+            },
+            {
+              "step": "Nonexistent entity returns NOT_FOUND",
+              "task": "comply_test_controller",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Not testable: requires comply_test_controller harness"
+              ]
+            }
+          ],
+          "summary": "Controller validation: all steps passed",
+          "total_duration_ms": 1,
+          "tested_at": "2026-04-19T11:21:22.294Z"
+        },
+        {
+          "agent_url": "https://adcp-signals-adaptor.evgeny-193.workers.dev/mcp",
+          "scenario": "deterministic_testing/deterministic_account",
+          "overall_passed": true,
+          "steps": [
+            {
+              "step": "Create sandbox account for state machine test",
+              "task": "sync_accounts",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Not testable: requires comply_test_controller harness"
+              ]
+            },
+            {
+              "step": "Find account for state machine test",
+              "task": "list_accounts",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Not testable: requires comply_test_controller harness"
+              ]
+            },
+            {
+              "step": "Force account to suspended",
+              "task": "comply_test_controller",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Not testable: requires comply_test_controller harness"
+              ]
+            },
+            {
+              "step": "Reactivate account",
+              "task": "comply_test_controller",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Not testable: requires comply_test_controller harness"
+              ]
+            },
+            {
+              "step": "Force account to payment_required",
+              "task": "comply_test_controller",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Not testable: requires comply_test_controller harness"
+              ]
+            },
+            {
+              "step": "Restore account to active",
+              "task": "comply_test_controller",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Not testable: requires comply_test_controller harness"
+              ]
+            }
+          ],
+          "summary": "Deterministic account state machine: all steps passed",
+          "total_duration_ms": 0,
+          "tested_at": "2026-04-19T11:21:22.294Z"
+        },
+        {
+          "agent_url": "https://adcp-signals-adaptor.evgeny-193.workers.dev/mcp",
+          "scenario": "deterministic_testing/deterministic_media_buy",
+          "overall_passed": true,
+          "steps": [
+            {
+              "step": "Create media buy for state machine test",
+              "task": "create_media_buy",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Not testable: requires comply_test_controller harness"
+              ]
+            },
+            {
+              "step": "Force media buy to active",
+              "task": "comply_test_controller",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Not testable: requires comply_test_controller harness"
+              ]
+            },
+            {
+              "step": "Verify media buy status via get_media_buys",
+              "task": "get_media_buys",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Not testable: requires comply_test_controller harness"
+              ]
+            },
+            {
+              "step": "Force media buy to completed (terminal)",
+              "task": "comply_test_controller",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Not testable: requires comply_test_controller harness"
+              ]
+            },
+            {
+              "step": "Reject transition from terminal state",
+              "task": "comply_test_controller",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Not testable: requires comply_test_controller harness"
+              ]
+            }
+          ],
+          "summary": "Deterministic media buy state machine: all steps passed",
+          "total_duration_ms": 0,
+          "tested_at": "2026-04-19T11:21:22.294Z"
+        },
+        {
+          "agent_url": "https://adcp-signals-adaptor.evgeny-193.workers.dev/mcp",
+          "scenario": "deterministic_testing/deterministic_creative",
+          "overall_passed": true,
+          "steps": [
+            {
+              "step": "Sync creative for state machine test",
+              "task": "sync_creatives",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Not testable: requires comply_test_controller harness"
+              ]
+            },
+            {
+              "step": "Force creative to approved",
+              "task": "comply_test_controller",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Not testable: requires comply_test_controller harness"
+              ]
+            },
+            {
+              "step": "Force creative to archived (terminal)",
+              "task": "comply_test_controller",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Not testable: requires comply_test_controller harness"
+              ]
+            },
+            {
+              "step": "Reject archived to processing",
+              "task": "comply_test_controller",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Not testable: requires comply_test_controller harness"
+              ]
+            },
+            {
+              "step": "Force fresh creative to rejected with reason",
+              "task": "comply_test_controller",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Not testable: requires comply_test_controller harness"
+              ]
+            }
+          ],
+          "summary": "Deterministic creative state machine: all steps passed",
+          "total_duration_ms": 1,
+          "tested_at": "2026-04-19T11:21:22.294Z"
+        },
+        {
+          "agent_url": "https://adcp-signals-adaptor.evgeny-193.workers.dev/mcp",
+          "scenario": "deterministic_testing/deterministic_session",
+          "overall_passed": true,
+          "steps": [
+            {
+              "step": "Initiate SI session",
+              "task": "si_initiate_session",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Not testable: agent lacks required tool"
+              ]
+            },
+            {
+              "step": "Force session timeout",
+              "task": "comply_test_controller",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Not testable: requires comply_test_controller harness"
+              ]
+            },
+            {
+              "step": "Verify messaging fails on terminated session",
+              "task": "si_send_message",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Not testable: requires comply_test_controller harness"
+              ]
+            }
+          ],
+          "summary": "Deterministic SI session state machine: all steps passed",
+          "total_duration_ms": 0,
+          "tested_at": "2026-04-19T11:21:22.294Z"
+        },
+        {
+          "agent_url": "https://adcp-signals-adaptor.evgeny-193.workers.dev/mcp",
+          "scenario": "deterministic_testing/deterministic_delivery",
+          "overall_passed": true,
+          "steps": [
+            {
+              "step": "Create media buy for delivery test",
+              "task": "create_media_buy",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Not testable: requires comply_test_controller harness"
+              ]
+            },
+            {
+              "step": "Simulate delivery data",
+              "task": "comply_test_controller",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Not testable: requires comply_test_controller harness"
+              ]
+            },
+            {
+              "step": "Verify delivery via get_media_buy_delivery",
+              "task": "get_media_buy_delivery",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Not testable: requires comply_test_controller harness"
+              ]
+            }
+          ],
+          "summary": "Deterministic delivery simulation: all steps passed",
+          "total_duration_ms": 0,
+          "tested_at": "2026-04-19T11:21:22.294Z"
+        },
+        {
+          "agent_url": "https://adcp-signals-adaptor.evgeny-193.workers.dev/mcp",
+          "scenario": "deterministic_testing/deterministic_budget",
+          "overall_passed": true,
+          "steps": [
+            {
+              "step": "Create media buy for budget test",
+              "task": "create_media_buy",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Not testable: requires comply_test_controller harness"
+              ]
+            },
+            {
+              "step": "Simulate 95% budget spend",
+              "task": "comply_test_controller",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Not testable: requires comply_test_controller harness"
+              ]
+            },
+            {
+              "step": "Simulate 100% budget depletion",
+              "task": "comply_test_controller",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Not testable: requires comply_test_controller harness"
+              ]
+            }
+          ],
+          "summary": "Deterministic budget simulation: all steps passed",
+          "total_duration_ms": 1,
+          "tested_at": "2026-04-19T11:21:22.294Z"
+        },
+        {
+          "agent_url": "https://adcp-signals-adaptor.evgeny-193.workers.dev/mcp",
+          "scenario": "schema_validation/capability_discovery",
+          "overall_passed": true,
+          "steps": [
+            {
+              "step": "Check agent capabilities",
+              "task": "get_adcp_capabilities",
+              "passed": true,
+              "duration_ms": 35,
+              "details": "✓ Response matches get-adcp-capabilities-response.json schema; ✓ Agent declares supported protocols; ✓ Response echoes back the context object; ✓ Context correlation_id returned unchanged",
+              "observation_data": {
+                "adcp": {
+                  "major_versions": [
+                    2,
+                    3
+                  ],
+                  "idempotency": {
+                    "replay_ttl_seconds": 86400
+                  }
+                },
+                "supported_protocols": [
+                  "signals"
+                ],
+                "signals": {
+                  "signal_categories": [
+                    "demographic",
+                    "interest",
+                    "purchase_intent",
+                    "geo",
+                    "composite"
+                  ],
+                  "dynamic_segment_generation": true,
+                  "activation_mode": "async",
+                  "provider": "AdCP Signals Adaptor - Demo Provider (Evgeny)",
+                  "destinations": [
+                    {
+                      "id": "mock_dsp",
+                      "name": "Mock DSP",
+                      "type": "dsp",
+                      "activation_supported": true
+                    },
+                    {
+                      "id": "mock_cleanroom",
+                      "name": "Mock Clean Room",
+                      "type": "cleanroom",
+                      "activation_supported": true
+                    },
+                    {
+                      "id": "mock_cdp",
+                      "name": "Mock CDP",
+                      "type": "cdp",
+                      "activation_supported": true
+                    },
+                    {
+                      "id": "mock_measurement",
+                      "name": "Mock Measurement Platform",
+                      "type": "measurement",
+                      "activation_supported": false
+                    }
+                  ],
+                  "limits": {
+                    "max_signals_per_request": 100,
+                    "max_rules_per_segment": 6
+                  }
+                },
+                "context": {
+                  "correlation_id": "schema_validation--get_capabilities"
+                },
+                "ext": {
+                  "ucp": {
+                    "supported_spaces": [
+                      "openai-te3-small-d512-v1"
+                    ],
+                    "supported_encodings": [
+                      "float32"
+                    ],
+                    "dimensions": [
+                      512
+                    ],
+                    "embedding_endpoint_template": "/signals/{signal_id}/embedding",
+                    "similarity_search": true,
+                    "phase": "llm-v1",
+                    "gts_version": "adcp-gts-v1.0"
+                  }
+                },
+                "_message": "{\n  \"adcp\": {\n    \"major_versions\": [\n      2,\n      3\n    ],\n    \"idempotency\": {\n      \"replay_ttl_seconds\": 86400\n    }\n  },\n  \"supported_protocols\": [\n    \"signals\"\n  ],\n  \"signals\": {\n    \"signal_categories\": [\n      \"demographic\",\n      \"interest\",\n      \"purchase_intent\",\n      \"geo\",\n      \"composite\"\n    ],\n    \"dynamic_segment_generation\": true,\n    \"activation_mode\": \"async\",\n    \"provider\": \"AdCP Signals Adaptor - Demo Provider (Evgeny)\",\n    \"destinations\": [\n      {\n        \"id\": \"mock_dsp\",\n        \"name\": \"Mock DSP\",\n        \"type\": \"dsp\",\n        \"activation_supported\": true\n      },\n      {\n        \"id\": \"mock_cleanroom\",\n        \"name\": \"Mock Clean Room\",\n        \"type\": \"cleanroom\",\n        \"activation_supported\": true\n      },\n      {\n        \"id\": \"mock_cdp\",\n        \"name\": \"Mock CDP\",\n        \"type\": \"cdp\",\n        \"activation_supported\": true\n      },\n      {\n        \"id\": \"mock_measurement\",\n        \"name\": \"Mock Measurement Platform\",\n        \"type\": \"measurement\",\n        \"activation_supported\": false\n      }\n    ],\n    \"limits\": {\n      \"max_signals_per_request\": 100,\n      \"max_rules_per_segment\": 6\n    }\n  },\n  \"ext\": {\n    \"ucp\": {\n      \"supported_spaces\": [\n        \"openai-te3-small-d512-v1\"\n      ],\n      \"supported_encodings\": [\n        \"float32\"\n      ],\n      \"dimensions\": [\n        512\n      ],\n      \"embedding_endpoint_template\": \"/signals/{signal_id}/embedding\",\n      \"similarity_search\": true,\n      \"phase\": \"llm-v1\",\n      \"gts_version\": \"adcp-gts-v1.0\"\n    }\n  },\n  \"context\": {\n    \"correlation_id\": \"schema_validation--get_capabilities\"\n  }\n}"
+              }
+            }
+          ],
+          "summary": "Capability discovery: all steps passed",
+          "total_duration_ms": 35,
+          "tested_at": "2026-04-19T11:21:22.375Z"
+        },
+        {
+          "agent_url": "https://adcp-signals-adaptor.evgeny-193.workers.dev/mcp",
+          "scenario": "schema_validation/schema_compliance",
+          "overall_passed": true,
+          "steps": [
+            {
+              "step": "Validate get_products response schema",
+              "task": "get_products",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Skipped: agent does not implement this tool"
+              ]
+            },
+            {
+              "step": "Validate pricing options structure",
+              "task": "get_products",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Skipped: agent does not implement this tool"
+              ]
+            }
+          ],
+          "summary": "Response schema compliance: all steps passed",
+          "total_duration_ms": 0,
+          "tested_at": "2026-04-19T11:21:22.375Z"
+        },
+        {
+          "agent_url": "https://adcp-signals-adaptor.evgeny-193.workers.dev/mcp",
+          "scenario": "schema_validation/format_id_reconciliation",
+          "overall_passed": true,
+          "steps": [
+            {
+              "step": "Get products and verify identifiers",
+              "task": "get_products",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Skipped: agent does not implement this tool"
+              ]
+            },
+            {
+              "step": "Verify format catalog includes product formats",
+              "task": "list_creative_formats",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Skipped: agent does not implement this tool"
+              ]
+            }
+          ],
+          "summary": "Format ID and pricing option reconciliation: all steps passed",
+          "total_duration_ms": 0,
+          "tested_at": "2026-04-19T11:21:22.375Z"
+        },
+        {
+          "agent_url": "https://adcp-signals-adaptor.evgeny-193.workers.dev/mcp",
+          "scenario": "schema_validation/temporal_validation",
+          "overall_passed": true,
+          "steps": [
+            {
+              "step": "Reject reversed flight dates",
+              "task": "create_media_buy",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Skipped: agent does not implement this tool"
+              ]
+            },
+            {
+              "step": "Handle past start date",
+              "task": "create_media_buy",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Skipped: agent does not implement this tool"
+              ]
+            }
+          ],
+          "summary": "Temporal constraint enforcement: all steps passed",
+          "total_duration_ms": 0,
+          "tested_at": "2026-04-19T11:21:22.375Z"
+        }
+      ],
+      "skipped_scenarios": [],
+      "observations": [],
+      "duration_ms": 171,
+      "mode": "deterministic"
+    },
+    {
+      "track": "signals",
+      "status": "skip",
+      "label": "Signals",
+      "scenarios": [],
+      "skipped_scenarios": [],
+      "observations": [],
+      "duration_ms": 0,
+      "mode": "observational"
+    },
+    {
+      "track": "error_handling",
+      "status": "pass",
+      "label": "Error Handling",
+      "scenarios": [
+        {
+          "agent_url": "https://adcp-signals-adaptor.evgeny-193.workers.dev/mcp",
+          "scenario": "error_compliance/capability_discovery",
+          "overall_passed": true,
+          "steps": [
+            {
+              "step": "Check agent capabilities",
+              "task": "get_adcp_capabilities",
+              "passed": true,
+              "duration_ms": 45,
+              "details": "✓ Response matches get-adcp-capabilities-response.json schema; ✓ Agent declares supported protocols; ✓ Response echoes back the context object; ✓ Context correlation_id returned unchanged",
+              "observation_data": {
+                "adcp": {
+                  "major_versions": [
+                    2,
+                    3
+                  ],
+                  "idempotency": {
+                    "replay_ttl_seconds": 86400
+                  }
+                },
+                "supported_protocols": [
+                  "signals"
+                ],
+                "signals": {
+                  "signal_categories": [
+                    "demographic",
+                    "interest",
+                    "purchase_intent",
+                    "geo",
+                    "composite"
+                  ],
+                  "dynamic_segment_generation": true,
+                  "activation_mode": "async",
+                  "provider": "AdCP Signals Adaptor - Demo Provider (Evgeny)",
+                  "destinations": [
+                    {
+                      "id": "mock_dsp",
+                      "name": "Mock DSP",
+                      "type": "dsp",
+                      "activation_supported": true
+                    },
+                    {
+                      "id": "mock_cleanroom",
+                      "name": "Mock Clean Room",
+                      "type": "cleanroom",
+                      "activation_supported": true
+                    },
+                    {
+                      "id": "mock_cdp",
+                      "name": "Mock CDP",
+                      "type": "cdp",
+                      "activation_supported": true
+                    },
+                    {
+                      "id": "mock_measurement",
+                      "name": "Mock Measurement Platform",
+                      "type": "measurement",
+                      "activation_supported": false
+                    }
+                  ],
+                  "limits": {
+                    "max_signals_per_request": 100,
+                    "max_rules_per_segment": 6
+                  }
+                },
+                "context": {
+                  "correlation_id": "error_compliance--get_capabilities"
+                },
+                "ext": {
+                  "ucp": {
+                    "supported_spaces": [
+                      "openai-te3-small-d512-v1"
+                    ],
+                    "supported_encodings": [
+                      "float32"
+                    ],
+                    "dimensions": [
+                      512
+                    ],
+                    "embedding_endpoint_template": "/signals/{signal_id}/embedding",
+                    "similarity_search": true,
+                    "phase": "llm-v1",
+                    "gts_version": "adcp-gts-v1.0"
+                  }
+                },
+                "_message": "{\n  \"adcp\": {\n    \"major_versions\": [\n      2,\n      3\n    ],\n    \"idempotency\": {\n      \"replay_ttl_seconds\": 86400\n    }\n  },\n  \"supported_protocols\": [\n    \"signals\"\n  ],\n  \"signals\": {\n    \"signal_categories\": [\n      \"demographic\",\n      \"interest\",\n      \"purchase_intent\",\n      \"geo\",\n      \"composite\"\n    ],\n    \"dynamic_segment_generation\": true,\n    \"activation_mode\": \"async\",\n    \"provider\": \"AdCP Signals Adaptor - Demo Provider (Evgeny)\",\n    \"destinations\": [\n      {\n        \"id\": \"mock_dsp\",\n        \"name\": \"Mock DSP\",\n        \"type\": \"dsp\",\n        \"activation_supported\": true\n      },\n      {\n        \"id\": \"mock_cleanroom\",\n        \"name\": \"Mock Clean Room\",\n        \"type\": \"cleanroom\",\n        \"activation_supported\": true\n      },\n      {\n        \"id\": \"mock_cdp\",\n        \"name\": \"Mock CDP\",\n        \"type\": \"cdp\",\n        \"activation_supported\": true\n      },\n      {\n        \"id\": \"mock_measurement\",\n        \"name\": \"Mock Measurement Platform\",\n        \"type\": \"measurement\",\n        \"activation_supported\": false\n      }\n    ],\n    \"limits\": {\n      \"max_signals_per_request\": 100,\n      \"max_rules_per_segment\": 6\n    }\n  },\n  \"ext\": {\n    \"ucp\": {\n      \"supported_spaces\": [\n        \"openai-te3-small-d512-v1\"\n      ],\n      \"supported_encodings\": [\n        \"float32\"\n      ],\n      \"dimensions\": [\n        512\n      ],\n      \"embedding_endpoint_template\": \"/signals/{signal_id}/embedding\",\n      \"similarity_search\": true,\n      \"phase\": \"llm-v1\",\n      \"gts_version\": \"adcp-gts-v1.0\"\n    }\n  },\n  \"context\": {\n    \"correlation_id\": \"error_compliance--get_capabilities\"\n  }\n}"
+              }
+            }
+          ],
+          "summary": "Capability discovery: all steps passed",
+          "total_duration_ms": 45,
+          "tested_at": "2026-04-19T11:21:22.340Z"
+        },
+        {
+          "agent_url": "https://adcp-signals-adaptor.evgeny-193.workers.dev/mcp",
+          "scenario": "error_compliance/error_responses",
+          "overall_passed": true,
+          "steps": [
+            {
+              "step": "Reject negative budget",
+              "task": "create_media_buy",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Skipped: agent does not implement this tool"
+              ]
+            },
+            {
+              "step": "Reject nonexistent product ID",
+              "task": "create_media_buy",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Skipped: agent does not implement this tool"
+              ]
+            },
+            {
+              "step": "Reject empty get_products request",
+              "task": "get_products",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Skipped: agent does not implement this tool"
+              ]
+            },
+            {
+              "step": "Reject reversed dates with error code",
+              "task": "create_media_buy",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Skipped: agent does not implement this tool"
+              ]
+            }
+          ],
+          "summary": "Error responses for invalid input: all steps passed",
+          "total_duration_ms": 0,
+          "tested_at": "2026-04-19T11:21:22.340Z"
+        },
+        {
+          "agent_url": "https://adcp-signals-adaptor.evgeny-193.workers.dev/mcp",
+          "scenario": "error_compliance/error_structure",
+          "overall_passed": true,
+          "steps": [
+            {
+              "step": "Validate error response structure",
+              "task": "create_media_buy",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Skipped: agent does not implement this tool"
+              ]
+            }
+          ],
+          "summary": "Error structure compliance: all steps passed",
+          "total_duration_ms": 1,
+          "tested_at": "2026-04-19T11:21:22.340Z"
+        },
+        {
+          "agent_url": "https://adcp-signals-adaptor.evgeny-193.workers.dev/mcp",
+          "scenario": "error_compliance/version_negotiation",
+          "overall_passed": true,
+          "steps": [
+            {
+              "step": "Reject unsupported adcp_major_version",
+              "task": "get_products",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Skipped: agent does not implement this tool"
+              ]
+            },
+            {
+              "step": "Accept supported adcp_major_version",
+              "task": "get_products",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Skipped: agent does not implement this tool"
+              ]
+            }
+          ],
+          "summary": "Protocol version validation: all steps passed",
+          "total_duration_ms": 0,
+          "tested_at": "2026-04-19T11:21:22.340Z"
+        },
+        {
+          "agent_url": "https://adcp-signals-adaptor.evgeny-193.workers.dev/mcp",
+          "scenario": "error_compliance/error_transport",
+          "overall_passed": true,
+          "steps": [
+            {
+              "step": "Validate error transport binding",
+              "task": "create_media_buy",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Skipped: agent does not implement this tool"
+              ]
+            }
+          ],
+          "summary": "Error transport bindings: all steps passed",
+          "total_duration_ms": 0,
+          "tested_at": "2026-04-19T11:21:22.340Z"
+        }
+      ],
+      "skipped_scenarios": [],
+      "observations": [],
+      "duration_ms": 46,
+      "mode": "observational"
+    }
+  ],
+  "tested_tracks": [
+    {
+      "track": "core",
+      "status": "pass",
+      "label": "Core Protocol",
+      "scenarios": [
+        {
+          "agent_url": "https://adcp-signals-adaptor.evgeny-193.workers.dev/mcp",
+          "scenario": "capability_discovery/protocol_discovery",
+          "overall_passed": true,
+          "steps": [
+            {
+              "step": "Discover agent capabilities",
+              "task": "get_adcp_capabilities",
+              "passed": true,
+              "duration_ms": 54,
+              "details": "✓ Response matches get-adcp-capabilities-response.json schema; ✓ Agent declares supported protocol versions; ✓ Agent declares which protocol domains it supports; ✓ Response echoes back the context object; ✓ Context correlation_id returned unchanged",
+              "observation_data": {
+                "adcp": {
+                  "major_versions": [
+                    2,
+                    3
+                  ],
+                  "idempotency": {
+                    "replay_ttl_seconds": 86400
+                  }
+                },
+                "supported_protocols": [
+                  "signals"
+                ],
+                "signals": {
+                  "signal_categories": [
+                    "demographic",
+                    "interest",
+                    "purchase_intent",
+                    "geo",
+                    "composite"
+                  ],
+                  "dynamic_segment_generation": true,
+                  "activation_mode": "async",
+                  "provider": "AdCP Signals Adaptor - Demo Provider (Evgeny)",
+                  "destinations": [
+                    {
+                      "id": "mock_dsp",
+                      "name": "Mock DSP",
+                      "type": "dsp",
+                      "activation_supported": true
+                    },
+                    {
+                      "id": "mock_cleanroom",
+                      "name": "Mock Clean Room",
+                      "type": "cleanroom",
+                      "activation_supported": true
+                    },
+                    {
+                      "id": "mock_cdp",
+                      "name": "Mock CDP",
+                      "type": "cdp",
+                      "activation_supported": true
+                    },
+                    {
+                      "id": "mock_measurement",
+                      "name": "Mock Measurement Platform",
+                      "type": "measurement",
+                      "activation_supported": false
+                    }
+                  ],
+                  "limits": {
+                    "max_signals_per_request": 100,
+                    "max_rules_per_segment": 6
+                  }
+                },
+                "context": {
+                  "correlation_id": "capability_discovery--get_capabilities"
+                },
+                "ext": {
+                  "ucp": {
+                    "supported_spaces": [
+                      "openai-te3-small-d512-v1"
+                    ],
+                    "supported_encodings": [
+                      "float32"
+                    ],
+                    "dimensions": [
+                      512
+                    ],
+                    "embedding_endpoint_template": "/signals/{signal_id}/embedding",
+                    "similarity_search": true,
+                    "phase": "llm-v1",
+                    "gts_version": "adcp-gts-v1.0"
+                  }
+                },
+                "_message": "{\n  \"adcp\": {\n    \"major_versions\": [\n      2,\n      3\n    ],\n    \"idempotency\": {\n      \"replay_ttl_seconds\": 86400\n    }\n  },\n  \"supported_protocols\": [\n    \"signals\"\n  ],\n  \"signals\": {\n    \"signal_categories\": [\n      \"demographic\",\n      \"interest\",\n      \"purchase_intent\",\n      \"geo\",\n      \"composite\"\n    ],\n    \"dynamic_segment_generation\": true,\n    \"activation_mode\": \"async\",\n    \"provider\": \"AdCP Signals Adaptor - Demo Provider (Evgeny)\",\n    \"destinations\": [\n      {\n        \"id\": \"mock_dsp\",\n        \"name\": \"Mock DSP\",\n        \"type\": \"dsp\",\n        \"activation_supported\": true\n      },\n      {\n        \"id\": \"mock_cleanroom\",\n        \"name\": \"Mock Clean Room\",\n        \"type\": \"cleanroom\",\n        \"activation_supported\": true\n      },\n      {\n        \"id\": \"mock_cdp\",\n        \"name\": \"Mock CDP\",\n        \"type\": \"cdp\",\n        \"activation_supported\": true\n      },\n      {\n        \"id\": \"mock_measurement\",\n        \"name\": \"Mock Measurement Platform\",\n        \"type\": \"measurement\",\n        \"activation_supported\": false\n      }\n    ],\n    \"limits\": {\n      \"max_signals_per_request\": 100,\n      \"max_rules_per_segment\": 6\n    }\n  },\n  \"ext\": {\n    \"ucp\": {\n      \"supported_spaces\": [\n        \"openai-te3-small-d512-v1\"\n      ],\n      \"supported_encodings\": [\n        \"float32\"\n      ],\n      \"dimensions\": [\n        512\n      ],\n      \"embedding_endpoint_template\": \"/signals/{signal_id}/embedding\",\n      \"similarity_search\": true,\n      \"phase\": \"llm-v1\",\n      \"gts_version\": \"adcp-gts-v1.0\"\n    }\n  },\n  \"context\": {\n    \"correlation_id\": \"capability_discovery--get_capabilities\"\n  }\n}"
+              }
+            },
+            {
+              "step": "Discover capabilities filtered by protocol",
+              "task": "get_adcp_capabilities",
+              "passed": true,
+              "duration_ms": 37,
+              "details": "✓ Response matches get-adcp-capabilities-response.json schema; ✓ Response echoes back the context object; ✓ Context correlation_id returned unchanged",
+              "observation_data": {
+                "adcp": {
+                  "major_versions": [
+                    2,
+                    3
+                  ],
+                  "idempotency": {
+                    "replay_ttl_seconds": 86400
+                  }
+                },
+                "supported_protocols": [
+                  "signals"
+                ],
+                "signals": {
+                  "signal_categories": [
+                    "demographic",
+                    "interest",
+                    "purchase_intent",
+                    "geo",
+                    "composite"
+                  ],
+                  "dynamic_segment_generation": true,
+                  "activation_mode": "async",
+                  "provider": "AdCP Signals Adaptor - Demo Provider (Evgeny)",
+                  "destinations": [
+                    {
+                      "id": "mock_dsp",
+                      "name": "Mock DSP",
+                      "type": "dsp",
+                      "activation_supported": true
+                    },
+                    {
+                      "id": "mock_cleanroom",
+                      "name": "Mock Clean Room",
+                      "type": "cleanroom",
+                      "activation_supported": true
+                    },
+                    {
+                      "id": "mock_cdp",
+                      "name": "Mock CDP",
+                      "type": "cdp",
+                      "activation_supported": true
+                    },
+                    {
+                      "id": "mock_measurement",
+                      "name": "Mock Measurement Platform",
+                      "type": "measurement",
+                      "activation_supported": false
+                    }
+                  ],
+                  "limits": {
+                    "max_signals_per_request": 100,
+                    "max_rules_per_segment": 6
+                  }
+                },
+                "context": {
+                  "correlation_id": "capability_discovery--get_capabilities_filtered"
+                },
+                "ext": {
+                  "ucp": {
+                    "supported_spaces": [
+                      "openai-te3-small-d512-v1"
+                    ],
+                    "supported_encodings": [
+                      "float32"
+                    ],
+                    "dimensions": [
+                      512
+                    ],
+                    "embedding_endpoint_template": "/signals/{signal_id}/embedding",
+                    "similarity_search": true,
+                    "phase": "llm-v1",
+                    "gts_version": "adcp-gts-v1.0"
+                  }
+                },
+                "_message": "{\n  \"adcp\": {\n    \"major_versions\": [\n      2,\n      3\n    ],\n    \"idempotency\": {\n      \"replay_ttl_seconds\": 86400\n    }\n  },\n  \"supported_protocols\": [\n    \"signals\"\n  ],\n  \"signals\": {\n    \"signal_categories\": [\n      \"demographic\",\n      \"interest\",\n      \"purchase_intent\",\n      \"geo\",\n      \"composite\"\n    ],\n    \"dynamic_segment_generation\": true,\n    \"activation_mode\": \"async\",\n    \"provider\": \"AdCP Signals Adaptor - Demo Provider (Evgeny)\",\n    \"destinations\": [\n      {\n        \"id\": \"mock_dsp\",\n        \"name\": \"Mock DSP\",\n        \"type\": \"dsp\",\n        \"activation_supported\": true\n      },\n      {\n        \"id\": \"mock_cleanroom\",\n        \"name\": \"Mock Clean Room\",\n        \"type\": \"cleanroom\",\n        \"activation_supported\": true\n      },\n      {\n        \"id\": \"mock_cdp\",\n        \"name\": \"Mock CDP\",\n        \"type\": \"cdp\",\n        \"activation_supported\": true\n      },\n      {\n        \"id\": \"mock_measurement\",\n        \"name\": \"Mock Measurement Platform\",\n        \"type\": \"measurement\",\n        \"activation_supported\": false\n      }\n    ],\n    \"limits\": {\n      \"max_signals_per_request\": 100,\n      \"max_rules_per_segment\": 6\n    }\n  },\n  \"ext\": {\n    \"ucp\": {\n      \"supported_spaces\": [\n        \"openai-te3-small-d512-v1\"\n      ],\n      \"supported_encodings\": [\n        \"float32\"\n      ],\n      \"dimensions\": [\n        512\n      ],\n      \"embedding_endpoint_template\": \"/signals/{signal_id}/embedding\",\n      \"similarity_search\": true,\n      \"phase\": \"llm-v1\",\n      \"gts_version\": \"adcp-gts-v1.0\"\n    }\n  },\n  \"context\": {\n    \"correlation_id\": \"capability_discovery--get_capabilities_filtered\"\n  }\n}"
+              }
+            }
+          ],
+          "summary": "Protocol and capability discovery: all steps passed",
+          "total_duration_ms": 96,
+          "tested_at": "2026-04-19T11:21:22.255Z"
+        },
+        {
+          "agent_url": "https://adcp-signals-adaptor.evgeny-193.workers.dev/mcp",
+          "scenario": "deterministic_testing/capability_discovery",
+          "overall_passed": true,
+          "steps": [
+            {
+              "step": "Check agent capabilities",
+              "task": "get_adcp_capabilities",
+              "passed": true,
+              "duration_ms": 36,
+              "details": "✓ Response matches get-adcp-capabilities-response.json schema; ✓ Agent declares supported protocols; ✓ Response echoes back the context object; ✓ Context correlation_id returned unchanged",
+              "observation_data": {
+                "adcp": {
+                  "major_versions": [
+                    2,
+                    3
+                  ],
+                  "idempotency": {
+                    "replay_ttl_seconds": 86400
+                  }
+                },
+                "supported_protocols": [
+                  "signals"
+                ],
+                "signals": {
+                  "signal_categories": [
+                    "demographic",
+                    "interest",
+                    "purchase_intent",
+                    "geo",
+                    "composite"
+                  ],
+                  "dynamic_segment_generation": true,
+                  "activation_mode": "async",
+                  "provider": "AdCP Signals Adaptor - Demo Provider (Evgeny)",
+                  "destinations": [
+                    {
+                      "id": "mock_dsp",
+                      "name": "Mock DSP",
+                      "type": "dsp",
+                      "activation_supported": true
+                    },
+                    {
+                      "id": "mock_cleanroom",
+                      "name": "Mock Clean Room",
+                      "type": "cleanroom",
+                      "activation_supported": true
+                    },
+                    {
+                      "id": "mock_cdp",
+                      "name": "Mock CDP",
+                      "type": "cdp",
+                      "activation_supported": true
+                    },
+                    {
+                      "id": "mock_measurement",
+                      "name": "Mock Measurement Platform",
+                      "type": "measurement",
+                      "activation_supported": false
+                    }
+                  ],
+                  "limits": {
+                    "max_signals_per_request": 100,
+                    "max_rules_per_segment": 6
+                  }
+                },
+                "context": {
+                  "correlation_id": "deterministic_testing--get_capabilities"
+                },
+                "ext": {
+                  "ucp": {
+                    "supported_spaces": [
+                      "openai-te3-small-d512-v1"
+                    ],
+                    "supported_encodings": [
+                      "float32"
+                    ],
+                    "dimensions": [
+                      512
+                    ],
+                    "embedding_endpoint_template": "/signals/{signal_id}/embedding",
+                    "similarity_search": true,
+                    "phase": "llm-v1",
+                    "gts_version": "adcp-gts-v1.0"
+                  }
+                },
+                "_message": "{\n  \"adcp\": {\n    \"major_versions\": [\n      2,\n      3\n    ],\n    \"idempotency\": {\n      \"replay_ttl_seconds\": 86400\n    }\n  },\n  \"supported_protocols\": [\n    \"signals\"\n  ],\n  \"signals\": {\n    \"signal_categories\": [\n      \"demographic\",\n      \"interest\",\n      \"purchase_intent\",\n      \"geo\",\n      \"composite\"\n    ],\n    \"dynamic_segment_generation\": true,\n    \"activation_mode\": \"async\",\n    \"provider\": \"AdCP Signals Adaptor - Demo Provider (Evgeny)\",\n    \"destinations\": [\n      {\n        \"id\": \"mock_dsp\",\n        \"name\": \"Mock DSP\",\n        \"type\": \"dsp\",\n        \"activation_supported\": true\n      },\n      {\n        \"id\": \"mock_cleanroom\",\n        \"name\": \"Mock Clean Room\",\n        \"type\": \"cleanroom\",\n        \"activation_supported\": true\n      },\n      {\n        \"id\": \"mock_cdp\",\n        \"name\": \"Mock CDP\",\n        \"type\": \"cdp\",\n        \"activation_supported\": true\n      },\n      {\n        \"id\": \"mock_measurement\",\n        \"name\": \"Mock Measurement Platform\",\n        \"type\": \"measurement\",\n        \"activation_supported\": false\n      }\n    ],\n    \"limits\": {\n      \"max_signals_per_request\": 100,\n      \"max_rules_per_segment\": 6\n    }\n  },\n  \"ext\": {\n    \"ucp\": {\n      \"supported_spaces\": [\n        \"openai-te3-small-d512-v1\"\n      ],\n      \"supported_encodings\": [\n        \"float32\"\n      ],\n      \"dimensions\": [\n        512\n      ],\n      \"embedding_endpoint_template\": \"/signals/{signal_id}/embedding\",\n      \"similarity_search\": true,\n      \"phase\": \"llm-v1\",\n      \"gts_version\": \"adcp-gts-v1.0\"\n    }\n  },\n  \"context\": {\n    \"correlation_id\": \"deterministic_testing--get_capabilities\"\n  }\n}"
+              }
+            }
+          ],
+          "summary": "Capability discovery: all steps passed",
+          "total_duration_ms": 36,
+          "tested_at": "2026-04-19T11:21:22.294Z"
+        },
+        {
+          "agent_url": "https://adcp-signals-adaptor.evgeny-193.workers.dev/mcp",
+          "scenario": "deterministic_testing/controller_validation",
+          "overall_passed": true,
+          "steps": [
+            {
+              "step": "List supported scenarios",
+              "task": "comply_test_controller",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Not testable: requires comply_test_controller harness"
+              ]
+            },
+            {
+              "step": "Unknown scenario returns error",
+              "task": "comply_test_controller",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Not testable: requires comply_test_controller harness"
+              ]
+            },
+            {
+              "step": "Missing params returns error",
+              "task": "comply_test_controller",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Not testable: requires comply_test_controller harness"
+              ]
+            },
+            {
+              "step": "Nonexistent entity returns NOT_FOUND",
+              "task": "comply_test_controller",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Not testable: requires comply_test_controller harness"
+              ]
+            }
+          ],
+          "summary": "Controller validation: all steps passed",
+          "total_duration_ms": 1,
+          "tested_at": "2026-04-19T11:21:22.294Z"
+        },
+        {
+          "agent_url": "https://adcp-signals-adaptor.evgeny-193.workers.dev/mcp",
+          "scenario": "deterministic_testing/deterministic_account",
+          "overall_passed": true,
+          "steps": [
+            {
+              "step": "Create sandbox account for state machine test",
+              "task": "sync_accounts",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Not testable: requires comply_test_controller harness"
+              ]
+            },
+            {
+              "step": "Find account for state machine test",
+              "task": "list_accounts",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Not testable: requires comply_test_controller harness"
+              ]
+            },
+            {
+              "step": "Force account to suspended",
+              "task": "comply_test_controller",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Not testable: requires comply_test_controller harness"
+              ]
+            },
+            {
+              "step": "Reactivate account",
+              "task": "comply_test_controller",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Not testable: requires comply_test_controller harness"
+              ]
+            },
+            {
+              "step": "Force account to payment_required",
+              "task": "comply_test_controller",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Not testable: requires comply_test_controller harness"
+              ]
+            },
+            {
+              "step": "Restore account to active",
+              "task": "comply_test_controller",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Not testable: requires comply_test_controller harness"
+              ]
+            }
+          ],
+          "summary": "Deterministic account state machine: all steps passed",
+          "total_duration_ms": 0,
+          "tested_at": "2026-04-19T11:21:22.294Z"
+        },
+        {
+          "agent_url": "https://adcp-signals-adaptor.evgeny-193.workers.dev/mcp",
+          "scenario": "deterministic_testing/deterministic_media_buy",
+          "overall_passed": true,
+          "steps": [
+            {
+              "step": "Create media buy for state machine test",
+              "task": "create_media_buy",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Not testable: requires comply_test_controller harness"
+              ]
+            },
+            {
+              "step": "Force media buy to active",
+              "task": "comply_test_controller",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Not testable: requires comply_test_controller harness"
+              ]
+            },
+            {
+              "step": "Verify media buy status via get_media_buys",
+              "task": "get_media_buys",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Not testable: requires comply_test_controller harness"
+              ]
+            },
+            {
+              "step": "Force media buy to completed (terminal)",
+              "task": "comply_test_controller",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Not testable: requires comply_test_controller harness"
+              ]
+            },
+            {
+              "step": "Reject transition from terminal state",
+              "task": "comply_test_controller",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Not testable: requires comply_test_controller harness"
+              ]
+            }
+          ],
+          "summary": "Deterministic media buy state machine: all steps passed",
+          "total_duration_ms": 0,
+          "tested_at": "2026-04-19T11:21:22.294Z"
+        },
+        {
+          "agent_url": "https://adcp-signals-adaptor.evgeny-193.workers.dev/mcp",
+          "scenario": "deterministic_testing/deterministic_creative",
+          "overall_passed": true,
+          "steps": [
+            {
+              "step": "Sync creative for state machine test",
+              "task": "sync_creatives",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Not testable: requires comply_test_controller harness"
+              ]
+            },
+            {
+              "step": "Force creative to approved",
+              "task": "comply_test_controller",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Not testable: requires comply_test_controller harness"
+              ]
+            },
+            {
+              "step": "Force creative to archived (terminal)",
+              "task": "comply_test_controller",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Not testable: requires comply_test_controller harness"
+              ]
+            },
+            {
+              "step": "Reject archived to processing",
+              "task": "comply_test_controller",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Not testable: requires comply_test_controller harness"
+              ]
+            },
+            {
+              "step": "Force fresh creative to rejected with reason",
+              "task": "comply_test_controller",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Not testable: requires comply_test_controller harness"
+              ]
+            }
+          ],
+          "summary": "Deterministic creative state machine: all steps passed",
+          "total_duration_ms": 1,
+          "tested_at": "2026-04-19T11:21:22.294Z"
+        },
+        {
+          "agent_url": "https://adcp-signals-adaptor.evgeny-193.workers.dev/mcp",
+          "scenario": "deterministic_testing/deterministic_session",
+          "overall_passed": true,
+          "steps": [
+            {
+              "step": "Initiate SI session",
+              "task": "si_initiate_session",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Not testable: agent lacks required tool"
+              ]
+            },
+            {
+              "step": "Force session timeout",
+              "task": "comply_test_controller",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Not testable: requires comply_test_controller harness"
+              ]
+            },
+            {
+              "step": "Verify messaging fails on terminated session",
+              "task": "si_send_message",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Not testable: requires comply_test_controller harness"
+              ]
+            }
+          ],
+          "summary": "Deterministic SI session state machine: all steps passed",
+          "total_duration_ms": 0,
+          "tested_at": "2026-04-19T11:21:22.294Z"
+        },
+        {
+          "agent_url": "https://adcp-signals-adaptor.evgeny-193.workers.dev/mcp",
+          "scenario": "deterministic_testing/deterministic_delivery",
+          "overall_passed": true,
+          "steps": [
+            {
+              "step": "Create media buy for delivery test",
+              "task": "create_media_buy",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Not testable: requires comply_test_controller harness"
+              ]
+            },
+            {
+              "step": "Simulate delivery data",
+              "task": "comply_test_controller",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Not testable: requires comply_test_controller harness"
+              ]
+            },
+            {
+              "step": "Verify delivery via get_media_buy_delivery",
+              "task": "get_media_buy_delivery",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Not testable: requires comply_test_controller harness"
+              ]
+            }
+          ],
+          "summary": "Deterministic delivery simulation: all steps passed",
+          "total_duration_ms": 0,
+          "tested_at": "2026-04-19T11:21:22.294Z"
+        },
+        {
+          "agent_url": "https://adcp-signals-adaptor.evgeny-193.workers.dev/mcp",
+          "scenario": "deterministic_testing/deterministic_budget",
+          "overall_passed": true,
+          "steps": [
+            {
+              "step": "Create media buy for budget test",
+              "task": "create_media_buy",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Not testable: requires comply_test_controller harness"
+              ]
+            },
+            {
+              "step": "Simulate 95% budget spend",
+              "task": "comply_test_controller",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Not testable: requires comply_test_controller harness"
+              ]
+            },
+            {
+              "step": "Simulate 100% budget depletion",
+              "task": "comply_test_controller",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Not testable: requires comply_test_controller harness"
+              ]
+            }
+          ],
+          "summary": "Deterministic budget simulation: all steps passed",
+          "total_duration_ms": 1,
+          "tested_at": "2026-04-19T11:21:22.294Z"
+        },
+        {
+          "agent_url": "https://adcp-signals-adaptor.evgeny-193.workers.dev/mcp",
+          "scenario": "schema_validation/capability_discovery",
+          "overall_passed": true,
+          "steps": [
+            {
+              "step": "Check agent capabilities",
+              "task": "get_adcp_capabilities",
+              "passed": true,
+              "duration_ms": 35,
+              "details": "✓ Response matches get-adcp-capabilities-response.json schema; ✓ Agent declares supported protocols; ✓ Response echoes back the context object; ✓ Context correlation_id returned unchanged",
+              "observation_data": {
+                "adcp": {
+                  "major_versions": [
+                    2,
+                    3
+                  ],
+                  "idempotency": {
+                    "replay_ttl_seconds": 86400
+                  }
+                },
+                "supported_protocols": [
+                  "signals"
+                ],
+                "signals": {
+                  "signal_categories": [
+                    "demographic",
+                    "interest",
+                    "purchase_intent",
+                    "geo",
+                    "composite"
+                  ],
+                  "dynamic_segment_generation": true,
+                  "activation_mode": "async",
+                  "provider": "AdCP Signals Adaptor - Demo Provider (Evgeny)",
+                  "destinations": [
+                    {
+                      "id": "mock_dsp",
+                      "name": "Mock DSP",
+                      "type": "dsp",
+                      "activation_supported": true
+                    },
+                    {
+                      "id": "mock_cleanroom",
+                      "name": "Mock Clean Room",
+                      "type": "cleanroom",
+                      "activation_supported": true
+                    },
+                    {
+                      "id": "mock_cdp",
+                      "name": "Mock CDP",
+                      "type": "cdp",
+                      "activation_supported": true
+                    },
+                    {
+                      "id": "mock_measurement",
+                      "name": "Mock Measurement Platform",
+                      "type": "measurement",
+                      "activation_supported": false
+                    }
+                  ],
+                  "limits": {
+                    "max_signals_per_request": 100,
+                    "max_rules_per_segment": 6
+                  }
+                },
+                "context": {
+                  "correlation_id": "schema_validation--get_capabilities"
+                },
+                "ext": {
+                  "ucp": {
+                    "supported_spaces": [
+                      "openai-te3-small-d512-v1"
+                    ],
+                    "supported_encodings": [
+                      "float32"
+                    ],
+                    "dimensions": [
+                      512
+                    ],
+                    "embedding_endpoint_template": "/signals/{signal_id}/embedding",
+                    "similarity_search": true,
+                    "phase": "llm-v1",
+                    "gts_version": "adcp-gts-v1.0"
+                  }
+                },
+                "_message": "{\n  \"adcp\": {\n    \"major_versions\": [\n      2,\n      3\n    ],\n    \"idempotency\": {\n      \"replay_ttl_seconds\": 86400\n    }\n  },\n  \"supported_protocols\": [\n    \"signals\"\n  ],\n  \"signals\": {\n    \"signal_categories\": [\n      \"demographic\",\n      \"interest\",\n      \"purchase_intent\",\n      \"geo\",\n      \"composite\"\n    ],\n    \"dynamic_segment_generation\": true,\n    \"activation_mode\": \"async\",\n    \"provider\": \"AdCP Signals Adaptor - Demo Provider (Evgeny)\",\n    \"destinations\": [\n      {\n        \"id\": \"mock_dsp\",\n        \"name\": \"Mock DSP\",\n        \"type\": \"dsp\",\n        \"activation_supported\": true\n      },\n      {\n        \"id\": \"mock_cleanroom\",\n        \"name\": \"Mock Clean Room\",\n        \"type\": \"cleanroom\",\n        \"activation_supported\": true\n      },\n      {\n        \"id\": \"mock_cdp\",\n        \"name\": \"Mock CDP\",\n        \"type\": \"cdp\",\n        \"activation_supported\": true\n      },\n      {\n        \"id\": \"mock_measurement\",\n        \"name\": \"Mock Measurement Platform\",\n        \"type\": \"measurement\",\n        \"activation_supported\": false\n      }\n    ],\n    \"limits\": {\n      \"max_signals_per_request\": 100,\n      \"max_rules_per_segment\": 6\n    }\n  },\n  \"ext\": {\n    \"ucp\": {\n      \"supported_spaces\": [\n        \"openai-te3-small-d512-v1\"\n      ],\n      \"supported_encodings\": [\n        \"float32\"\n      ],\n      \"dimensions\": [\n        512\n      ],\n      \"embedding_endpoint_template\": \"/signals/{signal_id}/embedding\",\n      \"similarity_search\": true,\n      \"phase\": \"llm-v1\",\n      \"gts_version\": \"adcp-gts-v1.0\"\n    }\n  },\n  \"context\": {\n    \"correlation_id\": \"schema_validation--get_capabilities\"\n  }\n}"
+              }
+            }
+          ],
+          "summary": "Capability discovery: all steps passed",
+          "total_duration_ms": 35,
+          "tested_at": "2026-04-19T11:21:22.375Z"
+        },
+        {
+          "agent_url": "https://adcp-signals-adaptor.evgeny-193.workers.dev/mcp",
+          "scenario": "schema_validation/schema_compliance",
+          "overall_passed": true,
+          "steps": [
+            {
+              "step": "Validate get_products response schema",
+              "task": "get_products",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Skipped: agent does not implement this tool"
+              ]
+            },
+            {
+              "step": "Validate pricing options structure",
+              "task": "get_products",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Skipped: agent does not implement this tool"
+              ]
+            }
+          ],
+          "summary": "Response schema compliance: all steps passed",
+          "total_duration_ms": 0,
+          "tested_at": "2026-04-19T11:21:22.375Z"
+        },
+        {
+          "agent_url": "https://adcp-signals-adaptor.evgeny-193.workers.dev/mcp",
+          "scenario": "schema_validation/format_id_reconciliation",
+          "overall_passed": true,
+          "steps": [
+            {
+              "step": "Get products and verify identifiers",
+              "task": "get_products",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Skipped: agent does not implement this tool"
+              ]
+            },
+            {
+              "step": "Verify format catalog includes product formats",
+              "task": "list_creative_formats",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Skipped: agent does not implement this tool"
+              ]
+            }
+          ],
+          "summary": "Format ID and pricing option reconciliation: all steps passed",
+          "total_duration_ms": 0,
+          "tested_at": "2026-04-19T11:21:22.375Z"
+        },
+        {
+          "agent_url": "https://adcp-signals-adaptor.evgeny-193.workers.dev/mcp",
+          "scenario": "schema_validation/temporal_validation",
+          "overall_passed": true,
+          "steps": [
+            {
+              "step": "Reject reversed flight dates",
+              "task": "create_media_buy",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Skipped: agent does not implement this tool"
+              ]
+            },
+            {
+              "step": "Handle past start date",
+              "task": "create_media_buy",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Skipped: agent does not implement this tool"
+              ]
+            }
+          ],
+          "summary": "Temporal constraint enforcement: all steps passed",
+          "total_duration_ms": 0,
+          "tested_at": "2026-04-19T11:21:22.375Z"
+        }
+      ],
+      "skipped_scenarios": [],
+      "observations": [],
+      "duration_ms": 171,
+      "mode": "deterministic"
+    },
+    {
+      "track": "error_handling",
+      "status": "pass",
+      "label": "Error Handling",
+      "scenarios": [
+        {
+          "agent_url": "https://adcp-signals-adaptor.evgeny-193.workers.dev/mcp",
+          "scenario": "error_compliance/capability_discovery",
+          "overall_passed": true,
+          "steps": [
+            {
+              "step": "Check agent capabilities",
+              "task": "get_adcp_capabilities",
+              "passed": true,
+              "duration_ms": 45,
+              "details": "✓ Response matches get-adcp-capabilities-response.json schema; ✓ Agent declares supported protocols; ✓ Response echoes back the context object; ✓ Context correlation_id returned unchanged",
+              "observation_data": {
+                "adcp": {
+                  "major_versions": [
+                    2,
+                    3
+                  ],
+                  "idempotency": {
+                    "replay_ttl_seconds": 86400
+                  }
+                },
+                "supported_protocols": [
+                  "signals"
+                ],
+                "signals": {
+                  "signal_categories": [
+                    "demographic",
+                    "interest",
+                    "purchase_intent",
+                    "geo",
+                    "composite"
+                  ],
+                  "dynamic_segment_generation": true,
+                  "activation_mode": "async",
+                  "provider": "AdCP Signals Adaptor - Demo Provider (Evgeny)",
+                  "destinations": [
+                    {
+                      "id": "mock_dsp",
+                      "name": "Mock DSP",
+                      "type": "dsp",
+                      "activation_supported": true
+                    },
+                    {
+                      "id": "mock_cleanroom",
+                      "name": "Mock Clean Room",
+                      "type": "cleanroom",
+                      "activation_supported": true
+                    },
+                    {
+                      "id": "mock_cdp",
+                      "name": "Mock CDP",
+                      "type": "cdp",
+                      "activation_supported": true
+                    },
+                    {
+                      "id": "mock_measurement",
+                      "name": "Mock Measurement Platform",
+                      "type": "measurement",
+                      "activation_supported": false
+                    }
+                  ],
+                  "limits": {
+                    "max_signals_per_request": 100,
+                    "max_rules_per_segment": 6
+                  }
+                },
+                "context": {
+                  "correlation_id": "error_compliance--get_capabilities"
+                },
+                "ext": {
+                  "ucp": {
+                    "supported_spaces": [
+                      "openai-te3-small-d512-v1"
+                    ],
+                    "supported_encodings": [
+                      "float32"
+                    ],
+                    "dimensions": [
+                      512
+                    ],
+                    "embedding_endpoint_template": "/signals/{signal_id}/embedding",
+                    "similarity_search": true,
+                    "phase": "llm-v1",
+                    "gts_version": "adcp-gts-v1.0"
+                  }
+                },
+                "_message": "{\n  \"adcp\": {\n    \"major_versions\": [\n      2,\n      3\n    ],\n    \"idempotency\": {\n      \"replay_ttl_seconds\": 86400\n    }\n  },\n  \"supported_protocols\": [\n    \"signals\"\n  ],\n  \"signals\": {\n    \"signal_categories\": [\n      \"demographic\",\n      \"interest\",\n      \"purchase_intent\",\n      \"geo\",\n      \"composite\"\n    ],\n    \"dynamic_segment_generation\": true,\n    \"activation_mode\": \"async\",\n    \"provider\": \"AdCP Signals Adaptor - Demo Provider (Evgeny)\",\n    \"destinations\": [\n      {\n        \"id\": \"mock_dsp\",\n        \"name\": \"Mock DSP\",\n        \"type\": \"dsp\",\n        \"activation_supported\": true\n      },\n      {\n        \"id\": \"mock_cleanroom\",\n        \"name\": \"Mock Clean Room\",\n        \"type\": \"cleanroom\",\n        \"activation_supported\": true\n      },\n      {\n        \"id\": \"mock_cdp\",\n        \"name\": \"Mock CDP\",\n        \"type\": \"cdp\",\n        \"activation_supported\": true\n      },\n      {\n        \"id\": \"mock_measurement\",\n        \"name\": \"Mock Measurement Platform\",\n        \"type\": \"measurement\",\n        \"activation_supported\": false\n      }\n    ],\n    \"limits\": {\n      \"max_signals_per_request\": 100,\n      \"max_rules_per_segment\": 6\n    }\n  },\n  \"ext\": {\n    \"ucp\": {\n      \"supported_spaces\": [\n        \"openai-te3-small-d512-v1\"\n      ],\n      \"supported_encodings\": [\n        \"float32\"\n      ],\n      \"dimensions\": [\n        512\n      ],\n      \"embedding_endpoint_template\": \"/signals/{signal_id}/embedding\",\n      \"similarity_search\": true,\n      \"phase\": \"llm-v1\",\n      \"gts_version\": \"adcp-gts-v1.0\"\n    }\n  },\n  \"context\": {\n    \"correlation_id\": \"error_compliance--get_capabilities\"\n  }\n}"
+              }
+            }
+          ],
+          "summary": "Capability discovery: all steps passed",
+          "total_duration_ms": 45,
+          "tested_at": "2026-04-19T11:21:22.340Z"
+        },
+        {
+          "agent_url": "https://adcp-signals-adaptor.evgeny-193.workers.dev/mcp",
+          "scenario": "error_compliance/error_responses",
+          "overall_passed": true,
+          "steps": [
+            {
+              "step": "Reject negative budget",
+              "task": "create_media_buy",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Skipped: agent does not implement this tool"
+              ]
+            },
+            {
+              "step": "Reject nonexistent product ID",
+              "task": "create_media_buy",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Skipped: agent does not implement this tool"
+              ]
+            },
+            {
+              "step": "Reject empty get_products request",
+              "task": "get_products",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Skipped: agent does not implement this tool"
+              ]
+            },
+            {
+              "step": "Reject reversed dates with error code",
+              "task": "create_media_buy",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Skipped: agent does not implement this tool"
+              ]
+            }
+          ],
+          "summary": "Error responses for invalid input: all steps passed",
+          "total_duration_ms": 0,
+          "tested_at": "2026-04-19T11:21:22.340Z"
+        },
+        {
+          "agent_url": "https://adcp-signals-adaptor.evgeny-193.workers.dev/mcp",
+          "scenario": "error_compliance/error_structure",
+          "overall_passed": true,
+          "steps": [
+            {
+              "step": "Validate error response structure",
+              "task": "create_media_buy",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Skipped: agent does not implement this tool"
+              ]
+            }
+          ],
+          "summary": "Error structure compliance: all steps passed",
+          "total_duration_ms": 1,
+          "tested_at": "2026-04-19T11:21:22.340Z"
+        },
+        {
+          "agent_url": "https://adcp-signals-adaptor.evgeny-193.workers.dev/mcp",
+          "scenario": "error_compliance/version_negotiation",
+          "overall_passed": true,
+          "steps": [
+            {
+              "step": "Reject unsupported adcp_major_version",
+              "task": "get_products",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Skipped: agent does not implement this tool"
+              ]
+            },
+            {
+              "step": "Accept supported adcp_major_version",
+              "task": "get_products",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Skipped: agent does not implement this tool"
+              ]
+            }
+          ],
+          "summary": "Protocol version validation: all steps passed",
+          "total_duration_ms": 0,
+          "tested_at": "2026-04-19T11:21:22.340Z"
+        },
+        {
+          "agent_url": "https://adcp-signals-adaptor.evgeny-193.workers.dev/mcp",
+          "scenario": "error_compliance/error_transport",
+          "overall_passed": true,
+          "steps": [
+            {
+              "step": "Validate error transport binding",
+              "task": "create_media_buy",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Skipped: agent does not implement this tool"
+              ]
+            }
+          ],
+          "summary": "Error transport bindings: all steps passed",
+          "total_duration_ms": 0,
+          "tested_at": "2026-04-19T11:21:22.340Z"
+        }
+      ],
+      "skipped_scenarios": [],
+      "observations": [],
+      "duration_ms": 46,
+      "mode": "observational"
+    }
+  ],
+  "skipped_tracks": [
+    {
+      "track": "signals",
+      "label": "Signals",
+      "reason": "No storyboards produced results for this track"
+    }
+  ],
+  "summary": {
+    "tracks_passed": 2,
+    "tracks_failed": 0,
+    "tracks_skipped": 1,
+    "tracks_partial": 0,
+    "headline": "All 2 track(s) pass"
+  },
+  "observations": [
+    {
+      "category": "tool_discovery",
+      "severity": "info",
+      "message": "Discovered 8 tools: [get_adcp_capabilities, get_signals, activate_signal, get_operation_status, get_similar_signals, query_signals_nl, get_concept, search_concepts]",
+      "evidence": {
+        "tools": [
+          "get_adcp_capabilities",
+          "get_signals",
+          "activate_signal",
+          "get_operation_status",
+          "get_similar_signals",
+          "query_signals_nl",
+          "get_concept",
+          "search_concepts"
+        ]
+      }
+    }
+  ],
+  "storyboards_executed": [
+    "capability_discovery",
+    "deterministic_testing",
+    "error_compliance",
+    "schema_validation",
+    "signals_baseline"
+  ],
+  "controller_detected": false,
+  "tested_at": "2026-04-19T11:21:22.382Z",
+  "total_duration_ms": 2131
+}

--- a/storyboard_report_post_upstream.json
+++ b/storyboard_report_post_upstream.json
@@ -1,0 +1,2098 @@
+{
+  "agent_url": "https://adcp-signals-adaptor.evgeny-193.workers.dev/mcp",
+  "agent_profile": {
+    "name": "E2E Test Client",
+    "tools": [
+      "get_adcp_capabilities",
+      "get_signals",
+      "activate_signal",
+      "get_operation_status",
+      "get_similar_signals",
+      "query_signals_nl",
+      "get_concept",
+      "search_concepts"
+    ],
+    "adcp_version": "v3",
+    "supported_protocols": [
+      "signals"
+    ],
+    "supports_governance": false,
+    "supports_si": false
+  },
+  "overall_status": "passing",
+  "tracks": [
+    {
+      "track": "core",
+      "status": "pass",
+      "label": "Core Protocol",
+      "scenarios": [
+        {
+          "agent_url": "https://adcp-signals-adaptor.evgeny-193.workers.dev/mcp",
+          "scenario": "capability_discovery/protocol_discovery",
+          "overall_passed": true,
+          "steps": [
+            {
+              "step": "Discover agent capabilities",
+              "task": "get_adcp_capabilities",
+              "passed": true,
+              "duration_ms": 31,
+              "details": "✓ Response matches get-adcp-capabilities-response.json schema; ✓ Agent declares supported protocol versions; ✓ Agent declares which protocol domains it supports; ✓ Response echoes back the context object; ✓ Context correlation_id returned unchanged",
+              "observation_data": {
+                "adcp": {
+                  "major_versions": [
+                    2,
+                    3
+                  ],
+                  "idempotency": {
+                    "replay_ttl_seconds": 86400
+                  }
+                },
+                "supported_protocols": [
+                  "signals"
+                ],
+                "signals": {
+                  "signal_categories": [
+                    "demographic",
+                    "interest",
+                    "purchase_intent",
+                    "geo",
+                    "composite"
+                  ],
+                  "dynamic_segment_generation": true,
+                  "activation_mode": "async",
+                  "provider": "AdCP Signals Adaptor - Demo Provider (Evgeny)",
+                  "destinations": [
+                    {
+                      "id": "mock_dsp",
+                      "name": "Mock DSP",
+                      "type": "dsp",
+                      "activation_supported": true
+                    },
+                    {
+                      "id": "mock_cleanroom",
+                      "name": "Mock Clean Room",
+                      "type": "cleanroom",
+                      "activation_supported": true
+                    },
+                    {
+                      "id": "mock_cdp",
+                      "name": "Mock CDP",
+                      "type": "cdp",
+                      "activation_supported": true
+                    },
+                    {
+                      "id": "mock_measurement",
+                      "name": "Mock Measurement Platform",
+                      "type": "measurement",
+                      "activation_supported": false
+                    }
+                  ],
+                  "limits": {
+                    "max_signals_per_request": 100,
+                    "max_rules_per_segment": 6
+                  }
+                },
+                "context": {
+                  "correlation_id": "capability_discovery--get_capabilities"
+                },
+                "ext": {
+                  "ucp": {
+                    "supported_spaces": [
+                      "openai-te3-small-d512-v1"
+                    ],
+                    "supported_encodings": [
+                      "float32"
+                    ],
+                    "dimensions": [
+                      512
+                    ],
+                    "embedding_endpoint_template": "/signals/{signal_id}/embedding",
+                    "similarity_search": true,
+                    "phase": "llm-v1",
+                    "gts_version": "adcp-gts-v1.0"
+                  }
+                },
+                "_message": "{\n  \"adcp\": {\n    \"major_versions\": [\n      2,\n      3\n    ],\n    \"idempotency\": {\n      \"replay_ttl_seconds\": 86400\n    }\n  },\n  \"supported_protocols\": [\n    \"signals\"\n  ],\n  \"signals\": {\n    \"signal_categories\": [\n      \"demographic\",\n      \"interest\",\n      \"purchase_intent\",\n      \"geo\",\n      \"composite\"\n    ],\n    \"dynamic_segment_generation\": true,\n    \"activation_mode\": \"async\",\n    \"provider\": \"AdCP Signals Adaptor - Demo Provider (Evgeny)\",\n    \"destinations\": [\n      {\n        \"id\": \"mock_dsp\",\n        \"name\": \"Mock DSP\",\n        \"type\": \"dsp\",\n        \"activation_supported\": true\n      },\n      {\n        \"id\": \"mock_cleanroom\",\n        \"name\": \"Mock Clean Room\",\n        \"type\": \"cleanroom\",\n        \"activation_supported\": true\n      },\n      {\n        \"id\": \"mock_cdp\",\n        \"name\": \"Mock CDP\",\n        \"type\": \"cdp\",\n        \"activation_supported\": true\n      },\n      {\n        \"id\": \"mock_measurement\",\n        \"name\": \"Mock Measurement Platform\",\n        \"type\": \"measurement\",\n        \"activation_supported\": false\n      }\n    ],\n    \"limits\": {\n      \"max_signals_per_request\": 100,\n      \"max_rules_per_segment\": 6\n    }\n  },\n  \"ext\": {\n    \"ucp\": {\n      \"supported_spaces\": [\n        \"openai-te3-small-d512-v1\"\n      ],\n      \"supported_encodings\": [\n        \"float32\"\n      ],\n      \"dimensions\": [\n        512\n      ],\n      \"embedding_endpoint_template\": \"/signals/{signal_id}/embedding\",\n      \"similarity_search\": true,\n      \"phase\": \"llm-v1\",\n      \"gts_version\": \"adcp-gts-v1.0\"\n    }\n  },\n  \"context\": {\n    \"correlation_id\": \"capability_discovery--get_capabilities\"\n  }\n}"
+              }
+            },
+            {
+              "step": "Discover capabilities filtered by protocol",
+              "task": "get_adcp_capabilities",
+              "passed": true,
+              "duration_ms": 36,
+              "details": "✓ Response matches get-adcp-capabilities-response.json schema; ✓ Response echoes back the context object; ✓ Context correlation_id returned unchanged",
+              "observation_data": {
+                "adcp": {
+                  "major_versions": [
+                    2,
+                    3
+                  ],
+                  "idempotency": {
+                    "replay_ttl_seconds": 86400
+                  }
+                },
+                "supported_protocols": [
+                  "signals"
+                ],
+                "signals": {
+                  "signal_categories": [
+                    "demographic",
+                    "interest",
+                    "purchase_intent",
+                    "geo",
+                    "composite"
+                  ],
+                  "dynamic_segment_generation": true,
+                  "activation_mode": "async",
+                  "provider": "AdCP Signals Adaptor - Demo Provider (Evgeny)",
+                  "destinations": [
+                    {
+                      "id": "mock_dsp",
+                      "name": "Mock DSP",
+                      "type": "dsp",
+                      "activation_supported": true
+                    },
+                    {
+                      "id": "mock_cleanroom",
+                      "name": "Mock Clean Room",
+                      "type": "cleanroom",
+                      "activation_supported": true
+                    },
+                    {
+                      "id": "mock_cdp",
+                      "name": "Mock CDP",
+                      "type": "cdp",
+                      "activation_supported": true
+                    },
+                    {
+                      "id": "mock_measurement",
+                      "name": "Mock Measurement Platform",
+                      "type": "measurement",
+                      "activation_supported": false
+                    }
+                  ],
+                  "limits": {
+                    "max_signals_per_request": 100,
+                    "max_rules_per_segment": 6
+                  }
+                },
+                "context": {
+                  "correlation_id": "capability_discovery--get_capabilities_filtered"
+                },
+                "ext": {
+                  "ucp": {
+                    "supported_spaces": [
+                      "openai-te3-small-d512-v1"
+                    ],
+                    "supported_encodings": [
+                      "float32"
+                    ],
+                    "dimensions": [
+                      512
+                    ],
+                    "embedding_endpoint_template": "/signals/{signal_id}/embedding",
+                    "similarity_search": true,
+                    "phase": "llm-v1",
+                    "gts_version": "adcp-gts-v1.0"
+                  }
+                },
+                "_message": "{\n  \"adcp\": {\n    \"major_versions\": [\n      2,\n      3\n    ],\n    \"idempotency\": {\n      \"replay_ttl_seconds\": 86400\n    }\n  },\n  \"supported_protocols\": [\n    \"signals\"\n  ],\n  \"signals\": {\n    \"signal_categories\": [\n      \"demographic\",\n      \"interest\",\n      \"purchase_intent\",\n      \"geo\",\n      \"composite\"\n    ],\n    \"dynamic_segment_generation\": true,\n    \"activation_mode\": \"async\",\n    \"provider\": \"AdCP Signals Adaptor - Demo Provider (Evgeny)\",\n    \"destinations\": [\n      {\n        \"id\": \"mock_dsp\",\n        \"name\": \"Mock DSP\",\n        \"type\": \"dsp\",\n        \"activation_supported\": true\n      },\n      {\n        \"id\": \"mock_cleanroom\",\n        \"name\": \"Mock Clean Room\",\n        \"type\": \"cleanroom\",\n        \"activation_supported\": true\n      },\n      {\n        \"id\": \"mock_cdp\",\n        \"name\": \"Mock CDP\",\n        \"type\": \"cdp\",\n        \"activation_supported\": true\n      },\n      {\n        \"id\": \"mock_measurement\",\n        \"name\": \"Mock Measurement Platform\",\n        \"type\": \"measurement\",\n        \"activation_supported\": false\n      }\n    ],\n    \"limits\": {\n      \"max_signals_per_request\": 100,\n      \"max_rules_per_segment\": 6\n    }\n  },\n  \"ext\": {\n    \"ucp\": {\n      \"supported_spaces\": [\n        \"openai-te3-small-d512-v1\"\n      ],\n      \"supported_encodings\": [\n        \"float32\"\n      ],\n      \"dimensions\": [\n        512\n      ],\n      \"embedding_endpoint_template\": \"/signals/{signal_id}/embedding\",\n      \"similarity_search\": true,\n      \"phase\": \"llm-v1\",\n      \"gts_version\": \"adcp-gts-v1.0\"\n    }\n  },\n  \"context\": {\n    \"correlation_id\": \"capability_discovery--get_capabilities_filtered\"\n  }\n}"
+              }
+            }
+          ],
+          "summary": "Protocol and capability discovery: all steps passed",
+          "total_duration_ms": 71,
+          "tested_at": "2026-04-19T19:32:28.285Z"
+        },
+        {
+          "agent_url": "https://adcp-signals-adaptor.evgeny-193.workers.dev/mcp",
+          "scenario": "deterministic_testing/capability_discovery",
+          "overall_passed": true,
+          "steps": [
+            {
+              "step": "Check agent capabilities",
+              "task": "get_adcp_capabilities",
+              "passed": true,
+              "duration_ms": 30,
+              "details": "✓ Response matches get-adcp-capabilities-response.json schema; ✓ Agent declares supported protocols; ✓ Response echoes back the context object; ✓ Context correlation_id returned unchanged",
+              "observation_data": {
+                "adcp": {
+                  "major_versions": [
+                    2,
+                    3
+                  ],
+                  "idempotency": {
+                    "replay_ttl_seconds": 86400
+                  }
+                },
+                "supported_protocols": [
+                  "signals"
+                ],
+                "signals": {
+                  "signal_categories": [
+                    "demographic",
+                    "interest",
+                    "purchase_intent",
+                    "geo",
+                    "composite"
+                  ],
+                  "dynamic_segment_generation": true,
+                  "activation_mode": "async",
+                  "provider": "AdCP Signals Adaptor - Demo Provider (Evgeny)",
+                  "destinations": [
+                    {
+                      "id": "mock_dsp",
+                      "name": "Mock DSP",
+                      "type": "dsp",
+                      "activation_supported": true
+                    },
+                    {
+                      "id": "mock_cleanroom",
+                      "name": "Mock Clean Room",
+                      "type": "cleanroom",
+                      "activation_supported": true
+                    },
+                    {
+                      "id": "mock_cdp",
+                      "name": "Mock CDP",
+                      "type": "cdp",
+                      "activation_supported": true
+                    },
+                    {
+                      "id": "mock_measurement",
+                      "name": "Mock Measurement Platform",
+                      "type": "measurement",
+                      "activation_supported": false
+                    }
+                  ],
+                  "limits": {
+                    "max_signals_per_request": 100,
+                    "max_rules_per_segment": 6
+                  }
+                },
+                "context": {
+                  "correlation_id": "deterministic_testing--get_capabilities"
+                },
+                "ext": {
+                  "ucp": {
+                    "supported_spaces": [
+                      "openai-te3-small-d512-v1"
+                    ],
+                    "supported_encodings": [
+                      "float32"
+                    ],
+                    "dimensions": [
+                      512
+                    ],
+                    "embedding_endpoint_template": "/signals/{signal_id}/embedding",
+                    "similarity_search": true,
+                    "phase": "llm-v1",
+                    "gts_version": "adcp-gts-v1.0"
+                  }
+                },
+                "_message": "{\n  \"adcp\": {\n    \"major_versions\": [\n      2,\n      3\n    ],\n    \"idempotency\": {\n      \"replay_ttl_seconds\": 86400\n    }\n  },\n  \"supported_protocols\": [\n    \"signals\"\n  ],\n  \"signals\": {\n    \"signal_categories\": [\n      \"demographic\",\n      \"interest\",\n      \"purchase_intent\",\n      \"geo\",\n      \"composite\"\n    ],\n    \"dynamic_segment_generation\": true,\n    \"activation_mode\": \"async\",\n    \"provider\": \"AdCP Signals Adaptor - Demo Provider (Evgeny)\",\n    \"destinations\": [\n      {\n        \"id\": \"mock_dsp\",\n        \"name\": \"Mock DSP\",\n        \"type\": \"dsp\",\n        \"activation_supported\": true\n      },\n      {\n        \"id\": \"mock_cleanroom\",\n        \"name\": \"Mock Clean Room\",\n        \"type\": \"cleanroom\",\n        \"activation_supported\": true\n      },\n      {\n        \"id\": \"mock_cdp\",\n        \"name\": \"Mock CDP\",\n        \"type\": \"cdp\",\n        \"activation_supported\": true\n      },\n      {\n        \"id\": \"mock_measurement\",\n        \"name\": \"Mock Measurement Platform\",\n        \"type\": \"measurement\",\n        \"activation_supported\": false\n      }\n    ],\n    \"limits\": {\n      \"max_signals_per_request\": 100,\n      \"max_rules_per_segment\": 6\n    }\n  },\n  \"ext\": {\n    \"ucp\": {\n      \"supported_spaces\": [\n        \"openai-te3-small-d512-v1\"\n      ],\n      \"supported_encodings\": [\n        \"float32\"\n      ],\n      \"dimensions\": [\n        512\n      ],\n      \"embedding_endpoint_template\": \"/signals/{signal_id}/embedding\",\n      \"similarity_search\": true,\n      \"phase\": \"llm-v1\",\n      \"gts_version\": \"adcp-gts-v1.0\"\n    }\n  },\n  \"context\": {\n    \"correlation_id\": \"deterministic_testing--get_capabilities\"\n  }\n}"
+              }
+            }
+          ],
+          "summary": "Capability discovery: all steps passed",
+          "total_duration_ms": 30,
+          "tested_at": "2026-04-19T19:32:28.317Z"
+        },
+        {
+          "agent_url": "https://adcp-signals-adaptor.evgeny-193.workers.dev/mcp",
+          "scenario": "deterministic_testing/controller_validation",
+          "overall_passed": true,
+          "steps": [
+            {
+              "step": "List supported scenarios",
+              "task": "comply_test_controller",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Not testable: requires comply_test_controller harness"
+              ]
+            },
+            {
+              "step": "Unknown scenario returns error",
+              "task": "comply_test_controller",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Not testable: requires comply_test_controller harness"
+              ]
+            },
+            {
+              "step": "Missing params returns error",
+              "task": "comply_test_controller",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Not testable: requires comply_test_controller harness"
+              ]
+            },
+            {
+              "step": "Nonexistent entity returns NOT_FOUND",
+              "task": "comply_test_controller",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Not testable: requires comply_test_controller harness"
+              ]
+            }
+          ],
+          "summary": "Controller validation: all steps passed",
+          "total_duration_ms": 1,
+          "tested_at": "2026-04-19T19:32:28.317Z"
+        },
+        {
+          "agent_url": "https://adcp-signals-adaptor.evgeny-193.workers.dev/mcp",
+          "scenario": "deterministic_testing/deterministic_account",
+          "overall_passed": true,
+          "steps": [
+            {
+              "step": "Create sandbox account for state machine test",
+              "task": "sync_accounts",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Not testable: requires comply_test_controller harness"
+              ]
+            },
+            {
+              "step": "Find account for state machine test",
+              "task": "list_accounts",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Not testable: requires comply_test_controller harness"
+              ]
+            },
+            {
+              "step": "Force account to suspended",
+              "task": "comply_test_controller",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Not testable: requires comply_test_controller harness"
+              ]
+            },
+            {
+              "step": "Reactivate account",
+              "task": "comply_test_controller",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Not testable: requires comply_test_controller harness"
+              ]
+            },
+            {
+              "step": "Force account to payment_required",
+              "task": "comply_test_controller",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Not testable: requires comply_test_controller harness"
+              ]
+            },
+            {
+              "step": "Restore account to active",
+              "task": "comply_test_controller",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Not testable: requires comply_test_controller harness"
+              ]
+            }
+          ],
+          "summary": "Deterministic account state machine: all steps passed",
+          "total_duration_ms": 0,
+          "tested_at": "2026-04-19T19:32:28.317Z"
+        },
+        {
+          "agent_url": "https://adcp-signals-adaptor.evgeny-193.workers.dev/mcp",
+          "scenario": "deterministic_testing/deterministic_media_buy",
+          "overall_passed": true,
+          "steps": [
+            {
+              "step": "Create media buy for state machine test",
+              "task": "create_media_buy",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Not testable: requires comply_test_controller harness"
+              ]
+            },
+            {
+              "step": "Force media buy to active",
+              "task": "comply_test_controller",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Not testable: requires comply_test_controller harness"
+              ]
+            },
+            {
+              "step": "Verify media buy status via get_media_buys",
+              "task": "get_media_buys",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Not testable: requires comply_test_controller harness"
+              ]
+            },
+            {
+              "step": "Force media buy to completed (terminal)",
+              "task": "comply_test_controller",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Not testable: requires comply_test_controller harness"
+              ]
+            },
+            {
+              "step": "Reject transition from terminal state",
+              "task": "comply_test_controller",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Not testable: requires comply_test_controller harness"
+              ]
+            }
+          ],
+          "summary": "Deterministic media buy state machine: all steps passed",
+          "total_duration_ms": 0,
+          "tested_at": "2026-04-19T19:32:28.317Z"
+        },
+        {
+          "agent_url": "https://adcp-signals-adaptor.evgeny-193.workers.dev/mcp",
+          "scenario": "deterministic_testing/deterministic_creative",
+          "overall_passed": true,
+          "steps": [
+            {
+              "step": "Sync creative for state machine test",
+              "task": "sync_creatives",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Not testable: requires comply_test_controller harness"
+              ]
+            },
+            {
+              "step": "Force creative to approved",
+              "task": "comply_test_controller",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Not testable: requires comply_test_controller harness"
+              ]
+            },
+            {
+              "step": "Force creative to archived (terminal)",
+              "task": "comply_test_controller",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Not testable: requires comply_test_controller harness"
+              ]
+            },
+            {
+              "step": "Reject archived to processing",
+              "task": "comply_test_controller",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Not testable: requires comply_test_controller harness"
+              ]
+            },
+            {
+              "step": "Force fresh creative to rejected with reason",
+              "task": "comply_test_controller",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Not testable: requires comply_test_controller harness"
+              ]
+            }
+          ],
+          "summary": "Deterministic creative state machine: all steps passed",
+          "total_duration_ms": 0,
+          "tested_at": "2026-04-19T19:32:28.317Z"
+        },
+        {
+          "agent_url": "https://adcp-signals-adaptor.evgeny-193.workers.dev/mcp",
+          "scenario": "deterministic_testing/deterministic_session",
+          "overall_passed": true,
+          "steps": [
+            {
+              "step": "Initiate SI session",
+              "task": "si_initiate_session",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Not testable: agent lacks required tool"
+              ]
+            },
+            {
+              "step": "Force session timeout",
+              "task": "comply_test_controller",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Not testable: requires comply_test_controller harness"
+              ]
+            },
+            {
+              "step": "Verify messaging fails on terminated session",
+              "task": "si_send_message",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Not testable: requires comply_test_controller harness"
+              ]
+            }
+          ],
+          "summary": "Deterministic SI session state machine: all steps passed",
+          "total_duration_ms": 1,
+          "tested_at": "2026-04-19T19:32:28.317Z"
+        },
+        {
+          "agent_url": "https://adcp-signals-adaptor.evgeny-193.workers.dev/mcp",
+          "scenario": "deterministic_testing/deterministic_delivery",
+          "overall_passed": true,
+          "steps": [
+            {
+              "step": "Create media buy for delivery test",
+              "task": "create_media_buy",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Not testable: requires comply_test_controller harness"
+              ]
+            },
+            {
+              "step": "Simulate delivery data",
+              "task": "comply_test_controller",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Not testable: requires comply_test_controller harness"
+              ]
+            },
+            {
+              "step": "Verify delivery via get_media_buy_delivery",
+              "task": "get_media_buy_delivery",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Not testable: requires comply_test_controller harness"
+              ]
+            }
+          ],
+          "summary": "Deterministic delivery simulation: all steps passed",
+          "total_duration_ms": 0,
+          "tested_at": "2026-04-19T19:32:28.317Z"
+        },
+        {
+          "agent_url": "https://adcp-signals-adaptor.evgeny-193.workers.dev/mcp",
+          "scenario": "deterministic_testing/deterministic_budget",
+          "overall_passed": true,
+          "steps": [
+            {
+              "step": "Create media buy for budget test",
+              "task": "create_media_buy",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Not testable: requires comply_test_controller harness"
+              ]
+            },
+            {
+              "step": "Simulate 95% budget spend",
+              "task": "comply_test_controller",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Not testable: requires comply_test_controller harness"
+              ]
+            },
+            {
+              "step": "Simulate 100% budget depletion",
+              "task": "comply_test_controller",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Not testable: requires comply_test_controller harness"
+              ]
+            }
+          ],
+          "summary": "Deterministic budget simulation: all steps passed",
+          "total_duration_ms": 0,
+          "tested_at": "2026-04-19T19:32:28.317Z"
+        },
+        {
+          "agent_url": "https://adcp-signals-adaptor.evgeny-193.workers.dev/mcp",
+          "scenario": "schema_validation/capability_discovery",
+          "overall_passed": true,
+          "steps": [
+            {
+              "step": "Check agent capabilities",
+              "task": "get_adcp_capabilities",
+              "passed": true,
+              "duration_ms": 31,
+              "details": "✓ Response matches get-adcp-capabilities-response.json schema; ✓ Agent declares supported protocols; ✓ Response echoes back the context object; ✓ Context correlation_id returned unchanged",
+              "observation_data": {
+                "adcp": {
+                  "major_versions": [
+                    2,
+                    3
+                  ],
+                  "idempotency": {
+                    "replay_ttl_seconds": 86400
+                  }
+                },
+                "supported_protocols": [
+                  "signals"
+                ],
+                "signals": {
+                  "signal_categories": [
+                    "demographic",
+                    "interest",
+                    "purchase_intent",
+                    "geo",
+                    "composite"
+                  ],
+                  "dynamic_segment_generation": true,
+                  "activation_mode": "async",
+                  "provider": "AdCP Signals Adaptor - Demo Provider (Evgeny)",
+                  "destinations": [
+                    {
+                      "id": "mock_dsp",
+                      "name": "Mock DSP",
+                      "type": "dsp",
+                      "activation_supported": true
+                    },
+                    {
+                      "id": "mock_cleanroom",
+                      "name": "Mock Clean Room",
+                      "type": "cleanroom",
+                      "activation_supported": true
+                    },
+                    {
+                      "id": "mock_cdp",
+                      "name": "Mock CDP",
+                      "type": "cdp",
+                      "activation_supported": true
+                    },
+                    {
+                      "id": "mock_measurement",
+                      "name": "Mock Measurement Platform",
+                      "type": "measurement",
+                      "activation_supported": false
+                    }
+                  ],
+                  "limits": {
+                    "max_signals_per_request": 100,
+                    "max_rules_per_segment": 6
+                  }
+                },
+                "context": {
+                  "correlation_id": "schema_validation--get_capabilities"
+                },
+                "ext": {
+                  "ucp": {
+                    "supported_spaces": [
+                      "openai-te3-small-d512-v1"
+                    ],
+                    "supported_encodings": [
+                      "float32"
+                    ],
+                    "dimensions": [
+                      512
+                    ],
+                    "embedding_endpoint_template": "/signals/{signal_id}/embedding",
+                    "similarity_search": true,
+                    "phase": "llm-v1",
+                    "gts_version": "adcp-gts-v1.0"
+                  }
+                },
+                "_message": "{\n  \"adcp\": {\n    \"major_versions\": [\n      2,\n      3\n    ],\n    \"idempotency\": {\n      \"replay_ttl_seconds\": 86400\n    }\n  },\n  \"supported_protocols\": [\n    \"signals\"\n  ],\n  \"signals\": {\n    \"signal_categories\": [\n      \"demographic\",\n      \"interest\",\n      \"purchase_intent\",\n      \"geo\",\n      \"composite\"\n    ],\n    \"dynamic_segment_generation\": true,\n    \"activation_mode\": \"async\",\n    \"provider\": \"AdCP Signals Adaptor - Demo Provider (Evgeny)\",\n    \"destinations\": [\n      {\n        \"id\": \"mock_dsp\",\n        \"name\": \"Mock DSP\",\n        \"type\": \"dsp\",\n        \"activation_supported\": true\n      },\n      {\n        \"id\": \"mock_cleanroom\",\n        \"name\": \"Mock Clean Room\",\n        \"type\": \"cleanroom\",\n        \"activation_supported\": true\n      },\n      {\n        \"id\": \"mock_cdp\",\n        \"name\": \"Mock CDP\",\n        \"type\": \"cdp\",\n        \"activation_supported\": true\n      },\n      {\n        \"id\": \"mock_measurement\",\n        \"name\": \"Mock Measurement Platform\",\n        \"type\": \"measurement\",\n        \"activation_supported\": false\n      }\n    ],\n    \"limits\": {\n      \"max_signals_per_request\": 100,\n      \"max_rules_per_segment\": 6\n    }\n  },\n  \"ext\": {\n    \"ucp\": {\n      \"supported_spaces\": [\n        \"openai-te3-small-d512-v1\"\n      ],\n      \"supported_encodings\": [\n        \"float32\"\n      ],\n      \"dimensions\": [\n        512\n      ],\n      \"embedding_endpoint_template\": \"/signals/{signal_id}/embedding\",\n      \"similarity_search\": true,\n      \"phase\": \"llm-v1\",\n      \"gts_version\": \"adcp-gts-v1.0\"\n    }\n  },\n  \"context\": {\n    \"correlation_id\": \"schema_validation--get_capabilities\"\n  }\n}"
+              }
+            }
+          ],
+          "summary": "Capability discovery: all steps passed",
+          "total_duration_ms": 31,
+          "tested_at": "2026-04-19T19:32:28.382Z"
+        },
+        {
+          "agent_url": "https://adcp-signals-adaptor.evgeny-193.workers.dev/mcp",
+          "scenario": "schema_validation/schema_compliance",
+          "overall_passed": true,
+          "steps": [
+            {
+              "step": "Validate get_products response schema",
+              "task": "get_products",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Skipped: agent does not implement this tool"
+              ]
+            },
+            {
+              "step": "Validate pricing options structure",
+              "task": "get_products",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Skipped: agent does not implement this tool"
+              ]
+            }
+          ],
+          "summary": "Response schema compliance: all steps passed",
+          "total_duration_ms": 0,
+          "tested_at": "2026-04-19T19:32:28.382Z"
+        },
+        {
+          "agent_url": "https://adcp-signals-adaptor.evgeny-193.workers.dev/mcp",
+          "scenario": "schema_validation/format_id_reconciliation",
+          "overall_passed": true,
+          "steps": [
+            {
+              "step": "Get products and verify identifiers",
+              "task": "get_products",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Skipped: agent does not implement this tool"
+              ]
+            },
+            {
+              "step": "Verify format catalog includes product formats",
+              "task": "list_creative_formats",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Skipped: agent does not implement this tool"
+              ]
+            }
+          ],
+          "summary": "Format ID and pricing option reconciliation: all steps passed",
+          "total_duration_ms": 0,
+          "tested_at": "2026-04-19T19:32:28.382Z"
+        },
+        {
+          "agent_url": "https://adcp-signals-adaptor.evgeny-193.workers.dev/mcp",
+          "scenario": "schema_validation/temporal_validation",
+          "overall_passed": true,
+          "steps": [
+            {
+              "step": "Reject reversed flight dates",
+              "task": "create_media_buy",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Skipped: agent does not implement this tool"
+              ]
+            },
+            {
+              "step": "Handle past start date",
+              "task": "create_media_buy",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Skipped: agent does not implement this tool"
+              ]
+            }
+          ],
+          "summary": "Temporal constraint enforcement: all steps passed",
+          "total_duration_ms": 0,
+          "tested_at": "2026-04-19T19:32:28.382Z"
+        }
+      ],
+      "skipped_scenarios": [],
+      "observations": [],
+      "duration_ms": 134,
+      "mode": "deterministic"
+    },
+    {
+      "track": "signals",
+      "status": "skip",
+      "label": "Signals",
+      "scenarios": [],
+      "skipped_scenarios": [],
+      "observations": [],
+      "duration_ms": 0,
+      "mode": "observational"
+    },
+    {
+      "track": "error_handling",
+      "status": "pass",
+      "label": "Error Handling",
+      "scenarios": [
+        {
+          "agent_url": "https://adcp-signals-adaptor.evgeny-193.workers.dev/mcp",
+          "scenario": "error_compliance/capability_discovery",
+          "overall_passed": true,
+          "steps": [
+            {
+              "step": "Check agent capabilities",
+              "task": "get_adcp_capabilities",
+              "passed": true,
+              "duration_ms": 33,
+              "details": "✓ Response matches get-adcp-capabilities-response.json schema; ✓ Agent declares supported protocols; ✓ Response echoes back the context object; ✓ Context correlation_id returned unchanged",
+              "observation_data": {
+                "adcp": {
+                  "major_versions": [
+                    2,
+                    3
+                  ],
+                  "idempotency": {
+                    "replay_ttl_seconds": 86400
+                  }
+                },
+                "supported_protocols": [
+                  "signals"
+                ],
+                "signals": {
+                  "signal_categories": [
+                    "demographic",
+                    "interest",
+                    "purchase_intent",
+                    "geo",
+                    "composite"
+                  ],
+                  "dynamic_segment_generation": true,
+                  "activation_mode": "async",
+                  "provider": "AdCP Signals Adaptor - Demo Provider (Evgeny)",
+                  "destinations": [
+                    {
+                      "id": "mock_dsp",
+                      "name": "Mock DSP",
+                      "type": "dsp",
+                      "activation_supported": true
+                    },
+                    {
+                      "id": "mock_cleanroom",
+                      "name": "Mock Clean Room",
+                      "type": "cleanroom",
+                      "activation_supported": true
+                    },
+                    {
+                      "id": "mock_cdp",
+                      "name": "Mock CDP",
+                      "type": "cdp",
+                      "activation_supported": true
+                    },
+                    {
+                      "id": "mock_measurement",
+                      "name": "Mock Measurement Platform",
+                      "type": "measurement",
+                      "activation_supported": false
+                    }
+                  ],
+                  "limits": {
+                    "max_signals_per_request": 100,
+                    "max_rules_per_segment": 6
+                  }
+                },
+                "context": {
+                  "correlation_id": "error_compliance--get_capabilities"
+                },
+                "ext": {
+                  "ucp": {
+                    "supported_spaces": [
+                      "openai-te3-small-d512-v1"
+                    ],
+                    "supported_encodings": [
+                      "float32"
+                    ],
+                    "dimensions": [
+                      512
+                    ],
+                    "embedding_endpoint_template": "/signals/{signal_id}/embedding",
+                    "similarity_search": true,
+                    "phase": "llm-v1",
+                    "gts_version": "adcp-gts-v1.0"
+                  }
+                },
+                "_message": "{\n  \"adcp\": {\n    \"major_versions\": [\n      2,\n      3\n    ],\n    \"idempotency\": {\n      \"replay_ttl_seconds\": 86400\n    }\n  },\n  \"supported_protocols\": [\n    \"signals\"\n  ],\n  \"signals\": {\n    \"signal_categories\": [\n      \"demographic\",\n      \"interest\",\n      \"purchase_intent\",\n      \"geo\",\n      \"composite\"\n    ],\n    \"dynamic_segment_generation\": true,\n    \"activation_mode\": \"async\",\n    \"provider\": \"AdCP Signals Adaptor - Demo Provider (Evgeny)\",\n    \"destinations\": [\n      {\n        \"id\": \"mock_dsp\",\n        \"name\": \"Mock DSP\",\n        \"type\": \"dsp\",\n        \"activation_supported\": true\n      },\n      {\n        \"id\": \"mock_cleanroom\",\n        \"name\": \"Mock Clean Room\",\n        \"type\": \"cleanroom\",\n        \"activation_supported\": true\n      },\n      {\n        \"id\": \"mock_cdp\",\n        \"name\": \"Mock CDP\",\n        \"type\": \"cdp\",\n        \"activation_supported\": true\n      },\n      {\n        \"id\": \"mock_measurement\",\n        \"name\": \"Mock Measurement Platform\",\n        \"type\": \"measurement\",\n        \"activation_supported\": false\n      }\n    ],\n    \"limits\": {\n      \"max_signals_per_request\": 100,\n      \"max_rules_per_segment\": 6\n    }\n  },\n  \"ext\": {\n    \"ucp\": {\n      \"supported_spaces\": [\n        \"openai-te3-small-d512-v1\"\n      ],\n      \"supported_encodings\": [\n        \"float32\"\n      ],\n      \"dimensions\": [\n        512\n      ],\n      \"embedding_endpoint_template\": \"/signals/{signal_id}/embedding\",\n      \"similarity_search\": true,\n      \"phase\": \"llm-v1\",\n      \"gts_version\": \"adcp-gts-v1.0\"\n    }\n  },\n  \"context\": {\n    \"correlation_id\": \"error_compliance--get_capabilities\"\n  }\n}"
+              }
+            }
+          ],
+          "summary": "Capability discovery: all steps passed",
+          "total_duration_ms": 34,
+          "tested_at": "2026-04-19T19:32:28.351Z"
+        },
+        {
+          "agent_url": "https://adcp-signals-adaptor.evgeny-193.workers.dev/mcp",
+          "scenario": "error_compliance/error_responses",
+          "overall_passed": true,
+          "steps": [
+            {
+              "step": "Reject negative budget",
+              "task": "create_media_buy",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Skipped: agent does not implement this tool"
+              ]
+            },
+            {
+              "step": "Reject nonexistent product ID",
+              "task": "create_media_buy",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Skipped: agent does not implement this tool"
+              ]
+            },
+            {
+              "step": "Reject empty get_products request",
+              "task": "get_products",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Skipped: agent does not implement this tool"
+              ]
+            },
+            {
+              "step": "Reject reversed dates with error code",
+              "task": "create_media_buy",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Skipped: agent does not implement this tool"
+              ]
+            }
+          ],
+          "summary": "Error responses for invalid input: all steps passed",
+          "total_duration_ms": 0,
+          "tested_at": "2026-04-19T19:32:28.351Z"
+        },
+        {
+          "agent_url": "https://adcp-signals-adaptor.evgeny-193.workers.dev/mcp",
+          "scenario": "error_compliance/error_structure",
+          "overall_passed": true,
+          "steps": [
+            {
+              "step": "Validate error response structure",
+              "task": "create_media_buy",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Skipped: agent does not implement this tool"
+              ]
+            }
+          ],
+          "summary": "Error structure compliance: all steps passed",
+          "total_duration_ms": 0,
+          "tested_at": "2026-04-19T19:32:28.351Z"
+        },
+        {
+          "agent_url": "https://adcp-signals-adaptor.evgeny-193.workers.dev/mcp",
+          "scenario": "error_compliance/version_negotiation",
+          "overall_passed": true,
+          "steps": [
+            {
+              "step": "Reject unsupported adcp_major_version",
+              "task": "get_products",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Skipped: agent does not implement this tool"
+              ]
+            },
+            {
+              "step": "Accept supported adcp_major_version",
+              "task": "get_products",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Skipped: agent does not implement this tool"
+              ]
+            }
+          ],
+          "summary": "Protocol version validation: all steps passed",
+          "total_duration_ms": 0,
+          "tested_at": "2026-04-19T19:32:28.351Z"
+        },
+        {
+          "agent_url": "https://adcp-signals-adaptor.evgeny-193.workers.dev/mcp",
+          "scenario": "error_compliance/error_transport",
+          "overall_passed": true,
+          "steps": [
+            {
+              "step": "Validate error transport binding",
+              "task": "create_media_buy",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Skipped: agent does not implement this tool"
+              ]
+            }
+          ],
+          "summary": "Error transport bindings: all steps passed",
+          "total_duration_ms": 0,
+          "tested_at": "2026-04-19T19:32:28.351Z"
+        }
+      ],
+      "skipped_scenarios": [],
+      "observations": [],
+      "duration_ms": 34,
+      "mode": "observational"
+    }
+  ],
+  "tested_tracks": [
+    {
+      "track": "core",
+      "status": "pass",
+      "label": "Core Protocol",
+      "scenarios": [
+        {
+          "agent_url": "https://adcp-signals-adaptor.evgeny-193.workers.dev/mcp",
+          "scenario": "capability_discovery/protocol_discovery",
+          "overall_passed": true,
+          "steps": [
+            {
+              "step": "Discover agent capabilities",
+              "task": "get_adcp_capabilities",
+              "passed": true,
+              "duration_ms": 31,
+              "details": "✓ Response matches get-adcp-capabilities-response.json schema; ✓ Agent declares supported protocol versions; ✓ Agent declares which protocol domains it supports; ✓ Response echoes back the context object; ✓ Context correlation_id returned unchanged",
+              "observation_data": {
+                "adcp": {
+                  "major_versions": [
+                    2,
+                    3
+                  ],
+                  "idempotency": {
+                    "replay_ttl_seconds": 86400
+                  }
+                },
+                "supported_protocols": [
+                  "signals"
+                ],
+                "signals": {
+                  "signal_categories": [
+                    "demographic",
+                    "interest",
+                    "purchase_intent",
+                    "geo",
+                    "composite"
+                  ],
+                  "dynamic_segment_generation": true,
+                  "activation_mode": "async",
+                  "provider": "AdCP Signals Adaptor - Demo Provider (Evgeny)",
+                  "destinations": [
+                    {
+                      "id": "mock_dsp",
+                      "name": "Mock DSP",
+                      "type": "dsp",
+                      "activation_supported": true
+                    },
+                    {
+                      "id": "mock_cleanroom",
+                      "name": "Mock Clean Room",
+                      "type": "cleanroom",
+                      "activation_supported": true
+                    },
+                    {
+                      "id": "mock_cdp",
+                      "name": "Mock CDP",
+                      "type": "cdp",
+                      "activation_supported": true
+                    },
+                    {
+                      "id": "mock_measurement",
+                      "name": "Mock Measurement Platform",
+                      "type": "measurement",
+                      "activation_supported": false
+                    }
+                  ],
+                  "limits": {
+                    "max_signals_per_request": 100,
+                    "max_rules_per_segment": 6
+                  }
+                },
+                "context": {
+                  "correlation_id": "capability_discovery--get_capabilities"
+                },
+                "ext": {
+                  "ucp": {
+                    "supported_spaces": [
+                      "openai-te3-small-d512-v1"
+                    ],
+                    "supported_encodings": [
+                      "float32"
+                    ],
+                    "dimensions": [
+                      512
+                    ],
+                    "embedding_endpoint_template": "/signals/{signal_id}/embedding",
+                    "similarity_search": true,
+                    "phase": "llm-v1",
+                    "gts_version": "adcp-gts-v1.0"
+                  }
+                },
+                "_message": "{\n  \"adcp\": {\n    \"major_versions\": [\n      2,\n      3\n    ],\n    \"idempotency\": {\n      \"replay_ttl_seconds\": 86400\n    }\n  },\n  \"supported_protocols\": [\n    \"signals\"\n  ],\n  \"signals\": {\n    \"signal_categories\": [\n      \"demographic\",\n      \"interest\",\n      \"purchase_intent\",\n      \"geo\",\n      \"composite\"\n    ],\n    \"dynamic_segment_generation\": true,\n    \"activation_mode\": \"async\",\n    \"provider\": \"AdCP Signals Adaptor - Demo Provider (Evgeny)\",\n    \"destinations\": [\n      {\n        \"id\": \"mock_dsp\",\n        \"name\": \"Mock DSP\",\n        \"type\": \"dsp\",\n        \"activation_supported\": true\n      },\n      {\n        \"id\": \"mock_cleanroom\",\n        \"name\": \"Mock Clean Room\",\n        \"type\": \"cleanroom\",\n        \"activation_supported\": true\n      },\n      {\n        \"id\": \"mock_cdp\",\n        \"name\": \"Mock CDP\",\n        \"type\": \"cdp\",\n        \"activation_supported\": true\n      },\n      {\n        \"id\": \"mock_measurement\",\n        \"name\": \"Mock Measurement Platform\",\n        \"type\": \"measurement\",\n        \"activation_supported\": false\n      }\n    ],\n    \"limits\": {\n      \"max_signals_per_request\": 100,\n      \"max_rules_per_segment\": 6\n    }\n  },\n  \"ext\": {\n    \"ucp\": {\n      \"supported_spaces\": [\n        \"openai-te3-small-d512-v1\"\n      ],\n      \"supported_encodings\": [\n        \"float32\"\n      ],\n      \"dimensions\": [\n        512\n      ],\n      \"embedding_endpoint_template\": \"/signals/{signal_id}/embedding\",\n      \"similarity_search\": true,\n      \"phase\": \"llm-v1\",\n      \"gts_version\": \"adcp-gts-v1.0\"\n    }\n  },\n  \"context\": {\n    \"correlation_id\": \"capability_discovery--get_capabilities\"\n  }\n}"
+              }
+            },
+            {
+              "step": "Discover capabilities filtered by protocol",
+              "task": "get_adcp_capabilities",
+              "passed": true,
+              "duration_ms": 36,
+              "details": "✓ Response matches get-adcp-capabilities-response.json schema; ✓ Response echoes back the context object; ✓ Context correlation_id returned unchanged",
+              "observation_data": {
+                "adcp": {
+                  "major_versions": [
+                    2,
+                    3
+                  ],
+                  "idempotency": {
+                    "replay_ttl_seconds": 86400
+                  }
+                },
+                "supported_protocols": [
+                  "signals"
+                ],
+                "signals": {
+                  "signal_categories": [
+                    "demographic",
+                    "interest",
+                    "purchase_intent",
+                    "geo",
+                    "composite"
+                  ],
+                  "dynamic_segment_generation": true,
+                  "activation_mode": "async",
+                  "provider": "AdCP Signals Adaptor - Demo Provider (Evgeny)",
+                  "destinations": [
+                    {
+                      "id": "mock_dsp",
+                      "name": "Mock DSP",
+                      "type": "dsp",
+                      "activation_supported": true
+                    },
+                    {
+                      "id": "mock_cleanroom",
+                      "name": "Mock Clean Room",
+                      "type": "cleanroom",
+                      "activation_supported": true
+                    },
+                    {
+                      "id": "mock_cdp",
+                      "name": "Mock CDP",
+                      "type": "cdp",
+                      "activation_supported": true
+                    },
+                    {
+                      "id": "mock_measurement",
+                      "name": "Mock Measurement Platform",
+                      "type": "measurement",
+                      "activation_supported": false
+                    }
+                  ],
+                  "limits": {
+                    "max_signals_per_request": 100,
+                    "max_rules_per_segment": 6
+                  }
+                },
+                "context": {
+                  "correlation_id": "capability_discovery--get_capabilities_filtered"
+                },
+                "ext": {
+                  "ucp": {
+                    "supported_spaces": [
+                      "openai-te3-small-d512-v1"
+                    ],
+                    "supported_encodings": [
+                      "float32"
+                    ],
+                    "dimensions": [
+                      512
+                    ],
+                    "embedding_endpoint_template": "/signals/{signal_id}/embedding",
+                    "similarity_search": true,
+                    "phase": "llm-v1",
+                    "gts_version": "adcp-gts-v1.0"
+                  }
+                },
+                "_message": "{\n  \"adcp\": {\n    \"major_versions\": [\n      2,\n      3\n    ],\n    \"idempotency\": {\n      \"replay_ttl_seconds\": 86400\n    }\n  },\n  \"supported_protocols\": [\n    \"signals\"\n  ],\n  \"signals\": {\n    \"signal_categories\": [\n      \"demographic\",\n      \"interest\",\n      \"purchase_intent\",\n      \"geo\",\n      \"composite\"\n    ],\n    \"dynamic_segment_generation\": true,\n    \"activation_mode\": \"async\",\n    \"provider\": \"AdCP Signals Adaptor - Demo Provider (Evgeny)\",\n    \"destinations\": [\n      {\n        \"id\": \"mock_dsp\",\n        \"name\": \"Mock DSP\",\n        \"type\": \"dsp\",\n        \"activation_supported\": true\n      },\n      {\n        \"id\": \"mock_cleanroom\",\n        \"name\": \"Mock Clean Room\",\n        \"type\": \"cleanroom\",\n        \"activation_supported\": true\n      },\n      {\n        \"id\": \"mock_cdp\",\n        \"name\": \"Mock CDP\",\n        \"type\": \"cdp\",\n        \"activation_supported\": true\n      },\n      {\n        \"id\": \"mock_measurement\",\n        \"name\": \"Mock Measurement Platform\",\n        \"type\": \"measurement\",\n        \"activation_supported\": false\n      }\n    ],\n    \"limits\": {\n      \"max_signals_per_request\": 100,\n      \"max_rules_per_segment\": 6\n    }\n  },\n  \"ext\": {\n    \"ucp\": {\n      \"supported_spaces\": [\n        \"openai-te3-small-d512-v1\"\n      ],\n      \"supported_encodings\": [\n        \"float32\"\n      ],\n      \"dimensions\": [\n        512\n      ],\n      \"embedding_endpoint_template\": \"/signals/{signal_id}/embedding\",\n      \"similarity_search\": true,\n      \"phase\": \"llm-v1\",\n      \"gts_version\": \"adcp-gts-v1.0\"\n    }\n  },\n  \"context\": {\n    \"correlation_id\": \"capability_discovery--get_capabilities_filtered\"\n  }\n}"
+              }
+            }
+          ],
+          "summary": "Protocol and capability discovery: all steps passed",
+          "total_duration_ms": 71,
+          "tested_at": "2026-04-19T19:32:28.285Z"
+        },
+        {
+          "agent_url": "https://adcp-signals-adaptor.evgeny-193.workers.dev/mcp",
+          "scenario": "deterministic_testing/capability_discovery",
+          "overall_passed": true,
+          "steps": [
+            {
+              "step": "Check agent capabilities",
+              "task": "get_adcp_capabilities",
+              "passed": true,
+              "duration_ms": 30,
+              "details": "✓ Response matches get-adcp-capabilities-response.json schema; ✓ Agent declares supported protocols; ✓ Response echoes back the context object; ✓ Context correlation_id returned unchanged",
+              "observation_data": {
+                "adcp": {
+                  "major_versions": [
+                    2,
+                    3
+                  ],
+                  "idempotency": {
+                    "replay_ttl_seconds": 86400
+                  }
+                },
+                "supported_protocols": [
+                  "signals"
+                ],
+                "signals": {
+                  "signal_categories": [
+                    "demographic",
+                    "interest",
+                    "purchase_intent",
+                    "geo",
+                    "composite"
+                  ],
+                  "dynamic_segment_generation": true,
+                  "activation_mode": "async",
+                  "provider": "AdCP Signals Adaptor - Demo Provider (Evgeny)",
+                  "destinations": [
+                    {
+                      "id": "mock_dsp",
+                      "name": "Mock DSP",
+                      "type": "dsp",
+                      "activation_supported": true
+                    },
+                    {
+                      "id": "mock_cleanroom",
+                      "name": "Mock Clean Room",
+                      "type": "cleanroom",
+                      "activation_supported": true
+                    },
+                    {
+                      "id": "mock_cdp",
+                      "name": "Mock CDP",
+                      "type": "cdp",
+                      "activation_supported": true
+                    },
+                    {
+                      "id": "mock_measurement",
+                      "name": "Mock Measurement Platform",
+                      "type": "measurement",
+                      "activation_supported": false
+                    }
+                  ],
+                  "limits": {
+                    "max_signals_per_request": 100,
+                    "max_rules_per_segment": 6
+                  }
+                },
+                "context": {
+                  "correlation_id": "deterministic_testing--get_capabilities"
+                },
+                "ext": {
+                  "ucp": {
+                    "supported_spaces": [
+                      "openai-te3-small-d512-v1"
+                    ],
+                    "supported_encodings": [
+                      "float32"
+                    ],
+                    "dimensions": [
+                      512
+                    ],
+                    "embedding_endpoint_template": "/signals/{signal_id}/embedding",
+                    "similarity_search": true,
+                    "phase": "llm-v1",
+                    "gts_version": "adcp-gts-v1.0"
+                  }
+                },
+                "_message": "{\n  \"adcp\": {\n    \"major_versions\": [\n      2,\n      3\n    ],\n    \"idempotency\": {\n      \"replay_ttl_seconds\": 86400\n    }\n  },\n  \"supported_protocols\": [\n    \"signals\"\n  ],\n  \"signals\": {\n    \"signal_categories\": [\n      \"demographic\",\n      \"interest\",\n      \"purchase_intent\",\n      \"geo\",\n      \"composite\"\n    ],\n    \"dynamic_segment_generation\": true,\n    \"activation_mode\": \"async\",\n    \"provider\": \"AdCP Signals Adaptor - Demo Provider (Evgeny)\",\n    \"destinations\": [\n      {\n        \"id\": \"mock_dsp\",\n        \"name\": \"Mock DSP\",\n        \"type\": \"dsp\",\n        \"activation_supported\": true\n      },\n      {\n        \"id\": \"mock_cleanroom\",\n        \"name\": \"Mock Clean Room\",\n        \"type\": \"cleanroom\",\n        \"activation_supported\": true\n      },\n      {\n        \"id\": \"mock_cdp\",\n        \"name\": \"Mock CDP\",\n        \"type\": \"cdp\",\n        \"activation_supported\": true\n      },\n      {\n        \"id\": \"mock_measurement\",\n        \"name\": \"Mock Measurement Platform\",\n        \"type\": \"measurement\",\n        \"activation_supported\": false\n      }\n    ],\n    \"limits\": {\n      \"max_signals_per_request\": 100,\n      \"max_rules_per_segment\": 6\n    }\n  },\n  \"ext\": {\n    \"ucp\": {\n      \"supported_spaces\": [\n        \"openai-te3-small-d512-v1\"\n      ],\n      \"supported_encodings\": [\n        \"float32\"\n      ],\n      \"dimensions\": [\n        512\n      ],\n      \"embedding_endpoint_template\": \"/signals/{signal_id}/embedding\",\n      \"similarity_search\": true,\n      \"phase\": \"llm-v1\",\n      \"gts_version\": \"adcp-gts-v1.0\"\n    }\n  },\n  \"context\": {\n    \"correlation_id\": \"deterministic_testing--get_capabilities\"\n  }\n}"
+              }
+            }
+          ],
+          "summary": "Capability discovery: all steps passed",
+          "total_duration_ms": 30,
+          "tested_at": "2026-04-19T19:32:28.317Z"
+        },
+        {
+          "agent_url": "https://adcp-signals-adaptor.evgeny-193.workers.dev/mcp",
+          "scenario": "deterministic_testing/controller_validation",
+          "overall_passed": true,
+          "steps": [
+            {
+              "step": "List supported scenarios",
+              "task": "comply_test_controller",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Not testable: requires comply_test_controller harness"
+              ]
+            },
+            {
+              "step": "Unknown scenario returns error",
+              "task": "comply_test_controller",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Not testable: requires comply_test_controller harness"
+              ]
+            },
+            {
+              "step": "Missing params returns error",
+              "task": "comply_test_controller",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Not testable: requires comply_test_controller harness"
+              ]
+            },
+            {
+              "step": "Nonexistent entity returns NOT_FOUND",
+              "task": "comply_test_controller",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Not testable: requires comply_test_controller harness"
+              ]
+            }
+          ],
+          "summary": "Controller validation: all steps passed",
+          "total_duration_ms": 1,
+          "tested_at": "2026-04-19T19:32:28.317Z"
+        },
+        {
+          "agent_url": "https://adcp-signals-adaptor.evgeny-193.workers.dev/mcp",
+          "scenario": "deterministic_testing/deterministic_account",
+          "overall_passed": true,
+          "steps": [
+            {
+              "step": "Create sandbox account for state machine test",
+              "task": "sync_accounts",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Not testable: requires comply_test_controller harness"
+              ]
+            },
+            {
+              "step": "Find account for state machine test",
+              "task": "list_accounts",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Not testable: requires comply_test_controller harness"
+              ]
+            },
+            {
+              "step": "Force account to suspended",
+              "task": "comply_test_controller",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Not testable: requires comply_test_controller harness"
+              ]
+            },
+            {
+              "step": "Reactivate account",
+              "task": "comply_test_controller",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Not testable: requires comply_test_controller harness"
+              ]
+            },
+            {
+              "step": "Force account to payment_required",
+              "task": "comply_test_controller",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Not testable: requires comply_test_controller harness"
+              ]
+            },
+            {
+              "step": "Restore account to active",
+              "task": "comply_test_controller",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Not testable: requires comply_test_controller harness"
+              ]
+            }
+          ],
+          "summary": "Deterministic account state machine: all steps passed",
+          "total_duration_ms": 0,
+          "tested_at": "2026-04-19T19:32:28.317Z"
+        },
+        {
+          "agent_url": "https://adcp-signals-adaptor.evgeny-193.workers.dev/mcp",
+          "scenario": "deterministic_testing/deterministic_media_buy",
+          "overall_passed": true,
+          "steps": [
+            {
+              "step": "Create media buy for state machine test",
+              "task": "create_media_buy",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Not testable: requires comply_test_controller harness"
+              ]
+            },
+            {
+              "step": "Force media buy to active",
+              "task": "comply_test_controller",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Not testable: requires comply_test_controller harness"
+              ]
+            },
+            {
+              "step": "Verify media buy status via get_media_buys",
+              "task": "get_media_buys",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Not testable: requires comply_test_controller harness"
+              ]
+            },
+            {
+              "step": "Force media buy to completed (terminal)",
+              "task": "comply_test_controller",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Not testable: requires comply_test_controller harness"
+              ]
+            },
+            {
+              "step": "Reject transition from terminal state",
+              "task": "comply_test_controller",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Not testable: requires comply_test_controller harness"
+              ]
+            }
+          ],
+          "summary": "Deterministic media buy state machine: all steps passed",
+          "total_duration_ms": 0,
+          "tested_at": "2026-04-19T19:32:28.317Z"
+        },
+        {
+          "agent_url": "https://adcp-signals-adaptor.evgeny-193.workers.dev/mcp",
+          "scenario": "deterministic_testing/deterministic_creative",
+          "overall_passed": true,
+          "steps": [
+            {
+              "step": "Sync creative for state machine test",
+              "task": "sync_creatives",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Not testable: requires comply_test_controller harness"
+              ]
+            },
+            {
+              "step": "Force creative to approved",
+              "task": "comply_test_controller",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Not testable: requires comply_test_controller harness"
+              ]
+            },
+            {
+              "step": "Force creative to archived (terminal)",
+              "task": "comply_test_controller",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Not testable: requires comply_test_controller harness"
+              ]
+            },
+            {
+              "step": "Reject archived to processing",
+              "task": "comply_test_controller",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Not testable: requires comply_test_controller harness"
+              ]
+            },
+            {
+              "step": "Force fresh creative to rejected with reason",
+              "task": "comply_test_controller",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Not testable: requires comply_test_controller harness"
+              ]
+            }
+          ],
+          "summary": "Deterministic creative state machine: all steps passed",
+          "total_duration_ms": 0,
+          "tested_at": "2026-04-19T19:32:28.317Z"
+        },
+        {
+          "agent_url": "https://adcp-signals-adaptor.evgeny-193.workers.dev/mcp",
+          "scenario": "deterministic_testing/deterministic_session",
+          "overall_passed": true,
+          "steps": [
+            {
+              "step": "Initiate SI session",
+              "task": "si_initiate_session",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Not testable: agent lacks required tool"
+              ]
+            },
+            {
+              "step": "Force session timeout",
+              "task": "comply_test_controller",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Not testable: requires comply_test_controller harness"
+              ]
+            },
+            {
+              "step": "Verify messaging fails on terminated session",
+              "task": "si_send_message",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Not testable: requires comply_test_controller harness"
+              ]
+            }
+          ],
+          "summary": "Deterministic SI session state machine: all steps passed",
+          "total_duration_ms": 1,
+          "tested_at": "2026-04-19T19:32:28.317Z"
+        },
+        {
+          "agent_url": "https://adcp-signals-adaptor.evgeny-193.workers.dev/mcp",
+          "scenario": "deterministic_testing/deterministic_delivery",
+          "overall_passed": true,
+          "steps": [
+            {
+              "step": "Create media buy for delivery test",
+              "task": "create_media_buy",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Not testable: requires comply_test_controller harness"
+              ]
+            },
+            {
+              "step": "Simulate delivery data",
+              "task": "comply_test_controller",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Not testable: requires comply_test_controller harness"
+              ]
+            },
+            {
+              "step": "Verify delivery via get_media_buy_delivery",
+              "task": "get_media_buy_delivery",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Not testable: requires comply_test_controller harness"
+              ]
+            }
+          ],
+          "summary": "Deterministic delivery simulation: all steps passed",
+          "total_duration_ms": 0,
+          "tested_at": "2026-04-19T19:32:28.317Z"
+        },
+        {
+          "agent_url": "https://adcp-signals-adaptor.evgeny-193.workers.dev/mcp",
+          "scenario": "deterministic_testing/deterministic_budget",
+          "overall_passed": true,
+          "steps": [
+            {
+              "step": "Create media buy for budget test",
+              "task": "create_media_buy",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Not testable: requires comply_test_controller harness"
+              ]
+            },
+            {
+              "step": "Simulate 95% budget spend",
+              "task": "comply_test_controller",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Not testable: requires comply_test_controller harness"
+              ]
+            },
+            {
+              "step": "Simulate 100% budget depletion",
+              "task": "comply_test_controller",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Not testable: requires comply_test_controller harness"
+              ]
+            }
+          ],
+          "summary": "Deterministic budget simulation: all steps passed",
+          "total_duration_ms": 0,
+          "tested_at": "2026-04-19T19:32:28.317Z"
+        },
+        {
+          "agent_url": "https://adcp-signals-adaptor.evgeny-193.workers.dev/mcp",
+          "scenario": "schema_validation/capability_discovery",
+          "overall_passed": true,
+          "steps": [
+            {
+              "step": "Check agent capabilities",
+              "task": "get_adcp_capabilities",
+              "passed": true,
+              "duration_ms": 31,
+              "details": "✓ Response matches get-adcp-capabilities-response.json schema; ✓ Agent declares supported protocols; ✓ Response echoes back the context object; ✓ Context correlation_id returned unchanged",
+              "observation_data": {
+                "adcp": {
+                  "major_versions": [
+                    2,
+                    3
+                  ],
+                  "idempotency": {
+                    "replay_ttl_seconds": 86400
+                  }
+                },
+                "supported_protocols": [
+                  "signals"
+                ],
+                "signals": {
+                  "signal_categories": [
+                    "demographic",
+                    "interest",
+                    "purchase_intent",
+                    "geo",
+                    "composite"
+                  ],
+                  "dynamic_segment_generation": true,
+                  "activation_mode": "async",
+                  "provider": "AdCP Signals Adaptor - Demo Provider (Evgeny)",
+                  "destinations": [
+                    {
+                      "id": "mock_dsp",
+                      "name": "Mock DSP",
+                      "type": "dsp",
+                      "activation_supported": true
+                    },
+                    {
+                      "id": "mock_cleanroom",
+                      "name": "Mock Clean Room",
+                      "type": "cleanroom",
+                      "activation_supported": true
+                    },
+                    {
+                      "id": "mock_cdp",
+                      "name": "Mock CDP",
+                      "type": "cdp",
+                      "activation_supported": true
+                    },
+                    {
+                      "id": "mock_measurement",
+                      "name": "Mock Measurement Platform",
+                      "type": "measurement",
+                      "activation_supported": false
+                    }
+                  ],
+                  "limits": {
+                    "max_signals_per_request": 100,
+                    "max_rules_per_segment": 6
+                  }
+                },
+                "context": {
+                  "correlation_id": "schema_validation--get_capabilities"
+                },
+                "ext": {
+                  "ucp": {
+                    "supported_spaces": [
+                      "openai-te3-small-d512-v1"
+                    ],
+                    "supported_encodings": [
+                      "float32"
+                    ],
+                    "dimensions": [
+                      512
+                    ],
+                    "embedding_endpoint_template": "/signals/{signal_id}/embedding",
+                    "similarity_search": true,
+                    "phase": "llm-v1",
+                    "gts_version": "adcp-gts-v1.0"
+                  }
+                },
+                "_message": "{\n  \"adcp\": {\n    \"major_versions\": [\n      2,\n      3\n    ],\n    \"idempotency\": {\n      \"replay_ttl_seconds\": 86400\n    }\n  },\n  \"supported_protocols\": [\n    \"signals\"\n  ],\n  \"signals\": {\n    \"signal_categories\": [\n      \"demographic\",\n      \"interest\",\n      \"purchase_intent\",\n      \"geo\",\n      \"composite\"\n    ],\n    \"dynamic_segment_generation\": true,\n    \"activation_mode\": \"async\",\n    \"provider\": \"AdCP Signals Adaptor - Demo Provider (Evgeny)\",\n    \"destinations\": [\n      {\n        \"id\": \"mock_dsp\",\n        \"name\": \"Mock DSP\",\n        \"type\": \"dsp\",\n        \"activation_supported\": true\n      },\n      {\n        \"id\": \"mock_cleanroom\",\n        \"name\": \"Mock Clean Room\",\n        \"type\": \"cleanroom\",\n        \"activation_supported\": true\n      },\n      {\n        \"id\": \"mock_cdp\",\n        \"name\": \"Mock CDP\",\n        \"type\": \"cdp\",\n        \"activation_supported\": true\n      },\n      {\n        \"id\": \"mock_measurement\",\n        \"name\": \"Mock Measurement Platform\",\n        \"type\": \"measurement\",\n        \"activation_supported\": false\n      }\n    ],\n    \"limits\": {\n      \"max_signals_per_request\": 100,\n      \"max_rules_per_segment\": 6\n    }\n  },\n  \"ext\": {\n    \"ucp\": {\n      \"supported_spaces\": [\n        \"openai-te3-small-d512-v1\"\n      ],\n      \"supported_encodings\": [\n        \"float32\"\n      ],\n      \"dimensions\": [\n        512\n      ],\n      \"embedding_endpoint_template\": \"/signals/{signal_id}/embedding\",\n      \"similarity_search\": true,\n      \"phase\": \"llm-v1\",\n      \"gts_version\": \"adcp-gts-v1.0\"\n    }\n  },\n  \"context\": {\n    \"correlation_id\": \"schema_validation--get_capabilities\"\n  }\n}"
+              }
+            }
+          ],
+          "summary": "Capability discovery: all steps passed",
+          "total_duration_ms": 31,
+          "tested_at": "2026-04-19T19:32:28.382Z"
+        },
+        {
+          "agent_url": "https://adcp-signals-adaptor.evgeny-193.workers.dev/mcp",
+          "scenario": "schema_validation/schema_compliance",
+          "overall_passed": true,
+          "steps": [
+            {
+              "step": "Validate get_products response schema",
+              "task": "get_products",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Skipped: agent does not implement this tool"
+              ]
+            },
+            {
+              "step": "Validate pricing options structure",
+              "task": "get_products",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Skipped: agent does not implement this tool"
+              ]
+            }
+          ],
+          "summary": "Response schema compliance: all steps passed",
+          "total_duration_ms": 0,
+          "tested_at": "2026-04-19T19:32:28.382Z"
+        },
+        {
+          "agent_url": "https://adcp-signals-adaptor.evgeny-193.workers.dev/mcp",
+          "scenario": "schema_validation/format_id_reconciliation",
+          "overall_passed": true,
+          "steps": [
+            {
+              "step": "Get products and verify identifiers",
+              "task": "get_products",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Skipped: agent does not implement this tool"
+              ]
+            },
+            {
+              "step": "Verify format catalog includes product formats",
+              "task": "list_creative_formats",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Skipped: agent does not implement this tool"
+              ]
+            }
+          ],
+          "summary": "Format ID and pricing option reconciliation: all steps passed",
+          "total_duration_ms": 0,
+          "tested_at": "2026-04-19T19:32:28.382Z"
+        },
+        {
+          "agent_url": "https://adcp-signals-adaptor.evgeny-193.workers.dev/mcp",
+          "scenario": "schema_validation/temporal_validation",
+          "overall_passed": true,
+          "steps": [
+            {
+              "step": "Reject reversed flight dates",
+              "task": "create_media_buy",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Skipped: agent does not implement this tool"
+              ]
+            },
+            {
+              "step": "Handle past start date",
+              "task": "create_media_buy",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Skipped: agent does not implement this tool"
+              ]
+            }
+          ],
+          "summary": "Temporal constraint enforcement: all steps passed",
+          "total_duration_ms": 0,
+          "tested_at": "2026-04-19T19:32:28.382Z"
+        }
+      ],
+      "skipped_scenarios": [],
+      "observations": [],
+      "duration_ms": 134,
+      "mode": "deterministic"
+    },
+    {
+      "track": "error_handling",
+      "status": "pass",
+      "label": "Error Handling",
+      "scenarios": [
+        {
+          "agent_url": "https://adcp-signals-adaptor.evgeny-193.workers.dev/mcp",
+          "scenario": "error_compliance/capability_discovery",
+          "overall_passed": true,
+          "steps": [
+            {
+              "step": "Check agent capabilities",
+              "task": "get_adcp_capabilities",
+              "passed": true,
+              "duration_ms": 33,
+              "details": "✓ Response matches get-adcp-capabilities-response.json schema; ✓ Agent declares supported protocols; ✓ Response echoes back the context object; ✓ Context correlation_id returned unchanged",
+              "observation_data": {
+                "adcp": {
+                  "major_versions": [
+                    2,
+                    3
+                  ],
+                  "idempotency": {
+                    "replay_ttl_seconds": 86400
+                  }
+                },
+                "supported_protocols": [
+                  "signals"
+                ],
+                "signals": {
+                  "signal_categories": [
+                    "demographic",
+                    "interest",
+                    "purchase_intent",
+                    "geo",
+                    "composite"
+                  ],
+                  "dynamic_segment_generation": true,
+                  "activation_mode": "async",
+                  "provider": "AdCP Signals Adaptor - Demo Provider (Evgeny)",
+                  "destinations": [
+                    {
+                      "id": "mock_dsp",
+                      "name": "Mock DSP",
+                      "type": "dsp",
+                      "activation_supported": true
+                    },
+                    {
+                      "id": "mock_cleanroom",
+                      "name": "Mock Clean Room",
+                      "type": "cleanroom",
+                      "activation_supported": true
+                    },
+                    {
+                      "id": "mock_cdp",
+                      "name": "Mock CDP",
+                      "type": "cdp",
+                      "activation_supported": true
+                    },
+                    {
+                      "id": "mock_measurement",
+                      "name": "Mock Measurement Platform",
+                      "type": "measurement",
+                      "activation_supported": false
+                    }
+                  ],
+                  "limits": {
+                    "max_signals_per_request": 100,
+                    "max_rules_per_segment": 6
+                  }
+                },
+                "context": {
+                  "correlation_id": "error_compliance--get_capabilities"
+                },
+                "ext": {
+                  "ucp": {
+                    "supported_spaces": [
+                      "openai-te3-small-d512-v1"
+                    ],
+                    "supported_encodings": [
+                      "float32"
+                    ],
+                    "dimensions": [
+                      512
+                    ],
+                    "embedding_endpoint_template": "/signals/{signal_id}/embedding",
+                    "similarity_search": true,
+                    "phase": "llm-v1",
+                    "gts_version": "adcp-gts-v1.0"
+                  }
+                },
+                "_message": "{\n  \"adcp\": {\n    \"major_versions\": [\n      2,\n      3\n    ],\n    \"idempotency\": {\n      \"replay_ttl_seconds\": 86400\n    }\n  },\n  \"supported_protocols\": [\n    \"signals\"\n  ],\n  \"signals\": {\n    \"signal_categories\": [\n      \"demographic\",\n      \"interest\",\n      \"purchase_intent\",\n      \"geo\",\n      \"composite\"\n    ],\n    \"dynamic_segment_generation\": true,\n    \"activation_mode\": \"async\",\n    \"provider\": \"AdCP Signals Adaptor - Demo Provider (Evgeny)\",\n    \"destinations\": [\n      {\n        \"id\": \"mock_dsp\",\n        \"name\": \"Mock DSP\",\n        \"type\": \"dsp\",\n        \"activation_supported\": true\n      },\n      {\n        \"id\": \"mock_cleanroom\",\n        \"name\": \"Mock Clean Room\",\n        \"type\": \"cleanroom\",\n        \"activation_supported\": true\n      },\n      {\n        \"id\": \"mock_cdp\",\n        \"name\": \"Mock CDP\",\n        \"type\": \"cdp\",\n        \"activation_supported\": true\n      },\n      {\n        \"id\": \"mock_measurement\",\n        \"name\": \"Mock Measurement Platform\",\n        \"type\": \"measurement\",\n        \"activation_supported\": false\n      }\n    ],\n    \"limits\": {\n      \"max_signals_per_request\": 100,\n      \"max_rules_per_segment\": 6\n    }\n  },\n  \"ext\": {\n    \"ucp\": {\n      \"supported_spaces\": [\n        \"openai-te3-small-d512-v1\"\n      ],\n      \"supported_encodings\": [\n        \"float32\"\n      ],\n      \"dimensions\": [\n        512\n      ],\n      \"embedding_endpoint_template\": \"/signals/{signal_id}/embedding\",\n      \"similarity_search\": true,\n      \"phase\": \"llm-v1\",\n      \"gts_version\": \"adcp-gts-v1.0\"\n    }\n  },\n  \"context\": {\n    \"correlation_id\": \"error_compliance--get_capabilities\"\n  }\n}"
+              }
+            }
+          ],
+          "summary": "Capability discovery: all steps passed",
+          "total_duration_ms": 34,
+          "tested_at": "2026-04-19T19:32:28.351Z"
+        },
+        {
+          "agent_url": "https://adcp-signals-adaptor.evgeny-193.workers.dev/mcp",
+          "scenario": "error_compliance/error_responses",
+          "overall_passed": true,
+          "steps": [
+            {
+              "step": "Reject negative budget",
+              "task": "create_media_buy",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Skipped: agent does not implement this tool"
+              ]
+            },
+            {
+              "step": "Reject nonexistent product ID",
+              "task": "create_media_buy",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Skipped: agent does not implement this tool"
+              ]
+            },
+            {
+              "step": "Reject empty get_products request",
+              "task": "get_products",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Skipped: agent does not implement this tool"
+              ]
+            },
+            {
+              "step": "Reject reversed dates with error code",
+              "task": "create_media_buy",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Skipped: agent does not implement this tool"
+              ]
+            }
+          ],
+          "summary": "Error responses for invalid input: all steps passed",
+          "total_duration_ms": 0,
+          "tested_at": "2026-04-19T19:32:28.351Z"
+        },
+        {
+          "agent_url": "https://adcp-signals-adaptor.evgeny-193.workers.dev/mcp",
+          "scenario": "error_compliance/error_structure",
+          "overall_passed": true,
+          "steps": [
+            {
+              "step": "Validate error response structure",
+              "task": "create_media_buy",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Skipped: agent does not implement this tool"
+              ]
+            }
+          ],
+          "summary": "Error structure compliance: all steps passed",
+          "total_duration_ms": 0,
+          "tested_at": "2026-04-19T19:32:28.351Z"
+        },
+        {
+          "agent_url": "https://adcp-signals-adaptor.evgeny-193.workers.dev/mcp",
+          "scenario": "error_compliance/version_negotiation",
+          "overall_passed": true,
+          "steps": [
+            {
+              "step": "Reject unsupported adcp_major_version",
+              "task": "get_products",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Skipped: agent does not implement this tool"
+              ]
+            },
+            {
+              "step": "Accept supported adcp_major_version",
+              "task": "get_products",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Skipped: agent does not implement this tool"
+              ]
+            }
+          ],
+          "summary": "Protocol version validation: all steps passed",
+          "total_duration_ms": 0,
+          "tested_at": "2026-04-19T19:32:28.351Z"
+        },
+        {
+          "agent_url": "https://adcp-signals-adaptor.evgeny-193.workers.dev/mcp",
+          "scenario": "error_compliance/error_transport",
+          "overall_passed": true,
+          "steps": [
+            {
+              "step": "Validate error transport binding",
+              "task": "create_media_buy",
+              "passed": true,
+              "duration_ms": 0,
+              "warnings": [
+                "Skipped: agent does not implement this tool"
+              ]
+            }
+          ],
+          "summary": "Error transport bindings: all steps passed",
+          "total_duration_ms": 0,
+          "tested_at": "2026-04-19T19:32:28.351Z"
+        }
+      ],
+      "skipped_scenarios": [],
+      "observations": [],
+      "duration_ms": 34,
+      "mode": "observational"
+    }
+  ],
+  "skipped_tracks": [
+    {
+      "track": "signals",
+      "label": "Signals",
+      "reason": "No storyboards produced results for this track"
+    }
+  ],
+  "summary": {
+    "tracks_passed": 2,
+    "tracks_failed": 0,
+    "tracks_skipped": 1,
+    "tracks_partial": 0,
+    "headline": "All 2 track(s) pass"
+  },
+  "observations": [
+    {
+      "category": "tool_discovery",
+      "severity": "info",
+      "message": "Discovered 8 tools: [get_adcp_capabilities, get_signals, activate_signal, get_operation_status, get_similar_signals, query_signals_nl, get_concept, search_concepts]",
+      "evidence": {
+        "tools": [
+          "get_adcp_capabilities",
+          "get_signals",
+          "activate_signal",
+          "get_operation_status",
+          "get_similar_signals",
+          "query_signals_nl",
+          "get_concept",
+          "search_concepts"
+        ]
+      }
+    }
+  ],
+  "storyboards_executed": [
+    "capability_discovery",
+    "deterministic_testing",
+    "error_compliance",
+    "schema_validation",
+    "signals_baseline"
+  ],
+  "controller_detected": false,
+  "tested_at": "2026-04-19T19:32:28.388Z",
+  "total_duration_ms": 1157
+}

--- a/tests/storyboard-conformance.test.ts
+++ b/tests/storyboard-conformance.test.ts
@@ -1,0 +1,262 @@
+// tests/storyboard-conformance.test.ts
+// Sec-12: regression pins for the AdCP signals storyboard baseline phases
+// (added upstream in adcp#2365). The runner sends specific request shapes
+// and validates specific response fields per phase. These tests pin those
+// shapes against our handlers so a future edit can't silently regress
+// conformance — even before the runner CLI release that ships the new
+// storyboards lands on npm.
+//
+// Source of truth for the request/response shapes:
+//   adcontextprotocol/adcp:static/compliance/source/protocols/signals/index.yaml
+//   adcontextprotocol/adcp:static/schemas/source/signals/get-signals-response.json
+//   adcontextprotocol/adcp:static/schemas/source/signals/activate-signal-response.json
+//   adcontextprotocol/adcp:static/schemas/source/core/signal-id.json (agent variant)
+
+import { describe, it, expect } from "vitest";
+import { toSignalSummary } from "../src/mappers/signalMapper";
+import type { CanonicalSignal } from "../src/types/signal";
+
+// ── Phase 2 (discovery) — get_signals response shape ─────────────────────────
+
+function makeFixtureSignal(): CanonicalSignal {
+  return {
+    signalId: "sig_drama_viewers",
+    taxonomySystem: "iab_audience_1_1",
+    name: "Drama Viewers",
+    description: "Heavy consumers of dramatic television content",
+    categoryType: "interest",
+    sourceSystems: ["nielsen_acr"],
+    destinations: ["mock_dsp", "mock_cleanroom"],
+    activationSupported: true,
+    estimatedAudienceSize: 5_400_000,
+    accessPolicy: "public_demo",
+    generationMode: "seeded",
+    status: "available",
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
+  };
+}
+
+describe("get_signals response — storyboard signal_id requirement", () => {
+  it("signals[].signal_id is present (schema-required field)", () => {
+    const summary = toSignalSummary(makeFixtureSignal());
+    expect(summary.signal_id).toBeDefined();
+  });
+
+  it("signals[].signal_id.source equals the agent discriminator", () => {
+    // Per /schemas/core/signal-id.json — source is the discriminator. We're
+    // an agent-native signals service (no upstream data-provider catalog),
+    // so the agent variant is the only correct value.
+    const summary = toSignalSummary(makeFixtureSignal());
+    expect(summary.signal_id.source).toBe("agent");
+  });
+
+  it("signals[].signal_id.agent_url is a valid https URL pointing at our MCP endpoint", () => {
+    const summary = toSignalSummary(makeFixtureSignal());
+    const url = summary.signal_id.agent_url;
+    expect(url).toMatch(/^https:\/\/.+\/mcp$/);
+    // Sanity: must parse as a URL (the schema says format: uri).
+    expect(() => new URL(url)).not.toThrow();
+  });
+
+  it("signals[].signal_id.id matches the agent-internal signal identifier pattern", () => {
+    // /schemas/core/signal-id.json agent variant requires
+    //   id: ^[a-zA-Z0-9_-]+$
+    const summary = toSignalSummary(makeFixtureSignal());
+    expect(summary.signal_id.id).toBe("sig_drama_viewers");
+    expect(summary.signal_id.id).toMatch(/^[a-zA-Z0-9_-]+$/);
+  });
+
+  it("signals[] retains signal_agent_segment_id alongside signal_id (both required)", () => {
+    // Storyboard checks BOTH `signal_id.source` AND `signal_agent_segment_id`.
+    // signal_id is the universal identifier (discriminator + source); the
+    // segment_id is the activation handle. Existing callers depend on it.
+    const summary = toSignalSummary(makeFixtureSignal());
+    expect(summary.signal_agent_segment_id).toBe("sig_drama_viewers");
+  });
+
+  it("signals[].pricing_options[0].pricing_option_id is captured (storyboard context_outputs)", () => {
+    // The storyboard captures this into a context variable that gets
+    // passed back to activate_signal. If the field is missing, the
+    // activation phase has no pricing_option_id to send.
+    const summary = toSignalSummary(makeFixtureSignal());
+    const opt = summary.pricing_options?.[0];
+    expect(opt).toBeDefined();
+    expect(typeof opt!.pricing_option_id).toBe("string");
+    expect(opt!.pricing_option_id.length).toBeGreaterThan(0);
+  });
+});
+
+// ── Phase 3 (activation) — destinations[] request shape + context echo ───────
+//
+// We can't easily exercise the full MCP handleToolCall path in a unit test
+// without standing up a fake D1 + KV. Instead, verify the helper that pulls
+// the destinations from the args (which is the actual logic the Sec-12 fix
+// targets). The end-to-end behaviour is covered by the live probe below
+// and by scripts/test-live.sh once we re-deploy.
+
+describe("activate_signal request-shape parsing", () => {
+  // Mirror the parsing rule from src/mcp/server.ts callActivateSignal:
+  //   args.destinations ?? args.deliver_to ?? args.deployments
+  // and pull type/agent_url/platform out of the first entry.
+  function parseDestinations(args: Record<string, unknown>) {
+    const raw = args["destinations"] ?? args["deliver_to"] ?? args["deployments"];
+    const firstEntry = Array.isArray(raw) ? (raw[0] as Record<string, unknown>) : undefined;
+    const firstType = firstEntry?.["type"] as string | undefined;
+    const destination = (firstEntry?.["agent_url"] as string)
+      ?? (firstEntry?.["platform"] as string)
+      ?? (args["destination"] as string)
+      ?? "mock_dsp";
+    const destinationType: "platform" | "agent" = firstType === "agent" ? "agent" : "platform";
+    return { destination, destinationType };
+  }
+
+  it("storyboard agent destination → type=agent, destination=agent_url", () => {
+    const result = parseDestinations({
+      destinations: [{ type: "agent", agent_url: "https://wonderstruck.salesagents.example" }],
+    });
+    expect(result.destinationType).toBe("agent");
+    expect(result.destination).toBe("https://wonderstruck.salesagents.example");
+  });
+
+  it("storyboard platform destination → type=platform, destination=requested platform name", () => {
+    const result = parseDestinations({
+      destinations: [{ type: "platform", platform: "the-trade-desk", account: "agency-123-ttd" }],
+    });
+    expect(result.destinationType).toBe("platform");
+    expect(result.destination).toBe("the-trade-desk");
+  });
+
+  it("legacy deliver_to.deployments shape still parses", () => {
+    const result = parseDestinations({
+      deliver_to: [{ type: "platform", platform: "mock_dsp" }],
+    });
+    expect(result.destinationType).toBe("platform");
+    expect(result.destination).toBe("mock_dsp");
+  });
+
+  it("legacy deployments alias still parses", () => {
+    const result = parseDestinations({
+      deployments: [{ type: "agent", agent_url: "https://example.com/agent" }],
+    });
+    expect(result.destinationType).toBe("agent");
+    expect(result.destination).toBe("https://example.com/agent");
+  });
+
+  it("falls back to mock_dsp when nothing is supplied (demo-friendly)", () => {
+    const result = parseDestinations({});
+    expect(result.destinationType).toBe("platform");
+    expect(result.destination).toBe("mock_dsp");
+  });
+
+  it("destinations array takes precedence over the legacy shapes", () => {
+    const result = parseDestinations({
+      destinations: [{ type: "agent", agent_url: "https://new-shape.example" }],
+      deliver_to: [{ type: "platform", platform: "old-shape-dsp" }],
+    });
+    expect(result.destinationType).toBe("agent");
+    expect(result.destination).toBe("https://new-shape.example");
+  });
+});
+
+// ── activationService destinations gate behavior ─────────────────────────────
+//
+// Direct test of the change in src/domain/activationService.ts:
+//   - platform destinations still gated by signal.destinations.includes(...)
+//   - agent destinations skip that check (signals MUST accept type=agent
+//     per docs/signals/specification.mdx:186)
+
+import { activateSignalService, ValidationError } from "../src/domain/activationService";
+import { findSignalById } from "../src/storage/signalRepo";
+import { vi } from "vitest";
+
+vi.mock("../src/storage/signalRepo", async () => {
+  const actual = await vi.importActual<typeof import("../src/storage/signalRepo")>("../src/storage/signalRepo");
+  return { ...actual, findSignalById: vi.fn() };
+});
+vi.mock("../src/storage/activationRepo", () => ({
+  createActivationJob: vi.fn(async () => {}),
+  findOperationById: vi.fn(),
+  updateJobStatus: vi.fn(),
+  markWebhookFired: vi.fn(),
+}));
+
+import { createLogger } from "../src/utils/logger";
+
+describe("activationService — destinations gate", () => {
+  const db = {} as unknown as import("../src/storage/db").DB;
+  const kv = {} as unknown as KVNamespace;
+  const logger = createLogger("test-sec12");
+
+  const stubSignal: CanonicalSignal = {
+    ...makeFixtureSignal(),
+    destinations: ["mock_dsp", "mock_cleanroom"],
+  };
+
+  it("platform destination IN whitelist → passes", async () => {
+    vi.mocked(findSignalById).mockResolvedValue(stubSignal);
+    const res = await activateSignalService(
+      db, kv,
+      { signalId: "sig_drama_viewers", destination: "mock_dsp", destinationType: "platform" },
+      logger,
+    );
+    expect(res.task_id).toBeDefined();
+  });
+
+  it("platform destination NOT in whitelist → ValidationError", async () => {
+    vi.mocked(findSignalById).mockResolvedValue(stubSignal);
+    await expect(
+      activateSignalService(
+        db, kv,
+        { signalId: "sig_drama_viewers", destination: "the-trade-desk", destinationType: "platform" },
+        logger,
+      ),
+    ).rejects.toBeInstanceOf(ValidationError);
+  });
+
+  it("agent destination (URL not in whitelist) → bypasses the check, passes", async () => {
+    // This is the Sec-12 regression pin. Pre-fix, this would throw
+    // ValidationError because "https://..." isn't in signal.destinations.
+    vi.mocked(findSignalById).mockResolvedValue(stubSignal);
+    const res = await activateSignalService(
+      db, kv,
+      {
+        signalId: "sig_drama_viewers",
+        destination: "https://wonderstruck.salesagents.example",
+        destinationType: "agent",
+      },
+      logger,
+    );
+    expect(res.task_id).toBeDefined();
+  });
+
+  it("agent destination skips whitelist even when URL coincidentally matches a platform name", async () => {
+    // Defensive: someone passing destinationType: "agent" with a non-URL
+    // should still pass — the type field is the gate, not URL parsing.
+    vi.mocked(findSignalById).mockResolvedValue(stubSignal);
+    const res = await activateSignalService(
+      db, kv,
+      { signalId: "sig_drama_viewers", destination: "mock_dsp", destinationType: "agent" },
+      logger,
+    );
+    expect(res.task_id).toBeDefined();
+  });
+
+  it("default destinationType (omitted) treated as platform — preserves existing test behavior", async () => {
+    vi.mocked(findSignalById).mockResolvedValue(stubSignal);
+    const res = await activateSignalService(
+      db, kv,
+      { signalId: "sig_drama_viewers", destination: "mock_dsp" }, // no destinationType
+      logger,
+    );
+    expect(res.task_id).toBeDefined();
+    // And not-in-whitelist should still throw without destinationType.
+    await expect(
+      activateSignalService(
+        db, kv,
+        { signalId: "sig_drama_viewers", destination: "the-trade-desk" },
+        logger,
+      ),
+    ).rejects.toBeInstanceOf(ValidationError);
+  });
+});


### PR DESCRIPTION
Pre-validation against the upstream signals storyboard (adcp#2365, merged 2026-04-19) found 3 of 3 incoming scenarios would fail when `@adcp/client` ships the new bundle. This PR fixes the gaps so the moment the client re-releases, our agent goes from **18 PASS / 1 SKIP** to **21 PASS / 0 SKIP** with no further code change.

## Gaps closed

1. **`signal_id` MISSING** from `get_signals` response (schema-required). Every signal now carries `{ source: "agent", agent_url: <self-MCP-URL>, id: <signalId> }` per /schemas/core/signal-id.json agent variant.
2. **`pricing_options` was `[]`** for signals lacking pricing — schema requires `minItems: 1`. Mapper emits a default sentinel option (`rate: 0, is_fixed: false`) for the unset case.
3. **`context.correlation_id` echo MISSING** on `get_signals` and `activate_signal`. Both handlers now copy `args.context` into the response.
4. **`args.destinations` (top-level, current spec) was NOT being read.** Handler only checked `args.deliver_to` / `args.deployments`. Fallback chain now starts with `args.destinations`; legacy shapes still parse for back-compat.
5. **Agent destinations failed validation** because their URL (`https://...`) isn't in the signal's `destinations` whitelist (platform IDs only). Per docs/signals/specification.mdx:186 every signals agent MUST accept `type=agent`. Service now skips the whitelist check when `destinationType === "agent"`.

## Tests

[tests/storyboard-conformance.test.ts](tests/storyboard-conformance.test.ts) — 17 pins covering signal_id shape, agent_url URL validity, pricing_options minItems, destinations[] parsing precedence (5 cases), activationService whitelist behavior (5 cases incl. agent bypass + default preservation).

- Type-check: 0 new errors (baseline 95)
- Unit tests: **261 passed / 12 skipped** (+17 new)

## Demo evidence committed

- [storyboard_report_capability_discovery.json](storyboard_report_capability_discovery.json) — capability_discovery alone, full per-step receipts
- [storyboard_report_full.json](storyboard_report_full.json) — full storyboard track today (Core 13/13, Error 5/5, Signals (not applicable))
- [storyboard_report_post_upstream.json](storyboard_report_post_upstream.json) — post-merge baseline showing why we needed Sec-12

## Test plan

- [x] `npx vitest run` — 261 pass
- [x] `npx tsc --noEmit` — 0 new errors
- [ ] Merge + deploy
- [ ] Re-probe live worker with the exact storyboard payloads, confirm signal_id present, context echo, agent + platform destinations resolve correctly
- [ ] Daily cron `8a1d4572` will auto-re-run the storyboard CLI when @adcp/client re-releases