### PR TITLE
Sec-38: finish Tier-1 HoldCo readiness plan (all 9 batches)

### DIFF
--- a/src/domain/capabilityService.ts
+++ b/src/domain/capabilityService.ts
@@ -10,12 +10,12 @@
 // Cache key bumped to v6 for the v3-conformant shape (ucp moved to ext)
 // then v7 for the HEAD-schema-conformant shape (adds adcp.idempotency).
 
-// Cache key bumped to v11 — Sec-32 follow-up adds ext.dts declaring IAB
-// Data Transparency Standard v1.2 support at the capabilities level.
-// Every signal already carries a full x_dts label; this hoists that
-// capability into the handshake so buyer agents can detect DTS support
-// before pulling the catalog.
-const CACHE_KEY = "adcp_capabilities_v11";
+// Cache key bumped to v13 — Sec-38 C9 adds TTD + DV360 sandbox
+// destinations (activation_supported=false until OAuth wired). v12
+// baseline: three ext blocks (id_resolution, measurement, governance).
+// v11 baseline: ext.dts declaring IAB Data Transparency Standard v1.2.
+// v10 baseline: ext.ucp declaring UCP embedding bridge + concept registry.
+const CACHE_KEY = "adcp_capabilities_v13";
 const CACHE_TTL_SECONDS = 3600;
 
 import { buildUcpCapability, type UcpCapabilityEnv } from "../ucp/vacDeclaration";
@@ -88,6 +88,13 @@ function buildStaticCapabilities(env: UcpCapabilityEnv): AdcpCapabilities {
         { id: "mock_cleanroom",   name: "Mock Clean Room",            type: "cleanroom",   activation_supported: true  },
         { id: "mock_cdp",         name: "Mock CDP",                   type: "cdp",         activation_supported: true  },
         { id: "mock_measurement", name: "Mock Measurement Platform",  type: "measurement", activation_supported: false },
+        // Sec-38 C9: DSP-stage destinations. TTD sandbox + DV360 sandbox
+        // are declared activation_supported=false because no real OAuth
+        // handshake is wired yet — buyer agents should fall through to
+        // mock_dsp for actual activation in this demo. Listing them at
+        // capability level signals the integration roadmap.
+        { id: "ttd_sandbox",      name: "The Trade Desk (sandbox)",   type: "dsp",         activation_supported: false },
+        { id: "dv360_sandbox",    name: "DV360 (sandbox)",            type: "dsp",         activation_supported: false },
       ],
       limits: {
         max_signals_per_request: 100,
@@ -132,6 +139,90 @@ function buildStaticCapabilities(env: UcpCapabilityEnv): AdcpCapabilities {
         // Document URL the label references for the data-provider's
         // privacy practices
         provider_privacy_policy_url: "https://adcp-signals-adaptor.evgeny-193.workers.dev/privacy",
+      },
+      // ext.id_resolution — cookieless posture + supported ID types.
+      // The signal-level x_dts.data_sources + audience_precision_levels
+      // already encode per-signal identity granularity; this hoists the
+      // provider-wide posture into the handshake so a buyer agent knows
+      // what IDs we can resolve before pulling rows. Graph partners are
+      // declared as `stage` = sandbox|roadmap|live; none are live today
+      // because this adaptor is a reference implementation.
+      id_resolution: {
+        supported: true,
+        cookieless_ready: true,
+        id_types_supported: [
+          "cookie_3p",
+          "maid_ios",
+          "maid_android",
+          "ctv_device",
+          "uid2",
+          "ramp_id",
+          "id5",
+          "hashed_email",
+          "ip_only",
+        ],
+        graph_partners: [
+          { name: "UID 2.0", stage: "sandbox", endpoint: null },
+          { name: "ID5", stage: "sandbox", endpoint: null },
+          { name: "LiveRamp RampID", stage: "roadmap", endpoint: null },
+          { name: "Yahoo ConnectID", stage: "roadmap", endpoint: null },
+        ],
+        resolution_method: "derived_from_dts",
+        resolution_surface:
+          "/signals/{signal_agent_segment_id} x_dts.data_sources + audience_precision_levels",
+      },
+      // ext.measurement — reach/overlap/lift/delivery surfaces. Reach and
+      // overlap are live (UI + /signals/overlap endpoint); lift and
+      // delivery-sim are declared as "mock" because the demo renders
+      // placeholder panels backed by synthetic numbers. Partner roadmap
+      // lists the measurement vendors this adaptor is architected to
+      // integrate with once connected.
+      measurement: {
+        supported: true,
+        reach_forecasting: {
+          supported: true,
+          endpoint: "/signals/{id} (detail panel)",
+          methodology: "logistic saturation against declared CPM + budget",
+        },
+        overlap_analysis: {
+          supported: true,
+          endpoint: "/signals/overlap",
+          methodology: "category_affinity × min/max Jaccard heuristic",
+        },
+        lift_measurement: {
+          supported: "mock",
+          partners_roadmap: ["Nielsen", "IAS", "DV", "Kantar", "Circana"],
+        },
+        delivery_simulation: {
+          supported: "mock",
+          surface: "/signals/{id} detail panel (post-activation)",
+        },
+      },
+      // ext.governance — audit log, sensitive-category flagging, opt-out.
+      // The D1-backed tool log (migrations/0006_mcp_tool_calls.sql) retains
+      // 7 days of MCP tool calls with 4KB arg truncation; buyer agents can
+      // export via CSV. Sensitive categories (health/financial/political)
+      // are surfaced via x_governance.sensitive on individual signals and
+      // rendered as a pill in the UI.
+      governance: {
+        audit_log: {
+          supported: true,
+          endpoint: "/mcp/recent",
+          retention_days: 7,
+          export_format: "csv_download",
+        },
+        sensitive_category_flagging: {
+          supported: true,
+          categories_flagged: ["health", "financial", "political"],
+          surface:
+            "x_governance.sensitive block on signal + UI pill in signal detail",
+        },
+        opt_out_url:
+          "https://adcp-signals-adaptor.evgeny-193.workers.dev/privacy#opt-out",
+        audience_bias_governance_schema: {
+          supported: true,
+          version: "adcp_3.0_rc",
+        },
       },
     },
   };

