### PR TITLE
Sec-40: weekly scheduled D1 purge for public-URL hygiene

### DIFF
--- a/src/domain/capabilityService.ts
+++ b/src/domain/capabilityService.ts
@@ -10,14 +10,14 @@
 // Cache key bumped to v6 for the v3-conformant shape (ucp moved to ext)
 // then v7 for the HEAD-schema-conformant shape (adds adcp.idempotency).
 
-// Cache key bumped to v14 — Sec-39 expands every destination entry with
-// integration metadata (stage, auth, activation_pattern, data_format,
-// latency, segment_refresh_sla, use_cases, docs_url, onboarding).
+// Cache key bumped to v15 — Sec-40 adds ext.governance.data_hygiene
+// declaring the weekly scheduled D1 purge (Sundays 06:00 UTC) + retention
+// windows for each table. v14 enriched destination entries.
 // v13 added TTD + DV360 sandbox destinations.
 // v12 added three ext blocks (id_resolution, measurement, governance).
 // v11 added ext.dts declaring IAB Data Transparency Standard v1.2.
 // v10 added ext.ucp declaring UCP embedding bridge + concept registry.
-const CACHE_KEY = "adcp_capabilities_v14";
+const CACHE_KEY = "adcp_capabilities_v15";
 const CACHE_TTL_SECONDS = 3600;
 
 import { buildUcpCapability, type UcpCapabilityEnv } from "../ucp/vacDeclaration";
@@ -343,6 +343,31 @@ function buildStaticCapabilities(env: UcpCapabilityEnv): AdcpCapabilities {
         audience_bias_governance_schema: {
           supported: true,
           version: "adcp_3.0_rc",
+        },
+        // Sec-40: data hygiene — public-URL demo hygiene. Declares what
+        // we keep vs sweep, the cadence, and how to trigger it manually.
+        // Retention values live in src/storage/scheduledPurge.ts
+        // (RETENTION object) — authoritative.
+        data_hygiene: {
+          supported: true,
+          schedule: { cron: "0 6 * * SUN", cadence: "weekly", timezone: "UTC" },
+          retention: {
+            dynamic_signals_days: 7,
+            activation_jobs_days: 30,
+            tool_call_log_days: 7,
+            oauth_state_minutes: 10,
+          },
+          preserved: [
+            "seeded signals (canonical catalog)",
+            "derived signals (shipped with code)",
+            "taxonomy nodes",
+            "source records",
+          ],
+          manual_trigger: {
+            method: "POST",
+            endpoint: "/admin/purge",
+            auth: "DEMO_API_KEY bearer",
+          },
         },
       },
     },

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,6 +33,8 @@ import {
     handleOAuthTokenStub,
 } from "./routes/wellKnown";
 import { handleAdminReseed } from "./routes/adminReseed";
+import { handleAdminPurge } from "./routes/adminPurge";
+import { runScheduledPurge } from "./storage/scheduledPurge";
 import { handleDemo } from "./routes/demo";
 import { handleEstimate } from "./routes/estimate";
 import { handleListOperations } from "./routes/listOperations";
@@ -341,6 +343,13 @@ export default {
             } else if (method === "POST" && path === "/admin/reseed") {
                 response = await handleAdminReseed(request, env, logger);
 
+                // ── Admin purge (Sec-40, auth-gated) ──────────────────────────────────
+                // Manual trigger for the weekly D1 housekeeping sweep. Same bearer
+                // gate as /admin/reseed. Cron-scheduled counterpart is wired via
+                // the `scheduled()` handler below.
+            } else if (method === "POST" && path === "/admin/purge") {
+                response = await handleAdminPurge(request, env, logger);
+
                 // ── Signal embedding ─────────────────────────────────────────────────
             } else if (method === "GET" && path.match(/^\/signals\/[^/]+\/embedding$/)) {
                 const signalId = path.split("/")[2] ?? "";
@@ -366,6 +375,32 @@ export default {
                 errorResponse("INTERNAL_ERROR", "An unexpected error occurred", 500)
             );
         }
