### PR TITLE
Sec-14: callback HTTP status codes (400 / 502 instead of 200-everywhere)

### DIFF
--- a/scripts/test-live.sh
+++ b/scripts/test-live.sh
@@ -193,10 +193,11 @@ run "linkedin status requires auth"       401 ''  "$BASE/auth/linkedin/status"
 run "linkedin status with auth reachable" 200 ''  -H "Authorization: Bearer $KEY" "$BASE/auth/linkedin/status"
 # /callback is intentionally public: LinkedIn's 302 back to the worker
 # carries only the OAuth state param, no bearer. The state mechanism
-# (single-use UUID in KV, issued on /init, consumed on /callback) is the
-# defense. A fabricated state must be rejected with the "Invalid State"
-# HTML page rather than proceeding to token exchange.
-run "linkedin callback fabricated state → Invalid State" 200 '' \
+# (single-use UUID in D1, issued on /init, consumed on /callback) is the
+# defense. A fabricated state is rejected with the "Invalid State"
+# HTML page AND now returns HTTP 400 (Sec-14) — caller-supplied bad
+# state is a 4xx, not a server-side success.
+run "linkedin callback fabricated state → 400 + Invalid State" 400 '' \
     "$BASE/auth/linkedin/callback?state=fabricated-by-attacker"
 # Additional correctness check — response body is the Invalid State page,
 # not some generic success. Shell-side since the body is HTML, not JSON.

--- a/src/activations/auth/linkedin.ts
+++ b/src/activations/auth/linkedin.ts
@@ -182,27 +182,35 @@ export async function handleLinkedInAuthCallback(
       has_error: !!error,
       ua: request.headers.get('user-agent') ?? null,
     }));
+    // 400: caller-side bug or replay. State was missing, expired, or already
+    // consumed — none of these are server faults; the client (LinkedIn redirect
+    // chain) supplied a value we can't honor.
     return htmlResponse('Invalid State', `
       <p style="color:#ef4444">OAuth state missing, expired, or already used.</p>
       <p>This protects against CSRF. Start the flow fresh.</p>
       <p>Restart the flow by calling <code>GET /auth/linkedin/init</code> with your API key.</p>
-    `);
+    `, 400);
   }
 
   if (error) {
+    // 502: LinkedIn (the upstream provider) returned an OAuth error response.
+    // The status code lets uptime/observability distinguish "we're down" from
+    // "user declined / scope rejected at LinkedIn."
     return htmlResponse('Authorization Failed', `
       <p style="color:#ef4444">LinkedIn returned an error:</p>
       <pre style="color:#fb923c">${escapeHtml(error)}: ${escapeHtml(errorDesc ?? '')}</pre>
       <p>Common causes: user denied access, or scopes not approved on your app.</p>
       <p>Restart the flow by calling <code>GET /auth/linkedin/init</code> with your API key.</p>
-    `);
+    `, 502);
   }
 
   if (!code) {
+    // 400: malformed callback — the redirect should always carry either a
+    // `code` or an `error`. Missing both means the client URL was tampered.
     return htmlResponse('Missing Code', `
       <p style="color:#ef4444">No authorization code in callback URL.</p>
       <p>Restart the flow by calling <code>GET /auth/linkedin/init</code> with your API key.</p>
-    `);
+    `, 400);
   }
 
   let tokenSet: LinkedInTokenSet;
@@ -210,12 +218,15 @@ export async function handleLinkedInAuthCallback(
     tokenSet = await exchangeCodeForTokens(code, env);
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
+    // 502: the LinkedIn token endpoint failed for us (network, 5xx, or
+    // bad client secret). Distinguishes server-side breakage from the
+    // 400 cases above (which are caller / URL problems).
     return htmlResponse('Token Exchange Failed', `
       <p style="color:#ef4444">Failed to exchange code for tokens:</p>
       <pre style="color:#fb923c">${escapeHtml(msg)}</pre>
       <p>Check LINKEDIN_CLIENT_SECRET is set correctly.</p>
       <p>Restart the flow by calling <code>GET /auth/linkedin/init</code> with your API key.</p>
-    `);
+    `, 502);
   }
 
   // Overwrite observability: the token KV keys are global (see
