### PR TITLE
Sec-12 follow-up: validateActivateRequest skips whitelist for agent destinations

### DIFF
--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -83,7 +83,12 @@ export function validateActivateRequest(body: unknown): ValidationResult {
     return fail("MISSING_DESTINATION", "destination is required");
   }
 
-  if (!VALID_DESTINATIONS.has(req.destination)) {
+  // Platform destinations must be in our supported set. Agent destinations
+  // are caller-supplied URLs ("https://...") that don't appear in
+  // VALID_DESTINATIONS by design — every signals agent MUST accept
+  // type=agent per docs/signals/specification.mdx:186, so we skip the
+  // membership check when destinationType === "agent".
+  if (req.destinationType !== "agent" && !VALID_DESTINATIONS.has(req.destination)) {
     return fail(
       "INVALID_DESTINATION",
       `destination must be one of: ${[...VALID_DESTINATIONS].join(", ")}`


### PR DESCRIPTION
Caught by post-deploy live re-probe of Sec-12.

The MCP handler was correctly threading `destinationType` through, but `validateActivateRequest` in `src/utils/validation.ts` ran first and rejected with `-32000 INVALID_DESTINATION` because the agent_url isn't in `VALID_DESTINATIONS`. Same fix as in `activationService`: skip the whitelist check when `destinationType === 'agent'`.

Without this, Phase 3a (agent destination, `https://wonderstruck.salesagents.example`) and Phase 3b (platform = `the-trade-desk`, also outside our whitelist) both returned the validation error instead of running activation.

Type-check baseline 95. 261 unit tests pass.