+    },
+
+    // Sec-40: weekly D1 housekeeping.
+    //
+    // Triggered by the cron schedule declared in wrangler.toml under
+    // [triggers].crons. Cloudflare invokes this outside the request path with
+    // a synthetic ScheduledEvent; anyone hitting the public URL can never
+    // reach it (it's not HTTP-addressable), so there's no auth concern here.
+    //
+    // ctx.waitUntil keeps the isolate alive until the purge finishes without
+    // blocking Cloudflare's scheduler callback. Errors are logged but never
+    // thrown — a failed housekeeping run must not take down subsequent
+    // cron firings.
+    async scheduled(
+        event: ScheduledEvent,
+        env: Env,
+        ctx: ExecutionContext,
+    ): Promise<void> {
+        const reqId = requestId();
+        const logger = createLogger(reqId);
+        logger.info("cron_fired", { cron: event.cron, scheduled: new Date(event.scheduledTime).toISOString() });
+        ctx.waitUntil(
+            runScheduledPurge(env, logger)
+                .then((r) => logger.info("cron_purge_done", { deleted: r.deleted, duration_ms: r.duration_ms, errors: r.errors.length }))
+                .catch((err) => logger.error("cron_purge_failed", { error: String(err) }))
+        );
     },
 };
 

--- a/src/routes/adminPurge.ts
+++ b/src/routes/adminPurge.ts
@@ -1,0 +1,38 @@
+// src/routes/adminPurge.ts
+// Sec-40: manual trigger for the weekly D1 housekeeping purge.
+//
+// The cron trigger in wrangler.toml runs this on schedule (Sundays 06:00 UTC),
+// but operators also want an ad-hoc button — e.g. right after a noisy demo
+// run, or before a review where you want the tool log to show only the
+// rehearsal. This endpoint wraps runScheduledPurge with the same auth gate
+// as /admin/reseed: DEMO_API_KEY bearer required.
+//
+// Runtime cost: O(rows deleted). At demo scale the full purge runs in well
+// under a second; the cron path uses ctx.waitUntil so the scheduled invocation
+// can return instantly, but the admin path waits for the result so the
+// operator can see the deletion counts inline.
+
+import type { Env } from "../types/env";
+import type { Logger } from "../utils/logger";
+import { jsonResponse, errorResponse, requireAuth } from "./shared";
+import { runScheduledPurge } from "../storage/scheduledPurge";
+
+export async function handleAdminPurge(
+  request: Request,
+  env: Env,
+  logger: Logger,
+): Promise<Response> {
+  if (request.method !== "POST") {
+    return new Response("Method Not Allowed", { status: 405 });
+  }
+  if (!requireAuth(request, env.DEMO_API_KEY)) {
+    return errorResponse(
+      "UNAUTHORIZED",
+      "Admin purge requires the DEMO_API_KEY bearer token.",
+      401,
+    );
+  }
+
+  const result = await runScheduledPurge(env, logger);
+  return jsonResponse(result);
+}

