### PR TITLE
Sec-47c hotfix: snapshot save must preserve expression_ast

### DIFF
--- a/src/domain/capabilityService.ts
+++ b/src/domain/capabilityService.ts
@@ -26,7 +26,10 @@
 // v10 baseline: ext.ucp.
 // v19: Sec-44 adds ext.compliance — in-band conformance results +
 // non-applicable scenario explanation referencing upstream adcp#2916.
-const CACHE_KEY = "adcp_capabilities_v19";
+// v20: Sec-47 adds audience_compose_ast endpoint for boolean expression trees.
+// The key version must be bumped any time the SHAPE of the capability response
+// changes, so clients that cache by key pick up the new fields.
+const CACHE_KEY = "adcp_capabilities_v20";
 const CACHE_TTL_SECONDS = 3600;
 
 import { buildUcpCapability, type UcpCapabilityEnv } from "../ucp/vacDeclaration";

--- a/src/routes/snapshots.ts
+++ b/src/routes/snapshots.ts
@@ -31,6 +31,12 @@ interface Composition {
   intersect?: string[];
   exclude?: string[];
   lookalike?: { seed_signal_id: string; k?: number; min_cosine?: number };
+  // Sec-47: optional boolean expression AST for snapshots saved from the
+  // Expression Tree Builder. Shape: { type:"signal"|"op", id, signal_id?,
+  // op?, children? }. Stored as opaque JSON — backend doesn't interpret
+  // on read/write, only the Expression tab does. Kept as `unknown` here
+  // to avoid coupling the snapshot route to the audienceMath AST type.
+  expression_ast?: unknown;
 }
 
 interface SnapshotBody {
@@ -103,6 +109,8 @@ export async function handleSnapshotSave(request: Request, env: Env, logger: Log
       intersect: body.composition.intersect ?? [],
       exclude:   body.composition.exclude ?? [],
       ...(body.composition.lookalike ? { lookalike: body.composition.lookalike } : {}),
+      // Sec-47: pass through the AST if the caller included one. Stored verbatim.
+      ...(body.composition.expression_ast ? { expression_ast: body.composition.expression_ast } : {}),
     },
     reach_at_save: typeof body.reach_at_save === "number" ? body.reach_at_save : 0,
     saved_at: new Date().toISOString(),


### PR DESCRIPTION
Post-deploy verification caught this: saving a snapshot with `composition.expression_ast` populated, reading it back, showed the AST dropped. `handleSnapshotSave` pick-lists known composition fields and silently ignored the new one.

Fix: add `expression_ast?: unknown` to the Composition interface; pass it through the save spread. Back-compat-safe (callers that don't send it see no change; existing stored snapshots read unchanged).