### PR TITLE
Sec-12 round 2: relax platform whitelist for storyboard conformance

### DIFF
--- a/src/domain/activationService.ts
+++ b/src/domain/activationService.ts
@@ -65,15 +65,22 @@ export async function activateSignalService(
   if (!signal.activationSupported) {
     throw new ValidationError(`Signal ${req.signalId} does not support activation`);
   }
-  // Platform destinations are gated by the signal's destinations whitelist
-  // (mock_dsp, mock_cleanroom, etc.). Agent destinations are SA URLs that
-  // aren't in that whitelist by design — every signal MUST accept agent
-  // activation per the signals spec, so we skip the membership check
-  // when the caller declared destinationType = "agent".
+  // Per-signal destinations list is now advisory metadata, not a rejection
+  // gate (Sec-12 round 2). The AdCP signals storyboard activates against
+  // arbitrary platform names (the-trade-desk, dv360, etc.) and the agent
+  // must return an async deployment record — `is_live: false` is
+  // explicitly valid per the activate-signal-response schema and is
+  // exactly what the MCP handler emits today. Real platform integrations,
+  // when wired, would light up `is_live: true` from the activation
+  // pipeline — not from this gate.
+  //
+  // We log unknown-platform requests at info so they're visible in tail.
   if (req.destinationType !== "agent" && !signal.destinations.includes(req.destination)) {
-    throw new ValidationError(
-      `Signal ${req.signalId} is not available for destination '${req.destination}'`
-    );
+    logger.info("activation_unknown_platform", {
+      signalId: req.signalId,
+      requested: req.destination,
+      knownDestinations: signal.destinations,
+    });
   }
 
   const opId = operationId();

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -83,17 +83,19 @@ export function validateActivateRequest(body: unknown): ValidationResult {
     return fail("MISSING_DESTINATION", "destination is required");
   }
 
-  // Platform destinations must be in our supported set. Agent destinations
-  // are caller-supplied URLs ("https://...") that don't appear in
-  // VALID_DESTINATIONS by design — every signals agent MUST accept
-  // type=agent per docs/signals/specification.mdx:186, so we skip the
-  // membership check when destinationType === "agent".
-  if (req.destinationType !== "agent" && !VALID_DESTINATIONS.has(req.destination)) {
-    return fail(
-      "INVALID_DESTINATION",
-      `destination must be one of: ${[...VALID_DESTINATIONS].join(", ")}`
-    );
-  }
+  // Platform-name whitelist removed (Sec-12 round 2): every signals agent
+  // MUST accept arbitrary platform identifiers and return an async
+  // deployment record per docs/signals/specification.mdx + the upstream
+  // signals storyboard baseline (adcp#2365). The runner activates against
+  // platforms like "the-trade-desk" / "dv360" against any signal — those
+  // were never in our VALID_DESTINATIONS, so the check rejected legitimate
+  // protocol-level conformance traffic.
+  //
+  // is_live: false is explicitly valid per the activate-signal-response
+  // schema; the MCP handler emits it for every activation, so accepting
+  // unknown platforms here is a no-op on the response shape.
+  //
+  // Agent destinations were already exempted; this just unifies the rule.
 
   return { ok: true };
 }

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -270,12 +270,19 @@ describe("Request validation", () => {
     expect(result.ok).toBe(false);
   });
 
-  it("rejects activation with invalid destination", () => {
+  // Sec-12 round 2: validator no longer rejects unknown platform names.
+  // Every signals agent MUST accept arbitrary platforms per the upstream
+  // signals storyboard baseline (adcp#2365); is_live: false is the
+  // correct response shape for platforms we don't have a real integration
+  // with — and the MCP handler emits exactly that for every activation.
+  // The rejection paths preserved here cover actually-malformed cases
+  // (missing field, wrong type), not policy filtering.
+  it("accepts activation with arbitrary platform name (storyboard conformance)", () => {
     const result = validateActivateRequest({
       signalId: "sig_demo_test",
-      destination: "real_dsp_that_doesnt_exist",
+      destination: "the-trade-desk",
     });
-    expect(result.ok).toBe(false);
+    expect(result.ok).toBe(true);
   });
 
   // The three "generate request" tests were removed alongside

--- a/tests/storyboard-conformance.test.ts
+++ b/tests/storyboard-conformance.test.ts
@@ -159,12 +159,16 @@ describe("activate_signal request-shape parsing", () => {
   });
 });
 