--- a/src/storage/scheduledPurge.ts
+++ b/src/storage/scheduledPurge.ts
@@ -1,0 +1,210 @@
+// src/storage/scheduledPurge.ts
+// Sec-40: weekly D1 housekeeping.
+//
+// This Worker is deployed on a public URL — anyone can hit /signals/search,
+// /mcp, /signals/estimate, etc. Even with a required bearer for mutating
+// paths, the public read surfaces and the one-click demo inevitably
+// accumulate transient data over time:
+//
+//   • dynamic signals — user-composed segments (generationMode='dynamic')
+//     created via /signals/generate-segment or NL brief fallback. These
+//     are never cleaned by the seed pipeline (which only touches an
+//     empty table) and would grow monotonically without a sweep.
+//
+//   • activation_jobs + activation_events — every activate_signal call
+//     persists a row. Demo traffic can produce thousands per week.
+//
+//   • mcp_tool_calls — already has opportunistic 1-in-100 cleanup in
+//     toolLogRepo.cleanup, but an explicit scheduled sweep guarantees
+//     the 7-day retention ceiling declared by ext.governance.audit_log.
+//
+//   • oauth_state — expired PKCE states (10-min TTL in practice). Not
+//     dangerous if they accumulate but the table is append-mostly
+//     without this cleanup.
+//
+// Not purged:
+//   • seeded / derived signals (generation_mode in ('seeded','derived'))
+//     — these are the canonical catalog shipped with the code. Deleting
+//     them would leave the service empty until the next reseed.
+//   • taxonomy_nodes — reference data, bounded.
+//   • source_records — reference data, small.
+//   • operator-owned LinkedIn tokens (if/when oauth_tokens table is
+//     added) — user-owned, not demo ephemera.
+//
+// Invocation paths:
+//   1. Cloudflare cron trigger — wired in wrangler.toml `[triggers].crons`
+//      on a weekly cadence (Sundays 06:00 UTC). Runs via the `scheduled()`
+//      export in src/index.ts.
+//   2. Manual admin POST /admin/purge — for ad-hoc maintenance. Bearer
+//      auth required (DEMO_API_KEY), so a random visitor can't trigger it.
+//
+// Both paths call runScheduledPurge() and get the same result shape back.
+
+import type { Env } from "../types/env";
+import type { Logger } from "../utils/logger";
+import { getDb, execute, queryAll } from "./db";
+
+// Retention windows. Declared at module scope so they can be referenced by
+// /capabilities and /data-hygiene surfaces without drift.
+export const RETENTION = {
+  dynamic_signals_days: 7,
+  activations_days: 30,      // longer than tool-log so post-mortems stay
+  tool_calls_days: 7,        // matches ext.governance.audit_log.retention_days
+  oauth_state_minutes: 10,   // hard TTL on PKCE flow window
+};
+
+export interface PurgeResult {
+  started_at: string;
+  duration_ms: number;
+  deleted: {
+    dynamic_signals: number;
+    signal_rules: number; // cascaded
+    activation_jobs: number;
+    activation_events: number;
+    mcp_tool_calls: number;
+    oauth_state: number;
+  };
+  retention: typeof RETENTION;
+  errors: string[];
+}
+
+export async function runScheduledPurge(
+  env: Env,
+  logger: Logger,
+): Promise<PurgeResult> {
+  const started = Date.now();
+  const result: PurgeResult = {
+    started_at: new Date(started).toISOString(),
+    duration_ms: 0,
+    deleted: {
+      dynamic_signals: 0,
+      signal_rules: 0,
+      activation_jobs: 0,
+      activation_events: 0,
+      mcp_tool_calls: 0,
+      oauth_state: 0,
+    },
+    retention: RETENTION,
+    errors: [],
+  };
+
+  const db = getDb(env);
+  logger.info("scheduled_purge_start", { retention: RETENTION });
+
+  const dayMs = 86_400_000;
+  const nowMs = Date.now();
+  const nowIso = new Date(nowMs).toISOString();
+
+  // ── 1. Dynamic signals (user-composed) older than retention window ──
+  // Count first so the response can report deletions; rules cascade via FK.
+  try {
+    const cutoffIso = new Date(nowMs - RETENTION.dynamic_signals_days * dayMs).toISOString();
+    const doomedSignals = await queryAll<{ signal_id: string }>(
+      db,
+      `SELECT signal_id FROM signals
+         WHERE generation_mode = 'dynamic'
+           AND COALESCE(updated_at, created_at) < ?`,
+      [cutoffIso],
+    );
+    if (doomedSignals.length > 0) {
+      // Count child rules before the cascade so we can report them
+      const ruleCount = await queryAll<{ c: number }>(
+        db,
+        `SELECT COUNT(*) AS c FROM signal_rules
+           WHERE signal_id IN (${doomedSignals.map(() => "?").join(",")})`,
+        doomedSignals.map((s) => s.signal_id),
+      );
+      result.deleted.signal_rules = ruleCount[0]?.c ?? 0;
+
+      await execute(
+        db,
+        `DELETE FROM signals
+           WHERE generation_mode = 'dynamic'
+             AND COALESCE(updated_at, created_at) < ?`,
+        [cutoffIso],
+      );
+      result.deleted.dynamic_signals = doomedSignals.length;
+    }
+  } catch (e) {
+    result.errors.push("dynamic_signals: " + String(e));
+  }
+
+  // ── 2. Activation jobs older than retention window ──
+  // Child events via FK; delete children first (no ON DELETE CASCADE declared
+  // on activation_events, so the parent delete would otherwise fail under
+  // strict FK enforcement).
+  try {
+    const cutoffIso = new Date(nowMs - RETENTION.activations_days * dayMs).toISOString();
+    const doomedJobs = await queryAll<{ operation_id: string }>(
+      db,
+      `SELECT operation_id FROM activation_jobs WHERE submitted_at < ?`,
+      [cutoffIso],
+    );
+    if (doomedJobs.length > 0) {
+      const eventCount = await queryAll<{ c: number }>(
+        db,
+        `SELECT COUNT(*) AS c FROM activation_events
+           WHERE operation_id IN (${doomedJobs.map(() => "?").join(",")})`,
+        doomedJobs.map((j) => j.operation_id),
+      );
+      result.deleted.activation_events = eventCount[0]?.c ?? 0;
+
+      await execute(
+        db,
+        `DELETE FROM activation_events
+           WHERE operation_id IN (${doomedJobs.map(() => "?").join(",")})`,
+        doomedJobs.map((j) => j.operation_id),
+      );
+      await execute(
+        db,
+        `DELETE FROM activation_jobs WHERE submitted_at < ?`,
+        [cutoffIso],
+      );
+      result.deleted.activation_jobs = doomedJobs.length;
+    }
+  } catch (e) {
+    result.errors.push("activation_jobs: " + String(e));
+  }
+
+  // ── 3. MCP tool call log (same 7-day ceiling as ext.governance) ──
+  try {
+    const cutoffMs = nowMs - RETENTION.tool_calls_days * dayMs;
+    const before = await queryAll<{ c: number }>(
+      db,
+      `SELECT COUNT(*) AS c FROM mcp_tool_calls WHERE created_at < ?`,
+      [cutoffMs],
+    );
+    const beforeCount = before[0]?.c ?? 0;
+    if (beforeCount > 0) {
+      await execute(db, `DELETE FROM mcp_tool_calls WHERE created_at < ?`, [cutoffMs]);
+      result.deleted.mcp_tool_calls = beforeCount;
+    }
+  } catch (e) {
+    result.errors.push("mcp_tool_calls: " + String(e));
+  }
+
+  // ── 4. Expired OAuth state (PKCE flow window) ──
+  try {
+    const before = await queryAll<{ c: number }>(
+      db,
+      `SELECT COUNT(*) AS c FROM oauth_state WHERE expires_at < ?`,
+      [nowIso],
+    );
+    const beforeCount = before[0]?.c ?? 0;
+    if (beforeCount > 0) {
+      await execute(db, `DELETE FROM oauth_state WHERE expires_at < ?`, [nowIso]);
+      result.deleted.oauth_state = beforeCount;
+    }
+  } catch (e) {
+    result.errors.push("oauth_state: " + String(e));
+  }
+
+  result.duration_ms = Date.now() - started;
+  logger.info("scheduled_purge_complete", {
+    duration_ms: result.duration_ms,
+    deleted: result.deleted,
+    errors: result.errors.length,
+  });
+
+  return result;
+}

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -25,3 +25,13 @@ id      = "e17c4c99b649460a92016e1257436f22"
 [dev]
 port           = 8787
 local_protocol = "http"
