### PR TITLE
Sec-27a: NaN guard on create_media_buy unparseable dates

### DIFF
--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -512,6 +512,25 @@ async function callActivateSignal(
     }
 }
 
+// Sec-27a: shared response for "field X didn't parse as ISO-8601". Kept
+// inline with callCreateMediaBuy because it's stub-specific and the call
+// sites need the echoed context block already computed.
+function parseFailure(
+    field: "start_time" | "end_time",
+    rawValue: string,
+    contextEcho: { context?: Record<string, unknown> },
+): unknown {
+    const response = {
+        errors: [{
+            code: "INVALID_REQUEST",
+            message: `${field} ${JSON.stringify(rawValue)} is not a valid ISO-8601 timestamp.`,
+            recovery: "correctable" as const,
+        }],
+        ...contextEcho,
+    };
+    return toolResult(JSON.stringify(response, null, 2), response);
+}
+
 // Sec-22 / Sec-24c: stub create_media_buy — we're a signals provider, not a
 // media-buy seller. Returns the spec-canonical error envelope —
 // `{ errors: [{ code, message }], context }` — per the AdCP error-compliance
@@ -519,6 +538,15 @@ async function callActivateSignal(
 // `adcp_error` fields the earlier revision carried as belt-and-braces for
 // the permissive runner extractor; extras risk colliding with future spec
 // fields of the same name.
+//
+// Upstream note: the runner's validateErrorCode extractor (adcp-client
+// v5.2.0, dist/lib/testing/storyboard/validations.js:383) does NOT resolve
+// `data.errors[0].code` — it reads `adcp_error.code` / `error_code` /
+// `code` / `error.code`, then falls back to regex-extracting the code
+// from `taskResult.error`. Our `errors[]` envelope passes the storyboard
+// via the regex fallback on `errors[0].message`, which is fragile.
+// Tracking fix upstream at adcontextprotocol/adcp#2535 — once landed we
+// get typed-field extraction instead of string-regex.
 async function callCreateMediaBuy(args: Record<string, unknown>): Promise<unknown> {
     const startTime = typeof args["start_time"] === "string" ? args["start_time"] : undefined;
     const endTime = typeof args["end_time"] === "string" ? args["end_time"] : undefined;
@@ -530,6 +558,21 @@ async function callCreateMediaBuy(args: Record<string, unknown>): Promise<unknow
     const now = Date.now();
     const startMs = startTime ? Date.parse(startTime) : Number.NaN;
     const endMs = endTime ? Date.parse(endTime) : Number.NaN;
+
+    // Sec-27a: unparseable-date guard. Before the temporal comparisons,
+    // reject requests where `start_time` / `end_time` is supplied but
+    // doesn't parse. NaN comparisons silently evaluate to `false`, so
+    // without this guard `{ start_time: "banana" }` skipped both
+    // INVALID_REQUEST branches and fell through to UNSUPPORTED_OPERATION
+    // / recovery: "terminal" — semantically wrong (the caller can fix
+    // the payload by sending a valid ISO-8601 string; it's not "this
+    // agent doesn't sell media"). Explicit INVALID_REQUEST / correctable.
+    if (startTime !== undefined && Number.isNaN(startMs)) {
+        return parseFailure("start_time", startTime, contextEcho);
+    }
+    if (endTime !== undefined && Number.isNaN(endMs)) {
+        return parseFailure("end_time", endTime, contextEcho);
+    }
 
     // Sec-25a / Sec-26a: `recovery` is an optional enum on core/error.json
     // ("transient" | "correctable" | "terminal"). The spec does NOT define

--- a/tests/createMediaBuy.test.ts
+++ b/tests/createMediaBuy.test.ts
@@ -1,0 +1,102 @@
+// tests/createMediaBuy.test.ts
+// Sec-27a: behavior tests for the create_media_buy stub's error envelope.
+// The handler isn't exported directly — exercise it via the MCP JSON-RPC
+// boundary so tests mirror what a conformance probe actually sends.
+
+import { describe, it, expect } from "vitest";
+import { handleMcpRequest } from "../src/mcp/server";
+import { createLogger } from "../src/utils/logger";
+
+const KEY = "demo-key-cmb-test";
+const env = { DEMO_API_KEY: KEY } as unknown as import("../src/types/env").Env;
+const logger = createLogger("cmb-test");
+
+async function call(args: Record<string, unknown>) {
+  const req = new Request("https://example.com/mcp", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "Authorization": `Bearer ${KEY}`,
+    },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "tools/call",
+      params: { name: "create_media_buy", arguments: args },
+    }),
+  });
+  const res = await handleMcpRequest(req, env, logger);
+  const body = await res.json() as {
+    result?: { structuredContent?: { errors?: Array<{ code: string; message: string; recovery?: string }>; context?: Record<string, unknown> } };
+  };
+  return body.result?.structuredContent;
+}
+
+describe("create_media_buy stub — error envelope", () => {
+  it("Sec-27a: unparseable start_time → INVALID_REQUEST / correctable (not UNSUPPORTED_OPERATION)", async () => {
+    // NaN comparisons silently evaluate to false, so without the parse
+    // guard `{ start_time: "banana" }` misrouted to the terminal
+    // UNSUPPORTED_OPERATION branch. Should now return INVALID_REQUEST /
+    // correctable — the caller can fix this by sending a valid ISO-8601
+    // string, so "terminal" was the wrong classification.
+    const sc = await call({
+      start_time: "banana",
+      end_time: "2027-12-31T23:59:59Z",
+      context: { correlation_id: "banana-start" },
+    });
+    expect(sc?.errors).toBeDefined();
+    expect(sc?.errors?.[0]?.code).toBe("INVALID_REQUEST");
+    expect(sc?.errors?.[0]?.recovery).toBe("correctable");
+    expect(sc?.errors?.[0]?.message).toMatch(/start_time.*not a valid ISO-8601/i);
+    expect(sc?.context?.correlation_id).toBe("banana-start");
+  });
+
+  it("Sec-27a: unparseable end_time → INVALID_REQUEST / correctable", async () => {
+    const sc = await call({
+      start_time: "2027-01-01T00:00:00Z",
+      end_time: "not-a-date",
+    });
+    expect(sc?.errors?.[0]?.code).toBe("INVALID_REQUEST");
+    expect(sc?.errors?.[0]?.recovery).toBe("correctable");
+    expect(sc?.errors?.[0]?.message).toMatch(/end_time.*not a valid ISO-8601/i);
+  });
+
+  it("past start_time → INVALID_REQUEST / correctable (unchanged by Sec-27a)", async () => {
+    const sc = await call({
+      start_time: "2020-01-01T00:00:00Z",
+      end_time: "2026-12-31T23:59:59Z",
+    });
+    expect(sc?.errors?.[0]?.code).toBe("INVALID_REQUEST");
+    expect(sc?.errors?.[0]?.recovery).toBe("correctable");
+    expect(sc?.errors?.[0]?.message).toMatch(/start_time.*is in the past/);
+  });
+
+  it("reversed dates → INVALID_REQUEST / correctable (unchanged)", async () => {
+    const sc = await call({
+      start_time: "2027-06-01T00:00:00Z",
+      end_time: "2027-01-01T00:00:00Z",
+    });
+    expect(sc?.errors?.[0]?.code).toBe("INVALID_REQUEST");
+    expect(sc?.errors?.[0]?.recovery).toBe("correctable");
+    expect(sc?.errors?.[0]?.message).toMatch(/end_time.*must be strictly after start_time/);
+  });
+
+  it("valid future request → UNSUPPORTED_OPERATION / terminal (unchanged)", async () => {
+    const sc = await call({
+      start_time: "2027-01-01T00:00:00Z",
+      end_time: "2027-06-01T00:00:00Z",
+    });
+    expect(sc?.errors?.[0]?.code).toBe("UNSUPPORTED_OPERATION");
+    expect(sc?.errors?.[0]?.recovery).toBe("terminal");
+  });
+
+  it("no dates supplied at all → UNSUPPORTED_OPERATION / terminal", async () => {
+    // Parse guard must only fire when the field was SUPPLIED but unparseable,
+    // not when the field is entirely absent. Absent fields fall through to
+    // the structural UNSUPPORTED_OPERATION branch — correct, because the
+    // request is well-formed, we just don't implement the operation.
+    const sc = await call({});
+    expect(sc?.errors?.[0]?.code).toBe("UNSUPPORTED_OPERATION");
+    expect(sc?.errors?.[0]?.recovery).toBe("terminal");
+  });
+});


