### PR TITLE
Sec-21: pricing_options schema alignment (HEAD discriminated union)

### DIFF
--- a/src/domain/signalService.ts
+++ b/src/domain/signalService.ts
@@ -256,13 +256,13 @@ function generateProposalsFromBrief(brief: string): CustomSignalProposal[] {
     category_type: result.categoryType,
     estimated_audience_size: result.estimatedAudienceSize,
     coverage_percentage: coveragePct,
+    // Sec-21: HEAD schema pricing discriminated union.
     pricing_options: [
       {
         pricing_option_id: `opt-custom-${result.signalId}`.slice(0, 64),
-        pricing_model: "cpm",
-        rate: 4.0,
+        model: "cpm" as const,
+        cpm: 4.0,
         currency: "USD",
-        is_fixed: true,
       },
     ],
     deployments: ["mock_dsp", "mock_cleanroom", "mock_cdp", "mock_measurement"].map((dest) => ({

--- a/src/mappers/signalMapper.ts
+++ b/src/mappers/signalMapper.ts
@@ -246,31 +246,31 @@ export function toSignalSummary(signal: CanonicalSignal): SignalSummary {
     };
   });
 
-  const pricingCpm = signal.pricing?.model === "mock_cpm" ? signal.pricing.value ?? 0 : undefined;
+  const pricingCpm = signal.pricing?.model === "mock_cpm" ? signal.pricing.value ?? 0 : 0;
   const pricingCurrency = signal.pricing?.currency ?? "USD";
   const pricingOptionId = `opt-${signal.pricing?.model ?? "none"}-${signal.signalId}`.slice(0, 64);
 
-  // pricing_options is schema-required with minItems: 1. Emit a default
-  // sentinel option for signals that lack explicit pricing — buyers can
-  // still reference its pricing_option_id from the storyboard's
-  // context_outputs even when the signal is "free / contact for pricing".
-  const pricingOptions = signal.pricing
+  // Sec-21: HEAD pricing schema (/schemas/core/signal-pricing.json) is a
+  // discriminated union on `model`. CPM variant requires { model: "cpm",
+  // cpm: number >= 0, currency: ISO 4217 }. pricing_options is required
+  // with minItems: 1 — signals lacking explicit pricing get a default
+  // 0-cpm sentinel so buyers still have a pricing_option_id to reference
+  // in the storyboard's context_outputs.
+  const pricingOptions: SignalSummary["pricing_options"] = signal.pricing
     ? [
         {
           pricing_option_id: pricingOptionId,
-          pricing_model: signal.pricing.model === "mock_cpm" ? "cpm" : "flat_fee",
-          ...(pricingCpm !== undefined ? { rate: pricingCpm } : {}),
+          model: "cpm" as const,
+          cpm: pricingCpm,
           currency: pricingCurrency,
-          is_fixed: true,
         },
       ]
     : [
         {
           pricing_option_id: `opt-default-${signal.signalId}`.slice(0, 64),
-          pricing_model: "cpm",
-          rate: 0,
+          model: "cpm" as const,
+          cpm: 0,
           currency: pricingCurrency,
-          is_fixed: false,
         },
       ];
 

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -58,7 +58,9 @@ export interface SearchSignalsResponse {
   hasMore: boolean;
 }
 
-// A proposed custom signal — not persisted until activated
+// A proposed custom signal — not persisted until activated. Shares the
+// pricing_options shape with SignalSummary (both validated on the wire
+// against /schemas/core/vendor-pricing-option.json).
 export interface CustomSignalProposal {
   signal_agent_segment_id: string;   // deterministic ID, valid for activation
   name: string;
@@ -67,13 +69,7 @@ export interface CustomSignalProposal {
   category_type: string;
   estimated_audience_size: number;
   coverage_percentage: number;
-  pricing_options: Array<{
-    pricing_option_id: string;
-    pricing_model: string;
-    rate?: number;
-    currency?: string;
-    is_fixed?: boolean;
-  }>;
+  pricing_options: SignalSummary["pricing_options"];
   deployments: SignalDeployment[];
   generation_rationale: string;      // why this segment matches the brief
 }
@@ -106,14 +102,19 @@ export interface SignalSummary {
   data_provider: string;
   coverage_percentage: number;
   deployments: SignalDeployment[];
+  /**
+   * Pricing options per /schemas/core/vendor-pricing-option.json.
+   * HEAD schema is a discriminated union on `model`. We only ship the
+   * CPM variant today (sufficient for demo / mock_cpm signals); the
+   * union here keeps the shape open for future flat_fee / per_unit
+   * expansions without another type change.
+   */
   pricing_options: Array<{
     pricing_option_id: string;
-    pricing_model: string;
-    rate?: number;
-    flat_fee?: number;
-    currency?: string;
-    is_fixed?: boolean;
-  }>;
+  } & (
+    | { model: "cpm"; cpm: number; currency: string }
+    | { model: "flat_fee"; amount: number; period: "monthly" | "quarterly" | "annual" | "campaign"; currency: string }
+  )>;
   category_type: SignalCategoryType;
   taxonomy_system: string;
   external_taxonomy_id?: string;


### PR DESCRIPTION
Second HEAD-schema drift found during full audit. `@adcp/client@5.2.0` (released 2026-04-20) ships the new signals storyboard phases, which validate `pricing_options` items against HEAD's discriminated-union shape on `model`.

### Before → After

```diff
- { pricing_model: "cpm", rate: 2.5, is_fixed: true }
+ { model: "cpm", cpm: 2.5, currency: "USD" }
```

### Changes

- [src/types/api.ts](src/types/api.ts) — `SignalSummary.pricing_options` is now a discriminated-union array (CPM + FlatFee variants typed in place; expandable to percent_of_media/per_unit/custom later). `CustomSignalProposal.pricing_options` aliased to `SignalSummary['pricing_options']`.
- [src/mappers/signalMapper.ts](src/mappers/signalMapper.ts) — builds CPM variant; default sentinel emits 0-cpm option.
- [src/domain/signalService.ts](src/domain/signalService.ts) — proposal builder uses CPM variant.

### Tests

- Type-check: 79 (test-only baseline; 0 in src/)
- Unit tests: **293 passed / 12 skipped** (no behavior change)
- Storyboard re-run pending after deploy