### PR TITLE
Sec-20: idempotency discriminated union (HEAD schema caught up)

### DIFF
--- a/scripts/pre-demo-audit.mjs
+++ b/scripts/pre-demo-audit.mjs
@@ -135,7 +135,19 @@ async function checkNlQuery() {
       body: JSON.stringify({ query: q, limit: 3 }),
     });
     const count = body.result?.matched_signals?.length ?? 0;
-    log(`nl-query — "${q.slice(0, 40)}..."`, status === 200 && body.success === true && count > 0, `${count} matches`);
+    const hasEstimate = typeof body.result?.estimated_size === 'number';
+    // NLAQ returns success=true in two shapes:
+    //   - Direct catalog matches (count > 0)
+    //   - Dimension-resolved estimate with no exact catalog match
+    //     (count=0 but estimated_size populated — valid for composite
+    //     queries like "graduate educated adults who are not low income")
+    // Same acceptance rule the live runner uses.
+    const ok = status === 200 && body.success === true && (count > 0 || hasEstimate);
+    log(
+      `nl-query — "${q.slice(0, 40)}..."`,
+      ok,
+      count > 0 ? `${count} matches` : hasEstimate ? `estimate: ${body.result.estimated_size}` : 'empty',
+    );
   }
 }
 
@@ -254,8 +266,11 @@ async function checkSecurity() {
   ]);
   log('linkedin/init unauth 401', li[0].status === 401);
   log('linkedin/status unauth 401', li[1].status === 401);
-  log('linkedin/callback public + state-invalid HTML',
-    li[2].status === 200 && li[2].raw.includes('Invalid State'));
+  // Sec-14 changed this from 200 → 400 (caller-side bad state, not a
+  // server-success). Body still contains "Invalid State" HTML for the
+  // browser; status now correctly distinguishes from real 200s.
+  log('linkedin/callback public + state-invalid HTML (400)',
+    li[2].status === 400 && li[2].raw.includes('Invalid State'));
   const liAuth = await fetchJson(`${BASE}/auth/linkedin/status`, { headers: auth });
   log('linkedin/status authed 200', liAuth.status === 200);
 
