### PR TITLE
Sec-25: recovery, default_max_results hint, batch + CORS tests

### DIFF
--- a/src/domain/capabilityService.ts
+++ b/src/domain/capabilityService.ts
@@ -10,10 +10,11 @@
 // Cache key bumped to v6 for the v3-conformant shape (ucp moved to ext)
 // then v7 for the HEAD-schema-conformant shape (adds adcp.idempotency).
 
-// Cache key bumped to v9 — idempotency sub-schema in HEAD switched to a
-// discriminated union requiring `supported: true`; any v8 cache entry
-// would fail schema validation against the HEAD spec. Evict on deploy.
-const CACHE_KEY = "adcp_capabilities_v9";
+// Cache key bumped to v10 — Sec-25b adds signals.limits.default_max_results
+// (the default rows get_signals returns when callers omit max_results);
+// a v9 cache entry would omit the hint and callers couldn't discover it
+// without reading the source. Evict on deploy.
+const CACHE_KEY = "adcp_capabilities_v10";
 const CACHE_TTL_SECONDS = 3600;
 
 import { buildUcpCapability, type UcpCapabilityEnv } from "../ucp/vacDeclaration";
@@ -90,6 +91,11 @@ function buildStaticCapabilities(env: UcpCapabilityEnv): AdcpCapabilities {
       limits: {
         max_signals_per_request: 100,
         max_rules_per_segment: 6,
+        // Sec-25b: advertise the default page size so callers know what
+        // they'll get when they omit `max_results`. Rich DTS+UCP payloads
+        // make 5 rows ≈50 KB; larger pages need an explicit `max_results`.
+        // Follows the same shape as the other declared limits.
+        default_max_results: 5,
       },
     },
     ext: {

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -531,21 +531,37 @@ async function callCreateMediaBuy(args: Record<string, unknown>): Promise<unknow
     const startMs = startTime ? Date.parse(startTime) : Number.NaN;
     const endMs = endTime ? Date.parse(endTime) : Number.NaN;
 
-    let code: string;
-    let message: string;
-    if (!Number.isNaN(startMs) && startMs < now) {
-        code = "INVALID_REQUEST";
-        message = `start_time ${startTime} is in the past — flight must not begin before now.`;
-    } else if (!Number.isNaN(startMs) && !Number.isNaN(endMs) && endMs <= startMs) {
-        code = "INVALID_REQUEST";
-        message = `end_time ${endTime} must be strictly after start_time ${startTime}.`;
-    } else {
-        code = "UNSUPPORTED_OPERATION";
-        message = "This agent sells signals, not media — create_media_buy is stubbed for conformance only.";
-    }
+    // Sec-25a: `recovery` is an optional enum on core/error.json
+    // ("transient" | "correctable" | "terminal"). UNSUPPORTED_OPERATION is
+    // as terminal as it gets — we structurally don't implement the tool,
+    // so a retrying buyer should stop. We omit `recovery` on INVALID_REQUEST
+    // because the right classification depends on the specific violation
+    // (a past start_time is correctable by resubmitting with a future
+    // start; a malformed payload is terminal for this request) — omitting
+    // lets the caller decide rather than advertising the wrong signal.
+    const errEntry: { code: string; message: string; recovery?: "terminal" } =
+        (() => {
+            if (!Number.isNaN(startMs) && startMs < now) {
+                return {
+                    code: "INVALID_REQUEST",
+                    message: `start_time ${startTime} is in the past — flight must not begin before now.`,
+                };
+            }
+            if (!Number.isNaN(startMs) && !Number.isNaN(endMs) && endMs <= startMs) {
+                return {
+                    code: "INVALID_REQUEST",
+                    message: `end_time ${endTime} must be strictly after start_time ${startTime}.`,
+                };
+            }
+            return {
+                code: "UNSUPPORTED_OPERATION",
+                message: "This agent sells signals, not media — create_media_buy is stubbed for conformance only.",
+                recovery: "terminal",
+            };
+        })();
 
     const response = {
-        errors: [{ code, message }],
+        errors: [errEntry],
         ...contextEcho,
     };
     return toolResult(JSON.stringify(response, null, 2), response);

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -553,6 +553,11 @@ export const ADCP_TOOLS: McpToolDefinition[] = [
                         properties: {
                             code: { type: "string" },
                             message: { type: "string" },
+                            // Sec-25a: optional recovery enum from core/error.json
+                            recovery: {
+                                type: "string",
+                                enum: ["transient", "correctable", "terminal"],
+                            },
                         },
                         additionalProperties: true,
                     },

--- a/tests/security.test.ts
+++ b/tests/security.test.ts
@@ -837,6 +837,32 @@ describe("handleMcpRequest — auth gate", () => {
     expect(byId[11].error?.code).toBe(-32001);
   });
 
+  it("Sec-25c: fully-authed batch (all messages require auth) stays HTTP 200 + per-message -32001", async () => {
+    // Boundary case: every message in the batch requires auth and none are
+    // authed. The single-request HTTP 401 path MUST NOT short-circuit here —
+    // JSON-RPC 2.0 batching processes messages independently, and blocking a
+    // batch at the transport layer would break clients that correctly expect
+    // per-message errors. Each tools/call message gets its own -32001 in the
+    // response array; HTTP stays 200.
+    const { status, body, res } = await callAndParse(
+      mcpReq([
+        { jsonrpc: "2.0", id: 30, method: "tools/call", params: { name: "get_adcp_capabilities", arguments: {} } },
+        { jsonrpc: "2.0", id: 31, method: "tools/call", params: { name: "get_signals", arguments: {} } },
+        { jsonrpc: "2.0", id: 32, method: "tools/call", params: { name: "activate_signal", arguments: {} } },
+      ]),
+    );
+    expect(status).toBe(200);
+    // No WWW-Authenticate on batched 200 — that header only appears on the
+    // single-request 401 path.
+    expect(res.headers.get("WWW-Authenticate")).toBeNull();
+    expect(Array.isArray(body)).toBe(true);
+    expect(body).toHaveLength(3);
+    for (const msg of body) {
+      expect(msg.error?.code).toBe(-32001);
+      expect(msg.result).toBeUndefined();
+    }
+  });
+
   it("oversized body (>1MB via Content-Length) rejected pre-parse with -32600", async () => {
     // We lie about Content-Length to avoid allocating a real 1MB body in the
     // test. The guard reads the header before touching request.json().

--- a/tests/wellKnown.test.ts
+++ b/tests/wellKnown.test.ts
@@ -1,0 +1,78 @@
+// tests/wellKnown.test.ts
+// Sec-25d: CORS + shape sanity on RFC 9728 + RFC 8414 endpoints.
+//
+// Browser-based buyer tooling discovers OAuth metadata with a cross-origin
+// fetch. Without Access-Control-Allow-Origin the browser blocks the read
+// silently and the agent appears unreachable — worse than a real 404
+// because the agent is serving the document, just behind CORS. These
+// tests pin the header presence so a future refactor of the response
+// builders can't regress it.
+
+import { describe, it, expect } from "vitest";
+import {
+  handleProtectedResourceMetadata,
+  handleAuthorizationServerMetadata,
+  handleOAuthTokenStub,
+} from "../src/routes/wellKnown";
+
+function req(url: string): Request {
+  return new Request(url, { method: "GET" });
+}
+
+describe("well-known OAuth endpoints — CORS + shape", () => {
+  it("protected-resource metadata serves Access-Control-Allow-Origin: *", () => {
+    const res = handleProtectedResourceMetadata(
+      req("https://agent.example.com/.well-known/oauth-protected-resource/mcp"),
+      "/mcp",
+    );
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBe("*");
+    expect(res.headers.get("Content-Type")).toContain("application/json");
+  });
+
+  it("protected-resource metadata has required RFC 9728 fields + resource matches agent URL", async () => {
+    const res = handleProtectedResourceMetadata(
+      req("https://agent.example.com/.well-known/oauth-protected-resource/mcp"),
+      "/mcp",
+    );
+    const body = await res.json() as Record<string, unknown>;
+    expect(body.resource).toBe("https://agent.example.com/mcp");
+    expect(Array.isArray(body.authorization_servers)).toBe(true);
+    expect((body.authorization_servers as unknown[]).length).toBeGreaterThan(0);
+    expect(body.bearer_methods_supported).toEqual(["header"]);
+  });
+
+  it("authorization-server metadata serves Access-Control-Allow-Origin: *", () => {
+    const res = handleAuthorizationServerMetadata(
+      req("https://agent.example.com/.well-known/oauth-authorization-server"),
+    );
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBe("*");
+    expect(res.headers.get("Content-Type")).toContain("application/json");
+  });
+
+  it("authorization-server metadata advertises empty grants (Sec-24a contract)", async () => {
+    // Sec-24a: we don't implement any OAuth grant, so grant_types_supported
+    // and response_types_supported MUST be empty arrays. Advertising grants
+    // we don't honor breaks any client that auto-discovers and attempts
+    // the flow.
+    const res = handleAuthorizationServerMetadata(
+      req("https://agent.example.com/.well-known/oauth-authorization-server"),
+    );
+    const body = await res.json() as Record<string, unknown>;
+    expect(body.issuer).toBe("https://agent.example.com");
+    expect(body.token_endpoint).toBe("https://agent.example.com/oauth/token");
+    expect(body.grant_types_supported).toEqual([]);
+    expect(body.response_types_supported).toEqual([]);
+  });
+
+  it("/oauth/token stub returns 501 with OAuth-shaped error body", async () => {
+    const res = handleOAuthTokenStub();
+    expect(res.status).toBe(501);
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBe("*");
+    const body = await res.json() as Record<string, unknown>;
+    // RFC 6749 §5.2 error shape — `error` + `error_description`
+    expect(body.error).toBe("unsupported_grant_type");
+    expect(typeof body.error_description).toBe("string");
+  });
+});


### PR DESCRIPTION
## Summary

Four items from the Sec-24 reviewer follow-up, ranked by severity.

### Sec-25a (P1) — `recovery: "terminal"` on UNSUPPORTED_OPERATION
Reviewer cited [core/error.json](https://adcontextprotocol.org/schemas/v3/core/error.json): optional `recovery` enum (`"transient" | "correctable" | "terminal"`). UNSUPPORTED_OPERATION is structurally terminal — stub never supports the tool — so a retrying buyer must stop.

Omitted on INVALID_REQUEST deliberately: the right classification is violation-specific (past `start_time` is correctable by resubmission; malformed payload is terminal for that request). Advertising the wrong signal is worse than omitting it.

Files: [src/mcp/server.ts:callCreateMediaBuy](src/mcp/server.ts) + [src/mcp/tools.ts](src/mcp/tools.ts).

### Sec-25b (P2) — `signals.limits.default_max_results: 5` capability hint
Reviewer: *"set a documented constant... and add a capability hint so callers know what to expect."*

Follows the same shape as the existing `max_signals_per_request: 100` / `max_rules_per_segment: 6`. Cache key bumped `v9 → v10`.

Files: [src/domain/capabilityService.ts](src/domain/capabilityService.ts).

### Sec-25c (P2) — fully-authed batch boundary test
Reviewer: *"Does all-auth-required batch stay HTTP 200 with per-message -32001, or short-circuit to 401?"*

New test in [tests/security.test.ts](tests/security.test.ts): three `tools/call` in one batch, all unauth. Asserts HTTP 200, three `-32001` per-message errors, no `WWW-Authenticate` header (that's single-request-only). Pins the batch-vs-single-request split so a future refactor can't collapse them.

### Sec-25d (P3) — CORS + shape tests on `.well-known`
Reviewer: *"If CORS headers aren't set on .well-known routes, browser-based buyer tooling breaks silently."*

New [tests/wellKnown.test.ts](tests/wellKnown.test.ts) — 5 tests pinning `Access-Control-Allow-Origin: *` on both well-known endpoints + RFC 9728 resource field matches agent URL + Sec-24a empty-grants contract + `/oauth/token` 501 + OAuth error body shape.

## Live verification (Version `bb444160`)

```
/capabilities → signals.limits.default_max_results: 5
create_media_buy UNSUPPORTED_OPERATION → { code, message, recovery: "terminal" }
create_media_buy INVALID_REQUEST → { code, message }  (no recovery)

✅  299 unit tests pass (+6 new)
✅  Compliance: 3/3 tracks pass, zero advisory items
```

## Deferred to Sec-26
- Upstream @adcp/client issue to add `data.errors?.[0]?.code` to the error_code extractor chain (reviewer is drafting it; we ride on the regex-fallback until it lands).
- HEAD schema drift recheck on `ext.ucp.phase` / `gts_version` / `signals.limits` (mechanical grep).
- Idempotency cache policy for the `create_media_buy` stub (current: bypasses cache; reviewer to confirm spec alignment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)