### PR TITLE
Pin @adcp/client to 5.2.0 + document upgrade discipline

### DIFF
--- a/README.md
+++ b/README.md
@@ -588,6 +588,30 @@ wrote.) A rollback to a shape that removes a field that callers
 started depending on is the failure mode; everyone else is fine with
 staleness under 1 hour.
 
+### Upgrading `@adcp/client`
+
+`@adcp/client` is pinned to an exact version (`"5.2.0"`, not `^5.2.0`)
+so compliance-runner behavior can't drift under us silently. Before
+bumping:
+
+1. Read the upstream release notes:
+   `https://github.com/adcontextprotocol/adcp-client/releases`.
+2. Check whether [adcontextprotocol/adcp#2535](https://github.com/adcontextprotocol/adcp/issues/2535)
+   landed. If it did, the runner's `validateErrorCode` now resolves
+   `data.errors[0].code` directly — the regex-on-message fallback
+   comment on `callCreateMediaBuy` in [src/mcp/server.ts](src/mcp/server.ts)
+   can be removed.
+
+   Quick check without an issue-watch:
+   ```bash
+   grep -n "errors\\?\\.\\[0\\]\\?\\.code" \
+     node_modules/@adcp/client/dist/lib/testing/storyboard/validations.js
+   ```
+   A match means the extractor was updated.
+
+3. Re-run `npm run compliance` before merging the bump — any storyboard
+   regression is almost certainly new spec / new probe, not our code.
+
 ## Regenerating Embedding Vectors
 
 ```bash

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "zod": "^3.23.8"
       },
       "devDependencies": {
-        "@adcp/client": "^5.2.0",
+        "@adcp/client": "5.2.0",
         "@cloudflare/workers-types": "^4.20241022.0",
         "@vitest/coverage-v8": "^2.0.0",
         "typescript": "^5.5.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "lint": "eslint src --ext .ts"
   },
   "devDependencies": {
-    "@adcp/client": "^5.2.0",
+    "@adcp/client": "5.2.0",
     "@cloudflare/workers-types": "^4.20241022.0",
     "@vitest/coverage-v8": "^2.0.0",
     "typescript": "^5.5.0",


### PR DESCRIPTION
## Summary

Exact-version pin so the compliance runner can't drift silently on an `npm install`. `^5.2.0` would have quietly picked up any 5.x release — including ones that change extractor semantics for [adcp#2535](https://github.com/adcontextprotocol/adcp/issues/2535) — without giving us a chance to re-verify error-code handling.

## Changes
- [package.json](package.json): `@adcp/client: "^5.2.0"` → `"5.2.0"`
- [package-lock.json](package-lock.json): updated (was already locked; now the range matches)
- [README.md](README.md): new § *Upgrading `@adcp/client`* subsection with a 3-step bump procedure, including a grep one-liner to verify whether adcp#2535 landed in a given runner version

## Test plan
- [x] `npm test` — 307 pass
- [x] `npm run compliance` — 3/3 tracks, zero advisories

🤖 Generated with [Claude Code](https://claude.com/claude-code)