### PR TITLE
Sec-26: recovery: correctable, mixed-auth isolation pairs, rollback runbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -563,6 +563,31 @@ curl -X POST https://adcp-signals-adaptor.evgeny-193.workers.dev/ucp/concepts/se
   -H "Authorization: Bearer $DEMO_API_KEY"
 ```
 
+### Rollback note — capability cache key
+
+`/capabilities` responses are cached in KV under a versioned key
+(`adcp_capabilities_v10` at the time of writing, see
+`src/domain/capabilityService.ts`). The key is bumped on every
+capability shape change so a deploy serves the new shape immediately
+without a manual cache flush.
+
+Rolling back **across** a cache-key bump (e.g. reverting from v10 to
+v9 shape) is NOT free: KV entries at the old version key may still
+be in the cache for up to `CACHE_TTL_SECONDS` (1 hour) and will be
+served to callers that hit the old code path. Either:
+
+- wait out the TTL before validating the rollback, or
+- flush the namespace explicitly:
+
+  ```bash
+  wrangler kv key delete --binding=SIGNALS_CACHE adcp_capabilities_v10
+  ```
+
+(`adcp_capabilities_vN` — substitute the key the rolled-forward code
+wrote.) A rollback to a shape that removes a field that callers
+started depending on is the failure mode; everyone else is fine with
+staleness under 1 hour.
+
 ## Regenerating Embedding Vectors
 
 ```bash

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -531,26 +531,33 @@ async function callCreateMediaBuy(args: Record<string, unknown>): Promise<unknow
     const startMs = startTime ? Date.parse(startTime) : Number.NaN;
     const endMs = endTime ? Date.parse(endTime) : Number.NaN;
 