--- a/src/domain/signals/crossVerticals.ts
+++ b/src/domain/signals/crossVerticals.ts
@@ -1,0 +1,130 @@
+// src/domain/signals/crossVerticals.ts
+// Sec-38 Tier-1 readiness: +80 cross-vertical signals that capture the
+// high-value combinations HoldCo planners ask for but single-axis
+// verticals don't express. Every entry is a first-class CanonicalSignal
+// — same mapper, same DTS label, same cross-taxonomy surface.
+//
+// Buckets (count in parens):
+//   seasonality × region      (20)  — holiday/event × DMA crossovers
+//   life-event temporal window (15) — 0-30 / 31-90 / 91-180 day framing
+//   B2B intent-in-window      (10) — fiscal-quarter-boxed buying intent
+//   sports × market           (12) — team fandom × geo × activation window
+//   CTV device × content      (12) — device class × content affinity
+//   1P-lookalike templates    (10) — modeled seed-audience templates
+//
+// All pricing calibrated against existing _helpers.ts CPM ladder.
+
+import type { CanonicalSignal } from "../../types/signal";
+import { make, cpm } from "./_helpers";
+
+const V_SR = "seasonal_x_region";
+const V_LW = "life_event_window";
+const V_BI = "b2b_intent_window";
+const V_SM = "sports_x_market";
+const V_CTV = "ctv_device_x_content";
+const V_LAL = "lookalike_template";
+
+export const CROSS_VERTICAL_SIGNALS: CanonicalSignal[] = [
+  // ── Seasonality × Region (20) ────────────────────────────────────────────
+  // Holiday / seasonal buyers crossed with top DMAs and regions. Enables
+  // "Q4 gifting in NY metro" or "Back-to-School in Top 10 DMAs" plans.
+  make("sr_q4_gifting_nyc",              "Q4 Gifting × NY Metro",              "Q4 holiday gift buyers in NY-NJ-CT DMA. Urban affluent gifting.", "purchase_intent", 7_800_000, cpm(9.00), V_SR),
+  make("sr_q4_gifting_la",               "Q4 Gifting × LA Metro",              "Q4 holiday gift buyers in LA metro DMA. Affluent gifting, experiential skew.", "purchase_intent", 6_200_000, cpm(9.00), V_SR),
+  make("sr_q4_gifting_chicago",          "Q4 Gifting × Chicago Metro",         "Q4 holiday gift buyers in Chicago DMA.", "purchase_intent", 3_400_000, cpm(8.50), V_SR),
+  make("sr_q4_gifting_top10_dma",        "Q4 Gifting × Top-10 DMA",            "Q4 gift buyers in Top-10 DMAs (NY, LA, Chi, Phi, Dal, Bay, DC, Houston, Boston, Atlanta).", "purchase_intent", 28_000_000, cpm(8.50), V_SR),
+  make("sr_bfcm_south",                  "Black Friday / CM × South Region",   "BF/CM shoppers in Southern US region. Deal-seeker density.", "purchase_intent", 15_800_000, cpm(7.50), V_SR),
+  make("sr_bfcm_midwest",                "Black Friday / CM × Midwest",        "BF/CM shoppers in Midwest region.", "purchase_intent", 10_200_000, cpm(7.00), V_SR),
+  make("sr_valentines_top25_dma",        "Valentine's × Top-25 DMA",           "Valentine's shoppers concentrated in Top-25 DMAs. Jewelry / restaurant / flowers.", "purchase_intent", 21_000_000, cpm(8.00), V_SR),
+  make("sr_mothers_day_south",           "Mother's Day × South",               "Mother's Day buyers in Southern US region.", "purchase_intent", 18_400_000, cpm(7.50), V_SR),
+  make("sr_back_to_school_tx_fl",        "BTS × Texas + Florida",              "Back-to-School K-12 parents in Texas + Florida (largest state populations).", "purchase_intent", 3_800_000, cpm(8.50), V_SR),
+  make("sr_back_to_school_northeast",    "BTS × Northeast",                    "Back-to-School K-12 parents in Northeast region.", "purchase_intent", 4_200_000, cpm(8.00), V_SR),
+  make("sr_summer_vacation_coastal",     "Summer Vacation × Coastal States",   "Summer vacation planners in CA, FL, NY, NJ, WA, MA coastal markets.", "purchase_intent", 11_600_000, cpm(8.00), V_SR),
+  make("sr_summer_vacation_mountain",    "Summer Vacation × Mountain Region",  "Summer vacation planners in Mountain region (CO, UT, ID, MT, WY, NM, AZ).", "purchase_intent", 3_400_000, cpm(8.50), V_SR),
+  make("sr_tax_season_top10_dma",        "Tax Season × Top-10 DMA",            "Tax-season active filers in Top-10 DMAs.", "purchase_intent", 14_200_000, cpm(7.00), V_SR),
+  make("sr_new_year_fitness_coastal",    "New Year Fitness × Coastal Metros",  "New Year resolution fitness shoppers in coastal metros. Premium gym / D2C fitness target.", "purchase_intent", 7_600_000, cpm(8.00), V_SR),
+  make("sr_july4_sunbelt",               "July 4 × Sun Belt",                  "July 4 weekend shoppers in Sun Belt states. Outdoor / grill / travel.", "purchase_intent", 12_800_000, cpm(7.00), V_SR),
+  make("sr_halloween_top25_dma",         "Halloween × Top-25 DMA",             "Halloween costume + candy buyers in Top-25 DMAs.", "purchase_intent", 9_400_000, cpm(7.50), V_SR),
+  make("sr_graduation_college_towns",    "Graduation × College Towns",         "Graduation gift buyers in top 40 college-town ZIPs.", "purchase_intent", 2_200_000, cpm(9.00), V_SR),
+  make("sr_wedding_season_south",        "Wedding Season × South",             "Wedding gift buyers in Southern US region (spring/summer peak).", "purchase_intent", 3_800_000, cpm(8.00), V_SR),
+  make("sr_spring_break_florida",        "Spring Break × Florida",             "Spring break travel planners with Florida destination intent.", "purchase_intent", 3_200_000, cpm(8.50), V_SR),
+  make("sr_q4_gifting_luxury_hhi",       "Q4 Gifting × Luxury HHI $250k+",     "Q4 holiday gift buyers with household income $250k+. Luxury gifting.", "purchase_intent", 3_400_000, cpm(11.00), V_SR),
+
+  // ── Life Event Temporal Windows (15) ─────────────────────────────────────
+  // Sharp-window framings beyond the base life_events set. Splits on
+  // 0-30 / 31-90 / 91-180 days post-event for precision targeting.
+  make("lw_new_mover_0_30_premium",      "New Mover 0-30d × HHI $100k+",       "Premium new movers in first 30 days. Furniture, insurance, financial-planning peak.", "demographic", 180_000, cpm(16.00), V_LW),
+  make("lw_new_homeowner_0_90d",         "New Homeowner 0-90d",                "Homeowners within 90 days of close. Big-ticket renovation + appliance surge.", "demographic", 420_000, cpm(14.50), V_LW),
+  make("lw_new_homeowner_91_180d",       "New Homeowner 91-180d",              "Homeowners 3-6 months post-close. Furniture completion + services adoption.", "demographic", 380_000, cpm(11.50), V_LW),
+  make("lw_expecting_2nd_trimester",     "Expecting Parent × 2nd Trimester",   "Expectant families in weeks 14-28. Peak registry + gear research window.", "demographic", 280_000, cpm(14.50), V_LW),
+  make("lw_expecting_3rd_trimester",     "Expecting Parent × 3rd Trimester",   "Expectant families in weeks 29-40. Final-purchase + hospital-bag window.", "demographic", 260_000, cpm(15.00), V_LW),
+  make("lw_new_parent_0_90d",            "New Parent 0-90 Days",               "Households with infant 0-3 months. Sleep products + diaper subscription peak.", "demographic", 420_000, cpm(14.00), V_LW),
+  make("lw_new_parent_91_180d",          "New Parent 91-180 Days",             "Households with infant 3-6 months. Solids introduction + gear upgrade.", "demographic", 400_000, cpm(12.50), V_LW),
+  make("lw_engaged_6_12mo_out",          "Engaged × Wedding 6-12mo Out",       "Engaged couples 6-12 months pre-wedding. Venue + attire purchase window.", "demographic", 480_000, cpm(12.50), V_LW),
+  make("lw_engaged_3_6mo_out",           "Engaged × Wedding 3-6mo Out",        "Engaged couples 3-6 months pre-wedding. Registry + detail-vendor window.", "demographic", 420_000, cpm(13.00), V_LW),
+  make("lw_newlyweds_0_90d",             "Newlyweds 0-90 Days",                "Just-married couples in first 90 days. Insurance + tax change + honeymoon recovery.", "demographic", 280_000, cpm(12.50), V_LW),
+  make("lw_recent_divorce_0_6mo",        "Recently Divorced 0-6 Months",       "Divorced adults in first 6 months. High financial-services + housing intent.", "demographic", 340_000, cpm(11.00), V_LW),
+  make("lw_empty_nester_0_12mo",         "Empty Nester 0-12 Months",           "Households with youngest child gone in last year. Downsize + travel + lifestyle shift.", "demographic", 680_000, cpm(9.50), V_LW),
+  make("lw_retiring_0_12mo",             "Recently Retired 0-12 Months",       "Adults retired in last 12 months. Healthcare + travel + advisory services peak.", "demographic", 780_000, cpm(10.50), V_LW),
+  make("lw_graduating_college_60d",      "Graduating College × 60-Day Window", "Seniors within 60 days of graduation. First-job financial + mover + apparel peak.", "demographic", 210_000, cpm(10.00), V_LW),
+  make("lw_job_change_0_90d",            "Recent Job Change 0-90 Days",        "Adults starting a new job in last 90 days. 401k rollover + apparel + commute purchases.", "demographic", 1_200_000, cpm(9.50), V_LW),
+
+  // ── B2B Intent-in-Window (10) ────────────────────────────────────────────
+  // Fiscal-quarter-boxed purchase intent for B2B categories. Critical for
+  // ABM campaigns timed to budget cycles.
+  make("bi_saas_procurement_q1",         "SaaS Procurement Intent × Q1",       "B2B buyers with active SaaS procurement signals in Q1 fiscal window.", "purchase_intent", 480_000, cpm(13.00), V_BI),
+  make("bi_saas_procurement_q4",         "SaaS Procurement Intent × Q4",       "B2B buyers with active SaaS procurement in Q4 use-it-or-lose-it budget window.", "purchase_intent", 720_000, cpm(14.00), V_BI),
+  make("bi_cybersec_eval_30d",           "Cybersecurity Evaluation × 30-Day",  "IT/Security buyers with active cybersecurity vendor evaluation in last 30 days.", "purchase_intent", 180_000, cpm(14.50), V_BI),
+  make("bi_cloud_migration_in_window",   "Cloud Migration × Active-RFP",       "B2B buyers with cloud-migration RFP activity in last 60 days.", "purchase_intent", 220_000, cpm(13.50), V_BI),
+  make("bi_hr_tech_renewal_60d",         "HR Tech × Renewal 60-Day",           "HR buyers within 60 days of contract renewal (payroll / HRIS / benefits).", "purchase_intent", 160_000, cpm(13.00), V_BI),
+  make("bi_martech_eval_90d",            "MarTech Evaluation × 90-Day",        "Marketing ops / CMO buyers with active martech RFP in last 90 days.", "purchase_intent", 140_000, cpm(13.50), V_BI),
+  make("bi_it_refresh_fy_end",           "IT Hardware Refresh × Fiscal-Year-End", "IT buyers with hardware refresh signals in fiscal-year-end window.", "purchase_intent", 280_000, cpm(12.00), V_BI),
+  make("bi_data_platform_eval",          "Data Platform Evaluation",           "Data / analytics buyers actively evaluating data-platform vendors (Snowflake/Databricks/BigQuery category).", "purchase_intent", 210_000, cpm(13.50), V_BI),
+  make("bi_dev_tools_in_window",         "Developer Tools × Active Eval",      "Engineering leaders with dev-tool purchase intent in last 60 days.", "purchase_intent", 140_000, cpm(12.50), V_BI),
+  make("bi_compliance_post_audit",       "Compliance Software × Post-Audit",   "Compliance / finance buyers within 90 days of audit finding. SOC2/PCI/HIPAA triggers.", "purchase_intent", 110_000, cpm(13.00), V_BI),
+
+  // ── Sports × Market (12) ─────────────────────────────────────────────────
+  // Team fandom crossed with DMA + activation window (regular season,
+  // playoffs, draft). Sportsbook + CPG + beverage premium category.
+  make("sm_nfl_patriots_boston",         "NFL Patriots Fans × Boston DMA",     "Active NFL Patriots fans in Boston DMA. In-season activation.", "interest", 980_000, cpm(9.50), V_SM),
+  make("sm_nfl_cowboys_dallas",          "NFL Cowboys Fans × Dallas DMA",      "Active NFL Cowboys fans in Dallas-Ft Worth DMA.", "interest", 1_800_000, cpm(9.50), V_SM),
+  make("sm_nba_warriors_bayarea",        "NBA Warriors Fans × Bay Area",       "Active NBA Warriors fans in SF Bay Area DMA.", "interest", 720_000, cpm(9.00), V_SM),
+  make("sm_nba_lakers_la",               "NBA Lakers Fans × LA Metro",         "Active NBA Lakers fans in LA metro DMA.", "interest", 1_400_000, cpm(9.50), V_SM),
+  make("sm_mlb_yankees_nyc",             "MLB Yankees Fans × NY Metro",        "Active MLB Yankees fans in NY DMA. Summer activation window.", "interest", 1_200_000, cpm(8.50), V_SM),
+  make("sm_mlb_dodgers_la",              "MLB Dodgers Fans × LA Metro",        "Active MLB Dodgers fans in LA metro DMA.", "interest", 1_100_000, cpm(8.50), V_SM),
+  make("sm_nhl_rangers_nyc",             "NHL Rangers Fans × NY Metro",        "Active NHL Rangers fans in NY metro DMA. Winter activation.", "interest", 420_000, cpm(8.00), V_SM),
+  make("sm_college_football_sec",        "College Football × SEC Footprint",   "College football fans in SEC-conference states (AL, GA, FL, TN, SC, LA, AR, MS, MO, TX, KY, OK).", "interest", 8_400_000, cpm(8.00), V_SM),
+  make("sm_college_football_big10",      "College Football × Big Ten",         "College football fans in Big Ten footprint states.", "interest", 6_200_000, cpm(8.00), V_SM),
+  make("sm_sportsbook_legal_states",     "Sports Bettors × Legal States",      "Adults with sports-betting activity in states where online sportsbook is legal.", "purchase_intent", 18_200_000, cpm(10.00), V_SM),
+  make("sm_sportsbook_playoff_window",   "Sports Bettors × Playoff Window",    "Active bettors with elevated wagering in playoff / March Madness / Super Bowl windows.", "purchase_intent", 8_400_000, cpm(11.00), V_SM),
+  make("sm_fantasy_sports_active",       "Fantasy Sports × Active Managers",   "Adults actively managing fantasy football / basketball / baseball teams.", "interest", 12_400_000, cpm(8.50), V_SM),
+
+  // ── CTV Device × Content (12) ────────────────────────────────────────────
+  // Device class × content affinity for CTV / OTT premium inventory.
+  make("ctv_roku_sports",                "Roku Households × Sports Affinity",  "Roku-device households with elevated live-sports content viewing.", "interest", 14_200_000, cpm(10.00), V_CTV),
+  make("ctv_samsung_drama",              "Samsung TV × Drama Affinity",        "Samsung Tizen households with high prestige-drama viewing (HBO/AMC/FX).", "interest", 11_400_000, cpm(9.50), V_CTV),
+  make("ctv_firetv_action",              "Fire TV × Action/Thriller",          "Amazon Fire TV households with elevated action/thriller content affinity.", "interest", 16_400_000, cpm(9.00), V_CTV),
+  make("ctv_appletv_docs",               "Apple TV × Documentary Affinity",    "Apple TV households with elevated documentary / prestige-non-fiction viewing.", "interest", 7_200_000, cpm(10.50), V_CTV),
+  make("ctv_roku_news",                  "Roku × News/Politics Affinity",      "Roku households with news / politics content affinity (excluded from political-advocacy use).", "interest", 9_600_000, cpm(8.50), V_CTV),
+  make("ctv_lg_kids",                    "LG TV × Kids/Family",                "LG webOS households with elevated kids / family content viewing.", "interest", 5_800_000, cpm(9.00), V_CTV),
+  make("ctv_vizio_reality",              "Vizio × Reality TV Affinity",        "Vizio households with reality TV / unscripted content affinity.", "interest", 10_200_000, cpm(8.50), V_CTV),
+  make("ctv_chromecast_gaming",          "Chromecast × Gaming Content",        "Chromecast-with-GoogleTV households with gaming content / streaming affinity.", "interest", 4_400_000, cpm(9.50), V_CTV),
+  make("ctv_roku_hispanic",              "Roku × Spanish-language Content",    "Roku households with elevated Spanish-language content viewing.", "interest", 6_200_000, cpm(9.00), V_CTV),
+  make("ctv_ott_cordcutter_premium",     "Cord-Cutter × Premium SVOD Stack",   "Cord-cutter households subscribing to 3+ premium SVOD services.", "interest", 18_400_000, cpm(10.00), V_CTV),
+  make("ctv_ctv_light_viewer",           "CTV Light Viewer (0-5h/wk)",         "Light CTV viewers (0-5 hours/week). Reach-efficient for incremental lift.", "interest", 32_000_000, cpm(7.50), V_CTV),
+  make("ctv_ctv_heavy_viewer",           "CTV Heavy Viewer (20+h/wk)",         "Heavy CTV viewers (20+ hours/week). Frequency-capped premium inventory.", "interest", 18_400_000, cpm(10.50), V_CTV),
+
+  // ── 1P Lookalike Templates (10) ──────────────────────────────────────────
+  // Modeled seed-audience lookalike templates. Shipped as `custom` so
+  // they're visibly distinct from seeded marketplace signals. These are
+  // the "drop in your 1P CSV" activation story.
+  make("lal_high_ltv_customers",         "1P Lookalike: High-LTV Customers",   "Modeled lookalike template matching top-quartile LTV customer seed. Upload 1P seed to refine.", "composite", 8_400_000, cpm(10.00), V_LAL, { generationMode: "derived" }),
+  make("lal_churn_risk_winback",         "1P Lookalike: Churn Risk / Winback", "Modeled winback template — lookalike of recently churned customers with re-engagement potential.", "composite", 4_200_000, cpm(9.50), V_LAL, { generationMode: "derived" }),
+  make("lal_saas_power_users",           "1P Lookalike: SaaS Power Users",     "Modeled lookalike of top-decile product-usage seed (B2B SaaS template).", "composite", 210_000, cpm(13.00), V_LAL, { generationMode: "derived" }),
+  make("lal_ecomm_repeat_buyers",        "1P Lookalike: E-Comm Repeat Buyers", "Modeled lookalike of 3+ order e-commerce customers.", "composite", 14_200_000, cpm(9.00), V_LAL, { generationMode: "derived" }),
+  make("lal_subscription_loyalists",     "1P Lookalike: Subscription Loyalists","Modeled lookalike of 12+ month subscription retainers (SVOD / D2C / news).", "composite", 11_400_000, cpm(9.50), V_LAL, { generationMode: "derived" }),
+  make("lal_mobile_app_engaged",         "1P Lookalike: Mobile App Engaged",   "Modeled lookalike of top-quartile mobile-app engagement seed.", "composite", 18_400_000, cpm(8.50), V_LAL, { generationMode: "derived" }),
+  make("lal_event_attendees",            "1P Lookalike: Event Attendees",      "Modeled lookalike of brand-event attendee seed (conference / activation / pop-up).", "composite", 3_200_000, cpm(10.00), V_LAL, { generationMode: "derived" }),
+  make("lal_premium_tier_upgraders",     "1P Lookalike: Premium Tier Upgraders","Modeled lookalike of users who upgraded to premium/paid tier.", "composite", 6_800_000, cpm(10.00), V_LAL, { generationMode: "derived" }),
+  make("lal_cart_abandoners_high_aov",   "1P Lookalike: High-AOV Cart Abandoners","Modeled lookalike of cart abandoners with above-median AOV. Retargeting expansion.", "composite", 4_400_000, cpm(9.50), V_LAL, { generationMode: "derived" }),
+  make("lal_b2b_qualified_leads",        "1P Lookalike: Qualified B2B Leads",  "Modeled lookalike of MQL-converted B2B contacts. Firmographic + intent template.", "composite", 380_000, cpm(12.50), V_LAL, { generationMode: "derived" }),
+];

--- a/src/domain/signals/index.ts
+++ b/src/domain/signals/index.ts
@@ -2,10 +2,12 @@
 // Barrel — aggregates all vertical signal files into a single
 // EXTENDED_VERTICAL_SIGNALS array consumed by the seed pipeline.
 //
-// 15 verticals × 20 signals = 300 signals. Added on top of the
-// SEEDED_SIGNALS + DERIVED_SIGNALS in signalModel.ts (~55 signals)
-// and ALL_ENRICHED_SIGNALS in enrichedSignalModel.ts, the live
-// catalog post-reseed is ~355 signals across every major DSP
+// 15 verticals × 20 signals = 300 signals, plus Sec-38 cross-vertical
+// additions (80 more: seasonality×region, life-event windows, B2B
+// intent windows, sports×market, CTV device×content, 1P lookalikes).
+// Added on top of the SEEDED_SIGNALS + DERIVED_SIGNALS in signalModel.ts
+// (~55 signals) and ALL_ENRICHED_SIGNALS in enrichedSignalModel.ts, the
+// live catalog post-reseed is ~435 signals across every major DSP
 // marketplace vertical.
 
 import type { CanonicalSignal } from "../../types/signal";
@@ -24,6 +26,7 @@ import { PSYCHOGRAPHIC_SIGNALS } from "./psychographic";
 import { INTEREST_EXT_SIGNALS } from "./interestExt";
 import { DEMOGRAPHIC_EXT_SIGNALS } from "./demographicExt";
 import { GEOGRAPHIC_EXT_SIGNALS } from "./geographicExt";