+
+# Sec-40: weekly D1 housekeeping purge.
+# Schedule: Sundays 06:00 UTC (01:00 ET / 22:00 PT Saturday).
+# The scheduled() handler in src/index.ts invokes runScheduledPurge which
+# sweeps: dynamic signals (>7d), activation_jobs + events (>30d),
+# mcp_tool_calls (>7d, matches ext.governance.audit_log.retention_days),
+# and expired OAuth state. Canonical seeded/derived signals are preserved.
+# Manual trigger available via POST /admin/purge (DEMO_API_KEY gated).
+[triggers]
+crons = ["0 6 * * SUN"]


### PR DESCRIPTION
## Summary

Public demo. Anyone can hit `/signals/search`, `/mcp`, `/signals/estimate`. Demo traffic accumulates transient rows — this adds automated weekly housekeeping.

### Cron-scheduled purge (Sundays 06:00 UTC)

Sweeps:
- **dynamic signals** (`generation_mode='dynamic'`) older than 7 days → cascades to `signal_rules`
- **activation_jobs** older than 30 days + their `activation_events`
- **mcp_tool_calls** older than 7 days (matches `ext.governance.audit_log.retention_days`)
- **oauth_state** with expired PKCE windows

Preserved (forever):
- Seeded + derived signals (canonical catalog)
- `taxonomy_nodes`, `source_records`
- Operator-owned tokens

### Mechanics
- `wrangler.toml [triggers].crons = ["0 6 * * SUN"]`
- `scheduled()` export in `src/index.ts` → `runScheduledPurge()` via `ctx.waitUntil`
- Manual trigger: `POST /admin/purge` (DEMO_API_KEY bearer, same gate as `/admin/reseed`). Returns deletion counts inline.

### Transparency
`ext.governance.data_hygiene` now declares the schedule, retention windows, manual trigger endpoint, and preserved tables — so reviewers see the policy at handshake time. Cache key v14 → v15.

## Test plan
- [x] `tsc --noEmit` clean
- [x] Deployed — `schedule: 0 6 * * SUN` registered by Cloudflare
- [x] `/capabilities` returns `ext.governance.data_hygiene` with full policy
- [ ] Run `POST /admin/purge` with DEMO_API_KEY → verify deletion counts returned
- [ ] Confirm via `wrangler tail` that cron fires on next Sunday 06:00 UTC

🤖 Generated with [Claude Code](https://claude.com/claude-code)