### PR TITLE
Sec-19: SECURITY_MODEL.md final cleanup — no open parked items

### DIFF
--- a/SECURITY_MODEL.md
+++ b/SECURITY_MODEL.md
@@ -2,67 +2,74 @@
 
 This document records trust-model constraints that cannot be inferred from
 reading the code alone. Skim this before opening a review issue about an
-access-control surface — the constraint may be intentional.
+access-control surface — the constraint may be intentional. As of Sec-19
+there are **no open parked items** — everything below describes active
+implementation patterns.
 
-## Trust model: single-operator demo
+## Trust model
 
-This repo is a reference implementation, not a multi-tenant service. The
-deployed Worker has one `DEMO_API_KEY` secret, shared by all operators
-with admin access to the deployment.
+One or more operators authenticate via `Authorization: Bearer <key>`.
+The bearer token IS the operator identity — different tokens map to
+different operators automatically via the operator-id derivation
+described below.
 
-## Shared LinkedIn token set
+Today the deployed Worker has one provisioned `DEMO_API_KEY` secret
+(single-operator demo posture), but the code is ready to handle
+multiple distinct tokens with full resource isolation between them.
+Provisioning additional tokens is purely a wrangler-secret operation
+and needs no code change.
 
-### Constraint
+## Per-operator resource scoping (Sec-18)
 
-LinkedIn OAuth tokens are stored under fixed, unqualified KV keys:
+Every inbound call that touches operator-scoped resources derives a
+stable identifier from the bearer token:
 
-- `linkedin:access_token`
-- `linkedin:refresh_token`
+```
+operator_id = base64url(sha256(bearer_token).slice(0, 9))   // 12 chars
+```
 
-See [src/activations/auth/linkedin.ts](src/activations/auth/linkedin.ts)
-(constants at the top of the file).
+See [src/utils/operatorId.ts](src/utils/operatorId.ts). Deterministic —
+same token → same ID across calls and across Workers. Different tokens
+→ different IDs, automatic isolation. 72 bits of namespace; collision
+space comfortably exceeds any plausible operator count.
 
-There is no per-operator or per-tenant scoping. Any caller holding
-`DEMO_API_KEY` who runs the `/auth/linkedin/init` → callback flow under
-their own LinkedIn account will overwrite the previous token set.
+The bearer is never logged or stored; the operator_id is a one-way
+derivative and is safe to use as a KV key suffix, DB column, or log
+field.
 
-### What this means in practice
+### What's scoped per operator
 
-- **DoS on the integration.** A second operator can invalidate the first
-  operator's session by re-authorizing.
-- **Activation runs under whichever LinkedIn identity authorized last.**
-  `/signals/activate/linkedin` uses `getValidAccessToken` which returns
-  whatever is currently in KV — so campaign creation charges, ad accounts,
-  and creative ownership follow the last-writer.
+**LinkedIn OAuth tokens** — stored under namespaced KV keys:
+`linkedin:access_token:<operator_id>`, `:refresh_token:<…>`,
+`:token_expires:<…>`, `:token_meta:<…>`. Two operators authorizing
+independently produce disjoint token sets. Re-authorizing only
+overwrites your own.
 
-### Why this is accepted for now
+**OAuth state rows** — the `oauth_state` D1 table carries the issuing
+operator_id. `/init` writes it; `/callback` (which runs public, no
+bearer) consumes the row via `DELETE … RETURNING operator_id` and
+uses the returned value to namespace token storage. See migration
+`0005_oauth_state_operator.sql` and `consumeOAuthState` in
+[src/activations/auth/linkedin.ts](src/activations/auth/linkedin.ts).
 
-This is a demo / single-operator deployment. Adding per-operator token
-scoping requires inventing an operator identity layer (session IDs,
-multi-tenant KV keys, per-operator state tracking) that is out of
-proportion for the current use case.
+**Activation calls** — `/signals/activate/linkedin` derives the
+operator_id from the bearer and threads it through the adapter
+chain to `getValidAccessToken`, so activations always run under the
+calling operator's LinkedIn identity.
 
