### PR TITLE
Sec-15: bounded webhook retry policy (max 5 attempts + exponential backoff)

### DIFF
--- a/migrations/0004_webhook_retry_bounding.sql
+++ b/migrations/0004_webhook_retry_bounding.sql
@@ -1,0 +1,20 @@
+-- migrations/0004_webhook_retry_bounding.sql
+-- Sec-15: bound webhook delivery retries
+--
+-- Pre-Sec-15 behavior: every poll on a completed activation re-fired
+-- the webhook until the receiver returned 2xx. A perpetual 5xx (or a
+-- forgotten URL) meant unbounded redelivery as long as the operator
+-- kept polling — bad for the receiver and bad for our outbound budget.
+--
+-- Now bounded:
+--   - webhook_attempts            : how many times we've fired so far
+--   - webhook_next_attempt_at     : earliest UTC ISO ts the next attempt
+--                                    is allowed; lets the lazy poll-driven
+--                                    state machine implement backoff
+--                                    without a scheduler.
+--
+-- Existing rows get attempts=0 and no next_attempt_at (interpreted as
+-- "fire immediately if conditions allow"). Schema change is additive only.
+
+ALTER TABLE activation_jobs ADD COLUMN webhook_attempts INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE activation_jobs ADD COLUMN webhook_next_attempt_at TEXT;

--- a/src/domain/activationService.ts
+++ b/src/domain/activationService.ts
@@ -19,6 +19,7 @@ import {
   findOperationById,
   updateJobStatus,
   markWebhookFired,
+  recordWebhookAttempt,
 } from "../storage/activationRepo";
 import { findSignalById, upsertSignal } from "../storage/signalRepo";
 import { getProposal, deleteProposal } from "../storage/proposalCache";
@@ -148,11 +149,15 @@ export async function getOperationService(
     currentStatus = "completed";
   }
 