### PR DESCRIPTION
## Summary

Single-item PR. Closes the latent bug the Sec-26 reviewer found: unparseable `start_time` / `end_time` strings like `"banana"` were misrouting to the terminal UNSUPPORTED_OPERATION branch because `NaN` comparisons silently evaluate to `false`, skipping the temporal checks.

## Fix
Top-of-function guard in [src/mcp/server.ts:callCreateMediaBuy](src/mcp/server.ts):
- `start_time` / `end_time` supplied but `Date.parse` returns `NaN` → emit `INVALID_REQUEST` with `recovery: "correctable"` via new `parseFailure` helper
- Absent fields still fall through to `UNSUPPORTED_OPERATION` (request is well-formed, we just don't implement the op)

## Upstream reference
Added code comment on `callCreateMediaBuy` citing [adcontextprotocol/adcp#2535](https://github.com/adcontextprotocol/adcp/issues/2535) — the runner `validateErrorCode` extractor bug you filed. Once landed, our `errors[]` envelope will be picked up via typed-field extraction instead of the fragile regex-on-message fallback.

## Tests
New [tests/createMediaBuy.test.ts](tests/createMediaBuy.test.ts) — 6 tests cementing the full error-envelope contract:
- banana `start_time` → INVALID_REQUEST / correctable
- non-date `end_time` → INVALID_REQUEST / correctable
- past `start_time` → INVALID_REQUEST / correctable (regression pin)
- reversed dates → INVALID_REQUEST / correctable (regression pin)
- valid future → UNSUPPORTED_OPERATION / terminal
- no dates at all → UNSUPPORTED_OPERATION / terminal (guard must only fire when field is *supplied* but unparseable)

## Live verification (Version `44e9d08b`)

```
banana start_time → { code: "INVALID_REQUEST", message: 'start_time "banana" is not a valid ISO-8601 timestamp.', recovery: "correctable" }

✅  307 unit tests pass (+6 new)
✅  Compliance: 3/3 tracks pass, zero advisory items
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)