-    // Sec-25a: `recovery` is an optional enum on core/error.json
-    // ("transient" | "correctable" | "terminal"). UNSUPPORTED_OPERATION is
-    // as terminal as it gets — we structurally don't implement the tool,
-    // so a retrying buyer should stop. We omit `recovery` on INVALID_REQUEST
-    // because the right classification depends on the specific violation
-    // (a past start_time is correctable by resubmitting with a future
-    // start; a malformed payload is terminal for this request) — omitting
-    // lets the caller decide rather than advertising the wrong signal.
-    const errEntry: { code: string; message: string; recovery?: "terminal" } =
+    // Sec-25a / Sec-26a: `recovery` is an optional enum on core/error.json
+    // ("transient" | "correctable" | "terminal"). The spec does NOT define
+    // a default for absent `recovery`, so every buyer implementation is
+    // free to interpret absence differently. Omitting it was ambiguous —
+    // a buyer that defaults to "transient" would hammer us on a malformed
+    // payload; one that defaults to "terminal" would give up on a past
+    // start_time a resubmit would fix. So we always classify explicitly:
+    //
+    //   - INVALID_REQUEST (temporal / shape) → "correctable": the caller
+    //     can either resubmit with valid dates or fix the payload. Neither
+    //     case requires human intervention, so "terminal" is wrong here.
+    //   - UNSUPPORTED_OPERATION → "terminal": we structurally don't
+    //     implement the tool, so a retrying buyer must stop.
+    const errEntry: { code: string; message: string; recovery: "correctable" | "terminal" } =
         (() => {
             if (!Number.isNaN(startMs) && startMs < now) {
                 return {
                     code: "INVALID_REQUEST",
                     message: `start_time ${startTime} is in the past — flight must not begin before now.`,
+                    recovery: "correctable",
                 };
             }
             if (!Number.isNaN(startMs) && !Number.isNaN(endMs) && endMs <= startMs) {
                 return {
                     code: "INVALID_REQUEST",
                     message: `end_time ${endTime} must be strictly after start_time ${startTime}.`,
+                    recovery: "correctable",
                 };
             }
             return {

--- a/tests/security.test.ts
+++ b/tests/security.test.ts
@@ -837,6 +837,45 @@ describe("handleMcpRequest — auth gate", () => {
     expect(byId[11].error?.code).toBe(-32001);
   });
 
+  // Sec-26b: broaden mixed-auth batch isolation coverage beyond tools/list.
+  // The existing tools/list+tools/call test proves per-message isolation
+  // for one public-method pair. These pin the invariant across the other
+  // public methods (initialize, ping) so a refactor that special-cases
+  // tools/list accidentally would still fail here.
+  it("Sec-26b: mixed batch [initialize, tools/call] — public succeeds, tool-call gets -32001", async () => {
+    const { status, body } = await callAndParse(
+      mcpReq([
+        { jsonrpc: "2.0", id: 40, method: "initialize", params: { protocolVersion: "2024-11-05", clientInfo: { name: "t", version: "1" } } },
+        { jsonrpc: "2.0", id: 41, method: "tools/call", params: { name: "get_adcp_capabilities", arguments: {} } },
+      ]),
+    );
+    expect(status).toBe(200);
+    expect(Array.isArray(body)).toBe(true);
+    const byId = Object.fromEntries(body.map((m: any) => [m.id, m]));
+    expect(byId[40].result?.serverInfo).toBeDefined();
+    expect(byId[40].error).toBeUndefined();
+    expect(byId[41].error?.code).toBe(-32001);
+    expect(byId[41].result).toBeUndefined();
+  });
+
+  it("Sec-26b: mixed batch [ping, tools/call] — public succeeds, tool-call gets -32001", async () => {
+    const { status, body } = await callAndParse(
+      mcpReq([
+        { jsonrpc: "2.0", id: 50, method: "ping", params: {} },
+        { jsonrpc: "2.0", id: 51, method: "tools/call", params: { name: "get_signals", arguments: {} } },
+      ]),
+    );
+    expect(status).toBe(200);
+    expect(Array.isArray(body)).toBe(true);
+    const byId = Object.fromEntries(body.map((m: any) => [m.id, m]));
+    // ping returns an empty object on success — presence of `result` is the
+    // signal, not any specific field inside it.
+    expect(byId[50].result).toBeDefined();
+    expect(byId[50].error).toBeUndefined();
+    expect(byId[51].error?.code).toBe(-32001);
+    expect(byId[51].result).toBeUndefined();
+  });
+
   it("Sec-25c: fully-authed batch (all messages require auth) stays HTTP 200 + per-message -32001", async () => {
     // Boundary case: every message in the batch requires auth and none are
     // authed. The single-request HTTP 401 path MUST NOT short-circuit here —


### PR DESCRIPTION
## Summary

Three reviewer items from the Sec-25 verdict. Shortest PR in the series.

### Sec-26a (P1) — `recovery: "correctable"` on INVALID_REQUEST
Reviewer: *"The spec has no documented default for absent `recovery`. Set it explicitly on all INVALID_REQUEST branches — "correctable" is accurate and removes the ambiguity."*

Both temporal-violation branches in [src/mcp/server.ts:callCreateMediaBuy](src/mcp/server.ts) now emit `recovery: "correctable"` (resubmit with valid dates fixes it). UNSUPPORTED_OPERATION stays `"terminal"`.

### Sec-26b (P2) — broaden mixed-auth batch isolation coverage
Reviewer: *"The batch-auth split is clear — pin it across more public-method pairs so a refactor that accidentally special-cases tools/list would still fail here."*

Two new tests in [tests/security.test.ts](tests/security.test.ts): `[initialize, tools/call]` and `[ping, tools/call]`. Each asserts public method succeeds + tools/call gets `-32001` + HTTP 200 overall.

### Sec-26c (P3) — document cache-key-bump rollback risk
Reviewer: *"Worth noting in your deploy runbook, not worth engineering around."*

New "Rollback note — capability cache key" subsection in [README.md](README.md) under *Deploying*. Operator awareness during revert windows (TTL up to 1h; explicit `wrangler kv key delete` command if faster flush needed).

## Live verification (Version `272743ef`)

```
past start_time       → recovery: "correctable"
reversed dates        → recovery: "correctable"
unsupported operation → recovery: "terminal"  (unchanged)

✅  301 unit tests pass (+2 new)
✅  Compliance: 3/3 tracks pass, zero advisory items
```

## Deferred to Sec-27 (still waiting on)

- Upstream @adcp/client issue — reviewer offered to draft, not yet filed
- HEAD schema drift recheck on `ext.ucp.phase` / `gts_version` / `signals.limits`
- Idempotency cache policy for create_media_buy stub

🤖 Generated with [Claude Code](https://claude.com/claude-code)