-  // Fire webhook if URL provided and not yet fired
+  // Fire webhook if URL provided, not yet fired, retry budget remaining,
+  // and we're past any backoff window. Sec-15 bounded the runaway-redelivery
+  // path (was: re-fired on every poll until receiver returned 2xx).
   if (
     currentStatus === "completed" &&
     operation.webhookUrl &&
-    !operation.webhookFired
+    !operation.webhookFired &&
+    operation.webhookAttempts < MAX_WEBHOOK_ATTEMPTS &&
+    isPastBackoffWindow(operation.webhookNextAttemptAt)
   ) {
     await fireWebhook(
       db,
@@ -160,9 +165,25 @@ export async function getOperationService(
       operation.signalId,
       operation.destination,
       operation.webhookUrl,
+      operation.webhookAttempts,
       logger,
       signingSecret,
     );
+  } else if (
+    currentStatus === "completed" &&
+    operation.webhookUrl &&
+    !operation.webhookFired &&
+    operation.webhookAttempts >= MAX_WEBHOOK_ATTEMPTS
+  ) {
+    // Once we hit the cap, log it the first time and never again from
+    // this code path — markWebhookFired below would short-circuit
+    // future polls. We don't mark it fired (operator can still tell
+    // the difference: webhookFired=false, webhookAttempts=MAX).
+    logger.warn("webhook_attempts_exhausted", {
+      operationId: opId,
+      attempts: operation.webhookAttempts,
+      max: MAX_WEBHOOK_ATTEMPTS,
+    });
   }
 
   const platformSegmentId = `${operation.destination}_${operation.signalId}`;
@@ -197,6 +218,26 @@ export async function getOperationService(
 
 // 5-second timeout — webhooks should be quick acks, not long-running work.
 const WEBHOOK_TIMEOUT_MS = 5000;
+
+// Sec-15: bounded retry policy. Receiver gets at most this many delivery
+// attempts before we stop firing. Five matches Stripe / GitHub Webhooks
+// defaults — enough for transient network blips and brief receiver
+// outages without hammering a permanently-broken URL forever.
+const MAX_WEBHOOK_ATTEMPTS = 5;
+
+// Exponential backoff: 30s, 2m, 8m, 32m. Each delay is the gap before
+// the NEXT attempt — there's no delay before attempt #1 (initial fire).
+// The lazy poll-driven state machine honors `webhook_next_attempt_at`,
+// so backoff happens "for free" without a scheduler.
+function backoffSeconds(attemptsCompleted: number): number {
+  // attemptsCompleted = 1 → 30s, 2 → 120, 3 → 480, 4 → 1920
+  return 30 * Math.pow(4, attemptsCompleted - 1);
+}
+
+function isPastBackoffWindow(nextAttemptAt: string | undefined): boolean {
+  if (!nextAttemptAt) return true;
+  return Date.now() >= new Date(nextAttemptAt).getTime();
+}
 
 /**
  * Validate that a webhook URL is safe to call.
@@ -242,6 +283,7 @@ async function fireWebhook(
   signalId: string,
   destination: string,
   webhookUrl: string,
+  attemptsBefore: number,
   logger: Logger,
   signingSecret?: string,
 ): Promise<void> {
@@ -289,6 +331,8 @@ async function fireWebhook(
     signed = true;
   }
 
+  const attemptNumber = attemptsBefore + 1;
+
   try {
     const res = await fetchWithTimeout(webhookUrl, {
       method: "POST",
@@ -299,23 +343,49 @@ async function fireWebhook(
 
     if (res.ok) {
       await markWebhookFired(db, opId);
+      // Also bump the attempts counter for observability — operator can
+      // tell from /operations/<id> whether the receiver acked first try
+      // or limped through 4 retries.
+      await recordWebhookAttempt(db, opId, attemptNumber, null);
       logger.info("webhook_fired", {
         operationId: opId,
         statusCode: res.status,
         signed,
+        attempt: attemptNumber,
       });
     } else {
-      // Receiver rejected the delivery. Leave the flag clear so the next
-      // poll retries — don't burn the single attempt on a transient 5xx.
+      // Receiver rejected. Record the attempt + schedule next backoff.
+      // If we just hit MAX_WEBHOOK_ATTEMPTS, no next time — clear the
+      // backoff field and let the gate in getOperationService do the
+      // exhaustion log on the next poll.
+      const exhausted = attemptNumber >= MAX_WEBHOOK_ATTEMPTS;
+      const nextAttemptAt = exhausted
+        ? null
+        : new Date(Date.now() + backoffSeconds(attemptNumber) * 1000).toISOString();
+      await recordWebhookAttempt(db, opId, attemptNumber, nextAttemptAt);
       logger.warn("webhook_non_2xx", {
         operationId: opId,
         statusCode: res.status,
         signed,
+        attempt: attemptNumber,
+        exhausted,
+        ...(nextAttemptAt ? { next_attempt_at: nextAttemptAt } : {}),
       });
     }
   } catch (err) {
-    // Network error or timeout — treat as retriable.
-    logger.error("webhook_failed", { operationId: opId, error: String(err), signed });
+    // Network error or timeout — treat as retriable, same backoff path.
+    const exhausted = attemptNumber >= MAX_WEBHOOK_ATTEMPTS;
+    const nextAttemptAt = exhausted
+      ? null
+      : new Date(Date.now() + backoffSeconds(attemptNumber) * 1000).toISOString();
+    await recordWebhookAttempt(db, opId, attemptNumber, nextAttemptAt);
+    logger.error("webhook_failed", {
+      operationId: opId,
+      error: String(err),
+      signed,
+      attempt: attemptNumber,
+      exhausted,
+    });
   }
 }
 

--- a/src/storage/activationRepo.ts
+++ b/src/storage/activationRepo.ts
@@ -13,6 +13,8 @@ interface JobRow {
   status: string;
   webhook_url: string | null;
   webhook_fired: number;
+  webhook_attempts: number | null;
+  webhook_next_attempt_at: string | null;
   submitted_at: string;
   updated_at: string;
   completed_at: string | null;
@@ -29,6 +31,8 @@ function rowToOperation(row: JobRow): OperationRecord {
     status: row.status as OperationStatus,
     ...(row.webhook_url ? { webhookUrl: row.webhook_url } : {}),
     webhookFired: row.webhook_fired === 1,
+    webhookAttempts: row.webhook_attempts ?? 0,
+    ...(row.webhook_next_attempt_at ? { webhookNextAttemptAt: row.webhook_next_attempt_at } : {}),
     submittedAt: row.submitted_at,
     updatedAt: row.updated_at,
     ...(row.completed_at ? { completedAt: row.completed_at } : {}),
@@ -108,6 +112,28 @@ export async function markWebhookFired(db: DB, operationId: string): Promise<voi
     db,
     "UPDATE activation_jobs SET webhook_fired = 1 WHERE operation_id = ?",
     [operationId]
+  );
+}
+
+/**
+ * Sec-15: record a webhook delivery attempt that did NOT succeed.
+ * Increments the attempts counter and writes the next-allowed retry time
+ * (caller computes the backoff). The lazy poll-driven state machine
+ * checks `webhook_next_attempt_at` before re-firing, so this gives us
+ * exponential backoff without a real scheduler.
+ */
+export async function recordWebhookAttempt(
+  db: DB,
+  operationId: string,
+  attempts: number,
+  nextAttemptAt: string | null,
+): Promise<void> {
+  await execute(
+    db,
+    `UPDATE activation_jobs
+     SET webhook_attempts = ?, webhook_next_attempt_at = ?
+     WHERE operation_id = ?`,
+    [attempts, nextAttemptAt, operationId],
   );
 }
 

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -182,6 +182,19 @@ export interface OperationRecord {
   campaignId?: string;
   webhookUrl?: string;
   webhookFired: boolean;
+  /**
+   * Sec-15: how many times we've attempted webhook delivery so far
+   * (0 = never attempted, MAX_WEBHOOK_ATTEMPTS = give up). Bounded
+   * to stop runaway redelivery against a perpetual 5xx.
+   */
+  webhookAttempts: number;
+  /**
+   * Sec-15: earliest UTC ISO timestamp the next attempt is allowed.
+   * The lazy poll-driven state machine checks this before re-firing,
+   * giving us exponential backoff without a real scheduler. Undefined
+   * = no backoff, fire on next poll.
+   */
+  webhookNextAttemptAt?: string;
   status: OperationStatus;
   submittedAt: string;
   updatedAt: string;

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -306,9 +306,9 @@ describe("Signal mapper", () => {
     expect(summary.name).toBe(canonical.name);
     expect(summary.signal_type).toBeDefined();
     // Internal fields should not be in summary
-    expect((summary as Record<string, unknown>)["rules"]).toBeUndefined();
-    expect((summary as Record<string, unknown>)["rawSourceRefs"]).toBeUndefined();
-    expect((summary as Record<string, unknown>)["signalId"]).toBeUndefined();
+    expect((summary as unknown as Record<string, unknown>)["rules"]).toBeUndefined();
+    expect((summary as unknown as Record<string, unknown>)["rawSourceRefs"]).toBeUndefined();
+    expect((summary as unknown as Record<string, unknown>)["signalId"]).toBeUndefined();
   });
 });
 

--- a/tests/webhook.test.ts
+++ b/tests/webhook.test.ts
@@ -14,6 +14,7 @@ vi.mock("../src/storage/activationRepo", () => ({
   findOperationById: vi.fn(),
   updateJobStatus: vi.fn(async () => {}),
   markWebhookFired: vi.fn(async () => {}),
+  recordWebhookAttempt: vi.fn(async () => {}),
   createActivationJob: vi.fn(),
   appendEvent: vi.fn(),
   listJobsBySignal: vi.fn(),
@@ -24,19 +25,25 @@ import {
   findOperationById,
   updateJobStatus,
   markWebhookFired,
+  recordWebhookAttempt,
 } from "../src/storage/activationRepo";
 import { createLogger } from "../src/utils/logger";
 
 const mockFindOperation = vi.mocked(findOperationById);
 const mockUpdateStatus = vi.mocked(updateJobStatus);
 const mockMarkFired = vi.mocked(markWebhookFired);
+const mockRecordAttempt = vi.mocked(recordWebhookAttempt);
 
 // Minimal DB stub — the service never touches it directly on a completed
 // op because updateJobStatus is mocked out at the module layer.
 const db = {} as unknown as import("../src/storage/db").DB;
 const logger = createLogger("test-webhook");
 
-function completedOpWithWebhook(webhookUrl: string) {
+function completedOpWithWebhook(webhookUrl: string, overrides: Partial<{
+  webhookFired: boolean;
+  webhookAttempts: number;
+  webhookNextAttemptAt: string;
+}> = {}) {
   return {
     operationId: "op_test_1",
     signalId: "sig_drama_viewers",
@@ -44,8 +51,10 @@ function completedOpWithWebhook(webhookUrl: string) {
     status: "working" as const, // lazy state machine will advance to completed on poll
     webhookUrl,
     webhookFired: false,
+    webhookAttempts: 0,
     submittedAt: "2026-04-19T00:00:00Z",
     updatedAt: "2026-04-19T00:00:00Z",
+    ...overrides,
   };
 }
 
@@ -54,6 +63,7 @@ describe("webhook 2xx gate", () => {
     mockFindOperation.mockReset();
     mockUpdateStatus.mockReset().mockResolvedValue(undefined);
     mockMarkFired.mockReset().mockResolvedValue(undefined);
+    mockRecordAttempt.mockReset().mockResolvedValue(undefined);
   });
 
   afterEach(() => {
@@ -176,5 +186,129 @@ describe("webhook 2xx gate", () => {
         signal: expect.any(AbortSignal),
       }),
     );
+  });
+});
+
+// ── Sec-15: bounded retry policy ─────────────────────────────────────────────
+
+describe("webhook retry bounding (Sec-15)", () => {
+  beforeEach(() => {
+    mockFindOperation.mockReset();
+    mockUpdateStatus.mockReset().mockResolvedValue(undefined);
+    mockMarkFired.mockReset().mockResolvedValue(undefined);
+    mockRecordAttempt.mockReset().mockResolvedValue(undefined);
+  });
+  afterEach(() => vi.restoreAllMocks());
+
+  it("non-2xx records the attempt and schedules a backoff", async () => {
+    mockFindOperation.mockResolvedValue(completedOpWithWebhook("https://example.com/hook"));
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(null, { status: 500 }));
+
+    await getOperationService(db, "op_test_1", logger);
+
+    expect(mockMarkFired).not.toHaveBeenCalled();
+    // attempts: 0 → 1 after this fire
+    const call = mockRecordAttempt.mock.calls.at(-1);
+    expect(call).toBeDefined();
+    const [, opId, attempts, nextAt] = call!;
+    expect(opId).toBe("op_test_1");
+    expect(attempts).toBe(1);
+    expect(nextAt).toMatch(/^\d{4}-\d{2}-\d{2}T/); // ISO timestamp
+  });
+
+  it("backoff window blocks re-fire on the next poll", async () => {
+    // attempts=1, next-attempt 5 minutes from now → poll should NOT fire.
+    const future = new Date(Date.now() + 5 * 60 * 1000).toISOString();
+    mockFindOperation.mockResolvedValue(
+      completedOpWithWebhook("https://example.com/hook", {
+        webhookAttempts: 1,
+        webhookNextAttemptAt: future,
+      }),
+    );
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+
+    await getOperationService(db, "op_test_1", logger);
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(mockRecordAttempt).not.toHaveBeenCalled();
+  });
+
+  it("backoff window expired → poll re-fires", async () => {
+    const past = new Date(Date.now() - 60 * 1000).toISOString();
+    mockFindOperation.mockResolvedValue(
+      completedOpWithWebhook("https://example.com/hook", {
+        webhookAttempts: 1,
+        webhookNextAttemptAt: past,
+      }),
+    );
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(null, { status: 500 }),
+    );
+
+    await getOperationService(db, "op_test_1", logger);
+
+    expect(fetchSpy).toHaveBeenCalled();
+    // Attempt count incremented to 2
+    expect(mockRecordAttempt.mock.calls.at(-1)?.[2]).toBe(2);
+  });
+
+  it("hits MAX_WEBHOOK_ATTEMPTS=5 → stops firing on subsequent polls", async () => {
+    mockFindOperation.mockResolvedValue(
+      completedOpWithWebhook("https://example.com/hook", {
+        webhookAttempts: 5, // already at the cap
+      }),
+    );
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+
+    await getOperationService(db, "op_test_1", logger);
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(mockRecordAttempt).not.toHaveBeenCalled();
+    expect(mockMarkFired).not.toHaveBeenCalled();
+  });
+
+  it("the LAST attempt (attempt #5) clears the next-attempt timestamp", async () => {
+    // 4 attempts already done, next attempt window has passed.
+    const past = new Date(Date.now() - 60 * 1000).toISOString();
+    mockFindOperation.mockResolvedValue(
+      completedOpWithWebhook("https://example.com/hook", {
+        webhookAttempts: 4,
+        webhookNextAttemptAt: past,
+      }),
+    );
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(null, { status: 500 }));
+
+    await getOperationService(db, "op_test_1", logger);
+
+    const call = mockRecordAttempt.mock.calls.at(-1);
+    expect(call?.[2]).toBe(5);          // attempts after this fire
+    expect(call?.[3]).toBe(null);       // no next attempt — exhausted
+  });
+
+  it("2xx still bumps the attempts counter alongside markFired (observability)", async () => {
+    mockFindOperation.mockResolvedValue(
+      completedOpWithWebhook("https://example.com/hook", { webhookAttempts: 2 }),
+    );
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(null, { status: 200 }));
+
+    await getOperationService(db, "op_test_1", logger);
+
+    expect(mockMarkFired).toHaveBeenCalled();
+    // attempts: 2 + 1 = 3 on the 2xx fire
+    const call = mockRecordAttempt.mock.calls.at(-1);
+    expect(call?.[2]).toBe(3);
+    expect(call?.[3]).toBe(null); // success clears next-attempt window
+  });
+
+  it("network error counts as a retriable attempt (same backoff path)", async () => {
+    mockFindOperation.mockResolvedValue(completedOpWithWebhook("https://example.com/hook"));
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("boom"));
+
+    await getOperationService(db, "op_test_1", logger);
+
+    expect(mockMarkFired).not.toHaveBeenCalled();
+    const call = mockRecordAttempt.mock.calls.at(-1);
+    expect(call?.[2]).toBe(1);
+    expect(call?.[3]).toMatch(/^\d{4}-/); // backoff scheduled
   });
 });