@@ -293,9 +308,16 @@ async function checkCors() {
 // ── Error paths (fail loudly, don't leak) ────────────────────────────────────
 
 async function checkErrors() {
-  const notFound = await fetchJson(`${BASE}/does-not-exist`);
-  log('error — 404 with clean JSON',
-    notFound.status === 404 && typeof notFound.body.error === 'string' && !notFound.body.error.includes('stack'));
+  // Intentional posture: top-level auth gate runs BEFORE route
+  // matching, so an unauth'd caller hitting an unknown path gets 401
+  // (can't enumerate routes). With auth, unknown routes get a clean
+  // 404 JSON. Both shapes are correct.
+  const notFoundUnauth = await fetchJson(`${BASE}/does-not-exist`);
+  log('error — unauth unknown path → 401 (no route enumeration)',
+    notFoundUnauth.status === 401);
+  const notFoundAuth = await fetchJson(`${BASE}/does-not-exist`, { headers: auth });
+  log('error — authed unknown path → 404 with clean JSON',
+    notFoundAuth.status === 404 && typeof notFoundAuth.body.error === 'string' && !notFoundAuth.body.error.includes('stack'));
   const badJson = await fetch(`${BASE}/signals/search`, {
     method: 'POST', headers: { ...auth, ...json }, body: 'not json',
   });

--- a/src/domain/capabilityService.ts
+++ b/src/domain/capabilityService.ts
@@ -10,10 +10,10 @@
 // Cache key bumped to v6 for the v3-conformant shape (ucp moved to ext)
 // then v7 for the HEAD-schema-conformant shape (adds adcp.idempotency).
 
-// Cache key bumped to v8 — the ext.ucp block is now engine-aware, so any
-// v7 cache entry written under the old static pseudo-declaring
-// UCP_CAPABILITY needs to be invalidated on next deploy.
-const CACHE_KEY = "adcp_capabilities_v8";
+// Cache key bumped to v9 — idempotency sub-schema in HEAD switched to a
+// discriminated union requiring `supported: true`; any v8 cache entry
+// would fail schema validation against the HEAD spec. Evict on deploy.
+const CACHE_KEY = "adcp_capabilities_v9";
 const CACHE_TTL_SECONDS = 3600;
 
 import { buildUcpCapability, type UcpCapabilityEnv } from "../ucp/vacDeclaration";
@@ -37,7 +37,7 @@ type AdcpCapabilities = {
      * absence; the live evaluator runs HEAD and does). Seller declares how
      * long a canonical response is retained for an idempotency_key.
      */
-    idempotency: { replay_ttl_seconds: number };
+    idempotency: { supported: true; replay_ttl_seconds: number };
   };
   supported_protocols: string[];
   signals?: unknown;
@@ -63,9 +63,11 @@ function buildStaticCapabilities(env: UcpCapabilityEnv): AdcpCapabilities {
   return {
     adcp: {
       major_versions: [2, 3],
-      // 24h replay window (recommended in the HEAD schema; min 3600, max 604800).
+      // HEAD schema models idempotency as a discriminated union keyed on
+      // `supported`. The IdempotencySupported variant requires both
+      // `supported: true` and `replay_ttl_seconds` (3600..604800 per spec).
       // Mutating tools (activate_signal) honour this — see activationRepo.
-      idempotency: { replay_ttl_seconds: 86400 },
+      idempotency: { supported: true, replay_ttl_seconds: 86400 },
     },
     supported_protocols: ["signals"],
     signals: {

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -101,9 +101,12 @@ export const ADCP_TOOLS: McpToolDefinition[] = [
                             minItems: 1,
                         },
                         idempotency: {
+                            // HEAD schema: discriminated union on `supported`.
+                            // We always declare the supported=true variant.
                             type: "object",
-                            required: ["replay_ttl_seconds"],
+                            required: ["supported", "replay_ttl_seconds"],
                             properties: {
+                                supported: { type: "boolean", const: true },
                                 replay_ttl_seconds: {
                                     type: "integer",
                                     minimum: 3600,

--- a/tests/security.test.ts
+++ b/tests/security.test.ts
@@ -120,12 +120,17 @@ describe("MCP tool definitions — outputSchema", () => {
     expect(props.context?.type).toBe("object");
   });
 
-  it("get_adcp_capabilities outputSchema requires adcp.idempotency.replay_ttl_seconds (HEAD schema)", () => {
+  it("get_adcp_capabilities outputSchema requires adcp.idempotency.{supported, replay_ttl_seconds} (HEAD schema discriminated union)", () => {
     const schema = getToolByName("get_adcp_capabilities")!.outputSchema!;
     const adcp = (schema.properties as Record<string, any>).adcp;
     expect(adcp.required).toContain("idempotency");
     const idempotency = adcp.properties.idempotency;
+    // Sec-20: HEAD schema made idempotency a discriminated union on
+    // `supported`. The supported=true variant (what we declare) requires
+    // both `supported: true` and `replay_ttl_seconds` in spec range.
+    expect(idempotency.required).toContain("supported");
     expect(idempotency.required).toContain("replay_ttl_seconds");
+    expect(idempotency.properties.supported.const).toBe(true);
     expect(idempotency.properties.replay_ttl_seconds.minimum).toBe(3600);
     expect(idempotency.properties.replay_ttl_seconds.maximum).toBe(604800);
   });
@@ -175,9 +180,10 @@ describe("getCapabilities runtime shape", () => {
     } as unknown as KVNamespace;
   }
 
-  it("includes adcp.idempotency.replay_ttl_seconds in spec range", async () => {
+  it("includes adcp.idempotency.{supported, replay_ttl_seconds} per HEAD discriminated-union schema (Sec-20)", async () => {
     const caps = await getCapabilities(makeStaticKv());
     expect(caps.adcp.idempotency).toBeDefined();
+    expect(caps.adcp.idempotency.supported).toBe(true);
     const ttl = caps.adcp.idempotency.replay_ttl_seconds;
     expect(typeof ttl).toBe("number");
     expect(ttl).toBeGreaterThanOrEqual(3600);


### PR DESCRIPTION
AdCP HEAD changed `adcp.idempotency` from a plain object to a discriminated union on the `supported` boolean. Caught by the full audit — `@adcp/client storyboard run` failed schema validation at `/adcp/idempotency`.

### Before → After

```diff
- { replay_ttl_seconds: 86400 }
+ { supported: true, replay_ttl_seconds: 86400 }
```

### Changes

- [src/domain/capabilityService.ts](src/domain/capabilityService.ts) — type + literal updated; CACHE_KEY bumped v8→v9 to evict stale cached responses
- [src/mcp/tools.ts](src/mcp/tools.ts) — `get_adcp_capabilities` outputSchema requires `[supported, replay_ttl_seconds]`; `supported.const = true`
- [tests/security.test.ts](tests/security.test.ts) — 2 tests updated to pin the new shape
- [scripts/pre-demo-audit.mjs](scripts/pre-demo-audit.mjs) — audit-script staleness cleanups (callback 400, 404 posture, NLAQ estimate-only acceptance)

### Tests

- Type-check: 79 (test-only baseline, unchanged)
- Unit: **293 passed / 12 skipped**
- Live suite + re-run of AdCP storyboard pending after deploy.