### PR TITLE
Sec-46: cumulative Journey mode + pre-clamp reach + clamp warning

### DIFF
--- a/src/analytics/audienceMath.ts
+++ b/src/analytics/audienceMath.ts
@@ -234,6 +234,7 @@ export interface JourneyStageInput {
 export interface JourneyStageOut {
   name: string;
   reach: number;
+  pre_clamp_reach: number;   // Sec-46: reach before monotone clamp (= reach when not clamped)
   conversion_rate: number;   // vs previous stage; 1.0 for stage 0
   cumulative_rate: number;   // vs stage 0; 1.0 for stage 0
   dropped_off: number;       // reach[i-1] - reach[i], 0 for stage 0
@@ -246,7 +247,8 @@ export function journeyFunnel(stages: JourneyStageInput[]): JourneyStageOut[] {
   const base = prev;
   for (let i = 0; i < stages.length; i++) {
     const st = stages[i]!;
-    let r = st.reach;
+    const raw = st.reach;
+    let r = raw;
     let clamped = false;
     if (i > 0 && r > prev) { r = prev; clamped = true; }
     const conv = i === 0 ? 1 : (prev > 0 ? r / prev : 0);
@@ -254,6 +256,7 @@ export function journeyFunnel(stages: JourneyStageInput[]): JourneyStageOut[] {
     out.push({
       name: st.name,
       reach: r,
+      pre_clamp_reach: raw,
       conversion_rate: Math.round(conv * 10000) / 10000,
       cumulative_rate: Math.round(cum * 10000) / 10000,
       dropped_off: i === 0 ? 0 : Math.max(0, prev - r),

--- a/src/routes/audienceAnalytics.ts
+++ b/src/routes/audienceAnalytics.ts
@@ -363,6 +363,7 @@ interface JourneyStageBody {
 
 interface JourneyBody {
   stages?: JourneyStageBody[];
+  cumulative?: boolean;   // Sec-46: default true — each stage is a subset of the prior
 }
 
 export async function handleAudienceJourney(request: Request, env: Env, logger: Logger): Promise<Response> {
@@ -370,6 +371,10 @@ export async function handleAudienceJourney(request: Request, env: Env, logger: 
   if (parsed.kind === "invalid") return errorResponse("INVALID_JSON", parsed.reason, 400);
   const body: JourneyBody = parsed.kind === "parsed" ? parsed.data : {};
   const stages = body.stages ?? [];
+  // Sec-46: cumulative mode (default) makes each stage a subset of the prior stage by
+  // folding the prior stage's signals into the current stage's intersect pool. Opt-out
+  // (`cumulative:false`) preserves the legacy "independent stages + monotone clamp" math.
+  const cumulative = body.cumulative !== false;
   if (stages.length < 2) return errorResponse("INVALID_INPUT", "At least 2 stages required", 400);
   if (stages.length > 6) return errorResponse("TOO_MANY_STAGES", `Max 6 stages; got ${stages.length}`, 400);
 
@@ -377,14 +382,22 @@ export async function handleAudienceJourney(request: Request, env: Env, logger: 
   const byId = indexById(catalog);
 
   const stageReaches: { name: string; reach: number; includeCount: number; intersectCount: number; excludeCount: number }[] = [];
+  const priorFilterPool: SignalSummary[] = [];  // cumulative-mode accumulator
   for (let i = 0; i < stages.length; i++) {
     const st = stages[i]!;
     const inc = (st.include ?? []).map((id) => byId.get(id)).filter((x): x is SignalSummary => !!x);
-    const itx = (st.intersect ?? []).map((id) => byId.get(id)).filter((x): x is SignalSummary => !!x);
+    const itxRaw = (st.intersect ?? []).map((id) => byId.get(id)).filter((x): x is SignalSummary => !!x);
     const exc = (st.exclude ?? []).map((id) => byId.get(id)).filter((x): x is SignalSummary => !!x);
-    if (inc.length === 0 && itx.length === 0) {
+    if (inc.length === 0 && itxRaw.length === 0) {
       return errorResponse("INVALID_STAGE", `Stage ${i} (${st.name ?? "unnamed"}) needs at least one include or intersect signal`, 400);
     }
+    // Cumulative mode: prior stages' signals become implicit intersects on this stage,
+    // which geometrically narrows reach (inclusion-exclusion monotone). We dedupe against
+    // the current stage's raw itx to avoid double-counting.
+    const seenItxIds = new Set(itxRaw.map((s) => s.signal_agent_segment_id));
+    const itx = cumulative && i > 0
+      ? [...itxRaw, ...priorFilterPool.filter((s) => !seenItxIds.has(s.signal_agent_segment_id))]
+      : itxRaw;
     const baseSet = inc.length > 0 ? inc : itx;
     const unionR = unionReach(inc);
     const intersectBase = unionR > 0 ? unionR : (itx[0]?.estimated_audience_size ?? 0);
@@ -395,12 +408,16 @@ export async function handleAudienceJourney(request: Request, env: Env, logger: 
       name: st.name ?? `stage_${i + 1}`,
       reach: finalR,
       includeCount: inc.length,
-      intersectCount: itx.length,
+      intersectCount: itxRaw.length,   // surface user-declared count, not cumulative-augmented
       excludeCount: exc.length,
     });
+    // Accumulate this stage's own signals for downstream stages.
+    for (const s of inc) priorFilterPool.push(s);
+    for (const s of itxRaw) priorFilterPool.push(s);
   }
 
   const funnel = journeyFunnel(stageReaches.map((s) => ({ name: s.name, reach: s.reach })));
+  const anyClamped = funnel.some((f) => f.clamped);
 
   return jsonResponse({
     stages: funnel.map((f, i) => ({
@@ -416,9 +433,15 @@ export async function handleAudienceJourney(request: Request, env: Env, logger: 
       biggest_dropoff_stage: funnel
         .map((f, i) => ({ i, name: f.name, dropped: f.dropped_off }))
         .sort((a, b) => b.dropped - a.dropped)[0]?.name ?? null,
+      any_clamped: anyClamped,
     },
-    method: "per_stage_compose_then_monotone_funnel",
-    note: "Stage reaches are clamped to be monotonically non-increasing (a subsequent stage can't exceed its predecessor). A `clamped:true` flag signals that the input breached the subset invariant.",
+    mode: cumulative ? "cumulative" : "independent",
+    method: cumulative
+      ? "prior_stage_signals_folded_as_intersects_then_monotone_safety_clamp"
+      : "per_stage_compose_then_monotone_funnel",
+    note: cumulative
+      ? "Cumulative mode (default): each stage is constructed as a subset of the prior stage — upstream signals are automatically folded into the current stage's intersect pool. Clamping should be rare and indicates a non-monotone heuristic edge case. Set `cumulative:false` to get independent per-stage sizing with after-the-fact monotone clamping (the legacy behavior)."
+      : "Independent-stage mode: each stage is sized on its own, then reaches are clamped to be monotonically non-increasing. A `clamped:true` flag signals that the stage's raw composition breached the subset invariant — planners should treat any clamp as a configuration error (the stage is broader than its parent), not a genuine funnel.",
   });
 }
 

--- a/src/routes/demo.ts
+++ b/src/routes/demo.ts
@@ -1005,7 +1005,7 @@ ${STYLES}
         <div class="pane-header">
           <div>
             <h1 class="pane-title">Journey Builder</h1>
-            <p class="pane-subtitle">Stack 2–5 audience stages (awareness → consideration → intent → conversion) and see per-stage reach, conversion rate vs the prior stage, cumulative rate vs top-of-funnel, and drop-off. Reach math reuses <code>/audience/compose</code> per stage; stages are clamped monotonically to preserve the subset invariant.</p>
+            <p class="pane-subtitle">Stack 2–6 audience stages (awareness → consideration → intent → conversion) and see per-stage reach, conversion rate vs the prior stage, cumulative rate vs top-of-funnel, and drop-off. <strong>Cumulative mode</strong> (default) makes each stage a subset of the prior by folding upstream signals in as implicit intersects — the mathematically correct funnel interpretation. <strong>Independent mode</strong> sizes each stage on its own and clamps after the fact — use when stages are sized from separate data sources.</p>
           </div>
           <div class="activations-controls">
             <button class="btn-secondary" id="journey-add">
@@ -1015,6 +1015,14 @@ ${STYLES}
               <svg class="ico"><use href="#icon-activations"/></svg><span>Compute funnel</span>
             </button>
           </div>
+        </div>
+        <div class="journey-mode-row">
+          <span class="journey-mode-label">Mode</span>
+          <div class="journey-mode-switch" role="tablist">
+            <button class="journey-mode-btn active" data-mode="cumulative" role="tab" aria-selected="true">Cumulative (subset)</button>
+            <button class="journey-mode-btn" data-mode="independent" role="tab" aria-selected="false">Independent (legacy)</button>
+          </div>
+          <span class="journey-mode-hint" id="journey-mode-hint">Each stage is a subset of the prior — upstream signals fold in as implicit intersects.</span>
         </div>
         <div id="journey-stages"></div>
         <div class="lab-panel lab-panel-full" style="margin-top:14px">
@@ -1687,6 +1695,7 @@ svg.ico path, svg.ico circle, svg.ico rect, svg.ico line { vector-effect: non-sc
 }
 .pill-success { background: var(--success-dim); color: var(--success); }
 .pill-warning { background: var(--warning-dim); color: var(--warning); }
+.pill-error   { background: rgba(255, 92, 92, 0.18); color: var(--error); }
 .pill-accent  { background: var(--accent-dim);  color: var(--accent); }
 .pill-muted   { background: var(--bg-raised);   color: var(--text-dim); border: 1px solid var(--border); }
 
@@ -3843,6 +3852,37 @@ textarea.lab-input { resize: vertical; line-height: 1.5; }
 .holdout-stats .k { font-size: 10.5px; color: var(--text-mut); text-transform: uppercase; letter-spacing: 0.04em; }
 .holdout-stats .v { font-size: 15px; margin-top: 2px; }
 
+/* ── Sec-46: Journey mode switch + clamp surfacing ─────────────────────── */
+.journey-mode-row {
+  display: flex; align-items: center; gap: 12px; flex-wrap: wrap;
+  margin: 0 0 16px 0; padding: 10px 12px;
+  background: var(--bg-surface); border: 1px solid var(--border); border-radius: 6px;
+}
+.journey-mode-label { font-size: 10.5px; text-transform: uppercase; letter-spacing: 0.04em; color: var(--text-mut); }
+.journey-mode-switch { display: inline-flex; background: var(--bg-soft, var(--bg-base)); border: 1px solid var(--border); border-radius: 5px; overflow: hidden; }
+.journey-mode-btn {
+  background: transparent; border: none; color: var(--text-mut);
+  padding: 6px 12px; font-size: 12px; cursor: pointer; font-family: inherit;
+}
+.journey-mode-btn.active { background: var(--accent); color: var(--bg-base); }
+.journey-mode-btn:not(.active):hover { color: var(--text); background: var(--bg-hover, var(--bg-surface)); }
+.journey-mode-hint { font-size: 11px; color: var(--text-mut); flex: 1; min-width: 200px; }
+.journey-warning-banner {
+  display: flex; gap: 12px; align-items: flex-start;
+  background: rgba(255, 92, 92, 0.08); border: 1px solid var(--error); border-left: 3px solid var(--error);
+  border-radius: 6px; padding: 10px 12px; margin-bottom: 14px;
+}
+.journey-warning-icon {
+  width: 20px; height: 20px; border-radius: 50%; background: var(--error); color: var(--bg-base);
+  display: flex; align-items: center; justify-content: center; font-size: 12px; font-weight: 700;
+  flex-shrink: 0;
+}
+.journey-warning-title { font-size: 12.5px; font-weight: 600; margin-bottom: 4px; color: var(--error); }
+.journey-warning-detail { font-size: 11.5px; line-height: 1.55; color: var(--text); }
+.journey-row-clamped { border-color: var(--error); }
+.journey-row-preclamp { color: var(--error); font-family: var(--font-mono); }
+.journey-row-preclamp-wrap { display: inline; }
+
 /* ── Sec-45: Journey Builder ───────────────────────────────────────────── */
 .journey-stage {
   background: var(--bg-surface); border: 1px solid var(--border);
@@ -4035,7 +4075,7 @@ const state = {
   },
   // Sec-44: Journey builder. Dynamic stage list; each stage has its own
   // include/intersect/exclude pool arrays.
-  journey: { stages: [], lastResult: null, loaded: false },
+  journey: { stages: [], lastResult: null, loaded: false, cumulative: true },
   // Sec-44: Scenario Planner — current / add / remove pools.
   planner: { cur: [], add: [], rem: [], lastResult: null, loaded: false },
   // Sec-44: Snapshots — fetched index + diff selection.
@@ -9260,6 +9300,22 @@ function ensureJourney() {
     _journeyRenderStages();
     _journeyRefreshRunBtn();
   });
+  // Sec-46: mode toggle (cumulative vs independent)
+  document.querySelectorAll(".journey-mode-btn").forEach(function (btn) {
+    btn.addEventListener("click", function () {
+      var mode = btn.dataset.mode;
+      state.journey.cumulative = mode === "cumulative";
+      document.querySelectorAll(".journey-mode-btn").forEach(function (b) {
+        var active = b === btn;
+        b.classList.toggle("active", active);
+        b.setAttribute("aria-selected", active ? "true" : "false");
+      });
+      var hint = document.getElementById("journey-mode-hint");
+      if (hint) hint.textContent = state.journey.cumulative
+        ? "Each stage is a subset of the prior — upstream signals fold in as implicit intersects."
+        : "Each stage is sized independently, then clamped monotonically. Use when stages come from separate data sources.";
+    });
+  });
   document.getElementById("journey-run").addEventListener("click", runJourney);
   _journeyRefreshRunBtn();
 }
@@ -9433,7 +9489,7 @@ async function runJourney() {
   try {
     var r = await fetch("/audience/journey", {
       method: "POST", headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ stages: stages }),
+      body: JSON.stringify({ stages: stages, cumulative: !!state.journey.cumulative }),
     });
     var data = await r.json();
     if (!r.ok || data.error) throw new Error(data.error || "HTTP " + r.status);
@@ -9449,12 +9505,17 @@ function _renderJourneyResult(data) {
   var stages = data.stages || [];
   if (stages.length === 0) { host.innerHTML = '<div class="empty-state"><div class="empty-title">Empty funnel</div></div>'; return; }
   var top = stages[0].reach || 0;
+  var mode = data.mode || "independent";
   var rows = stages.map(function (s, i) {
     var pct = top > 0 ? (s.reach / top) * 100 : 0;
     var convPrior = i === 0 ? null : (s.conversion_rate != null ? s.conversion_rate : null);
     var cumPct = (s.cumulative_rate != null ? s.cumulative_rate * 100 : pct);
-    var clampedMark = s.clamped ? ' <span class="pill pill-warning mono" style="font-size:10px">clamped</span>' : '';
-    return '<div class="journey-row">' +
+    var clampedMark = s.clamped ? ' <span class="pill pill-error mono" style="font-size:10px" title="Stage broader than its parent — clamped down. In cumulative mode this should never happen; in independent mode it means your stages aren\\'t a valid funnel.">clamped</span>' : '';
+    // Sec-46: when clamp happened, show both the pre-clamp (natively computed) reach and the clamped value.
+    var preClampLine = (s.clamped && s.pre_clamp_reach != null && s.pre_clamp_reach > s.reach)
+      ? '<span class="journey-row-preclamp">natively ' + fmtNumber(s.pre_clamp_reach) + ' · clamped to ' + fmtNumber(s.reach) + '</span>'
+      : '';
+    return '<div class="journey-row' + (s.clamped ? ' journey-row-clamped' : '') + '">' +
       '<div class="journey-row-head">' +
         '<span class="journey-row-name">' + escapeHtml(s.name || ("Stage " + (i + 1))) + clampedMark + '</span>' +
         '<span class="journey-row-reach mono">' + fmtNumber(s.reach || 0) + '</span>' +
@@ -9464,23 +9525,47 @@ function _renderJourneyResult(data) {
         '<span>' + cumPct.toFixed(1) + '% of top-of-funnel</span>' +
         (convPrior != null ? '<span>· ' + (convPrior * 100).toFixed(1) + '% vs prior</span>' : '<span>· top</span>') +
         (s.dropped_off != null && i > 0 ? '<span>· dropped ' + fmtNumber(s.dropped_off) + '</span>' : '') +
+        (preClampLine ? '<span class="journey-row-preclamp-wrap">· ' + preClampLine + '</span>' : '') +
       '</div>' +
     '</div>';
   }).join("");
   var overall = data.overall || {};
+  var modePill = '<span class="pill ' + (mode === "cumulative" ? "pill-success" : "pill-muted") + ' mono" style="font-size:10px;margin-left:8px">' + escapeHtml(mode) + '</span>';
   var summary =
     '<div class="journey-summary">' +
+      '<div><div class="k">Mode</div><div class="v">' + escapeHtml(mode) + '</div></div>' +
       '<div><div class="k">Top</div><div class="v mono">' + fmtNumber(overall.top_of_funnel || 0) + '</div></div>' +
       '<div><div class="k">Bottom</div><div class="v mono">' + fmtNumber(overall.bottom_of_funnel || 0) + '</div></div>' +
       '<div><div class="k">End-to-end</div><div class="v mono">' + ((overall.end_to_end_conversion || 0) * 100).toFixed(1) + '%</div></div>' +
       (overall.biggest_dropoff_stage ? '<div><div class="k">Biggest drop</div><div class="v">' + escapeHtml(overall.biggest_dropoff_stage) + '</div></div>' : '') +
     '</div>';
-  host.innerHTML = summary + '<div class="journey-funnel">' + rows + '</div>';
+  // Sec-46: surface a clear warning banner when ANY stage was clamped. In cumulative
+  // mode this is rare and points to a heuristic edge case; in independent mode it
+  // means the stages aren't actually a funnel (a later stage was broader than its
+  // parent) and the user should fix their composition, not trust the conversion
+  // numbers below (which read as 100% + 0 dropped after clamp — misleading).
+  var clampedStages = stages.filter(function (s) { return s.clamped; }).map(function (s) { return s.name; });
+  var warningBanner = "";
+  if (clampedStages.length > 0) {
+    warningBanner =
+      '<div class="journey-warning-banner">' +
+        '<div class="journey-warning-icon">!</div>' +
+        '<div class="journey-warning-body">' +
+          '<div class="journey-warning-title">' + clampedStages.length + ' stage' + (clampedStages.length === 1 ? '' : 's') + ' clamped: ' + escapeHtml(clampedStages.join(", ")) + '</div>' +
+          '<div class="journey-warning-detail">' +
+            (mode === "cumulative"
+              ? 'Cumulative mode should normally prevent this; heuristic edge case. Conversion + drop-off metrics on clamped stages read as 100% / 0 — ignore them.'
+              : 'Each clamped stage was <strong>broader than its parent</strong>, so it was capped. Conversion + drop-off metrics on clamped stages read as 100% / 0 — ignore them. Either fix the composition (later stages should narrow, not broaden) or switch to <strong>Cumulative</strong> mode to make subset-of-parent an enforced invariant.') +
+          '</div>' +
+        '</div>' +
+      '</div>';
+  }
+  host.innerHTML = warningBanner + summary + '<div class="journey-funnel">' + rows + '</div>';
   document.getElementById("journey-explainer").innerHTML = renderChartExplainer({
     what: "Stacked per-stage segmentation with a monotone reach funnel.",
-    how: "Each stage's reach is computed exactly like /audience/compose (inclusion-exclusion for union, Jaccard-decayed intersect, subtracted overlap for exclude). Stages are clamped so a later stage can never exceed its predecessor — a <code>clamped</code> flag surfaces when the input breached the subset invariant.",
-    read: "Bars show each stage's reach as a share of top-of-funnel. The % vs prior value is the conversion rate between consecutive stages; cumulative % is vs stage 1.",
-    limits: "Reach math is estimated (catalog-level, not user-level); treat the funnel as a planning sketch, not a production attribution chain.",
+    how: "<strong>Cumulative mode (default):</strong> each stage's signals are intersected with the union of upstream-stage signals, so stage <code>i</code> is automatically a subset of stage <code>i−1</code>. <strong>Independent mode:</strong> each stage is sized on its own via <code>/audience/compose</code>, then reaches are clamped to be monotonically non-increasing after the fact. Reach math: inclusion-exclusion for union, Jaccard-decayed intersect, subtracted overlap for exclude.",
+    read: "Bars show each stage's reach as a share of top-of-funnel. % vs prior is the conversion rate between consecutive stages; cumulative % is vs stage 1. A red <code>clamped</code> pill marks stages whose native reach exceeded the parent's — in independent mode that's almost always a configuration error.",
+    limits: "Reach math is estimated (catalog-level, not user-level); treat the funnel as a planning sketch, not a production attribution chain. Clamped stages' conversion and drop-off metrics are meaningless after clamp — look at pre-clamp reach to understand what the stage actually described.",
   });
 }
 

--- a/tests/audienceMath.test.ts
+++ b/tests/audienceMath.test.ts
@@ -254,6 +254,20 @@ describe("journeyFunnel", () => {
     expect(f[1]!.reach).toBe(500_000);
     expect(f[1]!.conversion_rate).toBe(1);
   });
+  // Sec-46: pre_clamp_reach surfaces the raw (pre-clamp) reach so the UI can explain
+  // why a clamped stage reads as "100% conversion, 0 dropped".
+  it("preserves the pre-clamp reach for surfacing in the UI", () => {
+    const f = journeyFunnel([{ name: "a", reach: 500_000 }, { name: "b", reach: 1_000_000 }]);
+    expect(f[1]!.clamped).toBe(true);
+    expect(f[1]!.pre_clamp_reach).toBe(1_000_000);
+    expect(f[1]!.reach).toBe(500_000);
+  });
+  it("pre_clamp_reach equals reach when no clamping occurred", () => {
+    const f = journeyFunnel([{ name: "a", reach: 1_000_000 }, { name: "b", reach: 300_000 }]);
+    expect(f[1]!.clamped).toBe(false);
+    expect(f[1]!.pre_clamp_reach).toBe(300_000);
+    expect(f[1]!.reach).toBe(300_000);
+  });
   it("conversion_rate is ratio of current to previous", () => {
     const f = journeyFunnel([{ name: "a", reach: 1_000_000 }, { name: "b", reach: 300_000 }, { name: "c", reach: 60_000 }]);
     expect(f[1]!.conversion_rate).toBeCloseTo(0.3, 3);


### PR DESCRIPTION
## Summary

Fixes the Sec-45 Journey UX issue where a clamped stage reads as "100% conversion, 0 dropped" — visually identical to a perfect funnel — hiding the fact that the user's composition isn't actually a funnel.

### Two fixes, both required

**1. Semantics — new \`cumulative\` mode (default \`true\`)**
Each stage's signals are folded into the next stage's intersect pool, so stage \`i\` is constructed as a subset of stage \`i−1\` by construction. Clamping remains as a safety net but should rarely trigger. Legacy behavior preserved via \`cumulative:false\`.

**2. Surface — \`pre_clamp_reach\` + warning banner**
Each stage now carries its pre-clamp reach so the UI can render "natively 2.5M → clamped to 1.0M". A red banner appears whenever ANY stage clamped, with mode-aware copy explaining what happened.

### Backend changes

- [\`journeyFunnel()\`](src/analytics/audienceMath.ts:243) — new \`pre_clamp_reach\` field.
- [\`handleAudienceJourney()\`](src/routes/audienceAnalytics.ts:368) — accepts \`cumulative?:boolean\` (default \`true\`). In cumulative mode, dedupes the prior pool against the stage's raw intersects and folds the rest in as implicit intersects. Response carries \`mode\` + \`overall.any_clamped\`.

### UI changes (Journey tab only)

- Mode toggle row with live hint copy ("Cumulative (subset)" vs "Independent (legacy)").
- Red warning banner on clamp, mode-aware explanation.
- Clamped stage rows get a red border + red \`clamped\` pill + extra "natively X · clamped to Y" line.
- New \`.pill-error\` class (parallel to \`.pill-warning\`).

### Tests
- 2 new cases: pre_clamp_reach populated on clamp; equals reach when no clamp.
- Full suite: **355 passed / 12 skipped** (+2 from Sec-45 baseline).
- Type-check: 0 new errors.

### Context
[Sec-45 PR #66](https://github.com/EvgenyAndroid/adcp-signals-adaptor/pull/66) shipped the Journey tab. Post-deploy verification caught this UX gap in the user's own test — stages showed "clamped" badge but conversion metrics looked perfect, which is confusing.

## Test plan

- [ ] Default mode (cumulative): build 2 stages where stage 2's signals are naturally broader than stage 1's → confirm no warning banner, reach naturally decreases (cumulative math forced stage 2 to be a subset).
- [ ] Switch to Independent mode, same stages → confirm red warning banner appears, stage 2 shows "natively X · clamped to Y", \`clamped\` pill is red.
- [ ] Default mode, valid funnel (each stage narrower) → no banner, no clamping, numbers make sense.
- [ ] Backend: \`curl /audience/journey -d '{"stages":[...], "cumulative":false}'\` → response contains \`mode:"independent"\`, \`pre_clamp_reach\` on every stage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)