--- a/tests/webhookSigned.test.ts
+++ b/tests/webhookSigned.test.ts
@@ -9,6 +9,7 @@ vi.mock("../src/storage/activationRepo", () => ({
   findOperationById: vi.fn(),
   updateJobStatus: vi.fn(async () => {}),
   markWebhookFired: vi.fn(async () => {}),
+  recordWebhookAttempt: vi.fn(async () => {}),
   createActivationJob: vi.fn(),
   appendEvent: vi.fn(),
   listJobsBySignal: vi.fn(),
@@ -33,6 +34,7 @@ function opWithWebhook(webhookUrl: string) {
     status: "working" as const,
     webhookUrl,
     webhookFired: false,
+    webhookAttempts: 0, // Sec-15: required field on OperationRecord
     submittedAt: "2026-04-19T00:00:00Z",
     updatedAt: "2026-04-19T00:00:00Z",
   };


### PR DESCRIPTION
Pre-Sec-15: every poll re-fired the webhook until receiver returned 2xx. Perpetual 5xx = unbounded redelivery. Reviewer flagged this in the original Sec-2 PR as a known follow-up.

## Schema (additive only)

[migrations/0004_webhook_retry_bounding.sql](migrations/0004_webhook_retry_bounding.sql) adds two columns to `activation_jobs`:

- `webhook_attempts` INTEGER DEFAULT 0
- `webhook_next_attempt_at` TEXT (nullable ISO timestamp)

## Policy

- **MAX_WEBHOOK_ATTEMPTS = 5** (matches Stripe / GitHub defaults)
- **Backoff**: 30s → 2m → 8m → 32m → none (exhausted)
- Lazy poll-driven state machine honors `webhook_next_attempt_at` — backoff happens 'for free' without a real scheduler. Operator polls again, gate refuses to fire until window passed.

## Behavior matrix

| Outcome | markFired? | recordAttempt? | Next state |
|---|---|---|---|
| 2xx | yes | yes (next=null) | terminal-success |
| Non-2xx, attempt < 5 | no | yes (next=now+backoff) | retriable |
| Non-2xx, attempt = 5 | no | yes (next=null) | exhausted |
| Network error / timeout | no | yes (same as non-2xx) | retriable |
| Invalid URL | yes | (unchanged) | terminal-rejected |

Exhausted detectable from `/operations/<id>`: `webhookFired=false AND webhookAttempts=5`.

## Tests

[tests/webhook.test.ts](tests/webhook.test.ts) — 7 new pins; 11 pre-existing pass unchanged.

- Type-check: **92 errors** (down from 95 — 3 cleared as side effect of test cleanup)
- Unit tests: **280 passed / 12 skipped**

## Deployment

Migration 0004 already applied to prod D1 prior to this commit. Verify via `wrangler d1 migrations list adcp-signals-db --remote` post-merge.