+import { CROSS_VERTICAL_SIGNALS } from "./crossVerticals";
 
 export const EXTENDED_VERTICAL_SIGNALS: CanonicalSignal[] = [
   ...AUTOMOTIVE_SIGNALS,
@@ -41,4 +44,5 @@ export const EXTENDED_VERTICAL_SIGNALS: CanonicalSignal[] = [
   ...INTEREST_EXT_SIGNALS,
   ...DEMOGRAPHIC_EXT_SIGNALS,
   ...GEOGRAPHIC_EXT_SIGNALS,
+  ...CROSS_VERTICAL_SIGNALS,
 ];

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ import { handleGetEmbedding } from "./routes/getEmbedding";
 import { handleGetGts } from "./routes/gts";
 import { handleSimulateHandshake } from "./routes/handshake";
 import { handleGetProjector } from "./routes/getProjector";
+import { handleUcpProjection, handleUcpSimilarity } from "./routes/ucpProjection";
 import { handleMcpRequest } from "./mcp/server";
 import { jsonResponse, errorResponse, requireAuth } from "./routes/shared";
 import { createLogger } from "./utils/logger";
@@ -132,6 +133,11 @@ export default {
             "/ucp/concepts",
             "/ucp/gts",
             "/ucp/simulate-handshake",
+            // Sec-38 B5: 2D projection + pairwise cosine heatmap. Public
+            // because the underlying data (real 512-d vectors) is already
+            // public via /signals/{id}/embedding.
+            "/ucp/projection",
+            "/ucp/similarity",
             "/auth/linkedin/callback",
             // RFC 9728 + 8414: OAuth discovery metadata MUST be reachable
             // without authentication so clients can bootstrap the flow.
@@ -205,6 +211,14 @@ export default {
                 // ── UCP Projector ─────────────────────────────────────────────────────
             } else if (method === "GET" && path === "/ucp/projector") {
                 response = handleGetProjector();
+
+                // ── UCP 2D Projection (for visualization) ─────────────────────────────
+            } else if (method === "GET" && path === "/ucp/projection") {
+                response = handleUcpProjection();
+
+                // ── UCP Pairwise Similarity Matrix ────────────────────────────────────
+            } else if (method === "GET" && path === "/ucp/similarity") {
+                response = handleUcpSimilarity(url);
 
                 // ── LinkedIn OAuth ────────────────────────────────────────────────────
                 // Only /callback is in publicPaths. /init and /status are

--- a/src/mappers/crossTaxonomy.ts
+++ b/src/mappers/crossTaxonomy.ts
@@ -1,0 +1,142 @@
+// src/mappers/crossTaxonomy.ts
+// Cross-taxonomy bridge — surfaces predicted segment IDs in the major
+// buyer-side taxonomies so a HoldCo buyer agent can immediately locate
+// an equivalent audience in its own workflow without manual translation.
+//
+// This is a demonstration-grade mapper: IDs are deterministic, derived
+// from the signal's canonical categoryType + name/vertical, and stamped
+// with a `stage` field so buyers know whether the mapping is live,
+// modeled, or roadmap. Production systems would replace this with a
+// real bridge table driven by Tranco / AbiliTec / UID 2.0 handshake.
+//
+// Taxonomies covered:
+//   - iab_content_3_0          — IAB Tech Lab Content Taxonomy 3.0
+//   - iab_audience_1_1         — IAB Audience Taxonomy 1.1 (our native)
+//   - liveramp_abilitec        — LiveRamp AbiliTec consumer graph
+//   - ttd_dmp                  — The Trade Desk first-party DMP
+//   - mastercard_spendingpulse — Mastercard SpendingPulse retail categories
+//   - nielsen_category         — Nielsen Category Audiences
+//
+// Shape is surfaced as x_cross_taxonomy on every SignalSummary.
+
+import type { CanonicalSignal } from "../types/signal";
+
+export type CrossTaxonomyStage = "live" | "modeled" | "roadmap";
+
+export interface CrossTaxonomyEntry {
+  system: string;
+  id: string;
+  label: string;
+  stage: CrossTaxonomyStage;
+}
+
+// Short hash for deterministic per-signal IDs. Same djb2-style hash
+// used in src/utils/ids.ts — kept local to avoid importing back up.
+function shortHash(s: string, mod: number): number {
+  let hash = 5381;
+  for (let i = 0; i < s.length; i++) {
+    hash = ((hash << 5) + hash) ^ s.charCodeAt(i);
+    hash = hash >>> 0;
+  }
+  return hash % mod;
+}
+
+// ── IAB Content 3.0 — topic-shape IDs (IAB-3-0-NNN)
+function iab30(signal: CanonicalSignal): CrossTaxonomyEntry {
+  const name = signal.name.toLowerCase();
+  const cat = signal.categoryType;
+  // Top-level IAB 3.0 tiers (partial — demonstrative)
+  const topic =
+    name.includes("auto") || name.includes("vehicle") ? { id: "T-3-0-001", label: "Automotive" }
+    : name.includes("finance") || name.includes("bank") || name.includes("invest") ? { id: "T-3-0-030", label: "Personal Finance" }
+    : name.includes("health") || name.includes("fitness") || name.includes("wellness") ? { id: "T-3-0-233", label: "Healthy Living" }
+    : name.includes("business") || name.includes("b2b") || name.includes("saas") ? { id: "T-3-0-052", label: "Business & Finance" }
+    : name.includes("travel") || name.includes("vacation") ? { id: "T-3-0-653", label: "Travel" }
+    : name.includes("parent") || name.includes("famil") || name.includes("kids") ? { id: "T-3-0-192", label: "Family & Relationships" }
+    : name.includes("sport") || name.includes("fitness") ? { id: "T-3-0-483", label: "Sports" }
+    : name.includes("tech") || name.includes("gadget") ? { id: "T-3-0-596", label: "Technology & Computing" }
+    : name.includes("food") || name.includes("restaurant") ? { id: "T-3-0-210", label: "Food & Drink" }
+    : name.includes("shop") || name.includes("retail") ? { id: "T-3-0-473", label: "Shopping" }
+    : name.includes("event") || name.includes("wedding") || name.includes("mover") ? { id: "T-3-0-186", label: "Events & Attractions" }
+    : name.includes("stream") || name.includes("media") || name.includes("ctv") ? { id: "T-3-0-324", label: "Television" }
+    : cat === "geo" ? { id: "T-3-0-293", label: "Geography" }
+    : cat === "demographic" ? { id: "T-3-0-186", label: "Demographics" }
+    : { id: "T-3-0-596", label: "General Interest" };
+  return { system: "iab_content_3_0", id: topic.id, label: topic.label, stage: "modeled" };
+}
+
+// ── LiveRamp AbiliTec cluster — 9-digit deterministic cluster ID
+function liveramp(signal: CanonicalSignal): CrossTaxonomyEntry {
+  const raw = shortHash("LR:" + signal.signalId, 900_000_000) + 100_000_000;
+  return {
+    system: "liveramp_abilitec",
+    id: "LR_" + raw.toString(),
+    label: signal.name,
+    stage: "roadmap", // we don't have a real AbiliTec handshake
+  };
+}
+
+// ── TTD DMP — 7-digit segment ID under partner namespace
+function ttdDmp(signal: CanonicalSignal): CrossTaxonomyEntry {
+  const raw = shortHash("TTD:" + signal.signalId, 9_000_000) + 1_000_000;
+  return {
+    system: "ttd_dmp",
+    id: "ttd_" + raw.toString(),
+    label: signal.name,
+    stage: "modeled",
+  };
+}
+
+// ── Mastercard SpendingPulse — retail category codes
+// (only meaningful for purchase_intent / retail-shaped signals)
+function mastercard(signal: CanonicalSignal): CrossTaxonomyEntry | null {
+  const name = signal.name.toLowerCase();
+  const cat = signal.categoryType;
+  if (cat !== "purchase_intent" && !name.includes("shop") && !name.includes("retail") && !name.includes("restaurant")) {
+    return null;
+  }
+  const bucket =
+    name.includes("restaurant") || name.includes("dining") ? { id: "MC-REST", label: "Restaurants (SpendingPulse)" }
+    : name.includes("apparel") || name.includes("fashion") ? { id: "MC-APPRL", label: "Apparel (SpendingPulse)" }
+    : name.includes("electronic") || name.includes("tech") ? { id: "MC-ELEC", label: "Electronics & Appliances (SpendingPulse)" }
+    : name.includes("grocer") || name.includes("food") ? { id: "MC-GROC", label: "Grocery (SpendingPulse)" }
+    : name.includes("travel") || name.includes("hotel") || name.includes("airline") ? { id: "MC-TRVL", label: "Travel (SpendingPulse)" }
+    : name.includes("luxury") ? { id: "MC-LUX", label: "Luxury Retail (SpendingPulse)" }
+    : { id: "MC-GEN", label: "General Retail (SpendingPulse)" };
+  return { system: "mastercard_spendingpulse", id: bucket.id, label: bucket.label, stage: "roadmap" };
+}
+
+// ── Nielsen Category Audiences — N-CAT-NNN
+function nielsen(signal: CanonicalSignal): CrossTaxonomyEntry {
+  const raw = shortHash("N:" + signal.signalId, 900) + 100;
+  return {
+    system: "nielsen_category",
+    id: "N-CAT-" + raw.toString(),
+    label: signal.name,
+    stage: "modeled",
+  };
+}
+
+/**
+ * Build the full cross-taxonomy entry list for a signal. Always includes
+ * the native iab_audience_1_1 entry plus iab_content_3_0, liveramp,
+ * ttd_dmp, nielsen. Mastercard SpendingPulse is retail-only so it's
+ * conditional.
+ */
+export function buildCrossTaxonomy(signal: CanonicalSignal): CrossTaxonomyEntry[] {
+  const entries: CrossTaxonomyEntry[] = [
+    {
+      system: "iab_audience_1_1",
+      id: signal.externalTaxonomyId ?? "0",
+      label: signal.name,
+      stage: "live",
+    },
+    iab30(signal),
+    liveramp(signal),
+    ttdDmp(signal),
+    nielsen(signal),
+  ];
+  const mc = mastercard(signal);
+  if (mc) entries.push(mc);
+  return entries;
+}

--- a/src/mappers/signalMapper.ts
+++ b/src/mappers/signalMapper.ts
@@ -1,5 +1,6 @@
 // src/mappers/signalMapper.ts
 import { toUcpHybridPayload } from "../ucp/ucpMapper";
+import { buildCrossTaxonomy } from "./crossTaxonomy";
 // Maps CanonicalSignal → AdCP spec response shape.
 // Includes buildDtsLabel() which generates a full DTS v1.2 label
 // embedded as x_dts — the AdCP v2.5+ extension field mechanism.
@@ -303,6 +304,7 @@ export function toSignalSummary(signal: CanonicalSignal): SignalSummary {
     status: signal.status,
     x_dts: buildDtsLabel(signal),
     x_ucp: toUcpHybridPayload(signal, buildDtsLabel(signal)),
+    x_cross_taxonomy: buildCrossTaxonomy(signal),
   };
 }
 

--- a/src/routes/demo.ts
+++ b/src/routes/demo.ts
@@ -103,6 +103,9 @@ ${STYLES}
       <button class="nav-item" data-tab="overlap">
         <svg class="ico"><use href="#icon-network"/></svg><span>Overlap</span>
       </button>
+      <button class="nav-item" data-tab="embedding">
+        <svg class="ico"><use href="#icon-chart"/></svg><span>Embedding</span>
+      </button>
       <button class="nav-item" data-tab="activations">
         <svg class="ico"><use href="#icon-activations"/></svg><span>Activations</span>
         <span class="nav-count" id="nav-activations-count">—</span>
@@ -111,6 +114,9 @@ ${STYLES}
       <div class="nav-group-label">Reference</div>
       <button class="nav-item" data-tab="capabilities">
         <svg class="ico"><use href="#icon-info"/></svg><span>Capabilities</span>
+      </button>
+      <button class="nav-item" data-tab="devkit">
+        <svg class="ico"><use href="#icon-book"/></svg><span>Dev kit</span>
       </button>
       <button class="nav-item" data-tab="toollog">
         <svg class="ico"><use href="#icon-activations"/></svg><span>Tool Log</span>
@@ -144,6 +150,7 @@ ${STYLES}
       <div class="topbar-meta">
         <span class="pill pill-muted mono">Sandbox</span>
         <span class="pill pill-muted mono" id="topbar-version">...</span>
+        <button class="kbd-hint" id="kbd-hint-btn" title="Keyboard shortcuts (press ?)">?</button>
       </div>
     </header>
 
@@ -447,6 +454,30 @@ ${STYLES}
             <div class="funnel-chart" id="funnel-chart">
               <div class="empty-state" style="padding:24px"><div class="empty-desc">Add a rule to see the funnel.</div></div>
             </div>
+
+            <!-- Sec-38 B6: Multi-signal audience stack. Lets a planner -->
+            <!-- combine several marketplace signals into an OR union and -->
+            <!-- see combined unique reach (deduplicated by category      -->
+            <!-- affinity × size ratio), total cost, blended CPM.         -->
+            <div class="builder-section-label" style="margin-top:24px">
+              Multi-signal audience stack
+              <span style="color:var(--text-mut);font-weight:400;text-transform:none;letter-spacing:0;margin-left:6px;font-family:var(--font-mono)">OR union · dedupe via heuristic Jaccard</span>
+            </div>
+            <div class="stack-search">
+              <svg class="ico"><use href="#icon-search"/></svg>
+              <input id="stack-search-input" placeholder="Type to add a signal by name…" autocomplete="off"/>
+            </div>
+            <div class="stack-suggestions" id="stack-suggestions"></div>
+            <div class="stack-list" id="stack-list">
+              <div class="empty-state" style="padding:14px"><div class="empty-desc">Pick 2-8 catalog signals to model a stacked audience. Useful when one rule-set can't cleanly capture the target.</div></div>
+            </div>
+            <div class="stack-summary" id="stack-summary" style="display:none">
+              <div class="stack-stat"><div class="stack-stat-label">Combined unique reach</div><div class="stack-stat-value" id="stack-unique">—</div></div>
+              <div class="stack-stat"><div class="stack-stat-label">Sum of signal sizes</div><div class="stack-stat-value" id="stack-sum">—</div></div>
+              <div class="stack-stat"><div class="stack-stat-label">Overlap waste</div><div class="stack-stat-value" id="stack-overlap">—</div></div>
+              <div class="stack-stat"><div class="stack-stat-label">Blended CPM</div><div class="stack-stat-value" id="stack-cpm">—</div></div>
+            </div>
+            <div class="stack-bar-wrap" id="stack-bar-wrap"></div>
           </div>
         </div>
       </section>
@@ -478,6 +509,49 @@ ${STYLES}
               <svg class="empty-icon"><use href="#icon-network"/></svg>
               <div class="empty-title">Select 2+ signals</div>
               <div class="empty-desc">Pairwise Jaccard scores render as a heat-matrix; 3+ signals also render an UpSet-style subset chart.</div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ── TAB: Embedding (Sec-38 B5) ─────────────────────────────────── -->
+      <!-- Three panels:                                                        -->
+      <!--   1) 2D scatter   — JL random-projection of 26 real 512-d vectors   -->
+      <!--   2) Heatmap      — pairwise cosine similarity (20×20)              -->
+      <!--   3) Cross-tax Sankey — bridge IAB 1.1 → IAB 3.0 → LR/TTD/Nielsen   -->
+      <section class="tab-pane" data-tab="embedding">
+        <div class="pane-header">
+          <div>
+            <h1 class="pane-title">Embedding space</h1>
+            <p class="pane-subtitle">Live view of the UCP semantic space powering semantic discovery. Real 512-dim <code>text-embedding-3-small</code> vectors, projected for inspection. Tight clusters = semantically adjacent audiences.</p>
+          </div>
+          <div class="activations-controls">
+            <button class="btn-secondary" id="emb-refresh">
+              <svg class="ico"><use href="#icon-chart"/></svg><span>Refresh</span>
+            </button>
+            <a class="btn-secondary" href="/ucp/projection" target="_blank" rel="noopener">
+              <svg class="ico"><use href="#icon-arrow-right"/></svg><span>/ucp/projection</span>
+            </a>
+          </div>
+        </div>
+        <div class="emb-grid">
+          <div class="emb-panel">
+            <div class="emb-panel-title">2D projection <span class="pill pill-muted mono" style="margin-left:8px">JL · 512→2</span></div>
+            <div id="emb-scatter" class="emb-scatter">
+              <div class="empty-state"><span class="spinner"></span><div class="empty-title">Loading projection…</div></div>
+            </div>
+            <div class="emb-legend" id="emb-legend"></div>
+          </div>
+          <div class="emb-panel">
+            <div class="emb-panel-title">Pairwise cosine similarity <span class="pill pill-muted mono" style="margin-left:8px">20×20</span></div>
+            <div id="emb-heatmap" class="emb-heatmap">
+              <div class="empty-state"><span class="spinner"></span><div class="empty-title">Loading heatmap…</div></div>
+            </div>
+          </div>
+          <div class="emb-panel emb-panel-wide">
+            <div class="emb-panel-title">Cross-taxonomy Sankey <span class="pill pill-muted mono" style="margin-left:8px">IAB 1.1 → 3.0 → LR/TTD/MC/Nielsen</span></div>
+            <div id="emb-sankey" class="emb-sankey">
+              <div class="empty-state"><span class="spinner"></span><div class="empty-title">Loading bridge…</div></div>
             </div>
           </div>
         </div>
@@ -515,6 +589,60 @@ ${STYLES}
         </div>
       </section>
 
+      <!-- ── TAB: Dev kit (Sec-38 B7 — C5 sandbox keys + C7 SDK snippets) ── -->
+      <section class="tab-pane" data-tab="devkit">
+        <div class="pane-header">
+          <div>
+            <h1 class="pane-title">Dev kit</h1>
+            <p class="pane-subtitle">Everything a buyer-agent engineer needs to integrate. Sandbox API key, SDK snippets in TypeScript / Python / Go / curl, and the full endpoint reference.</p>
+          </div>
+        </div>
+        <div class="devkit-grid">
+          <div class="devkit-panel">
+            <div class="devkit-panel-title">Sandbox API key</div>
+            <div class="devkit-key-shell">
+              <code id="devkit-key" class="devkit-key">—</code>
+              <button class="btn-secondary" id="devkit-key-reveal" style="padding:4px 12px;font-size:12px">Reveal</button>
+              <button class="btn-secondary" id="devkit-key-copy" style="padding:4px 12px;font-size:12px">Copy</button>
+            </div>
+            <div style="font-size:11px;color:var(--text-mut);margin-top:8px">Public demo key — read-only on catalog, write-once on /mcp activate_signal. Rate-limited at 60 req/min/IP. Rotate via Cloudflare Worker secret (DEMO_API_KEY).</div>
+          </div>
+          <div class="devkit-panel devkit-panel-wide">
+            <div class="devkit-panel-title">SDK snippets — <code>get_signals</code> with brief</div>
+            <div class="devkit-tabs">
+              <button class="devkit-tab active" data-lang="typescript">TypeScript</button>
+              <button class="devkit-tab" data-lang="python">Python</button>
+              <button class="devkit-tab" data-lang="go">Go</button>
+              <button class="devkit-tab" data-lang="curl">curl</button>
+            </div>
+            <pre class="devkit-code" id="devkit-code"></pre>
+            <div class="devkit-actions">
+              <button class="btn-secondary" id="devkit-copy-code" style="padding:4px 12px;font-size:12px">Copy snippet</button>
+            </div>
+          </div>
+          <div class="devkit-panel devkit-panel-wide">
+            <div class="devkit-panel-title">Endpoints</div>
+            <div class="devkit-endpoints">
+              <div class="ep-row"><span class="ep-method">POST</span><code>/mcp</code><span class="ep-note">JSON-RPC 2.0 · 8 tools · bearer auth</span></div>
+              <div class="ep-row"><span class="ep-method">GET</span><code>/capabilities</code><span class="ep-note">AdCP 3.0-rc capabilities handshake · public</span></div>
+              <div class="ep-row"><span class="ep-method">GET</span><code>/signals/search</code><span class="ep-note">Catalog search with filters · bearer</span></div>
+              <div class="ep-row"><span class="ep-method">POST</span><code>/signals/estimate</code><span class="ep-note">Rule-based audience sizing · public</span></div>
+              <div class="ep-row"><span class="ep-method">POST</span><code>/signals/overlap</code><span class="ep-note">Multi-signal Jaccard overlap · public</span></div>
+              <div class="ep-row"><span class="ep-method">GET</span><code>/signals/{id}/embedding</code><span class="ep-note">512-d UCP vector · public</span></div>
+              <div class="ep-row"><span class="ep-method">GET</span><code>/ucp/concepts</code><span class="ep-note">Concept registry · public</span></div>
+              <div class="ep-row"><span class="ep-method">GET</span><code>/ucp/gts</code><span class="ep-note">GTS anchors · public</span></div>
+              <div class="ep-row"><span class="ep-method">GET</span><code>/ucp/projection</code><span class="ep-note">2D JL projection of embedding space · public</span></div>
+              <div class="ep-row"><span class="ep-method">GET</span><code>/ucp/similarity?n=20</code><span class="ep-note">Pairwise cosine matrix · public</span></div>
+              <div class="ep-row"><span class="ep-method">GET</span><code>/openapi.json</code><span class="ep-note">Full OpenAPI 3.1 spec · public</span></div>
+              <div class="ep-row"><span class="ep-method">GET</span><code>/mcp/recent</code><span class="ep-note">Recent MCP tool calls (7-day retention) · public</span></div>
+              <div class="ep-row"><span class="ep-method">GET</span><code>/privacy</code><span class="ep-note">Provider privacy policy (DTS-referenced) · public</span></div>
+              <div class="ep-row"><span class="ep-method">GET</span><code>/.well-known/oauth-protected-resource/mcp</code><span class="ep-note">RFC 9728 metadata · public</span></div>
+              <div class="ep-row"><span class="ep-method">GET</span><code>/.well-known/oauth-authorization-server</code><span class="ep-note">RFC 8414 metadata · public</span></div>
+            </div>
+          </div>
+        </div>
+      </section>
+
       <!-- ── TAB: Tool Log (agent observability) ────────────────────────── -->
       <section class="tab-pane" data-tab="toollog">
         <div class="pane-header">
