### PR TITLE
Sec-24: reviewer P0 + P1 fixes (well-known, get_signals default, errors[] envelope)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -29,6 +29,7 @@ import { operatorIdFromRequest } from "./utils/operatorId";
 import {
     handleProtectedResourceMetadata,
     handleAuthorizationServerMetadata,
+    handleOAuthTokenStub,
 } from "./routes/wellKnown";
 
 // Seed data imported as text modules via wrangler assets
@@ -113,6 +114,10 @@ export default {
             // without authentication so clients can bootstrap the flow.
             "/.well-known/oauth-protected-resource",
             "/.well-known/oauth-authorization-server",
+            // Sec-24a: OAuth token endpoint is a documented 501 stub — must
+            // be reachable without auth so clients following the well-known
+            // advertisement get the terminal error rather than 401.
+            "/oauth/token",
         ];
         const isPublic = publicPaths.some((p) => path === p || path.startsWith(p + "/"));
 
@@ -147,6 +152,9 @@ export default {
 
             } else if (method === "GET" && path === "/.well-known/oauth-authorization-server") {
                 response = handleAuthorizationServerMetadata(request);
+
+            } else if (method === "POST" && path === "/oauth/token") {
+                response = handleOAuthTokenStub();
 
             } else if (method === "GET" && path === "/capabilities") {
                 response = await handleGetCapabilities(request, env, logger);

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -362,22 +362,7 @@ async function callGetSignals(
     env: Env
 ): Promise<unknown> {
     const filters = args["filters"] as Record<string, unknown> | undefined;
-    const deliverTo = args["deliver_to"] as Record<string, unknown> | undefined;
     const pagination = args["pagination"] as Record<string, unknown> | undefined;
-
-    // Probe-shaped request (security_baseline/api_key_path calls with an empty
-    // body per PROBE_TASK_ALLOWLIST semantics — auth-required, read-only,
-    // accepts empty). Full catalog with rich DTS + UCP payloads on every row
-    // serializes to ~200 KB; the runner's response ceiling is 65536 bytes.
-    // When nothing narrows the query, cap to 3 rows so a bare probe stays
-    // well under budget without changing the default for real callers.
-    const isProbeShape =
-        args["signal_spec"] === undefined &&
-        args["brief"] === undefined &&
-        args["signal_ids"] === undefined &&
-        (filters === undefined || Object.keys(filters).length === 0) &&
-        (deliverTo === undefined || Object.keys(deliverTo).length === 0);
-    const defaultLimit = isProbeShape ? 3 : 20;
 
     const req = {
         ...compactObj({
@@ -390,7 +375,15 @@ async function callGetSignals(
         }),
         // Use `!= null` (matches both null and undefined) instead of truthy
         // checks so a literal 0 isn't silently replaced by the default.
-        limit: numArg(args["max_results"], numArg(args["limit"], defaultLimit)),
+        //
+        // Sec-24b: global default of 5 (was 20 with a probe-shape carve-out
+        // to 3). Rich DTS + UCP payloads make 20-row responses >200 KB —
+        // breaking the security_baseline runner's 64 KB probe ceiling and
+        // many HTTP clients' default parse budgets. 5 rows serializes to
+        // ~50 KB, leaves headroom, and `hasMore` + `totalCount` in the
+        // response make pagination discoverable. Callers who want the
+        // bigger page still pass `max_results` explicitly.
+        limit: numArg(args["max_results"], numArg(args["limit"], 5)),
         offset: numArg(pagination?.["offset"], numArg(args["offset"], 0)),
     };
 
@@ -519,12 +512,13 @@ async function callActivateSignal(
     }
 }
 
-// Sec-22: stub create_media_buy — we're a signals provider, not a media-buy
-// seller. Returns an AdCP error envelope (L3 structured: `adcp_error.code`
-// AND top-level `error_code`) so the universal schema_validation storyboard's
-// past_start_reject_path can contribute `past_start_handled`. The runner
-// extracts error_code from `structuredContent.adcp_error.code` or `.error_code`
-// (validations.js:383). Context is echoed unchanged per /schemas/core/context.
+// Sec-22 / Sec-24c: stub create_media_buy — we're a signals provider, not a
+// media-buy seller. Returns the spec-canonical error envelope —
+// `{ errors: [{ code, message }], context }` — per the AdCP error-compliance
+// doc. Sec-24c: removed the non-spec `error_code` top-level and duplicate
+// `adcp_error` fields the earlier revision carried as belt-and-braces for
+// the permissive runner extractor; extras risk colliding with future spec
+// fields of the same name.
 async function callCreateMediaBuy(args: Record<string, unknown>): Promise<unknown> {
     const startTime = typeof args["start_time"] === "string" ? args["start_time"] : undefined;
     const endTime = typeof args["end_time"] === "string" ? args["end_time"] : undefined;
@@ -551,9 +545,7 @@ async function callCreateMediaBuy(args: Record<string, unknown>): Promise<unknow
     }
 
     const response = {
-        error_code: code,
-        adcp_error: { code, message },
-        message,
+        errors: [{ code, message }],
         ...contextEcho,
     };
     return toolResult(JSON.stringify(response, null, 2), response);

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -542,11 +542,21 @@ export const ADCP_TOOLS: McpToolDefinition[] = [
         },
         outputSchema: {
             type: "object",
-            required: ["error_code"],
+            required: ["errors"],
             properties: {
-                error_code: { type: "string" },
-                adcp_error: { type: "object", additionalProperties: true },
-                message: { type: "string" },
+                errors: {
+                    type: "array",
+                    minItems: 1,
+                    items: {
+                        type: "object",
+                        required: ["code", "message"],
+                        properties: {
+                            code: { type: "string" },
+                            message: { type: "string" },
+                        },
+                        additionalProperties: true,
+                    },
+                },
                 context: { type: "object", additionalProperties: true },
             },
             additionalProperties: true,

--- a/src/routes/wellKnown.ts
+++ b/src/routes/wellKnown.ts
@@ -39,11 +39,24 @@ export function handleProtectedResourceMetadata(request: Request, resourcePath: 
 }
 
 /**
- * RFC 8414 §3: authorization-server metadata. The minimal document must
- * expose `issuer` + `token_endpoint` and one of `grant_types_supported` or
- * `response_types_supported`. The `token_endpoint` is a nominal URL — a
- * full OAuth handshake is out of scope for this demo agent; the probe only
- * verifies reachability + shape.
+ * RFC 8414 §3: authorization-server metadata.
+ *
+ * Sec-24a: this agent doesn't implement an OAuth token endpoint for its
+ * primary API-key auth, so we MUST NOT advertise grant types we can't
+ * honor. A buyer agent that auto-discovers this document and attempts
+ * `client_credentials` would fail hard on the token endpoint and classify
+ * the agent as broken — worse than not advertising OAuth at all.
+ *
+ * So we advertise:
+ *   - `grant_types_supported: []` (empty array — RFC 8414 §2 permits)
+ *   - `response_types_supported: []`
+ *   - a `token_endpoint` that returns HTTP 501 so any client that ignores
+ *     the empty grants array still gets a clean, documented terminal
+ *     failure rather than 404.
+ *
+ * Clients following the spec read the empty arrays and skip the OAuth
+ * path; the conformance probe only validates document reachability +
+ * shape, which is still satisfied.
  */
 export function handleAuthorizationServerMetadata(request: Request): Response {
   const url = new URL(request.url);
@@ -51,15 +64,38 @@ export function handleAuthorizationServerMetadata(request: Request): Response {
   const body = {
     issuer: origin,
     token_endpoint: `${origin}/oauth/token`,
-    grant_types_supported: ["client_credentials"],
-    token_endpoint_auth_methods_supported: ["client_secret_basic"],
-    response_types_supported: ["token"],
+    grant_types_supported: [],
+    response_types_supported: [],
   };
   return new Response(JSON.stringify(body), {
     status: 200,
     headers: {
       "Content-Type": "application/json",
       "Cache-Control": "public, max-age=3600",
+      "Access-Control-Allow-Origin": "*",
+    },
+  });
+}
+
+/**
+ * RFC 6749 token endpoint — stub. Returns 501 Not Implemented with an
+ * OAuth-shaped `error` body so any client that ignored the empty
+ * `grant_types_supported` array still sees a documented terminal
+ * failure instead of 404. This agent authenticates with a static API
+ * key; see the /.well-known/oauth-authorization-server docstring.
+ */
+export function handleOAuthTokenStub(): Response {
+  const body = {
+    error: "unsupported_grant_type",
+    error_description:
+      "This agent does not implement OAuth token exchange. " +
+      "Authenticate with a static API key via `Authorization: Bearer <key>` on /mcp. " +
+      "The OAuth authorization-server metadata advertises an empty grant_types_supported.",
+  };
+  return new Response(JSON.stringify(body), {
+    status: 501,
+    headers: {
+      "Content-Type": "application/json",
       "Access-Control-Allow-Origin": "*",
     },
   });


### PR DESCRIPTION
## Summary

Three surgical fixes from the upstream reviewer punch list on Sec-22/23. All P0 + P1 items accepted; no pushback. P2/P3 items (recovery classification, batched-auth boundary test, CORS-on-.well-known, HEAD schema drift) deferred to Sec-25.

### Sec-24a (P0) — Stop advertising OAuth grants we don't implement
Reviewer: *"A buyer agent that discovers your OAuth metadata, attempts client_credentials against /oauth/token, and gets a 404 or 405 will classify your agent as broken."*

- `grant_types_supported: []` + `response_types_supported: []` in [src/routes/wellKnown.ts](src/routes/wellKnown.ts)
- New `POST /oauth/token` returns **HTTP 501** + OAuth-shaped `{"error":"unsupported_grant_type", ...}` body
- Route added to `publicPaths` in [src/index.ts](src/index.ts)

### Sec-24b (P1) — Replace probe-shape cap with honest global default
Reviewer: *"Mode-detection by field absence is fragile... silently throttled exploratory callers see 3 results and assume that's all."*

- Removed field-absence heuristic in [src/mcp/server.ts:callGetSignals](src/mcp/server.ts)
- Global default now `5` (was `20`). Rich DTS+UCP payloads made 20-row responses >200 KB; 5 rows ≈50 KB. `hasMore` + `totalCount` keep pagination discoverable.

### Sec-24c (P1) — Spec-canonical `errors[]` envelope
Reviewer: *"Top-level `error_code` is not in the schema... extras create confusion and could conflict with a future spec field."*

- [src/mcp/server.ts:callCreateMediaBuy](src/mcp/server.ts) now returns `{ errors: [{ code, message }], context }` only
- Dropped the `error_code` + `adcp_error` belt-and-braces mirrors
- Updated `outputSchema` in [src/mcp/tools.ts](src/mcp/tools.ts) to require `errors[*].{code,message}`

## Live verification (Version `743edab6`)

```
POST /oauth/token                                 → 501
/.well-known/oauth-authorization-server           → grant_types_supported: []
create_media_buy past start_time                  → { errors: [{code:"INVALID_REQUEST", ...}], context }
get_signals empty args                            → ~30 KB body

✅  Compliance: 3/3 tracks pass, zero How-to-Fix items
```

## Deferred from the reviewer punch list

- **P2** — `recovery: "terminal"` on `UNSUPPORTED_OPERATION` (need HEAD spec verification first)
- **P2** — batched all-auth-required boundary test
- **P3** — CORS on `.well-known`, publicPaths ↔ `/oauth/token` interaction test, pagination × default-limit test, idempotency cache policy for stub errors
- **P3** — HEAD schema drift check on `ext.ucp.phase` / `gts_version` / `signals.limits`

Will land as Sec-25.

## Test plan

- [x] Unit tests: 293 pass
- [x] Live endpoint probes all four Sec-24 surfaces
- [x] `npm run compliance` exit 0, zero advisory items
- [x] Deployed: `743edab6-17a8-41e0-98a2-c568fadb2024`
- [ ] User review + merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)