-// ── activationService destinations gate behavior ─────────────────────────────
+// ── activationService destinations behavior (post-Sec-12 round 2) ────────────
 //
-// Direct test of the change in src/domain/activationService.ts:
-//   - platform destinations still gated by signal.destinations.includes(...)
-//   - agent destinations skip that check (signals MUST accept type=agent
-//     per docs/signals/specification.mdx:186)
+// Per the AdCP signals storyboard baseline, every signals agent must accept
+// arbitrary platform destinations and return an async deployment record —
+// `is_live: false` is explicitly valid per the activate-signal-response
+// schema. The per-signal destinations[] list is now advisory metadata,
+// not a rejection gate. This pin documents the post-relaxation behavior:
+//   - platform IN signal.destinations  → activates
+//   - platform NOT in signal.destinations → activates (logs at info)
+//   - agent destination (URL)           → activates (skips check entirely)
 
 import { activateSignalService, ValidationError } from "../src/domain/activationService";
 import { findSignalById } from "../src/storage/signalRepo";
@@ -183,7 +187,7 @@ vi.mock("../src/storage/activationRepo", () => ({
 
 import { createLogger } from "../src/utils/logger";
 
-describe("activationService — destinations gate", () => {
+describe("activationService — destinations behavior (post-Sec-12 round 2)", () => {
   const db = {} as unknown as import("../src/storage/db").DB;
   const kv = {} as unknown as KVNamespace;
   const logger = createLogger("test-sec12");
@@ -193,7 +197,7 @@ describe("activationService — destinations gate", () => {
     destinations: ["mock_dsp", "mock_cleanroom"],
   };
 
-  it("platform destination IN whitelist → passes", async () => {
+  it("platform destination IN signal.destinations → activates", async () => {
     vi.mocked(findSignalById).mockResolvedValue(stubSignal);
     const res = await activateSignalService(
       db, kv,
@@ -203,20 +207,22 @@ describe("activationService — destinations gate", () => {
     expect(res.task_id).toBeDefined();
   });
 
-  it("platform destination NOT in whitelist → ValidationError", async () => {
+  it("platform destination NOT in signal.destinations → still activates (storyboard requires acceptance)", async () => {
+    // Pre-relaxation, this would throw ValidationError. The runner sends
+    // arbitrary platforms (the-trade-desk, dv360, etc.) against any
+    // signal — those were never in our destinations list, so rejecting
+    // them broke protocol-level conformance.
     vi.mocked(findSignalById).mockResolvedValue(stubSignal);
-    await expect(
-      activateSignalService(
-        db, kv,
-        { signalId: "sig_drama_viewers", destination: "the-trade-desk", destinationType: "platform" },
-        logger,
-      ),
-    ).rejects.toBeInstanceOf(ValidationError);
+    const res = await activateSignalService(
+      db, kv,
+      { signalId: "sig_drama_viewers", destination: "the-trade-desk", destinationType: "platform" },
+      logger,
+    );
+    expect(res.task_id).toBeDefined();
+    expect(res.status).toBe("pending");
   });
 
-  it("agent destination (URL not in whitelist) → bypasses the check, passes", async () => {
-    // This is the Sec-12 regression pin. Pre-fix, this would throw
-    // ValidationError because "https://..." isn't in signal.destinations.
+  it("agent destination (URL) → activates without any platform check", async () => {
     vi.mocked(findSignalById).mockResolvedValue(stubSignal);
     const res = await activateSignalService(
       db, kv,
@@ -230,31 +236,32 @@ describe("activationService — destinations gate", () => {
     expect(res.task_id).toBeDefined();
   });
 
-  it("agent destination skips whitelist even when URL coincidentally matches a platform name", async () => {
-    // Defensive: someone passing destinationType: "agent" with a non-URL
-    // should still pass — the type field is the gate, not URL parsing.
+  it("default destinationType (omitted) treats as platform AND still activates against unknowns", async () => {
     vi.mocked(findSignalById).mockResolvedValue(stubSignal);
-    const res = await activateSignalService(
+    const a = await activateSignalService(
       db, kv,
-      { signalId: "sig_drama_viewers", destination: "mock_dsp", destinationType: "agent" },
+      { signalId: "sig_drama_viewers", destination: "mock_dsp" },
       logger,
     );
-    expect(res.task_id).toBeDefined();
+    expect(a.task_id).toBeDefined();
+    const b = await activateSignalService(
+      db, kv,
+      { signalId: "sig_drama_viewers", destination: "the-trade-desk" },
+      logger,
+    );
+    expect(b.task_id).toBeDefined();
   });
 
-  it("default destinationType (omitted) treated as platform — preserves existing test behavior", async () => {
-    vi.mocked(findSignalById).mockResolvedValue(stubSignal);
-    const res = await activateSignalService(
-      db, kv,
-      { signalId: "sig_drama_viewers", destination: "mock_dsp" }, // no destinationType
-      logger,
-    );
-    expect(res.task_id).toBeDefined();
-    // And not-in-whitelist should still throw without destinationType.
+  // The activationSupported gate is the ONLY hard reject in the service now.
+  it("signals with activationSupported=false still throw ValidationError", async () => {
+    vi.mocked(findSignalById).mockResolvedValue({
+      ...stubSignal,
+      activationSupported: false,
+    });
     await expect(
       activateSignalService(
         db, kv,
-        { signalId: "sig_drama_viewers", destination: "the-trade-desk" },
+        { signalId: "sig_drama_viewers", destination: "mock_dsp", destinationType: "platform" },
         logger,
       ),
     ).rejects.toBeInstanceOf(ValidationError);


### PR DESCRIPTION
Post-deploy live re-probe of Sec-12 (PRs #28+#29) showed Phase 3b still failed: storyboard sends `platform: "the-trade-desk"` and our agent returned `-32000 INVALID_DESTINATION` because that platform isn't in our 4-entry mock_* whitelist.

Same root cause as the agent-destination fix in #29, just for the platform side. Protocol-level conformance requires accepting arbitrary platform names and returning an async deployment record. `is_live: false` is explicitly valid per the activate-signal-response schema and is exactly what the MCP handler emits.

## Two whitelists removed

1. **`src/utils/validation.ts`** — `validateActivateRequest` no longer rejects non-mock_* platforms. The `KNOWN_PLATFORMS` constant kept for /capabilities advisory metadata; only the rejection gate is removed.
2. **`src/domain/activationService.ts`** — `signal.destinations.includes()` demoted from throw to `logger.info("activation_unknown_platform")`. Real platform integrations (when wired) would still land in `signal.destinations`; the activation pipeline (not this gate) is where they'd flip is_live to true.

## Tests

Failing test in [tests/index.test.ts](tests/index.test.ts) inverted from "rejects unknown destination" → "accepts arbitrary platform name (storyboard conformance)".

[tests/storyboard-conformance.test.ts](tests/storyboard-conformance.test.ts) destinations-gate suite rewritten — 5 cases pinning new behavior: platform-in-list activates, platform-not-in-list **also activates** (storyboard requirement), agent destination, default-type fallback, activationSupported=false still throws (only remaining hard reject).

- Type-check: baseline 95 unchanged
- Unit tests: 261 passed / 12 skipped