@@ -545,6 +673,10 @@ ${STYLES}
             <button class="btn-secondary" id="toollog-refresh">
               <svg class="ico"><use href="#icon-activations"/></svg>
               <span>Refresh</span>
+            </button>
+            <button class="btn-secondary" id="toollog-export">
+              <svg class="ico"><use href="#icon-book"/></svg>
+              <span>Export CSV</span>
             </button>
           </div>
         </div>
@@ -653,6 +785,23 @@ ${STYLES}
 </div>
 
 <div id="toast" class="toast"></div>
+
+<!-- Keyboard shortcuts cheat-sheet (Sec-38 A7). Opened via \`?\`. -->
+<div id="kbd-overlay" class="kbd-overlay" role="dialog" aria-modal="true" aria-label="Keyboard shortcuts">
+  <div class="kbd-card">
+    <h3>Keyboard shortcuts</h3>
+    <div class="kbd-row"><span>Open Discover</span><span class="kbd-keys"><span class="kbd-key">g</span><span class="kbd-key">d</span></span></div>
+    <div class="kbd-row"><span>Open Catalog</span><span class="kbd-keys"><span class="kbd-key">g</span><span class="kbd-key">c</span></span></div>
+    <div class="kbd-row"><span>Open Builder</span><span class="kbd-keys"><span class="kbd-key">g</span><span class="kbd-key">b</span></span></div>
+    <div class="kbd-row"><span>Open Treemap</span><span class="kbd-keys"><span class="kbd-key">g</span><span class="kbd-key">t</span></span></div>
+    <div class="kbd-row"><span>Open Overlap</span><span class="kbd-keys"><span class="kbd-key">g</span><span class="kbd-key">o</span></span></div>
+    <div class="kbd-row"><span>Open Embedding</span><span class="kbd-keys"><span class="kbd-key">g</span><span class="kbd-key">e</span></span></div>
+    <div class="kbd-row"><span>Open Capabilities</span><span class="kbd-keys"><span class="kbd-key">g</span><span class="kbd-key">k</span></span></div>
+    <div class="kbd-row"><span>Open Dev kit</span><span class="kbd-keys"><span class="kbd-key">g</span><span class="kbd-key">v</span></span></div>
+    <div class="kbd-row"><span>Close detail panel</span><span class="kbd-keys"><span class="kbd-key">Esc</span></span></div>
+    <div class="kbd-row"><span>Toggle this sheet</span><span class="kbd-keys"><span class="kbd-key">?</span></span></div>
+  </div>
+</div>
 
 ${SCRIPT_TAG(safeKey)}
 </body>
@@ -1019,6 +1168,12 @@ svg.ico path, svg.ico circle, svg.ico rect, svg.ico line { vector-effect: non-sc
 }
 .nl-match-card:hover { background: var(--bg-hover); border-color: var(--border-strong); }
 .nl-match-card .nl-m-name { font-weight: 500; font-size: 13.5px; }
+.nl-match-card .nl-m-reason {
+  display: flex; gap: 5px; align-items: center;
+  font-size: 11px; color: var(--text-mut);
+  margin-top: 4px; font-family: var(--font-mono);
+}
+.nl-match-card .nl-m-reason .ico { width: 12px; height: 12px; opacity: 0.6; }
 .nl-match-card .nl-m-sub { font-size: 11.5px; color: var(--text-mut); font-family: var(--font-mono); margin-top: 2px; }
 .nl-match-card .nl-m-method { font-size: 10.5px; padding: 2px 8px; border-radius: 8px; font-family: var(--font-mono); white-space: nowrap; }
 .nl-match-card .nl-m-method.exact_rule { background: var(--success-dim); color: var(--success); }
@@ -2020,6 +2175,235 @@ svg.ico path, svg.ico circle, svg.ico rect, svg.ico line { vector-effect: non-sc
   font-family: var(--font-mono); font-size: 12px; outline: none;
 }
 
+/* Data lineage graph (Sec-38 B8 / C4) */
+.lineage-graph {
+  background: var(--bg-input); border: 1px solid var(--border);
+  border-radius: var(--radius-sm); padding: 8px;
+}
+.lineage-graph svg { width: 100%; height: auto; display: block; }
+
+/* Keyboard shortcut hint button in topbar (Sec-38 A7) */
+.kbd-hint {
+  width: 24px; height: 24px; border-radius: 50%;
+  background: var(--bg-raised); border: 1px solid var(--border);
+  color: var(--text-mut); font-family: var(--font-mono); font-size: 12px;
+  cursor: pointer; transition: all 0.12s;
+}
+.kbd-hint:hover { color: var(--text); border-color: var(--accent-border); }
+
+/* Keyboard shortcuts cheat-sheet (Sec-38 A7) */
+.kbd-overlay {
+  position: fixed; inset: 0; background: rgba(0,0,0,0.55);
+  z-index: 200; display: none; align-items: center; justify-content: center;
+}
+.kbd-overlay.open { display: flex; animation: fadeIn 0.18s ease; }
+.kbd-card {
+  background: var(--bg-surface); border: 1px solid var(--border);
+  border-radius: var(--radius-md); padding: 20px 24px;
+  min-width: 420px; max-width: 640px;
+  box-shadow: 0 20px 60px rgba(0,0,0,0.5);
+}
+.kbd-card h3 { margin: 0 0 14px 0; font-size: 15px; font-weight: 600; }
+.kbd-row {
+  display: flex; justify-content: space-between; align-items: center;
+  padding: 6px 0; border-bottom: 1px solid var(--border);
+  font-size: 12.5px;
+}
+.kbd-row:last-child { border-bottom: 0; }
+.kbd-keys { display: flex; gap: 4px; }
+.kbd-key {
+  font-family: var(--font-mono); font-size: 11px;
+  background: var(--bg-input); border: 1px solid var(--border);
+  border-radius: 3px; padding: 2px 8px; color: var(--text);
+}
+
+/* Dev kit tab (Sec-38 B7) */
+.devkit-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 14px; }
+.devkit-panel {
+  background: var(--bg-surface); border: 1px solid var(--border);
+  border-radius: var(--radius-md); padding: 14px 16px;
+}
+.devkit-panel-wide { grid-column: 1 / span 2; }
+.devkit-panel-title {
+  font-size: 12px; font-weight: 600; color: var(--text);
+  text-transform: uppercase; letter-spacing: 0.06em; margin-bottom: 10px;
+}
+.devkit-key-shell {
+  display: flex; gap: 8px; align-items: center;
+  background: var(--bg-input); border: 1px solid var(--border);
+  border-radius: var(--radius-sm); padding: 8px 12px;
+}
+.devkit-key {
+  flex: 1; font-family: var(--font-mono); font-size: 12px;
+  color: var(--text); user-select: all;
+}
+.devkit-tabs { display: flex; gap: 4px; margin-bottom: 10px; }
+.devkit-tab {
+  background: var(--bg-raised); border: 1px solid var(--border);
+  color: var(--text-mut); padding: 5px 12px; border-radius: 4px;
+  cursor: pointer; font-size: 11.5px; font-family: var(--font-mono);
+}
+.devkit-tab.active { color: var(--text); border-color: var(--accent-border); background: var(--accent-dim); }
+.devkit-code {
+  background: var(--bg-input); border: 1px solid var(--border);
+  border-radius: var(--radius-sm); padding: 12px 14px;
+  color: var(--text); font-family: var(--font-mono); font-size: 12px;
+  white-space: pre; overflow-x: auto; max-height: 380px; line-height: 1.55;
+}
+.devkit-actions { margin-top: 10px; display: flex; justify-content: flex-end; }
+.devkit-endpoints { display: flex; flex-direction: column; gap: 4px; }
+.ep-row {
+  display: grid; grid-template-columns: 60px 320px 1fr; gap: 10px; align-items: center;
+  background: var(--bg-input); border: 1px solid var(--border);
+  border-radius: var(--radius-sm); padding: 6px 10px;
+  font-size: 11.5px;
+}
+.ep-method { font-family: var(--font-mono); font-size: 10.5px; color: var(--accent); font-weight: 600; }
+.ep-row code { font-family: var(--font-mono); font-size: 11.5px; color: var(--text); }
+.ep-note { color: var(--text-mut); font-size: 11px; }
+
+/* Builder multi-signal stack (Sec-38 B6) */
+.stack-search {
+  display: flex; align-items: center; gap: 8px;
+  background: var(--bg-input); border: 1px solid var(--border);
+  border-radius: var(--radius-sm); padding: 6px 10px; margin-bottom: 6px;
+}
+.stack-search input {
+  flex: 1; background: transparent; border: 0; color: var(--text); outline: none;
+  font-size: 12.5px;
+}
+.stack-suggestions {
+  display: none; background: var(--bg-surface); border: 1px solid var(--border);
+  border-radius: var(--radius-sm); margin-bottom: 10px; max-height: 280px; overflow-y: auto;
+}
+.stack-sugg {
+  display: flex; justify-content: space-between; align-items: center;
+  padding: 8px 10px; border-bottom: 1px solid var(--border); cursor: pointer;
+}
+.stack-sugg:last-child { border-bottom: 0; }
+.stack-sugg:hover { background: var(--bg-hover); }
+.stack-sugg-name { font-size: 12px; color: var(--text); }
+.stack-sugg-meta { font-size: 10.5px; color: var(--text-mut); font-family: var(--font-mono); }
+.stack-sugg-empty { padding: 8px 12px; color: var(--text-mut); font-size: 11.5px; font-style: italic; }
+.stack-list { display: flex; flex-direction: column; gap: 6px; }
+.stack-chip {
+  display: flex; justify-content: space-between; align-items: center;
+  background: var(--bg-input); border: 1px solid var(--border);
+  border-radius: var(--radius-sm); padding: 8px 10px;
+}
+.stack-chip-name { font-size: 12px; color: var(--text); }
+.stack-chip-meta { font-size: 10.5px; color: var(--text-mut); font-family: var(--font-mono); }
+.stack-remove {
+  background: transparent; border: 0; color: var(--text-mut); cursor: pointer;
+  padding: 4px; border-radius: 4px;
+}
+.stack-remove:hover { color: var(--text); background: var(--bg-raised); }
+.stack-summary {
+  display: grid; grid-template-columns: repeat(4, 1fr); gap: 8px; margin-top: 12px;
+}
+.stack-stat {
+  background: var(--bg-input); border: 1px solid var(--border);
+  border-radius: var(--radius-sm); padding: 8px 10px;
+}
+.stack-stat-label { font-size: 10px; color: var(--text-mut); text-transform: uppercase; letter-spacing: 0.06em; }
+.stack-stat-value { font-size: 15px; font-weight: 600; font-variant-numeric: tabular-nums; margin-top: 2px; }
+.stack-bar-wrap { margin-top: 8px; }
+
+/* Embedding tab — 2D scatter + heatmap + Sankey (Sec-38 B5) */
+.emb-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 14px;
+}
+.emb-panel {
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  padding: 14px 16px;
+}
+.emb-panel-wide { grid-column: 1 / span 2; }
+.emb-panel-title {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  margin-bottom: 10px;
+  display: flex;
+  align-items: center;
+}
+.emb-scatter, .emb-heatmap, .emb-sankey {
+  background: var(--bg-input);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  min-height: 300px;
+  padding: 8px;
+}
+.emb-scatter svg, .emb-heatmap svg, .emb-sankey svg {
+  width: 100%; height: auto; display: block;
+}
+.emb-legend {
+  display: flex; gap: 12px; flex-wrap: wrap;
+  margin-top: 10px;
+}
+.emb-legend-item {
+  display: inline-flex; align-items: center; gap: 5px;
+  font-size: 11px; color: var(--text-mut); font-family: var(--font-mono);
+}
+.emb-legend-dot {
+  width: 10px; height: 10px; border-radius: 50%;
+  display: inline-block;
+}
+
+/* Measurement block — lift + delivery simulator + campaign overlap (Sec-38 B4) */
+.meas-row { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 8px; }
+.meas-cell {
+  background: var(--bg-input); border: 1px solid var(--border);
+  border-radius: var(--radius-sm); padding: 8px 10px;
+}
+.delivery-bars {
+  display: flex; gap: 2px; align-items: flex-end; height: 48px;
+  padding: 4px 0; background: var(--bg-input);
+  border: 1px solid var(--border); border-radius: var(--radius-sm);
+  padding-left: 6px; padding-right: 6px;
+}
+.delivery-bar {
+  flex: 1 1 0; min-width: 3px;
+  background: linear-gradient(180deg, var(--accent), var(--accent-dim));
+  border-radius: 1px;
+}
+.campaign-overlap { display: flex; flex-direction: column; gap: 4px; }
+.campaign-row {
+  display: grid; grid-template-columns: 180px 1fr 40px; gap: 10px; align-items: center;
+  font-size: 11.5px;
+}
+.campaign-name { color: var(--text); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.campaign-bar-wrap {
+  height: 10px; background: var(--bg-raised); border-radius: 3px; overflow: hidden;
+}
+.campaign-bar {
+  height: 100%; background: linear-gradient(90deg, var(--accent-dim), var(--accent));
+  min-width: 1%;
+}
+.campaign-pct { font-family: var(--font-mono); font-size: 11px; text-align: right; color: var(--text-mut); }
+
+/* Cross-taxonomy bridge (Sec-38 B2) */
+.cross-tax-grid { display: flex; flex-direction: column; gap: 4px; }
+.cross-tax-row {
+  display: grid; grid-template-columns: 200px 1fr 90px; gap: 10px; align-items: center;
+  padding: 6px 10px; background: var(--bg-input);
+  border: 1px solid var(--border); border-radius: var(--radius-sm);
+  font-size: 11.5px;
+}
+.cross-tax-sys { color: var(--text-mut); font-family: var(--font-mono); font-size: 11px; }
+.cross-tax-id code {
+  font-family: var(--font-mono); font-size: 11.5px; color: var(--text);
+  background: var(--bg-raised); padding: 2px 6px; border-radius: 3px;
+}
+.cross-tax-stage { text-align: right; }
+.pill-mut { color: var(--text-mut); background: var(--bg-raised); border: 1px solid var(--border); padding: 2px 6px; border-radius: 3px; font-size: 11px; }
+.pill-info { color: var(--accent); background: var(--accent-dim); border: 1px solid var(--accent-border); padding: 2px 6px; border-radius: 3px; font-size: 11px; }
+
 /* MCP inspector drawer (Sec-37 B7) */
 .mcp-inspect-btn {
   color: var(--text-mut); font-family: var(--font-mono);
@@ -2366,6 +2750,7 @@ function switchTab(name) {
     discover: "Discover", catalog: "Catalog", concepts: "Concepts",
     treemap: "Treemap", builder: "Builder", activations: "Activations",
     capabilities: "Capabilities", toollog: "Tool Log", overlap: "Overlap",
+    embedding: "Embedding space", devkit: "Dev kit",
   };
   document.getElementById("crumb-current").textContent = crumbMap[name] || name;
 
@@ -2376,6 +2761,8 @@ function switchTab(name) {
   if (name === "builder") ensureBuilder();
   if (name === "capabilities") loadCapabilities();
   if (name === "overlap") ensureOverlap();
+  if (name === "embedding") ensureEmbedding();
+  if (name === "devkit") ensureDevkit();
 
   // Activations tab: start polling when visible, stop when hidden
   if (name === "activations") startActivationsPolling();
@@ -2610,15 +2997,56 @@ function renderNlMatchCard(m) {
   const method = m.match_method || "embedding";
   const score = typeof m.match_score === "number" ? m.match_score.toFixed(2) : "—";
   const audience = m.estimated_audience_size != null ? fmtNumber(m.estimated_audience_size) : "—";
+  // Sec-38 B7 (C2): explain-this-match. Builds a short human-readable
+  // reason string from match_method + any matched tokens/rules the
+  // resolver echoed back. Shown as a tooltip-style sub-line so the
+  // planner understands *why* this signal scored.
+  const reason = explainMatch(m);
   return '' +
     '<div class="nl-match-card" data-sid="' + escapeHtml(sid) + '">' +
       '<div>' +
         '<div class="nl-m-name">' + escapeHtml(m.name || "(unnamed)") + dtsPill(m) + freshnessPill(m) + sensitivePill(m) + '</div>' +
         '<div class="nl-m-sub">' + escapeHtml(sid) + ' · ' + audience + ' audience</div>' +
+        (reason ? '<div class="nl-m-reason"><svg class="ico"><use href="#icon-info"/></svg><span>' + escapeHtml(reason) + '</span></div>' : "") +
       '</div>' +
       '<span class="nl-m-method ' + escapeHtml(method) + '">' + escapeHtml(method.replace(/_/g, " ")) + '</span>' +
       '<span class="nl-m-score">' + score + '</span>' +
     '</div>';
+}
+
+// Sec-38 B7 (C2): synthesize a human-readable explanation for why the
+// resolver matched this signal. Uses whatever breadcrumbs the resolver
+// emits (match_method + match_dimensions / matched_rules / matched_terms
+// / score_breakdown) and falls back to a method-class description.
+function explainMatch(m) {
+  const method = m.match_method || "embedding";
+  const parts = [];
+  if (Array.isArray(m.matched_dimensions) && m.matched_dimensions.length) {
+    parts.push("matched " + m.matched_dimensions.slice(0, 3).join(", "));
+  }
+  if (Array.isArray(m.matched_terms) && m.matched_terms.length) {
+    parts.push("lexical overlap: " + m.matched_terms.slice(0, 3).join(", "));
+  }
+  if (Array.isArray(m.matched_rules) && m.matched_rules.length) {
+    parts.push(m.matched_rules.length + " rules matched");
+  }
+  if (typeof m.match_score === "number") {
+    if (method === "embedding" || method === "semantic") {
+      parts.push("cos=" + m.match_score.toFixed(2));
+    } else if (method === "exact_rule" || method === "rule") {
+      parts.push("rule-exact");
+    } else if (method === "lexical") {
+      parts.push("token match");
+    }
+  }
+  if (parts.length === 0) {
+    // Method-class fallback
+    if (method === "embedding" || method === "semantic") return "Ranked by semantic similarity in the UCP embedding space.";
+    if (method === "exact_rule" || method === "rule") return "Matched directly on declared targeting rules.";
+    if (method === "lexical") return "Token-level overlap with the query.";
+    return "";
+  }
+  return parts.join(" · ");
 }
 
 function wireNlCardClicks() {
@@ -3040,6 +3468,47 @@ function openDetail(sig) {
       '<div class="detail-section-label">Reach &amp; frequency <span style="color:var(--text-mut);font-weight:400;text-transform:none;letter-spacing:0;margin-left:6px">@</span> <span class="reach-budget-input" style="display:inline-flex"><span style="color:var(--text-mut)">$</span><input id="reach-budget" type="number" value="10000" min="500" max="10000000" step="500"/><span style="color:var(--text-mut)">/ 30d</span></span></div>' +
       '<div class="reach-block" id="reach-block"></div>' +
     '</div>' +
+    // Sec-38 B4: Measurement & lift mock. Three sub-panels:
+    //   • Lift forecast     — synthetic baseline/exposed-group brand-lift
+    //   • Delivery simulator — daily pacing curve over 30-day flight
+    //   • Campaign overlap   — placeholder that would query advertiser's
+    //                          1P campaign IDs via cleanroom when wired
+    // All clearly labeled "mock" — the ext.measurement capability block
+    // declares them as supported:"mock" until a measurement partner lands.
+    '<div class="detail-section">' +
+      '<div class="detail-section-label">Measurement &amp; lift <span class="pill pill-mut" style="margin-left:8px;font-size:10px">mock</span></div>' +
+      '<div id="measurement-block" class="reach-block"></div>' +
+    '</div>' +
+    // Sec-38 B2: Cross-taxonomy bridge. Shows predicted IDs in IAB 3.0,
+    // LiveRamp AbiliTec, TTD DMP, Mastercard SpendingPulse, Nielsen so a
+    // HoldCo planner can locate the equivalent audience in their own
+    // taxonomy without manual translation.
+    (sig.x_cross_taxonomy && sig.x_cross_taxonomy.length
+      ? '<div class="detail-section">' +
+          '<div class="detail-section-label">Cross-taxonomy bridge <span style="color:var(--text-mut);font-weight:400;text-transform:none;letter-spacing:0;margin-left:6px">' + sig.x_cross_taxonomy.length + ' systems</span></div>' +
+          '<div class="cross-tax-grid">' +
+            sig.x_cross_taxonomy.map(function (e) {
+              var stageClass = e.stage === "live" ? "pill-success" : e.stage === "modeled" ? "pill-info" : "pill-mut";
+              return '<div class="cross-tax-row">' +
+                '<div class="cross-tax-sys">' + escapeHtml(e.system) + '</div>' +
+                '<div class="cross-tax-id"><code>' + escapeHtml(e.id) + '</code></div>' +
+                '<div class="cross-tax-stage"><span class="pill ' + stageClass + '" style="font-size:10px">' + escapeHtml(e.stage) + '</span></div>' +
+              '</div>';
+            }).join("") +
+          '</div>' +
+        '</div>'
+      : "") +
+    // Sec-38 B8 (C4): Data lineage graph. Visualizes the path from raw
+    // data sources → DTS methodology → audience surface → distribution.
+    // Renders as a 4-node horizontal flow derived from x_dts fields that
+    // the signal already carries (data_sources, inclusion_methodology,
+    // refresh_cadence, distribution platforms).
+    (sig.x_dts
+      ? '<div class="detail-section">' +
+          '<div class="detail-section-label">Data lineage <span style="color:var(--text-mut);font-weight:400;text-transform:none;letter-spacing:0;margin-left:6px">provenance chain</span></div>' +
+          renderLineageGraph(sig) +
+        '</div>'
+      : "") +
     // Sec-36: "More like this" — lazy-loads get_similar_signals on
     // click so the detail panel opens instantly. Cosine scores from
     // the UCP embedding index are shown per neighbor.
@@ -3080,6 +3549,7 @@ function openDetail(sig) {
 
   // Reach forecaster — pure compute, re-renders on budget input change
   renderReachBlock(sig);
+  renderMeasurementBlock(sig);
   const budgetInput = document.getElementById("reach-budget");
   if (budgetInput) {
     budgetInput.addEventListener("input", (e) => {
@@ -3087,6 +3557,7 @@ function openDetail(sig) {
       if (Number.isFinite(v) && v > 0) {
         state.reach.budgetUsd = v;
         renderReachBlock(sig);
+        renderMeasurementBlock(sig);
       }
     });
   }
@@ -3135,6 +3606,181 @@ function renderReachBlock(sig) {
       '<path d="' + path + ' L 300,50 L 0,50 Z" fill="var(--accent-dim)"/>' +
     '</svg></div>' +
     '<div style="font-size:10.5px;color:var(--text-mut);margin-top:8px">Methodology: CPM @ $' + cpm.toFixed(2) + ' · reach capped at 80% of addressable audience · logistic saturation τ=7 days. Mock — plug measurement partner for actuals.</div>';
+}
+
+// Sec-38 B8 (C4): Data lineage graph. Renders a horizontal 4-node flow
+// summarizing the signal's provenance chain from x_dts fields the signal
+// already carries. Nodes: (1) raw sources, (2) inclusion methodology,
+// (3) audience expression, (4) distribution deployments. Connectors are
+// simple SVG paths; no external graph library.
+function renderLineageGraph(sig) {
+  var dts = sig.x_dts || {};
+  var sources = Array.isArray(dts.data_sources) ? dts.data_sources : ["Online Survey"];
+  var methodology = dts.audience_inclusion_methodology || "Modeled";
+  var refresh = dts.audience_refresh || "Static";
+  var depPlatforms = (sig.deployments || []).map(function (d) { return d.platform || d.type; }).filter(Boolean);
+  var categoryType = sig.category_type || "—";
+  var size = sig.estimated_audience_size || 0;
+
+  var nodes = [
+    {
+      label: "Raw sources",
+      lines: sources.slice(0, 3),
+      extra: sources.length > 3 ? "+" + (sources.length - 3) + " more" : "",
+      color: "#2bd4a0",
+    },
+    {
+      label: "Methodology",
+      lines: [methodology, "Refresh: " + refresh],
+      extra: "",
+      color: "#4f8eff",
+    },
+    {
+      label: "Audience",
+      lines: [categoryType, fmtNumber(size) + " people"],
+      extra: "",
+      color: "#8b6eff",
+    },
+    {
+      label: "Distribution",
+      lines: depPlatforms.slice(0, 3),
+      extra: depPlatforms.length > 3 ? "+" + (depPlatforms.length - 3) + " more" : "",
+      color: "#ff7a5c",
+    },
+  ];
+
+  var W = 680, H = 130;
+  var nodeW = 140, nodeH = 74;
+  var gap = (W - nodes.length * nodeW) / (nodes.length - 1);
+  var yMid = (H - nodeH) / 2;
+  var nodesSvg = nodes.map(function (n, i) {
+    var x = i * (nodeW + gap);
+    return '<g transform="translate(' + x + ',' + yMid + ')">' +
+      '<rect x="0" y="0" width="' + nodeW + '" height="' + nodeH + '" rx="6" fill="' + n.color + '" fill-opacity="0.14" stroke="' + n.color + '" stroke-opacity="0.7" stroke-width="1.2"/>' +
+      '<text x="10" y="18" fill="' + n.color + '" font-size="10.5" font-weight="700" font-family="ui-sans-serif" text-transform="uppercase">' + escapeHtml(n.label) + '</text>' +
+      n.lines.map(function (ln, li) {
+        return '<text x="10" y="' + (34 + li * 13) + '" fill="var(--text)" font-size="11" font-family="ui-monospace">' + escapeHtml(String(ln).slice(0, 22)) + '</text>';
+      }).join("") +
+      (n.extra ? '<text x="10" y="' + (34 + n.lines.length * 13) + '" fill="var(--text-mut)" font-size="10" font-family="ui-monospace">' + escapeHtml(n.extra) + '</text>' : "") +
+    '</g>';
+  }).join("");
+
+  var connectorsSvg = "";
+  for (var i = 0; i < nodes.length - 1; i++) {
+    var x1 = i * (nodeW + gap) + nodeW;
+    var x2 = (i + 1) * (nodeW + gap);
+    var y = yMid + nodeH / 2;
+    connectorsSvg += '<path d="M' + x1 + ',' + y + ' C' + (x1 + gap / 2) + ',' + y + ' ' + (x1 + gap / 2) + ',' + y + ' ' + x2 + ',' + y + '" ' +
+      'fill="none" stroke="var(--text-mut)" stroke-opacity="0.4" stroke-width="1.2" marker-end="url(#lineage-arrow)"/>';
+  }
+
+  return '<div class="lineage-graph">' +
+    '<svg viewBox="0 0 ' + W + ' ' + H + '" preserveAspectRatio="xMidYMid meet">' +
+      '<defs><marker id="lineage-arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 Z" fill="var(--text-mut)" fill-opacity="0.5"/></marker></defs>' +
+      connectorsSvg + nodesSvg +
+    '</svg>' +
+  '</div>';
+}
+
+// Sec-38 B4: Measurement & lift mock panel. Three sub-panels:
+//   1) Lift forecast  — baseline vs exposed brand-awareness / purchase-intent
+//                       delta modeled as a function of signal specificity.
+//   2) Delivery sim   — daily pacing bars over 30 days (mock smooth delivery).
+//   3) Campaign over  — overlap-with-existing-campaigns placeholder tile.
+// All numbers are synthesized from (audience_size, cpm, budget) and the
+// signal's specificity (category_type + has rules). Clearly mock.
+function renderMeasurementBlock(sig) {
+  var host = document.getElementById("measurement-block");
+  if (!host) return;
+  var audience = sig.estimated_audience_size || 0;
+  var cpmOpt = fmtCPM(sig);
+  var cpm = cpmOpt.cpm || 5.0;
+  var budget = state.reach.budgetUsd;
+  var impressions = (budget * 1000) / cpm;
+
+  // Specificity score 0..1 — tightly-defined signals get higher lift.
+  // Purchase-intent composites > interest > demographic > geo.
+  var specScore =
+    sig.category_type === "purchase_intent" ? 0.85
+    : sig.category_type === "composite" ? 0.80
+    : sig.category_type === "interest" ? 0.65
+    : sig.category_type === "demographic" ? 0.45
+    : 0.40;
+  // Smaller audiences = more specific = higher lift (diminishing at extremes)
+  var sizeFactor = audience > 0 ? Math.min(1, 50_000_000 / (audience + 1_000_000)) : 0.5;
+  var liftPct = Math.max(2, Math.min(28, Math.round(specScore * sizeFactor * 32 * 10) / 10));
+  var baselineCTR = 0.12;
+  var exposedCTR = baselineCTR * (1 + liftPct / 100);
+
+  // Delivery simulator — 30-day bars with weekend dip + small noise
+  var bars = [];
+  for (var d = 0; d < 30; d++) {
+    var weekend = (d % 7 === 5 || d % 7 === 6) ? 0.75 : 1.0;
+    var noise = 0.85 + (Math.sin(d * 0.7 + sig.signal_agent_segment_id.length) + 1) * 0.12;
+    bars.push(weekend * noise);
+  }
+  var barMax = Math.max.apply(null, bars);
+  var dailyImps = impressions / 30;
+
+  // Campaign overlap — placeholder showing how a cleanroom match would work.
+  // We draw 3 fake campaign rows with synthesized overlap % derived from
+  // signal ID hash so it's stable per signal.
+  function hashFrac(s, salt) {
+    var h = 5381;
+    var str = s + salt;
+    for (var i = 0; i < str.length; i++) { h = ((h << 5) + h) ^ str.charCodeAt(i); h = h >>> 0; }
+    return (h % 1000) / 1000;
+  }
+  var sid = sig.signal_agent_segment_id || "";
+  var campaigns = [
+    { name: "Q1 Awareness · Display",   overlap: Math.round(hashFrac(sid, "q1d") * 24 + 4) },
+    { name: "Always-On · Retargeting",  overlap: Math.round(hashFrac(sid, "aor") * 38 + 10) },
+    { name: "CTV · Brand Pulse",        overlap: Math.round(hashFrac(sid, "ctv") * 18 + 2) },
+  ];
+
+  var liftColor = liftPct >= 15 ? "var(--ok)" : liftPct >= 8 ? "var(--accent)" : "var(--warn)";
+
+  host.innerHTML = '' +
+    // Lift forecast
+    '<div class="meas-row">' +
+      '<div class="meas-cell">' +
+        '<div class="reach-stat-label">Predicted brand-lift</div>' +
+        '<div class="reach-stat-value" style="color:' + liftColor + '">+' + liftPct.toFixed(1) + '%</div>' +
+        '<div style="font-size:10.5px;color:var(--text-mut);margin-top:2px">vs unexposed baseline</div>' +
+      '</div>' +
+      '<div class="meas-cell">' +
+        '<div class="reach-stat-label">Exposed CTR (mock)</div>' +
+        '<div class="reach-stat-value">' + (exposedCTR * 100).toFixed(2) + '%</div>' +
+        '<div style="font-size:10.5px;color:var(--text-mut);margin-top:2px">baseline ' + (baselineCTR * 100).toFixed(2) + '%</div>' +
+      '</div>' +
+      '<div class="meas-cell">' +
+        '<div class="reach-stat-label">Specificity score</div>' +
+        '<div class="reach-stat-value">' + (specScore * 100).toFixed(0) + '</div>' +
+        '<div style="font-size:10.5px;color:var(--text-mut);margin-top:2px">0-100 · drives lift</div>' +
+      '</div>' +
+    '</div>' +
+    // Delivery simulator
+    '<div style="font-size:10.5px;color:var(--text-mut);text-transform:uppercase;letter-spacing:0.08em;margin-top:14px;margin-bottom:6px">Delivery simulator — 30-day pacing</div>' +
+    '<div class="delivery-bars">' +
+      bars.map(function (b, i) {
+        var h = Math.max(4, Math.round((b / barMax) * 42));
+        var isWknd = (i % 7 === 5 || i % 7 === 6);
+        return '<div class="delivery-bar" title="Day ' + (i + 1) + ' · ~' + fmtNumber(Math.round(dailyImps * b)) + ' imps" style="height:' + h + 'px;opacity:' + (isWknd ? 0.55 : 1) + '"></div>';
+      }).join("") +
+    '</div>' +
+    '<div style="font-size:10.5px;color:var(--text-mut);margin-top:4px">Smooth pacing · ~' + fmtNumber(Math.round(dailyImps)) + ' imps/day avg · weekends dip ~25%</div>' +
+    // Campaign overlap placeholder
+    '<div style="font-size:10.5px;color:var(--text-mut);text-transform:uppercase;letter-spacing:0.08em;margin-top:14px;margin-bottom:6px">Overlap with existing campaigns <span style="text-transform:none;letter-spacing:0">(cleanroom-matched mock)</span></div>' +
+    '<div class="campaign-overlap">' +
+      campaigns.map(function (c) {
+        return '<div class="campaign-row">' +
+          '<div class="campaign-name">' + escapeHtml(c.name) + '</div>' +
+          '<div class="campaign-bar-wrap"><div class="campaign-bar" style="width:' + c.overlap + '%"></div></div>' +
+          '<div class="campaign-pct">' + c.overlap + '%</div>' +
+        '</div>';
+      }).join("") +
+    '</div>' +
+    '<div style="font-size:10.5px;color:var(--text-mut);margin-top:8px">Methodology: lift modeled from signal specificity × size-coverage. Plug a measurement partner (Nielsen / IAS / DV / Kantar / Circana) for actuals. Campaign overlap would resolve via your 1P campaign IDs in a cleanroom.</div>';
 }
 
 // Sec-37 B7: MCP inspector. Shows the get_signals{signal_ids:[sid]}
@@ -3553,6 +4199,133 @@ const MAX_RULES = 6;
 function ensureBuilder() {
   renderBuilderRules();
   debouncedEstimate();
+  ensureBuilderStack();
+}
+
+//────────────────────────────────────────────────────────────────────────
+// Sec-38 B6 — Builder multi-signal audience stack
+//────────────────────────────────────────────────────────────────────────
+var _builderStack = { selected: [], suggestions: [] };
+async function ensureBuilderStack() {
+  if (state.catalog.all.length === 0) await loadCatalog();
+  renderStackList();
+  renderStackSuggestions("");
+  var inp = document.getElementById("stack-search-input");
+  if (inp && !inp.__wired) {
+    inp.__wired = true;
+    inp.addEventListener("input", function (e) { renderStackSuggestions(e.target.value.toLowerCase()); });
+  }
+}
+function renderStackSuggestions(q) {
+  var host = document.getElementById("stack-suggestions");
+  if (!host) return;
+  if (!q || q.length < 2) { host.innerHTML = ""; host.style.display = "none"; return; }
+  var selectedIds = new Set(_builderStack.selected.map(function (s) { return s.signal_agent_segment_id; }));
+  var hits = state.catalog.all
+    .filter(function (s) { return !selectedIds.has(s.signal_agent_segment_id) && (s.name || "").toLowerCase().includes(q); })
+    .slice(0, 8);
+  if (!hits.length) { host.innerHTML = '<div class="stack-sugg-empty">No matches</div>'; host.style.display = "block"; return; }
+  host.innerHTML = hits.map(function (s) {
+    return '<div class="stack-sugg" data-sid="' + escapeHtml(s.signal_agent_segment_id) + '">' +
+      '<div><div class="stack-sugg-name">' + escapeHtml(s.name) + '</div>' +
+      '<div class="stack-sugg-meta">' + fmtNumber(s.estimated_audience_size) + ' · ' + escapeHtml(s.category_type || "") + '</div></div>' +
+      '<button class="btn-secondary" style="padding:2px 10px;font-size:11px">+ add</button>' +
+    '</div>';
+  }).join("");
+  host.style.display = "block";
+  host.querySelectorAll(".stack-sugg").forEach(function (el) {
+    el.addEventListener("click", function () {
+      var sid = el.dataset.sid;
+      var sig = state.catalog.all.find(function (x) { return x.signal_agent_segment_id === sid; });
+      if (sig && _builderStack.selected.length < 8) {
+        _builderStack.selected.push(sig);
+        document.getElementById("stack-search-input").value = "";
+        renderStackSuggestions("");
+        renderStackList();
+      }
+    });
+  });
+}
+function renderStackList() {
+  var host = document.getElementById("stack-list");
+  if (!host) return;
+  if (_builderStack.selected.length === 0) {
+    host.innerHTML = '<div class="empty-state" style="padding:14px"><div class="empty-desc">Pick 2-8 catalog signals to model a stacked audience. Useful when one rule-set can\\'t cleanly capture the target.</div></div>';
+    document.getElementById("stack-summary").style.display = "none";
+    document.getElementById("stack-bar-wrap").innerHTML = "";
+    return;
+  }
+  host.innerHTML = _builderStack.selected.map(function (s, i) {
+    return '<div class="stack-chip">' +
+      '<div><div class="stack-chip-name">' + escapeHtml(s.name) + '</div>' +
+      '<div class="stack-chip-meta">' + fmtNumber(s.estimated_audience_size) + ' · ' + escapeHtml(s.category_type || "") + '</div></div>' +
+      '<button class="stack-remove" data-idx="' + i + '"><svg class="ico"><use href="#icon-close"/></svg></button>' +
+    '</div>';
+  }).join("");
+  host.querySelectorAll(".stack-remove").forEach(function (b) {
+    b.addEventListener("click", function () {
+      _builderStack.selected.splice(parseInt(b.dataset.idx, 10), 1);
+      renderStackList();
+    });
+  });
+  computeStackSummary();
+}
+function computeStackSummary() {
+  var sigs = _builderStack.selected;
+  if (sigs.length < 2) {
+    document.getElementById("stack-summary").style.display = "none";
+    document.getElementById("stack-bar-wrap").innerHTML = "";
+    return;
+  }
+  var sum = 0, costWeighted = 0;
+  sigs.forEach(function (s) {
+    var sz = s.estimated_audience_size || 0;
+    var cpm = fmtCPM(s).cpm || 5;
+    sum += sz;
+    costWeighted += sz * cpm;
+  });
+  // Heuristic pairwise overlap via category affinity (same as overlap.ts)
+  function affinity(a, b) {
+    if (a.category_type === b.category_type) return 0.55;
+    return 0.20;
+  }
+  var overlap = 0;
+  for (var i = 0; i < sigs.length; i++) {
+    for (var j = i + 1; j < sigs.length; j++) {
+      var a = sigs[i], b = sigs[j];
+      var aff = affinity(a, b);
+      var minSz = Math.min(a.estimated_audience_size || 0, b.estimated_audience_size || 0);
+      overlap += aff * minSz * 0.6; // 0.6 dampener for higher-order dedupe
+    }
+  }
+  var uniqueReach = Math.max(0, sum - overlap);
+  var blendedCpm = sum > 0 ? costWeighted / sum : 0;
+
+  document.getElementById("stack-summary").style.display = "grid";
+  document.getElementById("stack-unique").textContent = fmtNumber(Math.round(uniqueReach));
+  document.getElementById("stack-sum").textContent = fmtNumber(Math.round(sum));
+  document.getElementById("stack-overlap").textContent = fmtNumber(Math.round(overlap)) + " (" + ((overlap / sum) * 100).toFixed(1) + "%)";
+  document.getElementById("stack-cpm").textContent = "$" + blendedCpm.toFixed(2);
+
+  // Stacked bar visualization — per signal contribution, overlap striped
+  var W = 520, H = 32;
+  var stackSvg = '<svg viewBox="0 0 ' + W + ' ' + H + '" preserveAspectRatio="none" style="width:100%;height:40px">';
+  var xPos = 0;
+  sigs.forEach(function (s, i) {
+    var sz = s.estimated_audience_size || 0;
+    var w = (sz / sum) * W;
+    var hue = (i * 47) % 360;
+    stackSvg += '<rect x="' + xPos + '" y="0" width="' + w.toFixed(1) + '" height="' + H + '" fill="hsl(' + hue + ' 60% 55%)" fill-opacity="0.85"><title>' + escapeHtml(s.name) + ': ' + fmtNumber(sz) + '</title></rect>';
+    xPos += w;
+  });
+  // Overlap stripe overlay
+  var overlapFrac = sum > 0 ? overlap / sum : 0;
+  stackSvg += '<pattern id="ov-stripe" patternUnits="userSpaceOnUse" width="8" height="8" patternTransform="rotate(45)"><line x1="0" y1="0" x2="0" y2="8" stroke="rgba(0,0,0,0.5)" stroke-width="3"/></pattern>';
+  stackSvg += '<rect x="' + ((1 - overlapFrac) * W).toFixed(1) + '" y="0" width="' + (overlapFrac * W).toFixed(1) + '" height="' + H + '" fill="url(#ov-stripe)"/>';
+  stackSvg += '</svg>';
+  document.getElementById("stack-bar-wrap").innerHTML =
+    stackSvg +
+    '<div style="font-size:10.5px;color:var(--text-mut);margin-top:6px">Each block ∝ signal size · striped area ∝ estimated overlap · unique reach = sum − overlap</div>';
 }
 
 function renderBuilderRules() {
@@ -4052,6 +4825,212 @@ async function ensureOverlap() {
   if (state.catalog.all.length === 0) await loadCatalog();
   renderOverlapChips();
   renderOverlapSuggestions("");
+}
+
+//────────────────────────────────────────────────────────────────────────
+// Sec-38 B5 — Embedding tab: 2D scatter + similarity heatmap + cross-tax Sankey
+//────────────────────────────────────────────────────────────────────────
+var _embeddingLoaded = false;
+async function ensureEmbedding() {
+  if (_embeddingLoaded) return;
+  _embeddingLoaded = true;
+  renderEmbeddingScatter();
+  renderEmbeddingHeatmap();
+  renderEmbeddingSankey();
+}
+document.getElementById("emb-refresh").addEventListener("click", function () {
+  _embeddingLoaded = false;
+  ensureEmbedding();
+});
+
+async function renderEmbeddingScatter() {
+  var host = document.getElementById("emb-scatter");
+  var legend = document.getElementById("emb-legend");
+  try {
+    var r = await fetch("/ucp/projection");
+    var data = await r.json();
+    var points = data.points || [];
+    if (!points.length) { host.innerHTML = '<div class="empty-state"><div class="empty-title">No embeddings</div></div>'; return; }
+    var xs = points.map(function (p) { return p.x; });
+    var ys = points.map(function (p) { return p.y; });
+    var xMin = Math.min.apply(null, xs), xMax = Math.max.apply(null, xs);
+    var yMin = Math.min.apply(null, ys), yMax = Math.max.apply(null, ys);
+    var pad = 0.1;
+    var W = 640, H = 380;
+    function sx(x) { return 40 + ((x - xMin) / (xMax - xMin + 1e-9)) * (W - 80); }
+    function sy(y) { return H - 30 - ((y - yMin) / (yMax - yMin + 1e-9)) * (H - 60); }
+    var colorMap = {
+      demographic:     "#4f8eff",
+      interest:        "#8b6eff",
+      purchase_intent: "#ff7a5c",
+      geo:             "#2bd4a0",
+      composite:       "#ffcb5c",
+    };
+    var svgDots = points.map(function (p) {
+      var color = colorMap[p.category] || "#8892a6";
+      return '<circle cx="' + sx(p.x).toFixed(1) + '" cy="' + sy(p.y).toFixed(1) + '" r="5" ' +
+        'fill="' + color + '" fill-opacity="0.85" stroke="rgba(255,255,255,0.2)" stroke-width="0.8">' +
+        '<title>' + escapeHtml(p.name) + ' (' + escapeHtml(p.category) + ')&#10;' + escapeHtml(p.description) + '</title>' +
+      '</circle>';
+    }).join("");
+    var svgLabels = points.map(function (p) {
+      var shortName = p.name.length > 22 ? p.name.slice(0, 20) + "…" : p.name;
+      return '<text x="' + (sx(p.x) + 8).toFixed(1) + '" y="' + (sy(p.y) + 4).toFixed(1) + '" ' +
+        'fill="var(--text-mut)" font-size="10" font-family="ui-sans-serif" paint-order="stroke fill" ' +
+        'stroke="var(--bg-surface)" stroke-width="2.5">' + escapeHtml(shortName) + '</text>';
+    }).join("");
+    host.innerHTML = '<svg viewBox="0 0 ' + W + ' ' + H + '" preserveAspectRatio="xMidYMid meet">' +
+      '<line x1="40" y1="' + (H - 30) + '" x2="' + (W - 40) + '" y2="' + (H - 30) + '" stroke="var(--border)" stroke-width="1"/>' +
+      '<line x1="40" y1="20" x2="40" y2="' + (H - 30) + '" stroke="var(--border)" stroke-width="1"/>' +
+      '<text x="' + (W - 40) + '" y="' + (H - 10) + '" text-anchor="end" fill="var(--text-mut)" font-size="10" font-family="ui-monospace">UCP₁ (random projection)</text>' +
+      '<text x="8" y="18" fill="var(--text-mut)" font-size="10" font-family="ui-monospace">UCP₂</text>' +
+      svgDots + svgLabels +
+    '</svg>';
+    var cats = Object.keys(colorMap);
+    legend.innerHTML = cats.map(function (c) {
+      return '<span class="emb-legend-item"><span class="emb-legend-dot" style="background:' + colorMap[c] + '"></span>' + escapeHtml(c) + '</span>';
+    }).join("");
+  } catch (e) {
+    host.innerHTML = '<div class="empty-state"><div class="empty-title">Could not load projection</div><div class="empty-desc">' + escapeHtml(String(e)) + '</div></div>';
+  }
+}
+
+async function renderEmbeddingHeatmap() {
+  var host = document.getElementById("emb-heatmap");
+  try {
+    var r = await fetch("/ucp/similarity?n=20");
+    var data = await r.json();
+    var n = data.n;
+    var matrix = data.matrix || [];
+    var names = data.signal_names || [];
+    var cell = 18;
+    var margin = 140;
+    var W = margin + n * cell + 20;
+    var H = margin + n * cell + 20;
+    function colorFor(v) {
+      // v in [-1, 1]. Diagonal = 1 (self). Map to a cool-warm scale.
+      var t = (v + 1) / 2; // 0..1
+      // lerp between dark blue and warm orange through white
+      if (t > 0.5) {
+        var f = (t - 0.5) * 2;
+        var rr = Math.round(255 * f + 60 * (1 - f));
+        var gg = Math.round(128 * f + 100 * (1 - f));
+        var bb = Math.round(90 * f + 200 * (1 - f));
+        return "rgb(" + rr + "," + gg + "," + bb + ")";
+      } else {
+        var f2 = t * 2;
+        var rr2 = Math.round(60 * f2 + 22 * (1 - f2));
+        var gg2 = Math.round(100 * f2 + 52 * (1 - f2));
+        var bb2 = Math.round(200 * f2 + 120 * (1 - f2));
+        return "rgb(" + rr2 + "," + gg2 + "," + bb2 + ")";
+      }
+    }
+    var svgCells = "";
+    for (var i = 0; i < n; i++) {
+      for (var j = 0; j < n; j++) {
+        var v = matrix[i * n + j];
+        svgCells += '<rect x="' + (margin + j * cell) + '" y="' + (margin + i * cell) + '" width="' + cell + '" height="' + cell + '" ' +
+          'fill="' + colorFor(v) + '" stroke="var(--bg-surface)" stroke-width="0.4">' +
+          '<title>' + escapeHtml(names[i] || "") + ' × ' + escapeHtml(names[j] || "") + ': cos=' + v.toFixed(3) + '</title>' +
+        '</rect>';
+      }
+    }
+    var svgRowLabels = names.map(function (nm, i) {
+      var shortName = nm.length > 22 ? nm.slice(0, 20) + "…" : nm;
+      return '<text x="' + (margin - 6) + '" y="' + (margin + i * cell + cell / 2 + 3) + '" text-anchor="end" fill="var(--text-mut)" font-size="9.5" font-family="ui-monospace">' + escapeHtml(shortName) + '</text>';
+    }).join("");
+    var svgColLabels = names.map(function (nm, j) {
+      var shortName = nm.length > 22 ? nm.slice(0, 20) + "…" : nm;
+      return '<text transform="rotate(-55 ' + (margin + j * cell + cell / 2) + ' ' + (margin - 6) + ')" x="' + (margin + j * cell + cell / 2) + '" y="' + (margin - 6) + '" text-anchor="start" fill="var(--text-mut)" font-size="9.5" font-family="ui-monospace">' + escapeHtml(shortName) + '</text>';
+    }).join("");
+    host.innerHTML = '<svg viewBox="0 0 ' + W + ' ' + H + '" preserveAspectRatio="xMinYMin meet">' +
+      svgCells + svgRowLabels + svgColLabels +
+    '</svg>' +
+    '<div style="margin-top:10px;display:flex;justify-content:space-between;font-size:10.5px;color:var(--text-mut);font-family:var(--font-mono)">' +
+      '<span>cos=-1</span><span>0</span><span>+1 (self)</span>' +
+    '</div>';
+  } catch (e) {
+    host.innerHTML = '<div class="empty-state"><div class="empty-title">Could not load heatmap</div></div>';
+  }
+}
+
+async function renderEmbeddingSankey() {
+  // Uses x_cross_taxonomy from the live catalog. Visualizes the bridge
+  // IAB 1.1 → IAB 3.0 → {LR, TTD, MC, Nielsen} as left-to-right flows
+  // aggregated by unique iab_3_0 topic. No external libs — pure SVG.
+  var host = document.getElementById("emb-sankey");
+  try {
+    if (state.catalog.all.length === 0) await loadCatalog();
+    var signals = state.catalog.all.slice(0, 50); // limit for readability
+    // Build flows: left=categoryType, mid=iab_content_3_0 label, right=system
+    var midCounts = {};    // iab30 label -> count
+    var rightFromMid = {}; // mid -> { system -> count }
+    signals.forEach(function (s) {
+      var tx = s.x_cross_taxonomy || [];
+      var iab30 = tx.find(function (e) { return e.system === "iab_content_3_0"; });
+      if (!iab30) return;
+      var midLabel = iab30.label;
+      midCounts[midLabel] = (midCounts[midLabel] || 0) + 1;
+      if (!rightFromMid[midLabel]) rightFromMid[midLabel] = {};
+      tx.forEach(function (e) {
+        if (e.system === "iab_content_3_0" || e.system === "iab_audience_1_1") return;
+        rightFromMid[midLabel][e.system] = (rightFromMid[midLabel][e.system] || 0) + 1;
+      });
+    });
+    var mids = Object.keys(midCounts).sort(function (a, b) { return midCounts[b] - midCounts[a]; }).slice(0, 8);
+    var rightSystems = ["liveramp_abilitec", "ttd_dmp", "nielsen_category", "mastercard_spendingpulse"];
+    var W = 960, H = 420;
+    var leftX = 40, midX = 360, rightX = 760;
+    var nodeW = 18;
+    var midSpace = (H - 40) / (mids.length || 1);
+    var rightSpace = (H - 40) / rightSystems.length;
+    // Nodes
+    var nodes = "";
+    mids.forEach(function (m, i) {
+      var y = 20 + i * midSpace;
+      var size = Math.max(16, Math.min(midSpace - 8, midCounts[m] * 6));
+      nodes += '<rect x="' + midX + '" y="' + y + '" width="' + nodeW + '" height="' + size + '" fill="var(--accent)" fill-opacity="0.7"/>' +
+        '<text x="' + (midX + nodeW + 8) + '" y="' + (y + size / 2 + 4) + '" fill="var(--text)" font-size="11" font-family="ui-sans-serif">' + escapeHtml(m) + ' · ' + midCounts[m] + '</text>';
+    });
+    rightSystems.forEach(function (sys, i) {
+      var y = 20 + i * rightSpace;
+      var size = Math.max(20, rightSpace - 20);
+      var totalForSys = 0;
+      mids.forEach(function (m) { totalForSys += (rightFromMid[m] && rightFromMid[m][sys]) || 0; });
+      nodes += '<rect x="' + rightX + '" y="' + y + '" width="' + nodeW + '" height="' + size + '" fill="#8b6eff" fill-opacity="0.7"/>' +
+        '<text x="' + (rightX + nodeW + 8) + '" y="' + (y + size / 2 + 4) + '" fill="var(--text)" font-size="11" font-family="ui-sans-serif">' + escapeHtml(sys) + ' · ' + totalForSys + '</text>';
+    });
+    // Left-column anchor
+    nodes += '<rect x="' + leftX + '" y="20" width="' + nodeW + '" height="' + (H - 40) + '" fill="#2bd4a0" fill-opacity="0.5"/>' +
+      '<text x="' + (leftX + nodeW + 8) + '" y="40" fill="var(--text)" font-size="11" font-family="ui-sans-serif">IAB Audience 1.1</text>' +
+      '<text x="' + (leftX + nodeW + 8) + '" y="56" fill="var(--text-mut)" font-size="10" font-family="ui-monospace">' + signals.length + ' signals</text>';
+    // Flows: left → mid (all one color), mid → right (colored per mid)
+    var flows = "";
+    mids.forEach(function (m, mi) {
+      var yMid = 20 + mi * midSpace + Math.min(midSpace - 8, midCounts[m] * 6) / 2;
+      // left→mid
+      var yLeft = 20 + (H - 40) / 2 + (mi - mids.length / 2) * 10;
+      var cx1 = leftX + nodeW + (midX - leftX - nodeW) / 2;
+      flows += '<path d="M' + (leftX + nodeW) + ',' + yLeft + ' C' + cx1 + ',' + yLeft + ' ' + cx1 + ',' + yMid + ' ' + midX + ',' + yMid + '" ' +
+        'fill="none" stroke="#2bd4a0" stroke-opacity="0.3" stroke-width="' + Math.max(1, midCounts[m] * 1.5) + '"/>';
+      // mid→right(s)
+      var rfm = rightFromMid[m] || {};
+      rightSystems.forEach(function (sys, ri) {
+        var count = rfm[sys] || 0;
+        if (!count) return;
+        var yRight = 20 + ri * rightSpace + rightSpace / 2;
+        var cx2 = midX + nodeW + (rightX - midX - nodeW) / 2;
+        flows += '<path d="M' + (midX + nodeW) + ',' + yMid + ' C' + cx2 + ',' + yMid + ' ' + cx2 + ',' + yRight + ' ' + rightX + ',' + yRight + '" ' +
+          'fill="none" stroke="#8b6eff" stroke-opacity="0.25" stroke-width="' + Math.max(1, count * 1.2) + '"/>';
+      });
+    });
+    host.innerHTML = '<svg viewBox="0 0 ' + W + ' ' + H + '" preserveAspectRatio="xMidYMid meet">' +
+      flows + nodes +
+    '</svg>' +
+    '<div style="font-size:10.5px;color:var(--text-mut);margin-top:8px">Left column: native IAB Audience 1.1 catalog. Middle: mapped IAB Content 3.0 topics. Right: buyer-side DMP / onboarder / measurement systems. Widths ∝ signal count. Stage flags (live/modeled/roadmap) surfaced in signal detail panel.</div>';
+  } catch (e) {
+    host.innerHTML = '<div class="empty-state"><div class="empty-title">Could not load bridge</div></div>';
+  }
 }
 
 document.getElementById("overlap-search-input").addEventListener("input", (e) => {
@@ -4868,6 +5847,181 @@ function wireToolLogExpanders() {
   });
 }
 
+// Sec-38 B7 — Dev kit tab (C5 sandbox keys + C7 SDK snippets)
+var _devkitLang = "typescript";
+var _devkitKeyShown = false;
+function ensureDevkit() {
+  renderDevkitCode();
+  updateDevkitKeyDisplay();
+}
+function updateDevkitKeyDisplay() {
+  var el = document.getElementById("devkit-key");
+  if (!el) return;
+  el.textContent = _devkitKeyShown ? DEMO_KEY : DEMO_KEY.slice(0, 8) + "••••••••••••••";
+  document.getElementById("devkit-key-reveal").textContent = _devkitKeyShown ? "Hide" : "Reveal";
+}
+(function wireDevkit() {
+  document.addEventListener("click", function (e) {
+    var t = e.target;
+    if (!(t instanceof Element)) return;
+    if (t.closest("#devkit-key-reveal")) {
+      _devkitKeyShown = !_devkitKeyShown; updateDevkitKeyDisplay(); return;
+    }
+    if (t.closest("#devkit-key-copy")) {
+      navigator.clipboard.writeText(DEMO_KEY).then(function () { showToast("Key copied"); }).catch(function () { showToast("Copy failed", true); });
+      return;
+    }
+    if (t.closest("#devkit-copy-code")) {
+      var code = document.getElementById("devkit-code")?.textContent || "";
+      navigator.clipboard.writeText(code).then(function () { showToast("Snippet copied"); }).catch(function () { showToast("Copy failed", true); });
+      return;
+    }
+    var tab = t.closest(".devkit-tab");
+    if (tab) {
+      _devkitLang = tab.dataset.lang;
+      document.querySelectorAll(".devkit-tab").forEach(function (b) { b.classList.toggle("active", b === tab); });
+      renderDevkitCode();
+    }
+  });
+})();
+function renderDevkitCode() {
+  var pre = document.getElementById("devkit-code");
+  if (!pre) return;
+  var origin = location.origin;
+  var snippets = {
+    typescript:
+      "// npm install @adcp/client\\n" +
+      "import { AdcpClient } from \\"@adcp/client\\";\\n" +
+      "\\n" +
+      "const client = new AdcpClient({\\n" +
+      "  endpoint: \\"" + origin + "/mcp\\",\\n" +
+      "  apiKey: process.env.ADCP_KEY!,  // bearer token\\n" +
+      "});\\n" +
+      "\\n" +
+      "const res = await client.getSignals({\\n" +
+      "  brief: \\"affluent families 35-44 interested in luxury travel\\",\\n" +
+      "  deliver_to: { deployments: [{ type: \\"platform\\", platform: \\"mock_dsp\\" }], countries: [\\"US\\"] },\\n" +
+      "  max_results: 10,\\n" +
+      "});\\n" +
+      "console.log(res.signals.length, \\"matches\\");\\n" +
+      "console.log(res.signals[0].x_cross_taxonomy);  // Sec-38 bridge IDs",
+    python:
+      "# pip install requests\\n" +
+      "import os, requests\\n" +
+      "\\n" +
+      "resp = requests.post(\\n" +
+      "    \\"" + origin + "/mcp\\",\\n" +
+      "    headers={\\"Authorization\\": f\\"Bearer {os.environ['ADCP_KEY']}\\"},\\n" +
+      "    json={\\n" +
+      "        \\"jsonrpc\\": \\"2.0\\", \\"id\\": 1, \\"method\\": \\"tools/call\\",\\n" +
+      "        \\"params\\": {\\n" +
+      "            \\"name\\": \\"get_signals\\",\\n" +
+      "            \\"arguments\\": {\\n" +
+      "                \\"brief\\": \\"affluent families 35-44 interested in luxury travel\\",\\n" +
+      "                \\"deliver_to\\": {\\"deployments\\": [{\\"type\\": \\"platform\\", \\"platform\\": \\"mock_dsp\\"}], \\"countries\\": [\\"US\\"]},\\n" +
+      "                \\"max_results\\": 10,\\n" +
+      "            },\\n" +
+      "        },\\n" +
+      "    },\\n" +
+      "    timeout=30,\\n" +
+      ")\\n" +
+      "print(resp.json()[\\"result\\"][\\"structuredContent\\"][\\"count\\"])",
+    go:
+      "package main\\n" +
+      "\\n" +
+      "import (\\n" +
+      "    \\"bytes\\"\\n" +
+      "    \\"encoding/json\\"\\n" +
+      "    \\"fmt\\"\\n" +
+      "    \\"net/http\\"\\n" +
+      "    \\"os\\"\\n" +
+      ")\\n" +
+      "\\n" +
+      "func main() {\\n" +
+      "    body, _ := json.Marshal(map[string]any{\\n" +
+      "        \\"jsonrpc\\": \\"2.0\\", \\"id\\": 1, \\"method\\": \\"tools/call\\",\\n" +
+      "        \\"params\\": map[string]any{\\n" +
+      "            \\"name\\": \\"get_signals\\",\\n" +
+      "            \\"arguments\\": map[string]any{\\n" +
+      "                \\"brief\\": \\"affluent families 35-44 interested in luxury travel\\",\\n" +
+      "                \\"deliver_to\\": map[string]any{\\"deployments\\": []any{map[string]any{\\"type\\": \\"platform\\", \\"platform\\": \\"mock_dsp\\"}}, \\"countries\\": []string{\\"US\\"}},\\n" +
+      "                \\"max_results\\": 10,\\n" +
+      "            },\\n" +
+      "        },\\n" +
+      "    })\\n" +
+      "    req, _ := http.NewRequest(\\"POST\\", \\"" + origin + "/mcp\\", bytes.NewReader(body))\\n" +
+      "    req.Header.Set(\\"Authorization\\", \\"Bearer \\"+os.Getenv(\\"ADCP_KEY\\"))\\n" +
+      "    req.Header.Set(\\"Content-Type\\", \\"application/json\\")\\n" +
+      "    resp, err := http.DefaultClient.Do(req)\\n" +
+      "    if err != nil { panic(err) }\\n" +
+      "    defer resp.Body.Close()\\n" +
+      "    var out map[string]any\\n" +
+      "    json.NewDecoder(resp.Body).Decode(&out)\\n" +
+      "    fmt.Println(out[\\"result\\"])\\n" +
+      "}",
+    curl:
+      "curl -s -X POST " + origin + "/mcp \\\\\\n" +
+      "  -H \\"Authorization: Bearer $ADCP_KEY\\" \\\\\\n" +
+      "  -H \\"Content-Type: application/json\\" \\\\\\n" +
+      "  -d '{\\n" +
+      "    \\"jsonrpc\\": \\"2.0\\", \\"id\\": 1, \\"method\\": \\"tools/call\\",\\n" +
+      "    \\"params\\": {\\n" +
+      "      \\"name\\": \\"get_signals\\",\\n" +
+      "      \\"arguments\\": {\\n" +
+      "        \\"brief\\": \\"affluent families 35-44 interested in luxury travel\\",\\n" +
+      "        \\"deliver_to\\": {\\"deployments\\":[{\\"type\\":\\"platform\\",\\"platform\\":\\"mock_dsp\\"}],\\"countries\\":[\\"US\\"]},\\n" +
+      "        \\"max_results\\": 10\\n" +
+      "      }\\n" +
+      "    }\\n" +
+      "  }'",
+  };
+  pre.textContent = snippets[_devkitLang] || "";
+}
+
+// Sec-38 A7: keyboard shortcuts. Two-key "go to" prefix (g+x). Single
+// keys: ? toggles the cheat sheet, Esc closes overlays + detail panel.
+// Ignore shortcuts while typing in an input/textarea.
+var _kbdPrefix = null, _kbdPrefixTimer = null;
+function _isEditable(el) {
+  if (!el) return false;
+  var t = el.tagName;
+  return t === "INPUT" || t === "TEXTAREA" || t === "SELECT" || el.isContentEditable;
+}
+document.addEventListener("keydown", function (ev) {
+  if (_isEditable(document.activeElement)) return;
+  var overlay = document.getElementById("kbd-overlay");
+  if (ev.key === "?" && !ev.ctrlKey && !ev.metaKey) {
+    overlay.classList.toggle("open");
+    ev.preventDefault();
+    return;
+  }
+  if (ev.key === "Escape") {
+    if (overlay.classList.contains("open")) { overlay.classList.remove("open"); return; }
+    var panel = document.getElementById("detail-panel");
+    if (panel && panel.classList.contains("open")) { closeDetail(); return; }
+    var drawer = document.getElementById("mcp-drawer");
+    if (drawer && drawer.classList.contains("open")) { drawer.classList.remove("open"); return; }
+    return;
+  }
+  if (_kbdPrefix === "g") {
+    var map = { d: "discover", c: "catalog", b: "builder", t: "treemap", o: "overlap", e: "embedding", k: "capabilities", v: "devkit", l: "toollog", a: "activations" };
+    var tab = map[ev.key.toLowerCase()];
+    if (tab) { switchTab(tab); _kbdPrefix = null; if (_kbdPrefixTimer) clearTimeout(_kbdPrefixTimer); return; }
+    _kbdPrefix = null;
+  }
+  if (ev.key === "g" && !ev.ctrlKey && !ev.metaKey) {
+    _kbdPrefix = "g";
+    if (_kbdPrefixTimer) clearTimeout(_kbdPrefixTimer);
+    _kbdPrefixTimer = setTimeout(function () { _kbdPrefix = null; }, 1200);
+  }
+});
+document.getElementById("kbd-overlay").addEventListener("click", function (ev) {
+  if (ev.target.id === "kbd-overlay") ev.currentTarget.classList.remove("open");
+});
+document.getElementById("kbd-hint-btn").addEventListener("click", function () {
+  document.getElementById("kbd-overlay").classList.toggle("open");
+});
+
 // Prime tool-log count in nav on first render
 (async () => {
   try {
@@ -4878,6 +6032,37 @@ function wireToolLogExpanders() {
     }
   } catch {}
 })();
+
+// Sec-38 B7: Tool Log CSV export. Downloads the currently-loaded entries
+// as CSV with the same field set rendered in the table (no PII, args
+// stripped to top-level keys by the server).
+document.getElementById("toollog-export").addEventListener("click", () => {
+  const rows = state.toolLog?.data || [];
+  if (!rows.length) { showToast("No entries to export"); return; }
+  const header = ["timestamp", "tool", "latency_ms", "resp_bytes", "caller", "status", "arg_keys"];
+  function csvEscape(v) {
+    const s = v === null || v === undefined ? "" : String(v);
+    return /[",\\n\\r]/.test(s) ? '"' + s.replace(/"/g, '""') + '"' : s;
+  }
+  const body = rows.map((e) => [
+    e.timestamp || e.ts || "",
+    e.tool || "",
+    e.latency_ms || "",
+    e.response_bytes || "",
+    e.caller || "",
+    e.status || (e.error ? "error" : "ok"),
+    Array.isArray(e.arg_keys) ? e.arg_keys.join("|") : (e.args_redacted || ""),
+  ].map(csvEscape).join(","));
+  const csv = header.join(",") + "\\n" + body.join("\\n");
+  const blob = new Blob([csv], { type: "text/csv" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = "mcp-tool-log-" + new Date().toISOString().slice(0, 10) + ".csv";
+  document.body.appendChild(a); a.click(); a.remove();
+  setTimeout(() => URL.revokeObjectURL(url), 1000);
+  showToast("CSV downloaded");
+});
 
 // Initial load hook: prime activations count in nav on first render so
 // operators see the real number without having to visit the tab.

--- a/src/routes/ucpProjection.ts
+++ b/src/routes/ucpProjection.ts
@@ -1,0 +1,176 @@
+/**
+ * src/routes/ucpProjection.ts
+ *
+ * Sec-38 B5: 2D projection of the UCP embedding space for visualization.
+ *
+ * Returns all 26 real signal vectors projected to 2 dimensions so the
+ * demo UI can render a scatter plot showing semantic neighborhoods.
+ *
+ * Algorithm: deterministic random projection (Johnson-Lindenstrauss).
+ * We draw two fixed 512-dim unit vectors from a seeded PRNG and dot each
+ * signal vector against them to get (x, y). JL guarantees approximate
+ * distance preservation — not as tight as PCA but:
+ *   • computable in <10ms in the Worker
+ *   • fully deterministic (fixed seed)
+ *   • needs no SVD / eigen library
+ *
+ * For a demo surface this is good enough to show clustering structure.
+ * The axes are labeled "UCP₁", "UCP₂" to avoid implying they are PC1/PC2.
+ *
+ * Public endpoint — no auth required.
+ *
+ * GET /ucp/projection
+ * Response shape:
+ * {
+ *   space_id:  "openai-te3-small-d512-v1",
+ *   method:    "random_projection_jl",
+ *   dimensions_in: 512,
+ *   dimensions_out: 2,
+ *   signed_at: ISO string,
+ *   points: [
+ *     { signal_id, name, category, x, y, norm }
+ *   ],
+ * }
+ *
+ * Also supports GET /ucp/similarity?n=20 — returns a 20×20 pairwise
+ * cosine similarity matrix over a deterministic sample for the heatmap
+ * visualization.
+ */
+
+import { SIGNAL_EMBEDDINGS } from "../domain/embeddingStore";
+import { jsonResponse } from "./shared";
+
+// Seeded xorshift32 PRNG — fully deterministic for a fixed seed.
+function makeRng(seed: number) {
+  let state = seed >>> 0;
+  if (state === 0) state = 0xdeadbeef;
+  return () => {
+    state ^= state << 13;
+    state ^= state >>> 17;
+    state ^= state << 5;
+    state = state >>> 0;
+    // map to [-1, 1]
+    return (state / 0xffffffff) * 2 - 1;
+  };
+}
+
+function randomUnitVector(dim: number, seed: number): number[] {
+  const rng = makeRng(seed);
+  const vec: number[] = [];
+  for (let i = 0; i < dim; i++) vec.push(rng());
+  const norm = Math.sqrt(vec.reduce((s, v) => s + v * v, 0));
+  return norm === 0 ? vec : vec.map((v) => v / norm);
+}
+
+function dot(a: number[], b: number[]): number {
+  let s = 0;
+  for (let i = 0; i < a.length; i++) s += (a[i] ?? 0) * (b[i] ?? 0);
+  return s;
+}
+
+// Infer category from signal_id prefix. The 26 seed signals use
+// readable slug prefixes that map to category types used elsewhere.
+function inferCategory(signalId: string): string {
+  if (signalId.startsWith("sig_age_")) return "demographic";
+  if (signalId.startsWith("sig_high_income") || signalId.includes("_income")) return "demographic";
+  if (signalId.includes("_college") || signalId.includes("_graduate") || signalId.includes("_educated")) return "demographic";
+  if (signalId.includes("_acs_")) return "demographic";
+  if (signalId.includes("stream") || signalId.includes("drama") || signalId.includes("viewer")) return "interest";
+  if (signalId.includes("intent") || signalId.includes("purchase")) return "purchase_intent";
+  if (signalId.includes("geo") || signalId.includes("dma")) return "geo";
+  return "interest";
+}
+
+// Humanize "sig_age_18_24" → "Age 18-24"
+function humanize(signalId: string): string {
+  return signalId
+    .replace(/^sig_/, "")
+    .replace(/_/g, " ")
+    .replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+interface ProjectionPoint {
+  signal_id: string;
+  name: string;
+  category: string;
+  description: string;
+  x: number;
+  y: number;
+  norm: number;
+}
+
+export function handleUcpProjection(): Response {
+  const DIM = 512;
+  const axisX = randomUnitVector(DIM, 0xabcdef01);
+  const axisY = randomUnitVector(DIM, 0x12345678);
+
+  const points: ProjectionPoint[] = [];
+  for (const [signalId, entry] of Object.entries(SIGNAL_EMBEDDINGS)) {
+    const x = dot(entry.vector, axisX);
+    const y = dot(entry.vector, axisY);
+    const n = Math.sqrt(entry.vector.reduce((s, v) => s + v * v, 0));
+    points.push({
+      signal_id: signalId,
+      name: humanize(signalId),
+      category: inferCategory(signalId),
+      description: entry.description,
+      x,
+      y,
+      norm: n,
+    });
+  }
+
+  return jsonResponse({
+    space_id: "openai-te3-small-d512-v1",
+    method: "random_projection_jl",
+    dimensions_in: DIM,
+    dimensions_out: 2,
+    signed_at: new Date().toISOString(),
+    seed_x: "0xabcdef01",
+    seed_y: "0x12345678",
+    point_count: points.length,
+    points,
+  });
+}
+
+/**
+ * GET /ucp/similarity — pairwise cosine similarity matrix over a
+ * deterministic sample of the embedding store.
+ *
+ * Query: ?n=20  (clamped to [2, 26])
+ *
+ * Used by the UI similarity heatmap. Returns signal_ids in order
+ * plus a flattened row-major matrix (length n*n).
+ */
+export function handleUcpSimilarity(url: URL): Response {
+  const nRaw = Number(url.searchParams.get("n") ?? 20);
+  const n = Math.max(2, Math.min(26, Number.isFinite(nRaw) ? Math.floor(nRaw) : 20));
+
+  const allIds = Object.keys(SIGNAL_EMBEDDINGS);
+  const sampledIds = allIds.slice(0, n);
+
+  // Fetch vectors + normalise (they should already be L2 but the stored
+  // vectors are pre-normalised so cos(a,b) = a·b).
+  const vectors = sampledIds
+    .map((id) => SIGNAL_EMBEDDINGS[id]?.vector)
+    .filter((v): v is number[] => Array.isArray(v));
+
+  const matrix: number[] = [];
+  for (let i = 0; i < vectors.length; i++) {
+    for (let j = 0; j < vectors.length; j++) {
+      const vi = vectors[i];
+      const vj = vectors[j];
+      if (!vi || !vj) { matrix.push(0); continue; }
+      matrix.push(Math.max(-1, Math.min(1, dot(vi, vj))));
+    }
+  }
+
+  return jsonResponse({
+    space_id: "openai-te3-small-d512-v1",
+    metric: "cosine",
+    n,
+    signal_ids: sampledIds,
+    signal_names: sampledIds.map(humanize),
+    matrix,
+  });
+}

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -124,6 +124,20 @@ export interface SignalSummary {
   status: string;
   x_dts?: DtsV12Label;
   x_ucp?: import("./ucp").UcpHybridPayload;
+  /**
+   * Cross-taxonomy bridge — deterministic predicted IDs in IAB 3.0,
+   * LiveRamp AbiliTec, TTD DMP, Mastercard SpendingPulse, and Nielsen
+   * so buyer agents can locate an equivalent audience in their native
+   * taxonomy. Each entry carries a `stage` (live|modeled|roadmap) so
+   * buyers know the confidence of the mapping. Built by
+   * src/mappers/crossTaxonomy.ts.
+   */
+  x_cross_taxonomy?: Array<{
+    system: string;
+    id: string;
+    label: string;
+    stage: "live" | "modeled" | "roadmap";
+  }>;
 }
 
 // Spec: discriminated union - type "platform" or "agent"


### PR DESCRIPTION
## Summary

Completes every item in `docs/TIER1_READINESS_PLAN.md` — Tier A + Tier B + Tier C, in 9 batches.

**Capability surface**
- `ext.id_resolution` — 9 ID types (cookie_3p, MAID iOS/Android, CTV, UID2, RampID, ID5, hashed_email, ip_only), 4 graph partners stage-flagged
- `ext.measurement` — reach / overlap / lift / delivery-sim with methodology + partner roadmap
- `ext.governance` — audit log + sensitive-category flagging + opt-out URL + bias schema
- TTD + DV360 sandbox destinations added (activation_supported=false pending OAuth)
- Cache key v11 → v13

**Cross-taxonomy bridge**
- New `src/mappers/crossTaxonomy.ts` — deterministic predicted IDs in IAB Content 3.0, LiveRamp AbiliTec, TTD DMP, Mastercard SpendingPulse, Nielsen, each stage-flagged `live|modeled|roadmap`
- Surfaced as `x_cross_taxonomy` on every `SignalSummary`
- Detail-panel grid + tab-level Sankey visualization

**+80 cross-vertical signals**
- `src/domain/signals/crossVerticals.ts` — seasonality×region (20), life-event windows (15), B2B intent-in-window (10), sports×market (12), CTV device×content (12), 1P lookalikes (10)
- Post-reseed catalog: **~435 signals**

**Measurement UI**
- Lift forecast (specificity-driven 2-28% predicted brand-lift)
- 30-day delivery simulator (pacing bars with weekend dips)
- Campaign-overlap placeholder (cleanroom-matched mock)

**Advanced UCP visualizations**
- `GET /ucp/projection` — deterministic JL random projection of 26 real 512-d vectors to 2D
- `GET /ucp/similarity?n=N` — pairwise cosine matrix
- New Embedding tab: scatter + 20×20 heatmap + cross-taxonomy Sankey

**Builder multi-signal stack**
- Typeahead picker (max 8) + combined unique reach via categoryAffinity-weighted overlap + stacked bar with overlap-waste stripe + blended CPM

**Dev surfaces**
- Explain-this-match reasons on NL results
- Tool Log CSV export (PII-safe — arg keys only, no values)
- New Dev-kit tab: sandbox key reveal/copy + TS/Python/Go/curl snippets + endpoint reference

**Polish**
- Keyboard shortcuts: `?` cheat-sheet, `g+x` two-key nav, `Esc` closes overlays
- Topbar `?` hint button
- Data-lineage graph in detail panel (sources → methodology → audience → distribution)

## Test plan

- [x] `npx tsc --noEmit` — zero errors in all new code (test-file pre-existing errors unchanged)
- [x] `npx wrangler deploy --dry-run` — clean build, 938 KB gzipped 245 KB
- [ ] Post-merge: hit `/capabilities` and verify new `ext.id_resolution` / `ext.measurement` / `ext.governance` blocks land
- [ ] Post-merge: hit `/ucp/projection` and `/ucp/similarity?n=20`, check Embedding tab renders scatter + heatmap + Sankey
- [ ] Post-merge: reseed catalog via admin endpoint — verify 80 new cross-vertical signals land and `x_cross_taxonomy` populates
- [ ] Post-merge: `?` opens shortcuts sheet; `g+e` jumps to Embedding tab
- [ ] Post-merge: signal detail panel shows Measurement panel + Cross-taxonomy bridge + Data-lineage graph

🤖 Generated with [Claude Code](https://claude.com/claude-code)