### PR TITLE
Sec-43: Audience Composer — set ops + saturation + affinity audit (backend + UI)

### DIFF
--- a/src/analytics/audienceMath.ts
+++ b/src/analytics/audienceMath.ts
@@ -1,0 +1,220 @@
+// src/analytics/audienceMath.ts
+// Sec-43: pure math for the audience composer endpoints.
+// No I/O, no DB, no fetch — testable in isolation.
+
+import type { SignalSummary } from "../types/api";
+
+// ── Vertical / geo classifiers ──────────────────────────────────────────────
+
+/** Mirrors verticalOf in portfolioEndpoints.ts so audits + portfolio stay aligned. */
+export function verticalOf(id: string): string {
+  if (id.startsWith("sig_b2b_firmo") || id.startsWith("sig_b2b_techno") || id.startsWith("sig_b2b_funding") || id.startsWith("sig_b2b_intent")) return "b2b_firmo_techno";
+  if (id.startsWith("sig_rmn_")) return "retail_media_network";
+  if (id.startsWith("sig_ctv_")) return "ctv_hispanic_daypart";
+  if (id.startsWith("sig_venue_")) return "venue_fenced";
+  if (id.startsWith("sig_weather_")) return "weather_triggered";
+  if (id.startsWith("sig_context_")) return "contextual_advanced";
+  if (id.startsWith("sig_lal_")) return "lookalike";
+  if (id.startsWith("sig_auto") || id.includes("automotive")) return "automotive";
+  if (id.startsWith("sig_b2b") || id.includes("b2b")) return "b2b";
+  if (id.startsWith("sig_finance") || id.includes("financial")) return "financial";
+  if (id.startsWith("sig_health")) return "health";
+  if (id.startsWith("sig_life_") || id.startsWith("sig_lw_")) return "life_events";
+  if (id.startsWith("sig_seasonal") || id.startsWith("sig_sr_")) return "seasonal";
+  if (id.startsWith("sig_media_") || id.includes("ctv")) return "media";
+  if (id.startsWith("sig_retail")) return "retail";
+  if (id.startsWith("sig_psycho")) return "psychographic";
+  if (id.startsWith("sig_geo_") || id.includes("_dma_") || id.includes("_region")) return "geo";
+  return "other";
+}
+
+/** Reach-as-geo proxy. Matches portfolioOptimizer.distributionVector banding. */
+export function geoBand(s: SignalSummary): string {
+  const r = s.estimated_audience_size ?? 0;
+  if (r >= 50_000_000) return "national";
+  if (r >= 10_000_000) return "multi_region";
+  if (r >= 1_000_000) return "metro";
+  return "local";
+}
+
+// ── Pairwise heuristic Jaccard ──────────────────────────────────────────────
+
+/**
+ * Heuristic pairwise overlap — returns an estimated count of users who would
+ * appear in both signals. Same shape as portfolioOptimizer's affinity Jaccard:
+ *   affinity × min(reach) × (min(reach) / max(reach))
+ * where affinity = 0.55 for matching category_type, 0.20 otherwise.
+ */
+export function pairOverlap(a: SignalSummary, b: SignalSummary): number {
+  const ra = a.estimated_audience_size ?? 0;
+  const rb = b.estimated_audience_size ?? 0;
+  if (ra === 0 || rb === 0) return 0;
+  const aff = a.category_type === b.category_type ? 0.55 : 0.20;
+  const minR = Math.min(ra, rb);
+  const maxR = Math.max(ra, rb);
+  return aff * (minR / maxR) * minR;
+}
+
+// ── Set-op reach folds ──────────────────────────────────────────────────────
+
+/** Inclusion-exclusion union over an ordered list. */
+export function unionReach(ss: SignalSummary[]): number {
+  if (ss.length === 0) return 0;
+  let acc = ss[0]!.estimated_audience_size ?? 0;
+  const pool: SignalSummary[] = [ss[0]!];
+  for (let i = 1; i < ss.length; i++) {
+    const next = ss[i]!;
+    const nextR = next.estimated_audience_size ?? 0;
+    const overlap = pool.reduce((s, p) => s + pairOverlap(next, p), 0);
+    acc += Math.max(0, nextR - overlap);
+    pool.push(next);
+  }
+  return Math.round(acc);
+}
+
+/**
+ * Intersect a current reach with each signal in `ss`, decaying by the
+ * pairwise overlap rate at each step. Returns count of users assumed to
+ * match the union AND every signal in `ss`.
+ */
+export function intersectReach(base: number, baseTemplate: SignalSummary | null, ss: SignalSummary[]): number {
+  if (ss.length === 0 || !baseTemplate) return base;
+  let r = base;
+  for (const next of ss) {
+    const nextR = next.estimated_audience_size ?? 0;
+    const baseProxy: SignalSummary = { ...baseTemplate, estimated_audience_size: r };
+    const overlap = pairOverlap(baseProxy, next);
+    const rate = r > 0 && nextR > 0 ? overlap / Math.min(r, nextR) : 0;
+    r = Math.round(r * Math.max(0, Math.min(1, rate)));
+  }
+  return r;
+}
+
+/** Suppress users that overlap with any signal in `ss`. */
+export function excludeReach(base: number, baseSet: SignalSummary[], ss: SignalSummary[]): number {
+  if (ss.length === 0 || baseSet.length === 0) return base;
+  let r = base;
+  for (const next of ss) {
+    const overlap = baseSet.reduce((s, p) => s + pairOverlap(next, p), 0);
+    r = Math.max(0, r - Math.round(overlap));
+  }
+  return r;
+}
+
+// ── Frequency saturation ────────────────────────────────────────────────────
+
+export interface SaturationPoint {
+  frequency: number;
+  reach_fraction: number;
+  unique_reach: number;
+  impressions: number;
+  cost_usd: number;
+  cost_per_unique_reach_usd: number;
+  marginal_reach: number;
+}
+
+/**
+ * Poisson exposure model: P(seen at least once | F) = 1 − exp(−F).
+ * Returns one point per requested frequency, plus per-step marginal reach.
+ */
+export function saturationCurve(reach: number, cpm: number, frequencies: number[]): SaturationPoint[] {
+  const out: SaturationPoint[] = [];
+  let prev = 0;
+  for (const f of frequencies) {
+    const reachFraction = 1 - Math.exp(-f);
+    const uniqueReach = Math.round(reach * reachFraction);
+    const impressions = Math.round(reach * f);
+    const cost = Math.round((impressions * cpm / 1000) * 100) / 100;
+    const cpUR = uniqueReach > 0 ? Math.round((cost / uniqueReach) * 10000) / 10000 : 0;
+    out.push({
+      frequency: f,
+      reach_fraction: Math.round(reachFraction * 10000) / 10000,
+      unique_reach: uniqueReach,
+      impressions,
+      cost_usd: cost,
+      cost_per_unique_reach_usd: cpUR,
+      marginal_reach: uniqueReach - prev,
+    });
+    prev = uniqueReach;
+  }
+  return out;
+}
+
+/**
+ * "Knee" of the saturation curve: first frequency whose marginal reach is
+ * less than half of the F=1 baseline gain. Returns null if no point qualifies.
+ */
+export function saturationKnee(curve: SaturationPoint[]): number | null {
+  const baseline = curve[0]?.unique_reach ?? 0;
+  for (let i = 1; i < curve.length; i++) {
+    if (curve[i]!.marginal_reach < baseline * 0.5) return curve[i]!.frequency;
+  }
+  return null;
+}
+
+// ── Affinity index / over-under analysis ────────────────────────────────────
+
+/**
+ * Reach-weighted share of `key(s)` over a row set. Returns map of
+ * key → fraction (0..1). Sums to 1.0 (or 0 if all reaches are zero).
+ */
+export function shareByKey<T extends SignalSummary>(rows: T[], key: (s: T) => string): Map<string, number> {
+  const totals = new Map<string, number>();
+  let grand = 0;
+  for (const s of rows) {
+    const r = s.estimated_audience_size ?? 0;
+    grand += r;
+    totals.set(key(s), (totals.get(key(s)) ?? 0) + r);
+  }
+  const out = new Map<string, number>();
+  for (const [k, v] of totals) out.set(k, grand > 0 ? v / grand : 0);
+  return out;
+}
+
+export interface AffinityRow {
+  key: string;
+  share: number;
+  selection_share: number;
+  index: number; // 100 = parity; capped to 600
+}
+
+/**
+ * For each key in `selection ∪ baseline`, compute its baseline share, its
+ * selection share, and the affinity index (selection_share / baseline_share × 100).
+ * Index is capped at 600 to bound display contrast on a tiny baseline.
+ */
+export function affinityRows(baseline: Map<string, number>, selection: Map<string, number>): AffinityRow[] {
+  const keys = new Set<string>([...baseline.keys(), ...selection.keys()]);
+  const rows: AffinityRow[] = [];
+  for (const k of keys) {
+    const b = baseline.get(k) ?? 0;
+    const s = selection.get(k) ?? 0;
+    const idx = b > 0 ? Math.round((s / b) * 100) : 0;
+    rows.push({
+      key: k,
+      share: Math.round(b * 10000) / 10000,
+      selection_share: Math.round(s * 10000) / 10000,
+      index: Math.min(600, idx),
+    });
+  }
+  rows.sort((a, b) => b.selection_share - a.selection_share);
+  return rows;
+}
+
+/** Mean of |index - 100| across rows with non-zero selection share. 0 = no skew. */
+export function skewScore(rows: AffinityRow[]): number {
+  const live = rows.filter((r) => r.selection_share > 0);
+  if (live.length === 0) return 0;
+  return Math.round(live.reduce((s, r) => s + Math.abs(r.index - 100), 0) / live.length);
+}
+
+/** Number of distinct buckets carrying ≥80% of selection share. */
+export function concentrationOf(rows: AffinityRow[]): number {
+  const sorted = [...rows].filter((r) => r.selection_share > 0).sort((a, b) => b.selection_share - a.selection_share);
+  let cum = 0;
+  for (let i = 0; i < sorted.length; i++) {
+    cum += sorted[i]!.selection_share;
+    if (cum >= 0.8) return i + 1;
+  }
+  return sorted.length;
+}