@@ -486,7 +497,20 @@ async function storeTokens(
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
-function htmlResponse(title: string, content: string): Response {
+/**
+ * Render the OAuth-callback HTML body with the right HTTP status.
+ *
+ * Default 200 (success page); error paths pass an explicit status so
+ * monitoring + cache-control behave correctly:
+ *   - Invalid State / Missing Code  → 400 (caller-side bug or replay)
+ *   - Authorization Failed (provider) → 502 (upstream returned an error)
+ *   - Token Exchange Failed         → 502 (upstream call failed)
+ *
+ * The HTML body remains identical between a 4xx/5xx and a 200 — browsers
+ * still render the same actionable error page; status is for non-browser
+ * observers (uptime probes, edge cache, log dashboards).
+ */
+function htmlResponse(title: string, content: string, status = 200): Response {
   return new Response(`<!DOCTYPE html>
 <html>
 <head>
@@ -508,7 +532,7 @@ function htmlResponse(title: string, content: string): Response {
   <h1>${title}</h1>
   ${content}
 </body>
-</html>`, { status: 200, headers: { 'Content-Type': 'text/html' } });
+</html>`, { status, headers: { 'Content-Type': 'text/html' } });
 }
 
 function json(body: unknown): Response {

--- a/tests/security.test.ts
+++ b/tests/security.test.ts
@@ -506,6 +506,63 @@ describe("OAuth state lifecycle", () => {
     expect(await res.text()).toContain("Invalid State");
   });
 
+  // Sec-14: status-code pins. Body contents stay the same; the status
+  // codes let monitoring + edge cache distinguish caller vs server vs
+  // provider failures.
+  it("Invalid State returns HTTP 400 (caller-side bad state)", async () => {
+    const { db } = makeOAuthDb();
+    const env = makeEnv(makeKv(), db);
+    const res = await handleLinkedInAuthCallback(
+      new Request("https://example.com/cb?state=fabricated"),
+      env,
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("Invalid State (no state at all) returns HTTP 400", async () => {
+    const { db } = makeOAuthDb();
+    const env = makeEnv(makeKv(), db);
+    const res = await handleLinkedInAuthCallback(
+      new Request("https://example.com/cb"),
+      env,
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("Authorization Failed (provider error) returns HTTP 502", async () => {
+    const { db } = makeOAuthDb();
+    const env = makeEnv(makeKv(), db);
+    // Issue a state we can spend so we get past the state-check branch
+    // and into the `if (error)` branch.
+    const initRes = await handleLinkedInAuthInit(env);
+    const html = await initRes.text();
+    const m = html.match(/href="([^"]*linkedin\.com[^"]*)"/);
+    if (!m || !m[1]) throw new Error("authorize URL not found");
+    const state = extractState(m[1].replace(/&amp;/g, "&"));
+    const res = await handleLinkedInAuthCallback(
+      new Request(`https://example.com/cb?state=${state}&error=access_denied`),
+      env,
+    );
+    expect(res.status).toBe(502);
+    expect(await res.text()).toContain("Authorization Failed");
+  });
+
+  it("Missing Code (no code, no error) returns HTTP 400", async () => {
+    const { db } = makeOAuthDb();
+    const env = makeEnv(makeKv(), db);
+    const initRes = await handleLinkedInAuthInit(env);
+    const html = await initRes.text();
+    const m = html.match(/href="([^"]*linkedin\.com[^"]*)"/);
+    if (!m || !m[1]) throw new Error("authorize URL not found");
+    const state = extractState(m[1].replace(/&amp;/g, "&"));
+    const res = await handleLinkedInAuthCallback(
+      new Request(`https://example.com/cb?state=${state}`), // no code, no error
+      env,
+    );
+    expect(res.status).toBe(400);
+    expect(await res.text()).toContain("Missing Code");
+  });
+
   it("callback escapes provider-supplied error_description", async () => {
     const { db } = makeOAuthDb();
     const env = makeEnv(makeKv(), db);


### PR DESCRIPTION
OAuth callback's error pages all returned HTTP 200 with HTML bodies. Reviewer-flagged previously as a low-priority nit; now closed.

## Status mapping

| Path | Was | Now | Reason |
|---|---|---|---|
| Success | 200 | 200 | Unchanged |
| Invalid State | 200 | **400** | Caller-supplied bad state (CSRF guard) |
| Missing Code | 200 | **400** | Malformed callback URL |
| Authorization Failed (provider) | 200 | **502** | LinkedIn returned an OAuth error |
| Token Exchange Failed | 200 | **502** | Our token-endpoint POST failed |

Body content is unchanged across the board — browsers still render the same actionable error page. The status code is for non-browser observers: uptime probes can now distinguish 'we're healthy and the user supplied bad state' (400, not an alert) from 'LinkedIn endpoint is failing for us' (502, page someone).

`htmlResponse(title, content, status = 200)` — single-line signature change; default preserves existing success call site.

## Tests
4 new status-code pins in [tests/security.test.ts](tests/security.test.ts). Existing body-content tests unchanged. `scripts/test-live.sh` updated to expect 400 on fabricated state.

- Type-check: baseline 95
- Unit tests: 269 / 12 skipped

## ⚠️ One caveat for ops
Uptime probes hitting `/auth/linkedin/callback?state=health-probe` will now see 400 instead of 200. Configs that only allow 2xx need to add 400 too.