-An observability signal for token overwrites exists:
-`linkedin_oauth_tokens_overwritten` warns on every callback where a prior
-token set existed. Watch `wrangler tail` for it — repeat overwrites are
-usually the first symptom that two operators are stepping on each other.
+### When multi-tenant scoping needs more
 
-### When to revisit
+The current design covers operators who each hold distinct bearer
+tokens. Genuinely multi-tenant products (end-user-facing UI where
+viewers see signals scoped to their org) would add:
 
-Reopen this decision if any of these become true:
+- A request-level session identity separate from the admin bearer
+  (JWT or cookie-session)
+- Per-tenant activation records / audit log
+- Compliance-driven per-customer credential isolation
 
-1. The Worker is deployed to a setting where more than one independent
-   operator holds `DEMO_API_KEY`.
-2. The product grows an end-user-facing UI that relies on LinkedIn
-   context per viewer/tenant.
-3. LinkedIn Ads credentials need to be rotated per customer for billing
-   or compliance reasons.
-
-The minimal redesign is: namespace the KV keys by an operator identifier
-derived from the request (e.g. hash of the calling `DEMO_API_KEY`, a
-per-operator secret, or an explicit `X-Operator-Id` header). Callback,
-`getValidAccessToken`, `/status`, and the activation route all resolve
-the namespace from the same source.
+None of those are in scope today. Reopen this section if a real
+multi-tenant requirement lands.
 
 ## Token encryption at rest
 
@@ -87,16 +94,19 @@ migration script needed.
 
 ## What does NOT live here
 
-- Code-level auth gates: see inline comments around `publicPaths` in
+- **Code-level auth gates**: see inline comments around `publicPaths` in
   [src/index.ts](src/index.ts) and `AUTHENTICATED_MCP_METHODS` in
   [src/mcp/server.ts](src/mcp/server.ts).
-- Webhook signing format: see
+- **Webhook signing format**: see
   [src/domain/webhookSigning.ts](src/domain/webhookSigning.ts) and the
   "Webhook signatures" section of README.md.
-- Webhook retry policy: bounded at 5 attempts with exponential backoff
+- **Webhook retry policy**: bounded at 5 attempts with exponential backoff
   (30s → 2m → 8m → 32m). See `MAX_WEBHOOK_ATTEMPTS` and `backoffSeconds`
   in [src/domain/activationService.ts](src/domain/activationService.ts).
-- Callback error-page HTTP status codes: 400 for caller-side bad state
+- **Callback error-page HTTP status codes**: 400 for caller-side bad state
   (Invalid State, Missing Code), 502 for upstream provider failures
   (Authorization Failed, Token Exchange Failed). 200 only on success.
   See `htmlResponse` in [src/activations/auth/linkedin.ts](src/activations/auth/linkedin.ts).
+- **OAuth state atomicity**: single-use via D1 `DELETE … RETURNING`. See
+  `consumeOAuthState` in
+  [src/activations/auth/linkedin.ts](src/activations/auth/linkedin.ts).


### PR DESCRIPTION
All three originally-parked items are now resolved:

| Item | Closed by |
|---|---|
| Shared LinkedIn token set | Sec-18 (per-operator namespacing) |
| Token encryption at rest | provisioned on prod worker |
| Callback HTTP status codes | Sec-14 (400/502 mapping) |

Doc was still framed as 'one genuine parked item plus one active feature' from Sec-17. Now there's nothing parked, so the shape changed:

- Opening paragraph states 'no open parked items' as of Sec-19
- Replaced 'Shared LinkedIn token set' (parked) section with 'Per-operator resource scoping' (active pattern) — documents the operator_id derivation, what's scoped per operator, and when genuine multi-tenancy would need more
- 'Trust model' rewritten from 'single-operator demo' to describe the actual posture: one provisioned key today, code ready to handle N distinct tokens with full isolation
- 'What does NOT live here' gained the D1-atomic OAuth state pointer

Doc-only. No code change.