--- a/src/domain/capabilityService.ts
+++ b/src/domain/capabilityService.ts
@@ -479,6 +479,10 @@ function buildStaticCapabilities(env: UcpCapabilityEnv): AdcpCapabilities {
           portfolio_from_brief:   { method: "POST", path: "/portfolio/from-brief" },
           portfolio_what_if:      { method: "POST", path: "/portfolio/what-if" },
           portfolio_hit_target:   { method: "POST", path: "/portfolio/hit-target" },
+          // Sec-43: audience composer + activation-planning analytics.
+          audience_compose:        { method: "POST", path: "/audience/compose" },
+          audience_saturation:     { method: "POST", path: "/audience/saturation" },
+          audience_affinity_audit: { method: "POST", path: "/audience/affinity-audit" },
         },
         methods: {
           similarity_metric:     "cosine",
@@ -487,6 +491,9 @@ function buildStaticCapabilities(env: UcpCapabilityEnv): AdcpCapabilities {
           portfolio_solver:      "greedy_marginal_reach",
           overlap_metrics:       ["jaccard", "kl_divergence", "mutual_information"],
           projection_algorithms: ["jl_random", "umap_local_refine"],
+          set_op_overlap_model:  "category_affinity_jaccard_pairwise_inclusion_exclusion",
+          saturation_model:      "poisson_1_minus_exp_neg_frequency",
+          affinity_index_basis:  "reach_weighted_share_vs_catalog_baseline",
         },
         limits: {
           max_arithmetic_terms:  6,
@@ -494,6 +501,9 @@ function buildStaticCapabilities(env: UcpCapabilityEnv): AdcpCapabilities {
           max_neighborhood_k:    50,
           max_query_vector_dim:  512,
           min_signals_for_info_overlap: 2,
+          max_compose_signals:   20,
+          max_saturation_signals: 15,
+          max_affinity_audit_signals: 20,
         },
         signal_facets: {
           x_analytics_fields: [

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,6 +37,11 @@ import {
   handleCrossSimilarity,
   handleTaxonomyReverse,
 } from "./routes/federationEndpoints";
+import {
+  handleAudienceCompose,
+  handleAudienceSaturation,
+  handleAffinityAudit,
+} from "./routes/audienceAnalytics";
 import { handleMcpRequest } from "./mcp/server";
 import { jsonResponse, errorResponse, requireAuth } from "./routes/shared";
 import { createLogger } from "./utils/logger";
@@ -188,6 +193,11 @@ export default {
             "/agents/federated-search",
             "/agents/cross-similarity",
             "/taxonomy/reverse",
+            // Sec-43: audience composer + activation-planning analytics.
+            // Read-only — same posture as /portfolio/* and /analytics/*.
+            "/audience/compose",
+            "/audience/saturation",
+            "/audience/affinity-audit",
             // Sec-41 seed diagnostic + idempotent incremental seed
             // trigger. /admin/reseed remains auth-gated (force=true path).
             "/admin/seed-status",
@@ -317,6 +327,14 @@ export default {
                 response = await handleCrossSimilarity(request);
             } else if (method === "POST" && path === "/taxonomy/reverse") {
                 response = await handleTaxonomyReverse(request, env, logger);
+
+                // ── Sec-43: Audience Composer + activation analytics ────────────────
+            } else if (method === "POST" && path === "/audience/compose") {
+                response = await handleAudienceCompose(request, env, logger);
+            } else if (method === "POST" && path === "/audience/saturation") {
+                response = await handleAudienceSaturation(request, env, logger);
+            } else if (method === "POST" && path === "/audience/affinity-audit") {
+                response = await handleAffinityAudit(request, env, logger);
 
                 // ── LinkedIn OAuth ────────────────────────────────────────────────────
                 // Only /callback is in publicPaths. /init and /status are

--- a/src/routes/analyticsEndpoints.ts
+++ b/src/routes/analyticsEndpoints.ts
@@ -403,6 +403,9 @@ export async function handleAnalyticsSummary(): Promise<Response> {
       "GET /analytics/lorenz",
       "GET /analytics/knn-graph",
       "POST /portfolio/optimize",
+      "POST /audience/compose",
+      "POST /audience/saturation",
+      "POST /audience/affinity-audit",
     ],
   });
 }

--- a/src/routes/audienceAnalytics.ts
+++ b/src/routes/audienceAnalytics.ts
@@ -1,0 +1,346 @@
+// src/routes/audienceAnalytics.ts
+// Sec-43: Audience Composer + activation-planning analytics.
+//
+// Three new endpoints layered on top of the existing portfolio +
+// embedding stack. All public, all read-only, all return JSON.
+//
+//   POST /audience/compose        — set ops (∪, ∩, −) + lookalike expand
+//   POST /audience/saturation     — frequency saturation curve (Poisson)
+//   POST /audience/affinity-audit — over/under-index vs catalog baseline
+//
+// Math notes:
+//
+// 1. Set ops over reach (no user-level membership)
+//    Catalog signals expose only `estimated_audience_size`. We model
+//    pairwise overlap with the same heuristic Jaccard the portfolio
+//    optimizer uses (category-affinity × min/max reach), then collapse:
+//      union(A, B)  = A + B − overlap(A, B)
+//      intersect(A, B) = overlap(A, B)
+//      A \ B = A − overlap(A, B)
+//    For >2 sets we apply the operation pairwise as a fold. This is
+//    approximate but consistent with /signals/overlap and the greedy
+//    optimizer — same heuristic, same answer shape.
+//
+// 2. Frequency saturation
+//    Under a Poisson exposure model, the expected fraction of an
+//    audience reached after I impressions on population R is
+//    1 − exp(−F) where F = I/R. We sample F = 1..15 and report
+//    incremental reach + diminishing returns.
+//
+// 3. Affinity audit
+//    Compare the composed audience's category × vertical × geo
+//    distribution against the catalog baseline. Over-index = ratio of
+//    selection share to baseline share, capped to (-100%, +500%).
+//    Same shape as the IAB Audience Profile / Nielsen Affinity Index.
+
+import type { Env } from "../types/env";
+import type { Logger } from "../utils/logger";
+import { jsonResponse, errorResponse, readJsonBody } from "./shared";
+import { getDb } from "../storage/db";
+import { searchSignals } from "../storage/signalRepo";
+import { toSignalSummary } from "../mappers/signalMapper";
+import type { SignalSummary } from "../types/api";
+import { SIGNAL_EMBEDDINGS } from "../domain/embeddingStore";
+import { topKCosine } from "../analytics/vectorMath";
+import {
+  verticalOf,
+  geoBand,
+  unionReach,
+  intersectReach,
+  excludeReach,
+  saturationCurve,
+  saturationKnee,
+  shareByKey,
+  affinityRows,
+  skewScore,
+  concentrationOf,
+  type AffinityRow,
+} from "../analytics/audienceMath";
+
+// ── shared helpers ──────────────────────────────────────────────────────────
+
+async function loadCatalog(env: Env, _logger: Logger): Promise<SignalSummary[]> {
+  const db = getDb(env);
+  const { signals } = await searchSignals(db, { limit: 1000, offset: 0 });
+  return signals.map(toSignalSummary);
+}
+
+function indexById(catalog: SignalSummary[]): Map<string, SignalSummary> {
+  const m = new Map<string, SignalSummary>();
+  for (const s of catalog) m.set(s.signal_agent_segment_id, s);
+  return m;
+}
+
+// ── POST /audience/compose ──────────────────────────────────────────────────
+
+interface ComposeBody {
+  include?: string[];     // union — at least one match
+  intersect?: string[];   // intersection — must match all
+  exclude?: string[];     // suppression — must NOT match
+  lookalike?: { seed_signal_id: string; k?: number; min_cosine?: number };
+}
+
+export async function handleAudienceCompose(request: Request, env: Env, logger: Logger): Promise<Response> {
+  const parsed = await readJsonBody<ComposeBody>(request);
+  if (parsed.kind === "invalid") return errorResponse("INVALID_JSON", parsed.reason, 400);
+  const body: ComposeBody = parsed.kind === "parsed" ? parsed.data : {};
+
+  const include = body.include ?? [];
+  const intersect = body.intersect ?? [];
+  const exclude = body.exclude ?? [];
+  const totalRefs = include.length + intersect.length + exclude.length;
+  if (totalRefs === 0 && !body.lookalike) {
+    return errorResponse("EMPTY_COMPOSITION", "Provide at least one of: include, intersect, exclude, lookalike", 400);
+  }
+  if (totalRefs > 20) return errorResponse("TOO_MANY_SIGNALS", `Max 20 signal references; got ${totalRefs}`, 400);
+
+  const catalog = await loadCatalog(env, logger);
+  const byId = indexById(catalog);
+
+  function resolve(ids: string[]): { resolved: SignalSummary[]; missing: string[] } {
+    const resolved: SignalSummary[] = [];
+    const missing: string[] = [];
+    for (const id of ids) {
+      const s = byId.get(id);
+      if (s) resolved.push(s);
+      else missing.push(id);
+    }
+    return { resolved, missing };
+  }
+  const inc = resolve(include);
+  const itx = resolve(intersect);
+  const exc = resolve(exclude);
+  const allMissing = [...inc.missing, ...itx.missing, ...exc.missing];
+  if (allMissing.length > 0) {
+    return errorResponse("UNKNOWN_SIGNALS", `Unknown signal ids: ${allMissing.join(", ")}`, 400);
+  }
+
+  // ── Lookalike expand (optional) ───────────────────────────────────────────
+  // Embedding cosine over the seed; we surface the top-K as candidates the
+  // caller can promote into `include` on a follow-up call. We do NOT auto-add
+  // them to the reach math — that would silently inflate the answer.
+  let lookalike: null | {
+    seed: string;
+    k: number;
+    min_cosine: number;
+    candidates: Array<{ signal_agent_segment_id: string; cosine: number; estimated_audience_size: number; name: string }>;
+  } = null;
+  if (body.lookalike?.seed_signal_id) {
+    const seed = body.lookalike.seed_signal_id;
+    if (!SIGNAL_EMBEDDINGS[seed]) {
+      return errorResponse("SEED_NOT_EMBEDDED", `Signal ${seed} has no embedding for lookalike expansion`, 400);
+    }
+    const k = Math.max(1, Math.min(25, body.lookalike.k ?? 10));
+    const minCos = typeof body.lookalike.min_cosine === "number" ? body.lookalike.min_cosine : 0.55;
+    const seedVec = SIGNAL_EMBEDDINGS[seed]!.vector;
+    const exclude = new Set([seed, ...include, ...intersect]);
+    const neighbors = topKCosine(seedVec, SIGNAL_EMBEDDINGS, k, exclude, minCos);
+    lookalike = {
+      seed,
+      k,
+      min_cosine: minCos,
+      candidates: neighbors.map((n) => {
+        const s = byId.get(n.id);
+        return {
+          signal_agent_segment_id: n.id,
+          cosine: Math.round(n.cosine * 10000) / 10000,
+          estimated_audience_size: s?.estimated_audience_size ?? 0,
+          name: s?.name ?? n.id,
+        };
+      }),
+    };
+  }
+
+  // ── Reach math (delegated to analytics/audienceMath) ──────────────────────
+  const baseSet = inc.resolved.length > 0 ? inc.resolved : itx.resolved;
+  const unionR = unionReach(inc.resolved);
+  const intersectBase = unionR > 0 ? unionR : (itx.resolved[0]?.estimated_audience_size ?? 0);
+  const intersectTpl = baseSet[0] ?? null;
+  // When include is empty we already consumed itx[0] as the base — drop it
+  // from the fold so we don't double-decay.
+  const intersectFold = itx.resolved.length > 0
+    ? (unionR > 0 ? itx.resolved : itx.resolved.slice(1))
+    : [];
+  const afterIntersect = intersectReach(intersectBase, intersectTpl, intersectFold);
+  const finalReach = excludeReach(afterIntersect, baseSet, exc.resolved);
+
+  // Naive cost: average CPM across include set, applied to final reach.
+  function cpmOf(s: SignalSummary): number {
+    const opt = s.pricing_options?.[0];
+    if (!opt) return 0;
+    if (opt.model === "cpm") return opt.cpm;
+    return 0; // flat_fee not amortized here
+  }
+  const costSet = inc.resolved.length > 0 ? inc.resolved : itx.resolved;
+  const avgCpm = costSet.length > 0
+    ? costSet.reduce((s, x) => s + cpmOf(x), 0) / costSet.length
+    : 0;
+  const estimatedCost = Math.round((finalReach * avgCpm / 1000) * 100) / 100;
+
+  // Confidence: shrink as composition complexity grows. Single union = high.
+  const complexity = inc.resolved.length + 2 * itx.resolved.length + exc.resolved.length;
+  const confidence: "high" | "medium" | "low" =
+    complexity <= 2 ? "high" : complexity <= 5 ? "medium" : "low";
+
+  return jsonResponse({
+    composition: {
+      include: inc.resolved.map((s) => ({ signal_agent_segment_id: s.signal_agent_segment_id, name: s.name, reach: s.estimated_audience_size ?? 0 })),
+      intersect: itx.resolved.map((s) => ({ signal_agent_segment_id: s.signal_agent_segment_id, name: s.name, reach: s.estimated_audience_size ?? 0 })),
+      exclude: exc.resolved.map((s) => ({ signal_agent_segment_id: s.signal_agent_segment_id, name: s.name, reach: s.estimated_audience_size ?? 0 })),
+    },
+    lookalike,
+    reach: {
+      union_only: unionR,
+      after_intersect: afterIntersect,
+      final: finalReach,
+    },
+    estimated_cpm: Math.round(avgCpm * 100) / 100,
+    estimated_cost_usd: estimatedCost,
+    confidence,
+    method: "pairwise_inclusion_exclusion_with_category_affinity_jaccard",
+    note: "Heuristic — catalog signals expose reach not user-level membership. Lookalike candidates are proposed (not auto-added) to keep the reach math auditable.",
+  });
+}
+
+// ── POST /audience/saturation ───────────────────────────────────────────────
+
+interface SaturationBody {
+  signal_ids?: string[];
+  reach?: number;             // override; otherwise computed as union of signal_ids
+  cpm?: number;               // override; otherwise averaged from signal_ids
+  budget_usd?: number;        // optional — clamps the curve at affordable F
+  frequencies?: number[];     // override sampled F values
+}
+
+export async function handleAudienceSaturation(request: Request, env: Env, logger: Logger): Promise<Response> {
+  const parsed = await readJsonBody<SaturationBody>(request);
+  if (parsed.kind === "invalid") return errorResponse("INVALID_JSON", parsed.reason, 400);
+  const body: SaturationBody = parsed.kind === "parsed" ? parsed.data : {};
+
+  let reach = body.reach ?? 0;
+  let cpm = body.cpm ?? 0;
+  const ids = body.signal_ids ?? [];
+
+  if (reach === 0 && ids.length === 0) {
+    return errorResponse("INVALID_INPUT", "Provide reach OR signal_ids[]", 400);
+  }
+
+  // Hydrate from catalog if signal_ids supplied.
+  let resolved: SignalSummary[] = [];
+  if (ids.length > 0) {
+    if (ids.length > 15) return errorResponse("TOO_MANY_SIGNALS", `Max 15 signal_ids; got ${ids.length}`, 400);
+    const catalog = await loadCatalog(env, logger);
+    const byId = indexById(catalog);
+    const missing: string[] = [];
+    for (const id of ids) {
+      const s = byId.get(id);
+      if (s) resolved.push(s);
+      else missing.push(id);
+    }
+    if (missing.length > 0) return errorResponse("UNKNOWN_SIGNALS", `Unknown signal ids: ${missing.join(", ")}`, 400);
+
+    if (reach === 0) reach = unionReach(resolved);
+    if (cpm === 0) {
+      const cpms = resolved.map((s) => {
+        const opt = s.pricing_options?.[0];
+        return opt && opt.model === "cpm" ? opt.cpm : 0;
+      }).filter((v) => v > 0);
+      cpm = cpms.length > 0 ? cpms.reduce((s, v) => s + v, 0) / cpms.length : 0;
+    }
+  }
+
+  if (reach <= 0) return errorResponse("INVALID_REACH", "reach must be > 0", 400);
+
+  const frequencies = (body.frequencies && body.frequencies.length > 0)
+    ? body.frequencies.filter((f) => f > 0 && f <= 30)
+    : [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 12, 15];
+
+  const curve = saturationCurve(reach, cpm, frequencies);
+  const knee = saturationKnee(curve);
+
+  // Affordable cap if budget supplied.
+  let affordableF: number | null = null;
+  if (typeof body.budget_usd === "number" && body.budget_usd > 0) {
+    for (const c of curve) {
+      if (c.cost_usd <= body.budget_usd) affordableF = c.frequency;
+    }
+  }
+
+  return jsonResponse({
+    reach_population: reach,
+    cpm,
+    signals: resolved.map((s) => ({ signal_agent_segment_id: s.signal_agent_segment_id, name: s.name })),
+    curve,
+    knee_frequency: knee,
+    affordable_frequency: affordableF,
+    budget_usd: body.budget_usd ?? null,
+    method: "poisson_exposure_1_minus_exp_neg_f",
+    note: "Assumes random-impression delivery. Real platforms with frequency-cap optimizers reach the knee faster; treat this as an upper bound on diminishing returns.",
+  });
+}
+
+// ── POST /audience/affinity-audit ───────────────────────────────────────────
+
+interface AffinityBody {
+  signal_ids?: string[];
+}
+
+export async function handleAffinityAudit(request: Request, env: Env, logger: Logger): Promise<Response> {
+  const parsed = await readJsonBody<AffinityBody>(request);
+  if (parsed.kind === "invalid") return errorResponse("INVALID_JSON", parsed.reason, 400);
+  const body: AffinityBody = parsed.kind === "parsed" ? parsed.data : {};
+  const ids = body.signal_ids ?? [];
+  if (ids.length === 0) return errorResponse("INVALID_INPUT", "signal_ids[] required", 400);
+  if (ids.length > 20) return errorResponse("TOO_MANY_SIGNALS", `Max 20 signal_ids; got ${ids.length}`, 400);
+
+  const catalog = await loadCatalog(env, logger);
+  const byId = indexById(catalog);
+  const selection: SignalSummary[] = [];
+  const missing: string[] = [];
+  for (const id of ids) {
+    const s = byId.get(id);
+    if (s) selection.push(s);
+    else missing.push(id);
+  }
+  if (missing.length > 0) return errorResponse("UNKNOWN_SIGNALS", `Unknown signal ids: ${missing.join(", ")}`, 400);
+
+  function audit(facet: string, key: (s: SignalSummary) => string): { facet: string; rows: AffinityRow[]; top_over: AffinityRow | null; top_under: AffinityRow | null } {
+    const baseline = shareByKey(catalog, key);
+    const sel = shareByKey(selection, key);
+    const rows = affinityRows(baseline, sel);
+    const ranked = [...rows].filter((r) => r.selection_share > 0).sort((a, b) => b.index - a.index);
+    return {
+      facet,
+      rows,
+      top_over: ranked[0] ?? null,
+      top_under: ranked[ranked.length - 1] ?? null,
+    };
+  }
+
+  const facets = [
+    audit("category_type", (s) => s.category_type),
+    audit("vertical", (s) => verticalOf(s.signal_agent_segment_id)),
+    audit("geo_band", (s) => geoBand(s)),
+    audit("data_provider", (s) => s.data_provider || "unknown"),
+  ];
+
+  const summary = {
+    selection_count: selection.length,
+    catalog_count: catalog.length,
+    skew_scores: facets.reduce<Record<string, number>>((acc, f) => {
+      acc[f.facet] = skewScore(f.rows);
+      return acc;
+    }, {}),
+    concentration: facets.reduce<Record<string, number>>((acc, f) => {
+      acc[f.facet] = concentrationOf(f.rows);
+      return acc;
+    }, {}),
+  };
+
+  return jsonResponse({
+    facets,
+    summary,
+    method: "reach_weighted_share_then_index_vs_catalog_baseline",
+    note: "Index = 100 × (selection_share / catalog_share). 100 = parity, 200 = 2× over-represented, 50 = under-represented. Capped at 600.",
+  });
+}

--- a/src/routes/demo.ts
+++ b/src/routes/demo.ts
@@ -114,6 +114,10 @@ ${STYLES}
         <svg class="ico"><use href="#icon-chart"/></svg><span>Portfolio</span>
         <span class="nav-tag">new</span>
       </button>
+      <button class="nav-item" data-tab="composer">
+        <svg class="ico"><use href="#icon-builder"/></svg><span>Composer</span>
+        <span class="nav-tag">new</span>
+      </button>
       <button class="nav-item" data-tab="seasonality">
         <svg class="ico"><use href="#icon-info"/></svg><span>Seasonality</span>
         <span class="nav-tag">new</span>
@@ -841,6 +845,139 @@ ${STYLES}
         <div class="lab-panel lab-panel-full" style="margin-top:14px">
           <div class="lab-panel-title">Seasonality heatmap \u2014 first 30 signals</div>
           <div id="sea-heatmap"><div class="empty-state"><span class="spinner"></span><div class="empty-title">Loading heatmap\u2026</div></div></div>
+        </div>
+      </section>
+
+      <!-- TAB: Composer (Sec-43) -->
+      <!-- Unified audience composition: set ops + lookalike expand +      -->
+      <!-- frequency-saturation planning + affinity audit. Talks to the    -->
+      <!-- /audience/* endpoints introduced in Sec-43 Part 1.              -->
+      <section class="tab-pane" data-tab="composer">
+        <div class="pane-header">
+          <div>
+            <h1 class="pane-title">Audience Composer</h1>
+            <p class="pane-subtitle">Compose audiences from catalog signals with set operations (union \u222a, intersect \u2229, exclude \u2212), optionally expand with embedding-based lookalikes, then plan activation via frequency-saturation curves and affinity audits vs the catalog baseline.</p>
+          </div>
+        </div>
+        <div class="port-subtabs">
+          <button class="lab-subtab active" data-composer="build">Set Builder</button>
+          <button class="lab-subtab" data-composer="saturation">Frequency Saturation</button>
+          <button class="lab-subtab" data-composer="affinity">Affinity Audit</button>
+        </div>
+
+        <!-- 1. Set Builder -->
+        <div class="lab-subpanel" data-composer-panel="build">
+          <div class="composer-grid">
+            <div class="lab-panel">
+              <div class="lab-panel-title">Include (union \u222a)</div>
+              <div class="builder-section-label">Selected <span style="color:var(--text-mut);font-weight:400;font-family:var(--font-mono)" id="comp-inc-count">0 / 8</span></div>
+              <div class="overlap-chips" id="comp-inc-chips"></div>
+              <div class="overlap-search">
+                <svg class="ico"><use href="#icon-search"/></svg>
+                <input id="comp-inc-search" placeholder="Search catalog\u2026" autocomplete="off"/>
+              </div>
+              <div class="overlap-suggestions" id="comp-inc-sugg"></div>
+            </div>
+            <div class="lab-panel">
+              <div class="lab-panel-title">Intersect (\u2229)</div>
+              <div class="builder-section-label">Selected <span style="color:var(--text-mut);font-weight:400;font-family:var(--font-mono)" id="comp-itx-count">0 / 4</span></div>
+              <div class="overlap-chips" id="comp-itx-chips"></div>
+              <div class="overlap-search">
+                <svg class="ico"><use href="#icon-search"/></svg>
+                <input id="comp-itx-search" placeholder="Search catalog\u2026" autocomplete="off"/>
+              </div>
+              <div class="overlap-suggestions" id="comp-itx-sugg"></div>
+            </div>
+            <div class="lab-panel">
+              <div class="lab-panel-title">Exclude (\u2212)</div>
+              <div class="builder-section-label">Selected <span style="color:var(--text-mut);font-weight:400;font-family:var(--font-mono)" id="comp-exc-count">0 / 4</span></div>
+              <div class="overlap-chips" id="comp-exc-chips"></div>
+              <div class="overlap-search">
+                <svg class="ico"><use href="#icon-search"/></svg>
+                <input id="comp-exc-search" placeholder="Search catalog\u2026" autocomplete="off"/>
+              </div>
+              <div class="overlap-suggestions" id="comp-exc-sugg"></div>
+            </div>
+          </div>
+          <div class="lab-panel" style="margin-top:14px">
+            <div class="lab-panel-title">Lookalike expand (optional)</div>
+            <div class="composer-lal-row">
+              <div>
+                <label class="lab-label">Seed signal (must have an embedding)</label>
+                <select id="comp-lal-seed" class="lab-input">
+                  <option value="">\u2014 none \u2014</option>
+                </select>
+              </div>
+              <div>
+                <label class="lab-label">Top K</label>
+                <input id="comp-lal-k" type="number" min="1" max="25" value="8" class="lab-input"/>
+              </div>
+              <div>
+                <label class="lab-label">Min cosine</label>
+                <input id="comp-lal-min" type="number" min="0" max="1" step="0.05" value="0.55" class="lab-input"/>
+              </div>
+              <button class="btn-primary" id="comp-run" style="justify-content:center;padding:10px 18px">
+                <svg class="ico"><use href="#icon-bolt"/></svg><span>Compute composition</span>
+              </button>
+            </div>
+          </div>
+          <div class="lab-panel lab-panel-full" style="margin-top:14px">
+            <div class="lab-panel-title">Result</div>
+            <div id="comp-results"><div class="empty-state"><div class="empty-desc">Pick at least one signal, then hit <strong>Compute composition</strong>. The system applies pairwise inclusion-exclusion for union, category-affinity Jaccard for intersect, and subtracts suppressed overlap for exclude. A lookalike seed surfaces top-K embedding neighbors as candidates you can add to the <em>Include</em> pool on the next pass.</div></div></div>
+            <div id="comp-explainer"></div>
+          </div>
+        </div>
+
+        <!-- 2. Frequency Saturation -->
+        <div class="lab-subpanel" data-composer-panel="saturation" style="display:none">
+          <div class="lab-grid">
+            <div class="lab-panel">
+              <div class="lab-panel-title">Audience + constraints</div>
+              <div class="builder-section-label">Selected signals <span style="color:var(--text-mut);font-weight:400;font-family:var(--font-mono)" id="comp-sat-count">0 / 10</span></div>
+              <div class="overlap-chips" id="comp-sat-chips"></div>
+              <div class="overlap-search">
+                <svg class="ico"><use href="#icon-search"/></svg>
+                <input id="comp-sat-search" placeholder="Search catalog\u2026" autocomplete="off"/>
+              </div>
+              <div class="overlap-suggestions" id="comp-sat-sugg"></div>
+              <label class="lab-label" style="margin-top:12px">Budget ($, optional)</label>
+              <input id="comp-sat-budget" type="number" min="0" step="1000" value="50000" class="lab-input"/>
+              <label class="lab-label" style="margin-top:8px">Reach override (optional)</label>
+              <input id="comp-sat-reach" type="number" min="0" step="1000" placeholder="auto from signals" class="lab-input"/>
+              <button class="btn-primary" id="comp-sat-run" style="margin-top:12px;width:100%;justify-content:center" disabled>
+                <svg class="ico"><use href="#icon-chart"/></svg><span>Compute saturation</span>
+              </button>
+            </div>
+            <div class="lab-panel lab-panel-wide">
+              <div class="lab-panel-title">Diminishing-returns curve</div>
+              <div id="comp-sat-results"><div class="empty-state"><div class="empty-desc">Pick at least one signal (or override reach), then hit <strong>Compute saturation</strong>. The system models <code>P(seen \u2265 1 | F) = 1 \u2212 exp(\u2212F)</code> across F=1..15 and flags the knee where marginal reach drops below 50% of the F=1 gain.</div></div></div>
+              <div id="comp-sat-explainer"></div>
+            </div>
+          </div>
+        </div>
+
+        <!-- 3. Affinity Audit -->
+        <div class="lab-subpanel" data-composer-panel="affinity" style="display:none">
+          <div class="lab-grid">
+            <div class="lab-panel">
+              <div class="lab-panel-title">Selection</div>
+              <div class="builder-section-label">Selected signals <span style="color:var(--text-mut);font-weight:400;font-family:var(--font-mono)" id="comp-aff-count">0 / 15</span></div>
+              <div class="overlap-chips" id="comp-aff-chips"></div>
+              <div class="overlap-search">
+                <svg class="ico"><use href="#icon-search"/></svg>
+                <input id="comp-aff-search" placeholder="Search catalog\u2026" autocomplete="off"/>
+              </div>
+              <div class="overlap-suggestions" id="comp-aff-sugg"></div>
+              <button class="btn-primary" id="comp-aff-run" style="margin-top:12px;width:100%;justify-content:center" disabled>
+                <svg class="ico"><use href="#icon-network"/></svg><span>Audit affinity</span>
+              </button>
+            </div>
+            <div class="lab-panel lab-panel-wide">
+              <div class="lab-panel-title">Over / under-index vs catalog baseline</div>
+              <div id="comp-aff-results"><div class="empty-state"><div class="empty-desc">Pick at least one signal and hit <strong>Audit affinity</strong>. For every facet (category, vertical, geo band, data provider) the system compares the reach-weighted share of your selection against the catalog baseline. Index 100 = at parity; 200 = 2\u00d7 over-represented; 50 = under-represented.</div></div></div>
+              <div id="comp-aff-explainer"></div>
+            </div>
+          </div>
         </div>
       </section>
 
@@ -3386,6 +3523,93 @@ textarea.lab-input { resize: vertical; line-height: 1.5; }
   .workspace { padding: 20px 18px 60px; }
   .kpi-row { grid-template-columns: 1fr 1fr; }
 }
+
+/* Sec-43: Audience Composer */
+.composer-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 14px; }
+.composer-lal-row {
+  display: grid; grid-template-columns: 2fr 1fr 1fr auto;
+  gap: 12px; align-items: end;
+}
+.composer-reach-cards {
+  display: grid; grid-template-columns: repeat(3, 1fr); gap: 10px; margin-bottom: 14px;
+}
+.composer-reach-card {
+  background: var(--bg-raised); border: 1px solid var(--border);
+  border-radius: var(--radius-md); padding: 12px 14px;
+}
+.composer-reach-card .label {
+  font-size: 10.5px; color: var(--text-mut); text-transform: uppercase;
+  letter-spacing: 0.08em; margin-bottom: 4px;
+}
+.composer-reach-card .value {
+  font-size: 22px; font-weight: 700; font-family: var(--font-mono);
+  color: var(--text);
+}
+.composer-reach-card .sub {
+  font-size: 10.5px; color: var(--text-mut); font-family: var(--font-mono); margin-top: 2px;
+}
+.composer-reach-card.final .value { color: var(--accent); }
+
+.composer-lal-list { display: flex; flex-direction: column; gap: 6px; margin-top: 10px; }
+.composer-lal-item {
+  display: flex; justify-content: space-between; align-items: center; gap: 10px;
+  background: var(--bg-raised); border: 1px solid var(--border);
+  border-radius: var(--radius-md); padding: 8px 12px;
+}
+.composer-lal-item .cos {
+  font-family: var(--font-mono); font-weight: 600; color: var(--accent-hot); font-size: 12px;
+}
+.composer-lal-item .add-btn {
+  background: transparent; border: 1px solid var(--border); color: var(--text);
+  padding: 4px 10px; border-radius: var(--radius-sm); font-size: 11px; cursor: pointer;
+}
+.composer-lal-item .add-btn:hover { background: var(--accent); color: #fff; border-color: var(--accent); }
+
+/* Saturation curve */
+.comp-sat-curve { width: 100%; height: 280px; margin-bottom: 12px; }
+.comp-sat-table { width: 100%; border-collapse: collapse; font-size: 11.5px; font-family: var(--font-mono); }
+.comp-sat-table th, .comp-sat-table td { padding: 6px 10px; text-align: right; }
+.comp-sat-table th {
+  font-size: 10.5px; color: var(--text-mut); text-transform: uppercase; letter-spacing: 0.06em;
+  border-bottom: 1px solid var(--border);
+}
+.comp-sat-table td { border-bottom: 1px solid rgba(255,255,255,0.04); }
+.comp-sat-table tr.knee td { background: rgba(255, 192, 64, 0.08); }
+
+/* Affinity bars */
+.comp-aff-facet { margin-bottom: 18px; }
+.comp-aff-facet-title {
+  font-size: 11px; color: var(--text-mut); text-transform: uppercase; letter-spacing: 0.08em;
+  margin-bottom: 8px;
+}
+.comp-aff-row {
+  display: grid; grid-template-columns: 180px 1fr 64px;
+  gap: 10px; align-items: center; margin-bottom: 4px; font-size: 11.5px;
+}
+.comp-aff-bar-track {
+  position: relative; height: 14px; background: var(--bg-raised);
+  border-radius: 3px; overflow: hidden;
+}
+.comp-aff-bar-fill {
+  position: absolute; top: 0; bottom: 0;
+  background: var(--accent);
+}
+.comp-aff-bar-fill.under { background: var(--text-mut); }
+.comp-aff-bar-fill.over  { background: var(--accent); }
+.comp-aff-bar-fill.heavy { background: var(--accent-hot); }
+.comp-aff-bar-track::before {
+  content: ""; position: absolute; left: 50%; top: 0; bottom: 0;
+  width: 1px; background: var(--border); z-index: 1;
+}
+.comp-aff-index {
+  font-family: var(--font-mono); font-weight: 600; text-align: right;
+}
+.comp-aff-key { color: var(--text); }
+
+@media (max-width: 1100px) {
+  .composer-grid { grid-template-columns: 1fr; }
+  .composer-lal-row { grid-template-columns: 1fr; }
+}
 </style>`;
 
 // The whole <script> block as a function so we can close-template it cleanly.
@@ -3433,6 +3657,14 @@ const state = {
   activations: { pollTimer: null, data: [] },
   toolLog: { pollTimer: null, data: [], paused: false, filter: "", expanded: new Set() },
   overlap: { selected: [], lastResult: null, searchQ: "" },
+  // Sec-43: Composer state. Five pickers (3 on Set Builder + 1 each on
+  // Saturation / Affinity) plus the last result payloads for rendering.
+  composer: {
+    inc: [], itx: [], exc: [],      // Set Builder pools
+    sat: [], aff: [],               // Saturation / Affinity pools
+    lastCompose: null, lastSat: null, lastAff: null,
+    loaded: false,
+  },
   reach: { budgetUsd: 10_000 },
   // Sec-39: detail panel UX — cycle-mode + collapsed-section memory
   ui: { detailMode: "narrow", collapsedSections: new Set() },
@@ -3661,8 +3893,8 @@ function switchTab(name) {
     treemap: "Treemap", builder: "Builder", activations: "Activations",
     capabilities: "Capabilities", toollog: "Tool Log", overlap: "Overlap",
     embedding: "Embedding space", devkit: "Dev kit", destinations: "Destinations",
-    lab: "Embedding Lab", portfolio: "Portfolio", seasonality: "Seasonality",
-    federation: "Federation",
+    lab: "Embedding Lab", portfolio: "Portfolio", composer: "Composer",
+    seasonality: "Seasonality", federation: "Federation",
   };
   document.getElementById("crumb-current").textContent = crumbMap[name] || name;
 
@@ -3678,6 +3910,7 @@ function switchTab(name) {
   if (name === "destinations") ensureDestinations();
   if (name === "lab") ensureLab();
   if (name === "portfolio") ensurePortfolio();
+  if (name === "composer") ensureComposer();
   if (name === "seasonality") ensureSeasonality();
   if (name === "federation") ensureFederation();
 
@@ -8075,6 +8308,427 @@ async function renderSeaHeatmap() {
   } catch (e) {
     host.innerHTML = '<div class="empty-state"><div class="empty-title" style="color:var(--error)">Could not load heatmap</div></div>';
   }
+}
+
+// ─── Composer (Sec-43) ─────────────────────────────────────────────────
+// Unified tab talking to POST /audience/{compose,saturation,affinity-audit}.
+// Five pickers share one generic wiring helper (wireCompPicker) — each
+// backed by state.composer[key]. All 5 pull from the already-loaded
+// state.catalog.all so the UI stays responsive.
+var _compLoaded = false;
+
+// max = max signals per pool; buttons = ids of buttons to enable once picker has ≥1 selection.
+function wireCompPicker(key, chipsId, searchId, suggId, countId, max, buttons) {
+  var searchEl = document.getElementById(searchId);
+  if (!searchEl) return;
+  // Debounced search
+  searchEl.addEventListener("input", function () {
+    compRenderSugg(key, searchEl.value.trim().toLowerCase(), suggId, max);
+  });
+  searchEl.addEventListener("focus", function () {
+    compRenderSugg(key, searchEl.value.trim().toLowerCase(), suggId, max);
+  });
+  // Initial render
+  compRenderChips(key, chipsId, countId, max, suggId, buttons);
+  compRenderSugg(key, "", suggId, max);
+}
+
+function compRenderChips(key, chipsId, countId, max, suggId, buttons) {
+  var host = document.getElementById(chipsId);
+  var countEl = document.getElementById(countId);
+  var list = state.composer[key] || [];
+  if (countEl) countEl.textContent = list.length + " / " + max;
+  // Toggle associated buttons
+  (buttons || []).forEach(function (bid) {
+    var b = document.getElementById(bid);
+    if (b) b.disabled = list.length < 1;
+  });
+  if (!host) return;
+  if (list.length === 0) {
+    host.innerHTML = '<div style="color:var(--text-mut);font-size:11.5px;padding:8px 0;font-style:italic">None.</div>';
+    return;
+  }
+  host.innerHTML = list.map(function (s, i) {
+    var sid = s.signal_agent_segment_id || (s.signal_id && s.signal_id.id) || "";
+    return '<div class="overlap-chip" data-sid="' + escapeHtml(sid) + '">' +
+      '<div><div class="oc-name">' + escapeHtml(s.name) + '</div>' +
+      '<div style="font-size:10.5px;color:var(--text-mut);font-family:var(--font-mono)">' +
+        fmtNumber(s.estimated_audience_size) + ' · ' + escapeHtml(s.category_type || "—") +
+      '</div></div>' +
+      '<button class="oc-remove" data-idx="' + i + '"><svg class="ico"><use href="#icon-close"/></svg></button>' +
+    '</div>';
+  }).join("");
+  host.querySelectorAll(".oc-remove").forEach(function (b) {
+    b.addEventListener("click", function () {
+      state.composer[key].splice(Number(b.dataset.idx), 1);
+      compRenderChips(key, chipsId, countId, max, suggId, buttons);
+      compRenderSugg(key, "", suggId, max);
+    });
+  });
+}
+
+function compRenderSugg(key, q, suggId, max) {
+  var host = document.getElementById(suggId);
+  if (!host) return;
+  var list = state.composer[key] || [];
+  if (list.length >= max) {
+    host.innerHTML = '<div style="color:var(--text-mut);font-size:11px;padding:6px 0">Max ' + max + '. Remove one to add another.</div>';
+    return;
+  }
+  var selectedIds = new Set(list.map(function (s) { return s.signal_agent_segment_id || (s.signal_id && s.signal_id.id); }));
+  var rows = state.catalog.all || [];
+  if (q) rows = rows.filter(function (s) {
+    return (s.name || "").toLowerCase().includes(q) || (s.description || "").toLowerCase().includes(q);
+  });
+  rows = rows.filter(function (s) {
+    return !selectedIds.has(s.signal_agent_segment_id || (s.signal_id && s.signal_id.id));
+  }).slice(0, 10);
+  if (rows.length === 0) {
+    host.innerHTML = '<div style="color:var(--text-mut);font-size:11.5px;padding:6px 0">No catalog matches.</div>';
+    return;
+  }
+  host.innerHTML = rows.map(function (s) {
+    var sid = s.signal_agent_segment_id || (s.signal_id && s.signal_id.id) || "";
+    return '<div class="overlap-suggestion" data-sid="' + escapeHtml(sid) + '">' +
+      '<div>' + escapeHtml(s.name) + '</div>' +
+      '<div class="sub">' + fmtNumber(s.estimated_audience_size) + ' · ' +
+      escapeHtml(s.category_type || "—") + ' · ' + escapeHtml(verticalOf(s)) + '</div>' +
+    '</div>';
+  }).join("");
+  host.querySelectorAll(".overlap-suggestion").forEach(function (el) {
+    el.addEventListener("click", function () {
+      var sid = el.dataset.sid;
+      var sig = state.catalog.all.find(function (x) {
+        return (x.signal_agent_segment_id || (x.signal_id && x.signal_id.id)) === sid;
+      });
+      if (!sig) return;
+      // Per-picker wiring table tells us chipsId/countId/buttons/max.
+      var meta = _compPickerMeta[key];
+      if (!meta) return;
+      if (state.composer[key].length >= meta.max) return;
+      state.composer[key].push(sig);
+      compRenderChips(key, meta.chipsId, meta.countId, meta.max, suggId, meta.buttons);
+      compRenderSugg(key, "", suggId, meta.max);
+    });
+  });
+}
+
+// Picker metadata so suggestion clicks know how to re-render.
+var _compPickerMeta = {};
+
+async function ensureComposer() {
+  if (_compLoaded) return;
+  _compLoaded = true;
+  if (state.catalog.all.length === 0) await loadCatalog();
+
+  // Build picker metadata + wire each.
+  _compPickerMeta = {
+    inc: { chipsId: "comp-inc-chips", countId: "comp-inc-count", buttons: ["comp-run"],     max: 8 },
+    itx: { chipsId: "comp-itx-chips", countId: "comp-itx-count", buttons: [],               max: 4 },
+    exc: { chipsId: "comp-exc-chips", countId: "comp-exc-count", buttons: [],               max: 4 },
+    sat: { chipsId: "comp-sat-chips", countId: "comp-sat-count", buttons: ["comp-sat-run"], max: 10 },
+    aff: { chipsId: "comp-aff-chips", countId: "comp-aff-count", buttons: ["comp-aff-run"], max: 15 },
+  };
+  wireCompPicker("inc", "comp-inc-chips", "comp-inc-search", "comp-inc-sugg", "comp-inc-count", 8,  ["comp-run"]);
+  wireCompPicker("itx", "comp-itx-chips", "comp-itx-search", "comp-itx-sugg", "comp-itx-count", 4,  []);
+  wireCompPicker("exc", "comp-exc-chips", "comp-exc-search", "comp-exc-sugg", "comp-exc-count", 4,  []);
+  wireCompPicker("sat", "comp-sat-chips", "comp-sat-search", "comp-sat-sugg", "comp-sat-count", 10, ["comp-sat-run"]);
+  wireCompPicker("aff", "comp-aff-chips", "comp-aff-search", "comp-aff-sugg", "comp-aff-count", 15, ["comp-aff-run"]);
+
+  // Subtabs
+  document.querySelectorAll(".lab-subtab[data-composer]").forEach(function (btn) {
+    btn.addEventListener("click", function () {
+      var target = btn.dataset.composer;
+      document.querySelectorAll(".lab-subtab[data-composer]").forEach(function (b) {
+        b.classList.toggle("active", b === btn);
+      });
+      document.querySelectorAll(".lab-subpanel[data-composer-panel]").forEach(function (p) {
+        p.style.display = p.dataset.composerPanel === target ? "" : "none";
+      });
+    });
+  });
+
+  // Lookalike seed dropdown — only signals whose id appears in the
+  // embedding store can be seeded (the backend returns SEED_NOT_EMBEDDED
+  // otherwise). We probe /ucp/projection for the canonical embedded set.
+  try {
+    var projRes = await fetch("/ucp/projection");
+    var projData = await projRes.json();
+    var embIds = new Set((projData.points || []).map(function (p) { return p.signal_id; }));
+    var seedSel = document.getElementById("comp-lal-seed");
+    if (seedSel) {
+      var opts = ['<option value="">— none —</option>'];
+      state.catalog.all.forEach(function (s) {
+        var sid = s.signal_agent_segment_id || (s.signal_id && s.signal_id.id);
+        if (!sid || !embIds.has(sid)) return;
+        opts.push('<option value="' + escapeHtml(sid) + '">' + escapeHtml(s.name) + '</option>');
+      });
+      seedSel.innerHTML = opts.join("");
+    }
+  } catch (e) { /* dropdown stays minimal on fetch failure */ }
+
+  document.getElementById("comp-run").addEventListener("click", runCompose);
+  document.getElementById("comp-sat-run").addEventListener("click", runSaturation);
+  document.getElementById("comp-aff-run").addEventListener("click", runAffinity);
+}
+
+// ── Set Builder run ─────────────────────────────────────────────────────
+function _ids(list) {
+  return (list || []).map(function (s) { return s.signal_agent_segment_id || (s.signal_id && s.signal_id.id); }).filter(Boolean);
+}
+
+async function runCompose() {
+  var host = document.getElementById("comp-results");
+  var include = _ids(state.composer.inc);
+  var intersect = _ids(state.composer.itx);
+  var exclude = _ids(state.composer.exc);
+  var seedEl = document.getElementById("comp-lal-seed");
+  var kEl = document.getElementById("comp-lal-k");
+  var minEl = document.getElementById("comp-lal-min");
+  var seed = seedEl ? seedEl.value : "";
+  var body = { include: include, intersect: intersect, exclude: exclude };
+  if (seed) body.lookalike = { seed_signal_id: seed, k: Number(kEl.value) || 8, min_cosine: Number(minEl.value) || 0 };
+  host.innerHTML = '<div class="empty-state"><span class="spinner"></span><div class="empty-title">Computing composition…</div></div>';
+  try {
+    var r = await fetch("/audience/compose", {
+      method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(body),
+    });
+    var data = await r.json();
+    if (!r.ok || data.error) throw new Error(data.error || "HTTP " + r.status);
+    state.composer.lastCompose = data;
+    renderComposeResult(data);
+  } catch (e) {
+    host.innerHTML = '<div class="empty-state" style="border-color:var(--error)"><div class="empty-title" style="color:var(--error)">' + escapeHtml(e.message) + '</div></div>';
+  }
+}
+
+function renderComposeResult(data) {
+  var host = document.getElementById("comp-results");
+  var r = data.reach || {};
+  var cards =
+    '<div class="composer-reach-cards">' +
+      '<div class="composer-reach-card"><div class="label">Union (∪)</div><div class="value">' + fmtNumber(r.union_only || 0) + '</div><div class="sub">include-only reach</div></div>' +
+      '<div class="composer-reach-card"><div class="label">After intersect (∩)</div><div class="value">' + fmtNumber(r.after_intersect || 0) + '</div><div class="sub">narrowed by must-match</div></div>' +
+      '<div class="composer-reach-card final"><div class="label">Final</div><div class="value">' + fmtNumber(r.final || 0) + '</div><div class="sub">after exclude (−)</div></div>' +
+    '</div>';
+  var confColor = data.confidence === "high" ? "var(--success)" : data.confidence === "medium" ? "var(--warning)" : "var(--text-mut)";
+  var meta =
+    '<div style="display:flex;gap:14px;flex-wrap:wrap;font-size:12px;color:var(--text-mut);margin-bottom:14px">' +
+      '<div>CPM: <span class="mono" style="color:var(--text)">$' + (data.estimated_cpm || 0).toFixed(2) + '</span></div>' +
+      '<div>Est. cost: <span class="mono" style="color:var(--text)">$' + fmtNumber(data.estimated_cost_usd || 0) + '</span></div>' +
+      '<div>Confidence: <span class="mono" style="color:' + confColor + '">' + escapeHtml(data.confidence || "—") + '</span></div>' +
+    '</div>';
+  var lal = "";
+  if (data.lookalike && data.lookalike.candidates && data.lookalike.candidates.length > 0) {
+    lal =
+      '<div class="lab-panel-title" style="margin-top:14px">Lookalike candidates (seed: ' + escapeHtml(data.lookalike.seed) + ')</div>' +
+      '<div class="composer-lal-list">' +
+        data.lookalike.candidates.map(function (c) {
+          return '<div class="composer-lal-item">' +
+            '<div><div>' + escapeHtml(c.name) + '</div>' +
+            '<div style="font-size:10.5px;color:var(--text-mut);font-family:var(--font-mono)">' +
+              fmtNumber(c.estimated_audience_size) +
+            '</div></div>' +
+            '<div style="display:flex;align-items:center;gap:10px">' +
+              '<span class="cos">' + c.cosine.toFixed(3) + '</span>' +
+              '<button class="add-btn" data-sid="' + escapeHtml(c.signal_agent_segment_id) + '">+ include</button>' +
+            '</div>' +
+          '</div>';
+        }).join("") +
+      '</div>';
+  }
+  host.innerHTML = cards + meta + lal;
+  host.querySelectorAll(".add-btn").forEach(function (b) {
+    b.addEventListener("click", function () {
+      var sid = b.dataset.sid;
+      var sig = state.catalog.all.find(function (x) {
+        return (x.signal_agent_segment_id || (x.signal_id && x.signal_id.id)) === sid;
+      });
+      if (!sig) return;
+      if (state.composer.inc.length >= 8) { showToast("Include pool is full (max 8).", true); return; }
+      if (_ids(state.composer.inc).indexOf(sid) >= 0) return;
+      state.composer.inc.push(sig);
+      compRenderChips("inc", "comp-inc-chips", "comp-inc-count", 8, "comp-inc-sugg", ["comp-run"]);
+      compRenderSugg("inc", "", "comp-inc-sugg", 8);
+      showToast("Added to Include pool.", false);
+    });
+  });
+  document.getElementById("comp-explainer").innerHTML = renderChartExplainer({
+    what: "Set-ops composition with embedding-based lookalike proposals.",
+    how: "Union uses pairwise inclusion-exclusion against a category-affinity Jaccard heuristic (0.55 within category, 0.20 across). Intersect decays the base by the pairwise overlap rate; exclude subtracts suppressed overlap. Lookalikes are embedding k-NN against the seed.",
+    read: "<strong>Union</strong> ≥ largest single signal, ≤ sum of reaches. <strong>Final</strong> = after the whole set-op chain. Lookalike candidates are proposals — they do NOT auto-add to the reach math, so numbers stay auditable.",
+    limits: "Catalog signals only expose estimated reach (not user-level membership); overlap is heuristic. For production deployments wire this to a clean-room with real membership data.",
+  });
+}
+
+// ── Saturation run ──────────────────────────────────────────────────────
+async function runSaturation() {
+  var host = document.getElementById("comp-sat-results");
+  var ids = _ids(state.composer.sat);
+  var body = { signal_ids: ids };
+  var budget = Number(document.getElementById("comp-sat-budget").value) || 0;
+  var reachOverride = Number(document.getElementById("comp-sat-reach").value) || 0;
+  if (budget > 0) body.budget_usd = budget;
+  if (reachOverride > 0) body.reach = reachOverride;
+  host.innerHTML = '<div class="empty-state"><span class="spinner"></span><div class="empty-title">Computing saturation…</div></div>';
+  try {
+    var r = await fetch("/audience/saturation", {
+      method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(body),
+    });
+    var data = await r.json();
+    if (!r.ok || data.error) throw new Error(data.error || "HTTP " + r.status);
+    state.composer.lastSat = data;
+    renderSaturationResult(data);
+  } catch (e) {
+    host.innerHTML = '<div class="empty-state" style="border-color:var(--error)"><div class="empty-title" style="color:var(--error)">' + escapeHtml(e.message) + '</div></div>';
+  }
+}
+
+function renderSaturationResult(data) {
+  var host = document.getElementById("comp-sat-results");
+  var curve = data.curve || [];
+  if (curve.length === 0) {
+    host.innerHTML = '<div class="empty-state"><div class="empty-title">Empty curve</div></div>';
+    return;
+  }
+  // SVG line chart — two series: unique_reach (filled area) + marginal_reach (dots).
+  var W = 640, H = 260, P = 40;
+  var maxR = 0, maxMarg = 0;
+  curve.forEach(function (c) {
+    if (c.unique_reach > maxR) maxR = c.unique_reach;
+    if (c.marginal_reach > maxMarg) maxMarg = c.marginal_reach;
+  });
+  var xScale = function (i) { return P + i * ((W - 2 * P) / Math.max(1, curve.length - 1)); };
+  var yScale = function (v) { return H - P - v / Math.max(1, maxR) * (H - 2 * P); };
+  var yScaleMarg = function (v) { return H - P - v / Math.max(1, maxMarg) * (H - 2 * P); };
+
+  var areaPts = "M " + P + " " + (H - P) + " ";
+  curve.forEach(function (c, i) { areaPts += "L " + xScale(i) + " " + yScale(c.unique_reach) + " "; });
+  areaPts += "L " + xScale(curve.length - 1) + " " + (H - P) + " Z";
+
+  var kneeIdx = data.knee_frequency != null
+    ? curve.findIndex(function (c) { return c.frequency === data.knee_frequency; })
+    : -1;
+
+  var svg = '<svg class="comp-sat-curve" viewBox="0 0 ' + W + ' ' + H + '" preserveAspectRatio="xMidYMid meet">' +
+    '<path d="' + areaPts + '" fill="rgba(79,142,255,0.18)" stroke="none"/>' +
+    '<path d="' + curve.map(function (c, i) { return (i === 0 ? "M " : "L ") + xScale(i) + " " + yScale(c.unique_reach); }).join(" ") +
+      '" fill="none" stroke="var(--accent)" stroke-width="1.8"/>';
+  curve.forEach(function (c, i) {
+    svg += '<circle cx="' + xScale(i) + '" cy="' + yScaleMarg(c.marginal_reach) + '" r="2.5" fill="var(--accent-hot)" opacity="0.7"/>';
+  });
+  if (kneeIdx >= 0) {
+    svg += '<line x1="' + xScale(kneeIdx) + '" y1="' + P + '" x2="' + xScale(kneeIdx) + '" y2="' + (H - P) + '" stroke="var(--warning)" stroke-width="1" stroke-dasharray="4,3"/>';
+    svg += '<text x="' + xScale(kneeIdx) + '" y="' + (P - 6) + '" text-anchor="middle" font-size="10" fill="var(--warning)">knee · F=' + data.knee_frequency + '</text>';
+  }
+  // Axis labels
+  curve.forEach(function (c, i) {
+    svg += '<text x="' + xScale(i) + '" y="' + (H - P + 14) + '" text-anchor="middle" font-size="9" fill="var(--text-mut)">' + c.frequency + '</text>';
+  });
+  svg += '<text x="' + (W / 2) + '" y="' + (H - 6) + '" text-anchor="middle" font-size="10" fill="var(--text-mut)">Frequency (avg exposures per user)</text>';
+  svg += '<text x="10" y="' + P + '" font-size="9" fill="var(--accent)">' + fmtNumber(maxR) + ' reach</text>';
+  svg += '<text x="10" y="' + (H - P) + '" font-size="9" fill="var(--text-mut)">0</text>';
+  svg += '</svg>';
+
+  var rows = curve.map(function (c) {
+    var cls = (data.knee_frequency === c.frequency) ? "knee" : "";
+    return '<tr class="' + cls + '">' +
+      '<td>' + c.frequency + '</td>' +
+      '<td>' + fmtNumber(c.unique_reach) + '</td>' +
+      '<td>' + (c.reach_fraction * 100).toFixed(1) + '%</td>' +
+      '<td>' + fmtNumber(c.marginal_reach) + '</td>' +
+      '<td>' + fmtNumber(c.impressions) + '</td>' +
+      '<td>$' + fmtNumber(c.cost_usd) + '</td>' +
+      '<td>$' + (c.cost_per_unique_reach_usd || 0).toFixed(4) + '</td>' +
+    '</tr>';
+  }).join("");
+  var table =
+    '<table class="comp-sat-table">' +
+      '<thead><tr><th>F</th><th>Unique reach</th><th>% pop</th><th>Marginal</th><th>Impressions</th><th>Cost</th><th>CP unique</th></tr></thead>' +
+      '<tbody>' + rows + '</tbody>' +
+    '</table>';
+  var meta =
+    '<div style="display:flex;gap:18px;flex-wrap:wrap;font-size:12px;color:var(--text-mut);margin-bottom:10px">' +
+      '<div>Population: <span class="mono" style="color:var(--text)">' + fmtNumber(data.reach_population || 0) + '</span></div>' +
+      '<div>CPM: <span class="mono" style="color:var(--text)">$' + (data.cpm || 0).toFixed(2) + '</span></div>' +
+      (data.knee_frequency != null ? '<div>Knee: <span class="mono" style="color:var(--warning)">F=' + data.knee_frequency + '</span></div>' : '') +
+      (data.affordable_frequency != null ? '<div>Affordable under budget: <span class="mono" style="color:var(--success)">F=' + data.affordable_frequency + '</span></div>' : '') +
+    '</div>';
+  host.innerHTML = meta + svg + table;
+  document.getElementById("comp-sat-explainer").innerHTML = renderChartExplainer({
+    what: "Frequency saturation curve under a Poisson exposure model.",
+    how: "<code>P(seen ≥ 1 | F) = 1 − exp(−F)</code>. At each sampled F, we compute unique reach, impressions, cost (impressions × CPM / 1000), and marginal reach vs the previous step. The knee is the first F where each +1 buys less than half the F=1 baseline gain.",
+    read: "<strong>Before the knee</strong> spend mostly buys new reach. <strong>After the knee</strong> spend mostly buys repeat exposures of users you've already hit. Use the affordable-F line to pick your cap.",
+    limits: "Assumes random-impression delivery. Real DSPs with frequency-cap optimizers reach the knee faster; this is an upper bound on diminishing returns.",
+  });
+}
+
+// ── Affinity audit run ──────────────────────────────────────────────────
+async function runAffinity() {
+  var host = document.getElementById("comp-aff-results");
+  var ids = _ids(state.composer.aff);
+  host.innerHTML = '<div class="empty-state"><span class="spinner"></span><div class="empty-title">Auditing affinity…</div></div>';
+  try {
+    var r = await fetch("/audience/affinity-audit", {
+      method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ signal_ids: ids }),
+    });
+    var data = await r.json();
+    if (!r.ok || data.error) throw new Error(data.error || "HTTP " + r.status);
+    state.composer.lastAff = data;
+    renderAffinityResult(data);
+  } catch (e) {
+    host.innerHTML = '<div class="empty-state" style="border-color:var(--error)"><div class="empty-title" style="color:var(--error)">' + escapeHtml(e.message) + '</div></div>';
+  }
+}
+
+function renderAffinityResult(data) {
+  var host = document.getElementById("comp-aff-results");
+  var summary = data.summary || {};
+  var facets = data.facets || [];
+
+  // Bars: centered at 100 (parity). Width proportional to |index − 100| / 500
+  // clamped to the half of the track (so index=200 fills 20%; index=600 caps).
+  function bar(row) {
+    var idx = row.index;
+    var isOver = idx > 100;
+    var delta = Math.min(500, Math.abs(idx - 100));
+    var widthPct = (delta / 500) * 50; // 0..50% of track width
+    var cls = idx >= 150 ? "heavy" : isOver ? "over" : "under";
+    var style = isOver
+      ? 'left:50%;width:' + widthPct + '%;'
+      : 'right:50%;width:' + widthPct + '%;';
+    return '<div class="comp-aff-row">' +
+      '<div class="comp-aff-key">' + escapeHtml(row.key) + '</div>' +
+      '<div class="comp-aff-bar-track">' +
+        '<div class="comp-aff-bar-fill ' + cls + '" style="' + style + '"></div>' +
+      '</div>' +
+      '<div class="comp-aff-index" style="color:' + (isOver ? 'var(--accent)' : 'var(--text-mut)') + '">' + idx + '</div>' +
+    '</div>';
+  }
+
+  var facetsHtml = facets.map(function (f) {
+    var rows = (f.rows || []).filter(function (r) { return r.selection_share > 0 || r.share > 0.02; }).slice(0, 10);
+    return '<div class="comp-aff-facet">' +
+      '<div class="comp-aff-facet-title">' + escapeHtml(f.facet) +
+        ' · skew ' + (summary.skew_scores ? summary.skew_scores[f.facet] : "—") +
+        ' · concentration ' + (summary.concentration ? summary.concentration[f.facet] : "—") +
+      '</div>' +
+      rows.map(bar).join("") +
+    '</div>';
+  }).join("");
+
+  var top =
+    '<div style="display:flex;gap:14px;flex-wrap:wrap;font-size:12px;color:var(--text-mut);margin-bottom:14px">' +
+      '<div>Selection: <span class="mono" style="color:var(--text)">' + (summary.selection_count || 0) + '</span> signals</div>' +
+      '<div>Catalog: <span class="mono" style="color:var(--text)">' + (summary.catalog_count || 0) + '</span> signals</div>' +
+    '</div>';
+  host.innerHTML = top + facetsHtml;
+  document.getElementById("comp-aff-explainer").innerHTML = renderChartExplainer({
+    what: "Reach-weighted affinity index vs the catalog baseline.",
+    how: "For each facet (category / vertical / geo band / data provider), share = sum(reach) in each bucket / sum(reach) overall. Index = 100 × (selection_share / baseline_share), capped at 600.",
+    read: "Bars extend RIGHT of the center line for <strong>over-indexed</strong> buckets (your selection is heavier there than the catalog is) and LEFT for under-indexed. Skew = mean |index − 100| across live rows; concentration = buckets needed to cover 80% of selection share.",
+    limits: "This is a meta-audit of your signal picks, not of the users those signals enroll. It tells you whether your portfolio is biased toward a vertical or provider — not whether the underlying users are.",
+  });
 }
 
 // ─── Federation (partial — more in Part 3) ───────────────────────────────

--- a/tests/audienceMath.test.ts
+++ b/tests/audienceMath.test.ts
@@ -1,0 +1,237 @@
+// tests/audienceMath.test.ts
+// Sec-43: pure-math tests for the audience composer helpers.
+
+import { describe, it, expect } from "vitest";
+import type { SignalSummary } from "../src/types/api";
+import {
+  verticalOf,
+  geoBand,
+  pairOverlap,
+  unionReach,
+  intersectReach,
+  excludeReach,
+  saturationCurve,
+  saturationKnee,
+  shareByKey,
+  affinityRows,
+  skewScore,
+  concentrationOf,
+} from "../src/analytics/audienceMath";
+
+// ── fixtures ────────────────────────────────────────────────────────────────
+
+function sig(over: Partial<SignalSummary> & { signal_agent_segment_id: string }): SignalSummary {
+  return {
+    signal_id: { source: "agent", agent_url: "https://x", id: over.signal_agent_segment_id },
+    signal_agent_segment_id: over.signal_agent_segment_id,
+    name: over.name ?? over.signal_agent_segment_id,
+    description: "",
+    signal_type: "marketplace",
+    data_provider: "test",
+    coverage_percentage: 1,
+    deployments: [],
+    pricing_options: [{ pricing_option_id: "p1", model: "cpm", cpm: 5, currency: "USD" }],
+    category_type: (over.category_type ?? "interest") as SignalSummary["category_type"],
+    taxonomy_system: "iab_audience_1_1",
+    generation_mode: "seeded",
+    estimated_audience_size: over.estimated_audience_size ?? 1_000_000,
+    status: "available",
+    ...over,
+  } as SignalSummary;
+}
+
+// ── classifiers ─────────────────────────────────────────────────────────────
+
+describe("verticalOf", () => {
+  it("recognizes B2B firmographic prefixes", () => {
+    expect(verticalOf("sig_b2b_firmo_software_5000")).toBe("b2b_firmo_techno");
+    expect(verticalOf("sig_b2b_techno_aws")).toBe("b2b_firmo_techno");
+  });
+  it("recognizes retail media + CTV + venue + weather variants", () => {
+    expect(verticalOf("sig_rmn_walmart_grocery")).toBe("retail_media_network");
+    expect(verticalOf("sig_ctv_hispanic_primetime")).toBe("ctv_hispanic_daypart");
+    expect(verticalOf("sig_venue_stadium_nfl")).toBe("venue_fenced");
+    expect(verticalOf("sig_weather_heatwave_ne")).toBe("weather_triggered");
+  });
+  it("falls back to other for unrecognized ids", () => {
+    expect(verticalOf("sig_unknown_thing")).toBe("other");
+  });
+});
+
+describe("geoBand", () => {
+  it("bands by reach", () => {
+    expect(geoBand(sig({ signal_agent_segment_id: "a", estimated_audience_size: 100_000_000 }))).toBe("national");
+    expect(geoBand(sig({ signal_agent_segment_id: "a", estimated_audience_size: 20_000_000 }))).toBe("multi_region");
+    expect(geoBand(sig({ signal_agent_segment_id: "a", estimated_audience_size: 2_000_000 }))).toBe("metro");
+    expect(geoBand(sig({ signal_agent_segment_id: "a", estimated_audience_size: 100_000 }))).toBe("local");
+  });
+});
+
+// ── pairOverlap ─────────────────────────────────────────────────────────────
+
+describe("pairOverlap", () => {
+  it("returns 0 when either reach is 0", () => {
+    const a = sig({ signal_agent_segment_id: "a", estimated_audience_size: 0 });
+    const b = sig({ signal_agent_segment_id: "b", estimated_audience_size: 1_000_000 });
+    expect(pairOverlap(a, b)).toBe(0);
+  });
+  it("uses higher affinity for matching category", () => {
+    const a = sig({ signal_agent_segment_id: "a", estimated_audience_size: 1_000_000, category_type: "interest" });
+    const b = sig({ signal_agent_segment_id: "b", estimated_audience_size: 1_000_000, category_type: "interest" });
+    const c = sig({ signal_agent_segment_id: "c", estimated_audience_size: 1_000_000, category_type: "demographic" });
+    expect(pairOverlap(a, b)).toBeGreaterThan(pairOverlap(a, c));
+  });
+  it("scales with min reach", () => {
+    const a = sig({ signal_agent_segment_id: "a", estimated_audience_size: 1_000_000, category_type: "interest" });
+    const small = sig({ signal_agent_segment_id: "b", estimated_audience_size: 100_000, category_type: "interest" });
+    const large = sig({ signal_agent_segment_id: "c", estimated_audience_size: 10_000_000, category_type: "interest" });
+    expect(pairOverlap(a, small)).toBeLessThan(pairOverlap(a, large));
+  });
+});
+
+// ── set ops ─────────────────────────────────────────────────────────────────
+
+describe("unionReach", () => {
+  it("returns 0 for empty input", () => {
+    expect(unionReach([])).toBe(0);
+  });
+  it("returns single signal reach for length 1", () => {
+    const a = sig({ signal_agent_segment_id: "a", estimated_audience_size: 750_000 });
+    expect(unionReach([a])).toBe(750_000);
+  });
+  it("union of two signals is between max(reach) and sum(reach)", () => {
+    const a = sig({ signal_agent_segment_id: "a", estimated_audience_size: 1_000_000, category_type: "interest" });
+    const b = sig({ signal_agent_segment_id: "b", estimated_audience_size: 1_000_000, category_type: "interest" });
+    const u = unionReach([a, b]);
+    expect(u).toBeGreaterThanOrEqual(1_000_000);
+    expect(u).toBeLessThanOrEqual(2_000_000);
+  });
+  it("union grows monotonically with added signals", () => {
+    const a = sig({ signal_agent_segment_id: "a", estimated_audience_size: 1_000_000 });
+    const b = sig({ signal_agent_segment_id: "b", estimated_audience_size: 800_000 });
+    const c = sig({ signal_agent_segment_id: "c", estimated_audience_size: 600_000 });
+    expect(unionReach([a])).toBeLessThanOrEqual(unionReach([a, b]));
+    expect(unionReach([a, b])).toBeLessThanOrEqual(unionReach([a, b, c]));
+  });
+});
+
+describe("intersectReach", () => {
+  it("returns base unchanged when fold is empty", () => {
+    expect(intersectReach(500_000, null, [])).toBe(500_000);
+  });
+  it("intersection ≤ base", () => {
+    const tpl = sig({ signal_agent_segment_id: "a", estimated_audience_size: 1_000_000, category_type: "interest" });
+    const next = sig({ signal_agent_segment_id: "b", estimated_audience_size: 1_000_000, category_type: "interest" });
+    expect(intersectReach(1_000_000, tpl, [next])).toBeLessThanOrEqual(1_000_000);
+  });
+});
+
+describe("excludeReach", () => {
+  it("returns base when nothing to exclude", () => {
+    expect(excludeReach(500_000, [], [])).toBe(500_000);
+  });
+  it("exclusion ≤ base, never negative", () => {
+    const a = sig({ signal_agent_segment_id: "a", estimated_audience_size: 1_000_000, category_type: "interest" });
+    const huge = sig({ signal_agent_segment_id: "huge", estimated_audience_size: 100_000_000, category_type: "interest" });
+    const r = excludeReach(1_000_000, [a], [huge]);
+    expect(r).toBeGreaterThanOrEqual(0);
+    expect(r).toBeLessThanOrEqual(1_000_000);
+  });
+});
+
+// ── saturation ──────────────────────────────────────────────────────────────
+
+describe("saturationCurve", () => {
+  it("F=1 reaches ≈63% under Poisson", () => {
+    const c = saturationCurve(1_000_000, 5, [1]);
+    expect(c[0]!.reach_fraction).toBeCloseTo(1 - Math.exp(-1), 4);
+    expect(c[0]!.unique_reach).toBeGreaterThan(620_000);
+    expect(c[0]!.unique_reach).toBeLessThan(640_000);
+  });
+  it("unique_reach is monotonically non-decreasing as F grows", () => {
+    const c = saturationCurve(1_000_000, 5, [1, 2, 3, 5, 10]);
+    for (let i = 1; i < c.length; i++) {
+      expect(c[i]!.unique_reach).toBeGreaterThanOrEqual(c[i - 1]!.unique_reach);
+    }
+  });
+  it("marginal_reach is non-increasing (diminishing returns)", () => {
+    const c = saturationCurve(1_000_000, 5, [1, 2, 3, 4, 5]);
+    for (let i = 1; i < c.length; i++) {
+      expect(c[i]!.marginal_reach).toBeLessThanOrEqual(c[i - 1]!.marginal_reach + 1);
+    }
+  });
+  it("cost = impressions × cpm / 1000", () => {
+    const c = saturationCurve(1_000_000, 10, [3]);
+    expect(c[0]!.cost_usd).toBeCloseTo((1_000_000 * 3) * 10 / 1000, 2);
+  });
+});
+
+describe("saturationKnee", () => {
+  it("returns a frequency past F=1 for a sensible curve", () => {
+    const c = saturationCurve(1_000_000, 5, [1, 2, 3, 4, 5, 6, 7, 8, 10, 15]);
+    const knee = saturationKnee(c);
+    expect(knee).not.toBeNull();
+    expect(knee).toBeGreaterThan(1);
+  });
+  it("returns null when only F=1 sampled", () => {
+    expect(saturationKnee(saturationCurve(1_000_000, 5, [1]))).toBeNull();
+  });
+});
+
+// ── affinity / share ───────────────────────────────────────────────────────
+
+describe("shareByKey", () => {
+  it("sums to 1.0 when at least one row has non-zero reach", () => {
+    const rows = [
+      sig({ signal_agent_segment_id: "a", estimated_audience_size: 1_000_000, category_type: "interest" }),
+      sig({ signal_agent_segment_id: "b", estimated_audience_size: 3_000_000, category_type: "demographic" }),
+    ];
+    const m = shareByKey(rows, (s) => s.category_type);
+    const sum = [...m.values()].reduce((s, v) => s + v, 0);
+    expect(sum).toBeCloseTo(1, 4);
+  });
+});
+
+describe("affinityRows", () => {
+  it("computes index 100 at parity, 200 at 2x over-rep", () => {
+    const baseline = new Map([["a", 0.5], ["b", 0.5]]);
+    const sel = new Map([["a", 1.0], ["b", 0.0]]);
+    const rows = affinityRows(baseline, sel);
+    const a = rows.find((r) => r.key === "a")!;
+    const b = rows.find((r) => r.key === "b")!;
+    expect(a.index).toBe(200);
+    expect(b.index).toBe(0);
+  });
+  it("caps index at 600 for tiny baselines", () => {
+    const baseline = new Map([["a", 0.001]]);
+    const sel = new Map([["a", 1.0]]);
+    const rows = affinityRows(baseline, sel);
+    expect(rows[0]!.index).toBe(600);
+  });
+});
+
+describe("skewScore", () => {
+  it("0 when all rows are at parity", () => {
+    const rows = affinityRows(new Map([["a", 0.5], ["b", 0.5]]), new Map([["a", 0.5], ["b", 0.5]]));
+    expect(skewScore(rows)).toBe(0);
+  });
+  it("higher when selection diverges from baseline", () => {
+    const flat = affinityRows(new Map([["a", 0.5], ["b", 0.5]]), new Map([["a", 0.5], ["b", 0.5]]));
+    const skewed = affinityRows(new Map([["a", 0.5], ["b", 0.5]]), new Map([["a", 1.0], ["b", 0.0]]));
+    expect(skewScore(skewed)).toBeGreaterThan(skewScore(flat));
+  });
+});
+
+describe("concentrationOf", () => {
+  it("returns 1 when one bucket holds ≥80%", () => {
+    const rows = affinityRows(new Map([["a", 1.0]]), new Map([["a", 1.0]]));
+    expect(concentrationOf(rows)).toBe(1);
+  });
+  it("returns multiple when share is spread", () => {
+    const rows = affinityRows(
+      new Map([["a", 0.25], ["b", 0.25], ["c", 0.25], ["d", 0.25]]),
+      new Map([["a", 0.25], ["b", 0.25], ["c", 0.25], ["d", 0.25]]),
+    );
+    expect(concentrationOf(rows)).toBeGreaterThanOrEqual(3);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a composition + activation-planning surface on top of the GA 3.0 analytics stack. Two commits — backend first, UI second — so the slices can land / revert independently.

| Commit | Scope |
|---|---|
| `401c442` | Part 1 — three public endpoints + pure-math module + 28 unit tests |
| `fc3420e` | Part 2 — new Composer tab in `demo.ts` talking to those endpoints |

Addresses these buckets from the audience use-case brief: *Core Segmentation* (rule-based + exclusion), *Lookalike / similarity modeling*, *Frequency saturation curves*, *Diminishing returns modeling*, *Affinity index*, *Bias detection*, *Audience portfolio gap analysis*.

## Backend endpoints (part 1)

All public, read-only, JSON. Math is pure + in `src/analytics/audienceMath.ts` — no I/O, testable.

- **`POST /audience/compose`** — set ops (∪, ∩, −) over signal ids with optional embedding-based lookalike candidate proposals. Reuses the category-affinity Jaccard heuristic from `portfolioOptimizer` so reach math stays consistent with `/portfolio/*` and `/signals/overlap`. Returns `reach.{union_only, after_intersect, final}`, estimated CPM/cost, confidence pill.
- **`POST /audience/saturation`** — Poisson exposure model `P(seen ≥ 1 | F) = 1 − exp(−F)` over a composed audience or raw reach. Returns the per-frequency curve, knee point (first F where marginal reach drops below 50% of F=1 baseline), and affordable-F cap when a budget is supplied.
- **`POST /audience/affinity-audit`** — reach-weighted over/under-index across category × vertical × geo_band × data_provider, vs catalog baseline. Index 100 = parity, capped at 600. Per-facet skew score + concentration summary.

Wired into:
- `src/index.ts` publicPaths + dispatch
- `src/domain/capabilityService.ts` `ext.ucp.analytics.endpoints` (so buyer agents discover the new surface area via `/capabilities`)
- `src/routes/analyticsEndpoints.ts` `/analytics/summary` advertising

OpenAPI intentionally not updated — matches the existing convention where `/portfolio/*` and `/analytics/*` are discovered via `/capabilities` + `/analytics/summary` rather than per-endpoint OpenAPI registration.

## UI (part 2)

New "Composer" sidebar entry (Workspace group, `new` tag), crumb-wired, with three sub-panels driven by the part-1 endpoints.

- **Set Builder** → `POST /audience/compose`
  Three parallel pickers (Include max 8, Intersect max 4, Exclude max 4) + optional lookalike seed row (seed / top-K / min-cosine). Result panel renders three reach cards (union → afterIntersect → final), CPM + est-cost + confidence strip, and lookalike candidates with one-click "+ include" promotion. Candidates are *proposed*, never auto-added, so the reach math stays auditable.
- **Frequency Saturation** → `POST /audience/saturation`
  Picker (max 10) + optional budget + reach override. SVG line chart with unique reach area + marginal reach dots + knee marker; per-F table with impressions / cost / cost-per-unique-reach, knee row highlighted; affordable-F callout when the budget fits.
- **Affinity Audit** → `POST /audience/affinity-audit`
  Picker (max 15) → centered-at-100 horizontal bars across four facets. Bars extend right for over-index, left for under-index, with per-facet skew + concentration summaries.

Five pickers share one generic `wireCompPicker` helper. State lives under `state.composer.{inc,itx,exc,sat,aff,lastCompose,lastSat,lastAff}`. Lookalike seed dropdown is pre-filtered to embedded signals (pulled from `/ucp/projection`) so the UI never offers a seed the backend would reject with `SEED_NOT_EMBEDDED`. Every render ships a `renderChartExplainer` block (what / how / read / limits) matching the Embedding Lab + Portfolio conventions.

## Test plan

- [x] `npx tsc --noEmit` — 0 new errors (80 → 80 pre-existing test-file errors unchanged)
- [x] `npx vitest run` — 339 passed / 12 skipped, no regressions
- [x] 28 new unit tests (`tests/audienceMath.test.ts`) cover monotonicity of union reach, Poisson F=1 ≈ 63%, knee detection, parity index (100), 2× over-index (200), 600 cap on tiny baselines, concentration
- [ ] Manual smoke: preview deploy → open `/`, click **Composer**, pick 2-3 signals in each picker, hit run on all three sub-panels
- [ ] curl the endpoints on the preview URL:
  ```
  curl -X POST $URL/audience/compose       -d '{"include":["sig_..."]}'       -H 'content-type: application/json'
  curl -X POST $URL/audience/saturation    -d '{"signal_ids":["sig_..."],"budget_usd":50000}' -H 'content-type: application/json'
  curl -X POST $URL/audience/affinity-audit -d '{"signal_ids":["sig_..."]}' -H 'content-type: application/json'
  ```
- [ ] Verify `/capabilities` now lists `audience_compose` / `audience_saturation` / `audience_affinity_audit` under `ext.ucp.analytics.endpoints`
