### PR TITLE
Sec-48: multi-agent orchestrator — directory + probe + fan-out + capability matrix

### DIFF
--- a/src/domain/agentRegistry.ts
+++ b/src/domain/agentRegistry.ts
@@ -1,0 +1,260 @@
+// src/domain/agentRegistry.ts
+// Sec-48: curated list of AdCP directory agents we know about. Seed data
+// was compiled 2026-04-24 from the directory listing. Use it as the
+// starting set for probe-all + orchestration. Directory agents marked
+// "Issues" in the directory (Bidcliq, BidMachine, Apex, AdCP Test Agent,
+// Equativ) are included here with stage="known_issue" so the UI can
+// surface "we tried" without attempting to call them.
+
+export type AgentStage = "live" | "roadmap" | "known_issue";
+export type AgentRole = "signals" | "buying" | "creative" | "unclassified";
+
+export interface RegisteredAgent {
+  id: string;
+  name: string;
+  vendor: string;
+  mcp_url: string | null;
+  capabilities_url?: string | null;
+  stage: AgentStage;
+  role: AgentRole;
+  protocols: string[];
+  specialties?: string[];
+  tools_exposed?: string[];
+  notes?: string;
+  /** Approximate tool count as listed in the public directory. Used as a
+   * baseline for UI rendering before a live probe returns the real tools. */
+  directory_tool_count?: number;
+  mcp_version?: string;
+}
+
+export const SELF_AGENT_ID = "evgeny_signals";
+export const SELF_URL = "https://adcp-signals-adaptor.evgeny-193.workers.dev";
+
+export const AGENT_REGISTRY: RegisteredAgent[] = [
+  {
+    id: "evgeny_signals",
+    name: "Evgeny AdCP Signals adapter",
+    vendor: "Evgeny",
+    mcp_url: SELF_URL + "/mcp",
+    capabilities_url: SELF_URL + "/capabilities",
+    stage: "live",
+    role: "signals",
+    protocols: ["adcp_3.0", "ucp_0.2", "dts_1.2", "mcp_streamable_http"],
+    specialties: [
+      "cross_taxonomy_bridge_9_systems",
+      "ucp_embedding_live",
+      "dts_label_v12",
+      "embedding_lab_analytics",
+      "portfolio_optimizer",
+      "audience_composer_ast",
+    ],
+    tools_exposed: [
+      "get_adcp_capabilities", "get_signals", "activate_signal",
+      "get_operation_status", "get_similar_signals", "query_signals_nl",
+      "get_concept", "search_concepts",
+    ],
+    directory_tool_count: 8,
+  },
+  {
+    id: "dstillery",
+    name: "AdCP Signals Discovery Agent (Dstillery)",
+    vendor: "Dstillery",
+    mcp_url: "https://adcp-signals-agent.dstillery.com/mcp",
+    capabilities_url: null,
+    stage: "live",
+    role: "signals",
+    protocols: ["adcp_3.0", "mcp_streamable_http"],
+    specialties: ["behavioral_audiences", "ttd_deployment", "precision_segments"],
+    tools_exposed: ["get_signals"],
+    mcp_version: "2.13.1",
+    directory_tool_count: 1,
+  },
+  // ── Creative agents ───────────────────────────────────────────────────
+  {
+    id: "advertible",
+    name: "Advertible Inc.",
+    vendor: "Advertible",
+    mcp_url: "https://adcp.4dvertible.com/mcp",
+    stage: "live",
+    role: "creative",
+    protocols: ["adcp_3.0", "mcp_streamable_http"],
+    specialties: ["native_sizeless_formats", "retail_media_native"],
+    directory_tool_count: 2,
+  },
+  {
+    id: "celtra",
+    name: "Celtra Creative Agent",
+    vendor: "Celtra",
+    mcp_url: "https://adcp-mcp.celtra.com/mcp",
+    stage: "live",
+    role: "creative",
+    protocols: ["adcp_3.0", "mcp_streamable_http"],
+    specialties: ["creative_authoring", "dynamic_creative"],
+    directory_tool_count: 5,
+  },
+  // ── Buying agents ─────────────────────────────────────────────────────
+  {
+    id: "adzymic_apx",
+    name: "Adzymic (APX)",
+    vendor: "Adzymic",
+    mcp_url: "https://apx.sales-agent.adzymic.ai/mcp",
+    stage: "live",
+    role: "buying",
+    protocols: ["adcp_3.0", "mcp_streamable_http"],
+    directory_tool_count: 12,
+  },
+  {
+    id: "adzymic_sph",
+    name: "Adzymic (SPH)",
+    vendor: "Adzymic",
+    mcp_url: "https://sph.sales-agent.adzymic.ai/mcp",
+    stage: "live",
+    role: "buying",
+    protocols: ["adcp_3.0", "mcp_streamable_http"],
+    directory_tool_count: 12,
+  },
+  {
+    id: "adzymic_tsl",
+    name: "Adzymic (TSL)",
+    vendor: "Adzymic",
+    mcp_url: "https://tsl.sales-agent.adzymic.ai/mcp",
+    stage: "live",
+    role: "buying",
+    protocols: ["adcp_3.0", "mcp_streamable_http"],
+    directory_tool_count: 12,
+  },
+  {
+    id: "adzymic_mediacorp",
+    name: "Adzymic (Mediacorp)",
+    vendor: "Adzymic",
+    mcp_url: "https://mediacorp.sales-agent.adzymic.ai/mcp",
+    stage: "live",
+    role: "buying",
+    protocols: ["adcp_3.0", "mcp_streamable_http"],
+    directory_tool_count: 12,
+  },
+  {
+    id: "content_ignite",
+    name: "Content Ignite",
+    vendor: "Content Ignite",
+    mcp_url: "https://sales-agent.contentignite.com",
+    stage: "live",
+    role: "buying",
+    protocols: ["adcp_3.0", "mcp_streamable_http"],
+    directory_tool_count: 16,
+  },
+  {
+    id: "claire_pub",
+    name: "Claire Sales Agent",
+    vendor: "Philippe Giendaj",
+    mcp_url: "https://sales-agent.claire.pub/mcp/",
+    stage: "live",
+    role: "buying",
+    protocols: ["adcp_3.0", "mcp_streamable_http"],
+    directory_tool_count: 16,
+  },
+  {
+    id: "claire_scope3",
+    name: "Claire (Scope3 deployment)",
+    vendor: "Philippe Giendaj",
+    mcp_url: "https://6138516b.sales-agent.scope3.com/mcp",
+    stage: "live",
+    role: "buying",
+    protocols: ["adcp_3.0", "mcp_streamable_http"],
+    directory_tool_count: 16,
+  },
+  {
+    id: "swivel",
+    name: "Swivel",
+    vendor: "Swivel",
+    mcp_url: "https://adcp.swivel.ai/mcp",
+    stage: "live",
+    role: "buying",
+    protocols: ["adcp_3.0", "mcp_streamable_http"],
+    directory_tool_count: 8,
+  },
+  // ── Known-issue agents (skipped on probe-all) ─────────────────────────
+  {
+    id: "bidcliq",
+    name: "Bidcliq",
+    vendor: "Bidcliq",
+    mcp_url: "https://agents.bidcliq.com/mcp",
+    stage: "known_issue",
+    role: "unclassified",
+    protocols: ["adcp_3.0"],
+    notes: "Directory discovery error: MCP endpoint unreachable at tried paths.",
+  },
+  {
+    id: "bidmachine",
+    name: "BidMachine Seller Agent",
+    vendor: "BidMachine",
+    mcp_url: "https://adcp.bidmachine.io/adcp/mcp",
+    stage: "known_issue",
+    role: "unclassified",
+    protocols: ["adcp_3.0"],
+    notes: "Directory: unclassified / handshake issues.",
+  },
+  {
+    id: "adcp_test_agent",
+    name: "AdCP Test Agent",
+    vendor: "BigAds",
+    mcp_url: "https://test-agent.adcontextprotocol.org/mcp",
+    stage: "known_issue",
+    role: "unclassified",
+    protocols: ["adcp_3.0"],
+    notes: "Directory: degraded status.",
+  },
+  {
+    id: "equativ",
+    name: "Equativ",
+    vendor: "Equativ",
+    mcp_url: "https://adcp.equativ.com/v1/discover",
+    stage: "known_issue",
+    role: "unclassified",
+    protocols: ["adcp_3.0"],
+    notes: "Directory: unclassified.",
+  },
+  // ── Roadmap (no MCP endpoint yet) ─────────────────────────────────────
+  {
+    id: "peer39",
+    name: "Peer39",
+    vendor: "Peer39",
+    mcp_url: null,
+    stage: "roadmap",
+    role: "signals",
+    protocols: ["adcp_3.0"],
+    specialties: ["contextual", "brand_safety", "cookieless_contextual"],
+  },
+  {
+    id: "scope3",
+    name: "Scope3",
+    vendor: "Scope3",
+    mcp_url: null,
+    stage: "roadmap",
+    role: "signals",
+    protocols: ["adcp_3.0"],
+    specialties: ["sustainability", "carbon_aware_audiences"],
+  },
+  {
+    id: "liveramp",
+    name: "LiveRamp",
+    vendor: "LiveRamp",
+    mcp_url: null,
+    stage: "roadmap",
+    role: "signals",
+    protocols: ["adcp_3.0"],
+    specialties: ["id_resolution", "abilitec_graph", "ramp_id"],
+  },
+];
+
+export function getLiveAgents(): RegisteredAgent[] {
+  return AGENT_REGISTRY.filter((a) => a.stage === "live");
+}
+
+export function getAgentsByRole(role: AgentRole): RegisteredAgent[] {
+  return AGENT_REGISTRY.filter((a) => a.role === role);
+}
+
+export function findAgent(id: string): RegisteredAgent | undefined {
+  return AGENT_REGISTRY.find((a) => a.id === id);
+}

--- a/src/domain/capabilityService.ts
+++ b/src/domain/capabilityService.ts
@@ -27,9 +27,12 @@
 // v19: Sec-44 adds ext.compliance — in-band conformance results +
 // non-applicable scenario explanation referencing upstream adcp#2916.
 // v20: Sec-47 adds audience_compose_ast endpoint for boolean expression trees.
+// v21: Sec-48 adds agent-syndication endpoints (/agents/directory, /agents/probe-all,
+// /agents/orchestrate, /agents/capability-matrix) + federation.multi_agent_orchestrator
+// experimental feature flag.
 // The key version must be bumped any time the SHAPE of the capability response
 // changes, so clients that cache by key pick up the new fields.
-const CACHE_KEY = "adcp_capabilities_v20";
+const CACHE_KEY = "adcp_capabilities_v21";
 const CACHE_TTL_SECONDS = 3600;
 
 import { buildUcpCapability, type UcpCapabilityEnv } from "../ucp/vacDeclaration";
@@ -153,6 +156,7 @@ function buildStaticCapabilities(env: UcpCapabilityEnv): AdcpCapabilities {
       "portfolio.from_brief",
       "federation.a2a_dstillery",
       "federation.cross_similarity",
+      "federation.multi_agent_orchestrator",
       "governance.data_hygiene",
       "governance.audit_log",
       "measurement.reach_forecaster",
@@ -523,6 +527,11 @@ function buildStaticCapabilities(env: UcpCapabilityEnv): AdcpCapabilities {
           audience_holdout:        { method: "POST", path: "/audience/holdout" },
           // Sec-47: boolean expression AST composer.
           audience_compose_ast:    { method: "POST", path: "/audience/compose-ast" },
+          // Sec-48: agent syndication — multi-A2A orchestration over a curated directory.
+          agents_directory:        { method: "GET",  path: "/agents/directory" },
+          agents_probe_all:        { method: "GET",  path: "/agents/probe-all" },
+          agents_orchestrate:      { method: "POST", path: "/agents/orchestrate" },
+          agents_capability_matrix:{ method: "GET",  path: "/agents/capability-matrix" },
           snapshot_save:           { method: "POST",   path: "/snapshots" },
           snapshot_list:           { method: "GET",    path: "/snapshots" },
           snapshot_get:            { method: "GET",    path: "/snapshots/:id" },

--- a/src/federation/genericMcpClient.ts
+++ b/src/federation/genericMcpClient.ts
@@ -1,0 +1,260 @@
+// src/federation/genericMcpClient.ts
+// Sec-48: generic MCP Streamable-HTTP client for probing + calling tools
+// on ANY AdCP agent. Factored from the Dstillery-specific dstilleryClient.ts
+// (which predates this generalization — it stays in place for its existing
+// callers; once those migrate, it can collapse to a thin wrapper over this).
+//
+// What's generic:
+//   - session handshake (initialize → extract mcp-session-id → notifications/initialized)
+//   - SSE response parsing (last `data:` line)
+//   - tools/list and tools/call wrappers with per-URL session cache
+//   - session TTL + one-shot retry on session-related errors
+//
+// What's NOT generic (yet):
+//   - protocol version (default 2024-11-05, configurable per call)
+//   - authentication (some agents may require bearer; current list doesn't)
+//   - SSE streaming beyond last-data-line (good enough for tools/call which
+//     returns a single response event; not sufficient if we ever consume
+//     streamed intermediate events)
+//
+// Per-isolate session cache keyed by URL. Cloudflare recycles isolates
+// frequently; this is best-effort, we renew on every cold start.
+
+const SESSION_TTL_MS = 9 * 60 * 1000;
+const _sessions = new Map<string, { id: string; atMs: number }>();
+
+/** Parse an SSE response body and return the last `data:` payload as JSON. */
+function parseSSELastData(text: string): unknown | null {
+  const lines = text.split(/\r?\n/);
+  const dataLines = lines.filter((l) => l.startsWith("data: "));
+  if (dataLines.length === 0) {
+    // Fallback: maybe the body is plain JSON (some servers don't SSE-frame).
+    try { return JSON.parse(text); } catch { return null; }
+  }
+  const last = dataLines[dataLines.length - 1]!;
+  try { return JSON.parse(last.slice(6)); }
+  catch { return null; }
+}
+
+interface InitOptions {
+  protocolVersion?: string;
+  clientInfo?: { name: string; version: string };
+  timeoutMs?: number;
+}
+
+async function initializeSession(url: string, opts: InitOptions = {}): Promise<{ sessionId: string | null; serverInfo?: { name: string; version?: string }; protocolVersion?: string; error?: string }> {
+  const timeoutMs = opts.timeoutMs ?? 15_000;
+  const protocolVersion = opts.protocolVersion ?? "2024-11-05";
+  const clientInfo = opts.clientInfo ?? { name: "evgeny_signals_probe", version: "48.0" };
+  try {
+    const res = await fetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "Accept": "application/json, text/event-stream",
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0", id: 1, method: "initialize",
+        params: { protocolVersion, capabilities: {}, clientInfo },
+      }),
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+    if (!res.ok) {
+      const body = await res.text().catch(() => "");
+      return { sessionId: null, error: `HTTP ${res.status}: ${body.slice(0, 200)}` };
+    }
+    const sessionId = res.headers.get("mcp-session-id");
+    const bodyText = await res.text();
+    const parsed = parseSSELastData(bodyText) as {
+      result?: {
+        serverInfo?: { name: string; version?: string };
+        protocolVersion?: string;
+      };
+      error?: { code: number; message: string };
+    } | null;
+    const result: {
+      sessionId: string | null;
+      serverInfo?: { name: string; version?: string };
+      protocolVersion?: string;
+      error?: string;
+    } = { sessionId };
+    if (parsed?.result?.serverInfo) result.serverInfo = parsed.result.serverInfo;
+    if (parsed?.result?.protocolVersion) result.protocolVersion = parsed.result.protocolVersion;
+    if (parsed?.error) result.error = parsed.error.message;
+    // Post-initialize notification (best-effort — many servers require it before tool calls)
+    if (sessionId) {
+      try {
+        await fetch(url, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            "Accept": "application/json, text/event-stream",
+            "mcp-session-id": sessionId,
+          },
+          body: JSON.stringify({ jsonrpc: "2.0", method: "notifications/initialized" }),
+          signal: AbortSignal.timeout(5_000),
+        });
+      } catch { /* non-critical */ }
+    }
+    return result;
+  } catch (e) {
+    return { sessionId: null, error: String((e as Error).message || e) };
+  }
+}
+
+async function ensureSession(url: string, opts?: InitOptions): Promise<string | null> {
+  const now = Date.now();
+  const cached = _sessions.get(url);
+  if (cached && now - cached.atMs < SESSION_TTL_MS) return cached.id;
+  const init = await initializeSession(url, opts);
+  if (init.sessionId) {
+    _sessions.set(url, { id: init.sessionId, atMs: now });
+  }
+  return init.sessionId;
+}
+
+/** Clear a cached session (e.g. on session-related error). */
+function invalidateSession(url: string): void {
+  _sessions.delete(url);
+}
+
+// ── Probe ──────────────────────────────────────────────────────────────────
+
+export interface ProbeResult {
+  url: string;
+  alive: boolean;
+  error?: string;
+  latency_ms: number;
+  server_info?: { name: string; version?: string };
+  protocol_version?: string;
+  tools?: Array<{ name: string; description?: string }>;
+}
+
+export async function probeAgent(url: string, opts?: { timeoutMs?: number }): Promise<ProbeResult> {
+  const start = Date.now();
+  const timeoutMs = opts?.timeoutMs ?? 10_000;
+  const init = await initializeSession(url, { timeoutMs });
+  if (!init.sessionId) {
+    return {
+      url,
+      alive: false,
+      ...(init.error ? { error: init.error } : { error: "session_init_failed" }),
+      latency_ms: Date.now() - start,
+    };
+  }
+  // Cache the fresh session so follow-up calls can reuse it.
+  _sessions.set(url, { id: init.sessionId, atMs: start });
+  // tools/list
+  try {
+    const res = await fetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "Accept": "application/json, text/event-stream",
+        "mcp-session-id": init.sessionId,
+      },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 2, method: "tools/list", params: {} }),
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+    const text = await res.text();
+    const body = parseSSELastData(text) as {
+      result?: { tools?: Array<{ name: string; description?: string }> };
+      error?: { code: number; message: string };
+    } | null;
+    const result: ProbeResult = {
+      url,
+      alive: true,
+      latency_ms: Date.now() - start,
+    };
+    if (init.serverInfo) result.server_info = init.serverInfo;
+    if (init.protocolVersion) result.protocol_version = init.protocolVersion;
+    if (body?.result?.tools) result.tools = body.result.tools;
+    if (body?.error) result.error = body.error.message;
+    return result;
+  } catch (e) {
+    return {
+      url,
+      alive: false,
+      error: String((e as Error).message || e),
+      latency_ms: Date.now() - start,
+      ...(init.serverInfo ? { server_info: init.serverInfo } : {}),
+    };
+  }
+}
+
+/** Probe many agents in parallel with a per-call timeout. */
+export async function probeAgents(urls: string[], opts?: { timeoutMs?: number }): Promise<ProbeResult[]> {
+  return Promise.all(urls.map((u) => probeAgent(u, opts)));
+}
+
+// ── Tool call ──────────────────────────────────────────────────────────────
+
+export interface ToolCallResult {
+  ok: boolean;
+  error?: string;
+  latency_ms: number;
+  content?: unknown;
+  structured_content?: unknown;
+  is_error?: boolean;
+}
+
+async function callToolOnce(url: string, sessionId: string, name: string, args: Record<string, unknown>, timeoutMs: number): Promise<ToolCallResult> {
+  const start = Date.now();
+  const res = await fetch(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "Accept": "application/json, text/event-stream",
+      "mcp-session-id": sessionId,
+    },
+    body: JSON.stringify({
+      jsonrpc: "2.0", id: Date.now(), method: "tools/call",
+      params: { name, arguments: args },
+    }),
+    signal: AbortSignal.timeout(timeoutMs),
+  });
+  const text = await res.text();
+  const body = parseSSELastData(text) as {
+    result?: {
+      content?: unknown;
+      structuredContent?: unknown;
+      isError?: boolean;
+    };
+    error?: { code: number; message: string };
+  } | null;
+  const elapsed = Date.now() - start;
+  if (body?.error) {
+    return { ok: false, error: body.error.message, latency_ms: elapsed };
+  }
+  if (!body?.result) {
+    return { ok: false, error: "empty_or_invalid_sse", latency_ms: elapsed };
+  }
+  const out: ToolCallResult = {
+    ok: !body.result.isError,
+    latency_ms: elapsed,
+  };
+  if (body.result.content !== undefined) out.content = body.result.content;
+  if (body.result.structuredContent !== undefined) out.structured_content = body.result.structuredContent;
+  if (body.result.isError !== undefined) out.is_error = body.result.isError;
+  return out;
+}
+
+export async function callAgentTool(url: string, name: string, args: Record<string, unknown>, opts?: { timeoutMs?: number }): Promise<ToolCallResult> {
+  const timeoutMs = opts?.timeoutMs ?? 20_000;
+  const start = Date.now();
+  try {
+    let session = await ensureSession(url, { timeoutMs });
+    if (!session) {
+      return { ok: false, error: "session_init_failed", latency_ms: Date.now() - start };
+    }
+    let r = await callToolOnce(url, session, name, args, timeoutMs);
+    if (r.error && /session/i.test(r.error)) {
+      invalidateSession(url);
+      session = await ensureSession(url, { timeoutMs });
+      if (session) r = await callToolOnce(url, session, name, args, timeoutMs);
+    }
+    return r;
+  } catch (e) {
+    return { ok: false, error: String((e as Error).message || e), latency_ms: Date.now() - start };
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,6 +38,12 @@ import {
   handleTaxonomyReverse,
 } from "./routes/federationEndpoints";
 import {
+  handleAgentsDirectory,
+  handleAgentsProbeAll,
+  handleAgentsOrchestrate,
+  handleAgentsCapabilityMatrix,
+} from "./routes/agentsEndpoints";
+import {
   handleAudienceCompose,
   handleAudienceSaturation,
   handleAffinityAudit,
@@ -203,6 +209,11 @@ export default {
             "/agents/registry",
             "/agents/federated-search",
             "/agents/cross-similarity",
+            // Sec-48: agent syndication — directory, live probe, multi-A2A orchestration.
+            "/agents/directory",
+            "/agents/probe-all",
+            "/agents/orchestrate",
+            "/agents/capability-matrix",
             "/taxonomy/reverse",
             // Sec-43: audience composer + activation-planning analytics.
             // Read-only — same posture as /portfolio/* and /analytics/*.
@@ -344,6 +355,16 @@ export default {
                 response = await handleCrossSimilarity(request);
             } else if (method === "POST" && path === "/taxonomy/reverse") {
                 response = await handleTaxonomyReverse(request, env, logger);
+
+                // ── Sec-48: agent syndication (directory + probe + orchestrate) ──
+            } else if (method === "GET" && path === "/agents/directory") {
+                response = handleAgentsDirectory();
+            } else if (method === "GET" && path === "/agents/probe-all") {
+                response = await handleAgentsProbeAll(request, env, logger);
+            } else if (method === "POST" && path === "/agents/orchestrate") {
+                response = await handleAgentsOrchestrate(request, env, logger);
+            } else if (method === "GET" && path === "/agents/capability-matrix") {
+                response = await handleAgentsCapabilityMatrix(request, env, logger);
 
                 // ── Sec-43: Audience Composer + activation analytics ────────────────
             } else if (method === "POST" && path === "/audience/compose") {

--- a/src/routes/agentsEndpoints.ts
+++ b/src/routes/agentsEndpoints.ts
@@ -1,0 +1,270 @@
+// src/routes/agentsEndpoints.ts
+// Sec-48: agent syndication — directory listing, live probe fan-out,
+// and cross-agent orchestration over the generic MCP client.
+//
+//   GET  /agents/directory      — static registry (no network)
+//   GET  /agents/probe-all      — probe every live agent in parallel
+//   POST /agents/orchestrate    — fan-out a signals search to all live
+//                                  signals agents; merge results
+//
+// Existing Sec-41 endpoints stay in place:
+//   GET  /agents/registry       — legacy-shape list (kept for back-compat)
+//   POST /agents/federated-search — Dstillery-specific; the new
+//                                  /agents/orchestrate is its superset
+
+import type { Env } from "../types/env";
+import type { Logger } from "../utils/logger";
+import { jsonResponse, errorResponse, readJsonBody } from "./shared";
+import {
+  AGENT_REGISTRY,
+  getLiveAgents,
+  getAgentsByRole,
+  findAgent,
+  type RegisteredAgent,
+} from "../domain/agentRegistry";
+import { probeAgents, callAgentTool, type ProbeResult } from "../federation/genericMcpClient";
+
+// ── GET /agents/directory ───────────────────────────────────────────────────
+
+export function handleAgentsDirectory(): Response {
+  const byRole: Record<string, number> = {};
+  const byStage: Record<string, number> = {};
+  for (const a of AGENT_REGISTRY) {
+    byRole[a.role] = (byRole[a.role] ?? 0) + 1;
+    byStage[a.stage] = (byStage[a.stage] ?? 0) + 1;
+  }
+  return jsonResponse({
+    version: "sec_48_v1",
+    count: AGENT_REGISTRY.length,
+    by_role: byRole,
+    by_stage: byStage,
+    agents: AGENT_REGISTRY,
+    note: "Static directory snapshot. Hit /agents/probe-all for live liveness + tool-list per agent.",
+  });
+}
+
+// ── GET /agents/probe-all ───────────────────────────────────────────────────
+
+export async function handleAgentsProbeAll(request: Request, _env: Env, logger: Logger): Promise<Response> {
+  const url = new URL(request.url);
+  const roleFilter = url.searchParams.get("role");
+  const timeoutMs = Math.max(1000, Math.min(30_000, Number(url.searchParams.get("timeout_ms")) || 8000));
+
+  let targets: RegisteredAgent[] = getLiveAgents();
+  if (roleFilter) targets = targets.filter((a) => a.role === roleFilter);
+
+  const withUrls = targets.filter((a): a is RegisteredAgent & { mcp_url: string } => !!a.mcp_url);
+  const urls = withUrls.map((a) => a.mcp_url);
+  const probeResults = await probeAgents(urls, { timeoutMs });
+
+  const results = withUrls.map((agent, i) => {
+    const r = probeResults[i]!;
+    const diff: { baseline?: number; observed?: number; delta?: number } = {};
+    if (agent.directory_tool_count !== undefined) diff.baseline = agent.directory_tool_count;
+    if (r.tools) diff.observed = r.tools.length;
+    if (diff.baseline !== undefined && diff.observed !== undefined) diff.delta = diff.observed - diff.baseline;
+    return {
+      id: agent.id,
+      name: agent.name,
+      vendor: agent.vendor,
+      role: agent.role,
+      mcp_url: agent.mcp_url,
+      probe: r,
+      tool_count_diff: diff,
+    };
+  });
+
+  const aliveCount = results.filter((r) => r.probe.alive).length;
+  const avgLatency = results.length > 0
+    ? Math.round(results.reduce((s, r) => s + r.probe.latency_ms, 0) / results.length)
+    : 0;
+
+  logger.info("agents_probe_all", {
+    probed: results.length,
+    alive: aliveCount,
+    role_filter: roleFilter ?? null,
+  });
+
+  return jsonResponse({
+    probed_at: new Date().toISOString(),
+    timeout_ms: timeoutMs,
+    ...(roleFilter ? { role_filter: roleFilter } : {}),
+    count: results.length,
+    alive_count: aliveCount,
+    avg_latency_ms: avgLatency,
+    results,
+    note: "Per-agent probe result. tool_count_diff compares directory baseline vs live tools/list — negative delta means fewer tools than directory declared.",
+  });
+}
+
+// ── POST /agents/orchestrate ────────────────────────────────────────────────
+// Fan-out a signal-discovery brief to all live signals agents in parallel.
+// Each agent gets called with tools/call on its declared signals tool;
+// results are merged and tagged with source_agent for provenance.
+
+interface OrchestrateBody {
+  brief?: string;
+  tool?: string;
+  max_results_per_agent?: number;
+  include_agents?: string[];   // optional allowlist
+  exclude_agents?: string[];   // optional denylist
+  timeout_ms?: number;
+}
+
+interface OrchestratePerAgent {
+  id: string;
+  name: string;
+  vendor: string;
+  url: string;
+  ok: boolean;
+  error?: string;
+  latency_ms: number;
+  signal_count: number;
+  signals: unknown[];
+}
+
+export async function handleAgentsOrchestrate(request: Request, _env: Env, logger: Logger): Promise<Response> {
+  const parsed = await readJsonBody<OrchestrateBody>(request);
+  if (parsed.kind === "invalid") return errorResponse("INVALID_JSON", parsed.reason, 400);
+  const body: OrchestrateBody = parsed.kind === "parsed" ? parsed.data : {};
+  if (!body.brief || body.brief.trim().length === 0) return errorResponse("INVALID_INPUT", "brief required", 400);
+  if (body.brief.length > 500) return errorResponse("INVALID_INPUT", "brief max 500 chars", 400);
+
+  const tool = body.tool ?? "get_signals";
+  const maxResults = Math.max(1, Math.min(50, body.max_results_per_agent ?? 10));
+  const timeoutMs = Math.max(1000, Math.min(30_000, body.timeout_ms ?? 12_000));
+
+  let targets: RegisteredAgent[] = getAgentsByRole("signals").filter((a) => a.stage === "live" && a.mcp_url);
+  if (body.include_agents?.length) {
+    const allow = new Set(body.include_agents);
+    targets = targets.filter((a) => allow.has(a.id));
+  }
+  if (body.exclude_agents?.length) {
+    const deny = new Set(body.exclude_agents);
+    targets = targets.filter((a) => !deny.has(a.id));
+  }
+  if (targets.length === 0) return errorResponse("NO_TARGETS", "No live signals agents matched filters.", 400);
+
+  const perAgent: OrchestratePerAgent[] = await Promise.all(targets.map(async (a): Promise<OrchestratePerAgent> => {
+    const res = await callAgentTool(a.mcp_url!, tool, {
+      signal_spec: body.brief,
+      max_results: maxResults,
+    }, { timeoutMs });
+    const structured = res.structured_content as { signals?: unknown[] } | undefined;
+    const signals = structured?.signals ?? [];
+    const out: OrchestratePerAgent = {
+      id: a.id,
+      name: a.name,
+      vendor: a.vendor,
+      url: a.mcp_url!,
+      ok: res.ok,
+      latency_ms: res.latency_ms,
+      signal_count: signals.length,
+      signals: signals.map((s) => ({ source_agent: a.id, ...(s as object) })),
+    };
+    if (res.error) out.error = res.error;
+    return out;
+  }));
+
+  const merged = perAgent.flatMap((p) => p.signals);
+  const agentsQueried = perAgent.map((p) => p.id);
+  const agentsSucceeded = perAgent.filter((p) => p.ok).map((p) => p.id);
+  const agentsFailed = perAgent.filter((p) => !p.ok).map((p) => ({ id: p.id, error: p.error ?? "unknown" }));
+
+  logger.info("agents_orchestrate", {
+    brief_chars: body.brief.length,
+    agents_queried: agentsQueried.length,
+    agents_succeeded: agentsSucceeded.length,
+    total_signals: merged.length,
+    max_per_agent: maxResults,
+  });
+
+  return jsonResponse({
+    brief: body.brief,
+    tool,
+    agents_queried: agentsQueried,
+    agents_succeeded: agentsSucceeded,
+    agents_failed: agentsFailed,
+    per_agent: perAgent.map((p) => ({
+      id: p.id, name: p.name, vendor: p.vendor,
+      ok: p.ok, ...(p.error ? { error: p.error } : {}),
+      latency_ms: p.latency_ms, signal_count: p.signal_count,
+    })),
+    total_signals: merged.length,
+    signals: merged,
+    method: "parallel_mcp_tools_call_per_live_signals_agent",
+    note: "Signals from each agent carry source_agent to preserve provenance. Failed agents don't block the merge. For schema-normalized signals use the existing /agents/federated-search which applies a Dstillery-specific mapper; this endpoint is transport-level only.",
+  });
+}
+
+// ── GET /agents/capability-matrix ────────────────────────────────────────────
+// Side-by-side comparison: row per tool name, column per live agent, cell
+// shows whether the agent declares it (from probe-all). Useful to see
+// which agents cluster on the same tool set.
+
+export async function handleAgentsCapabilityMatrix(request: Request, _env: Env, logger: Logger): Promise<Response> {
+  const url = new URL(request.url);
+  const timeoutMs = Math.max(1000, Math.min(30_000, Number(url.searchParams.get("timeout_ms")) || 8000));
+  const roleFilter = url.searchParams.get("role");
+
+  let targets: RegisteredAgent[] = getLiveAgents().filter((a) => a.mcp_url);
+  if (roleFilter) targets = targets.filter((a) => a.role === roleFilter);
+
+  const urls = targets.map((a) => a.mcp_url!);
+  const probeResults = await probeAgents(urls, { timeoutMs });
+
+  // Collect union of all tool names observed.
+  const allTools = new Set<string>();
+  const perAgentTools: Map<string, Set<string>> = new Map();
+  for (let i = 0; i < targets.length; i++) {
+    const agent = targets[i]!;
+    const probe: ProbeResult = probeResults[i]!;
+    const toolNames = new Set((probe.tools ?? []).map((t) => t.name));
+    perAgentTools.set(agent.id, toolNames);
+    for (const t of toolNames) allTools.add(t);
+  }
+
+  const toolList = Array.from(allTools).sort();
+  const matrix = toolList.map((tool) => ({
+    tool,
+    supported_by: targets.filter((a) => perAgentTools.get(a.id)?.has(tool)).map((a) => a.id),
+  }));
+
+  // Per-agent summary: tool count, unique tools (only this agent declares them).
+  const summary = targets.map((agent) => {
+    const mine = perAgentTools.get(agent.id) ?? new Set<string>();
+    const unique = Array.from(mine).filter((t) => {
+      // Unique = no other agent declares this tool.
+      for (const [otherId, otherTools] of perAgentTools) {
+        if (otherId !== agent.id && otherTools.has(t)) return false;
+      }
+      return true;
+    });
+    return {
+      id: agent.id,
+      name: agent.name,
+      role: agent.role,
+      tool_count: mine.size,
+      unique_tools: unique,
+      alive: probeResults[targets.indexOf(agent)]!.alive,
+    };
+  });
+
+  logger.info("agents_capability_matrix", {
+    agents: targets.length,
+    tools_total: toolList.length,
+    role_filter: roleFilter ?? null,
+  });
+
+  return jsonResponse({
+    probed_at: new Date().toISOString(),
+    ...(roleFilter ? { role_filter: roleFilter } : {}),
+    agents: summary,
+    tools: matrix,
+    tool_count: toolList.length,
+    note: "Matrix rows = tool names (union across probed agents), columns = supported_by list. Summary shows each agent's tool count + tools unique to it.",
+  });
+}
+
+// Kept for reference — utility not used directly by endpoints.
+export { findAgent };

--- a/src/routes/demo.ts
+++ b/src/routes/demo.ts
@@ -145,6 +145,10 @@ ${STYLES}
         <svg class="ico"><use href="#icon-network"/></svg><span>Federation</span>
         <span class="nav-tag nav-tag-muted">a2a</span>
       </button>
+      <button class="nav-item" data-tab="orchestrator">
+        <svg class="ico"><use href="#icon-network"/></svg><span>Orchestrator</span>
+        <span class="nav-tag">new</span>
+      </button>
       <button class="nav-item" data-tab="activations">
         <svg class="ico"><use href="#icon-activations"/></svg><span>Activations</span>
         <span class="nav-count" id="nav-activations-count">—</span>
@@ -1214,6 +1218,47 @@ ${STYLES}
         <div class="lab-panel lab-panel-full" style="margin-top:14px">
           <div class="lab-panel-title">Agent registry</div>
           <div id="fed-registry"><div class="empty-state"><span class="spinner"></span><div class="empty-title">Loading agent registry\u2026</div></div></div>
+        </div>
+      </section>
+
+      <!-- ── TAB: Orchestrator (Sec-48) ──────────────────────────────────── -->
+      <section class="tab-pane" data-tab="orchestrator">
+        <div class="pane-header">
+          <div>
+            <h1 class="pane-title">Multi-Agent Orchestrator <span class="pill pill-accent" style="margin-left:8px;font-size:10px">Sec-48</span></h1>
+            <p class="pane-subtitle">Live view of every AdCP agent we know about. Probe each MCP endpoint in parallel to see who's up, what they expose, and how fast they respond. Fan out a signals brief to all live signals agents with one click, or compare tool surfaces side-by-side.</p>
+          </div>
+          <div class="activations-controls">
+            <button class="btn-secondary" id="orch-refresh">
+              <svg class="ico"><use href="#icon-chart"/></svg><span>Probe all</span>
+            </button>
+          </div>
+        </div>
+        <div class="orch-summary" id="orch-summary"></div>
+        <div class="lab-panel lab-panel-full" style="margin-top:8px">
+          <div class="lab-panel-title">Agents <span class="pill pill-muted mono" id="orch-agents-count" style="margin-left:8px">—</span></div>
+          <div id="orch-agents"><div class="empty-state"><span class="spinner"></span><div class="empty-title">Loading directory\u2026</div></div></div>
+        </div>
+        <div class="lab-grid" style="margin-top:14px">
+          <div class="lab-panel">
+            <div class="lab-panel-title">Fan-out signals brief</div>
+            <label class="lab-label">Brief</label>
+            <textarea id="orch-brief" class="lab-input" rows="3" placeholder="automotive intenders in-market for EVs"></textarea>
+            <label class="lab-label" style="margin-top:8px">Max results per agent</label>
+            <input id="orch-max" type="number" min="1" max="50" value="10" class="lab-input"/>
+            <button class="btn-primary" id="orch-run" style="margin-top:12px;width:100%;justify-content:center">
+              <svg class="ico"><use href="#icon-bolt"/></svg><span>Fan out to all signals agents</span>
+            </button>
+            <div style="font-size:11px;color:var(--text-mut);margin-top:8px">Calls <code>/agents/orchestrate</code> → each signals agent's <code>get_signals</code> in parallel. Results tagged with <code>source_agent</code>.</div>
+          </div>
+          <div class="lab-panel lab-panel-wide">
+            <div class="lab-panel-title">Merged results</div>
+            <div id="orch-results"><div class="empty-state"><div class="empty-desc">Enter a brief, hit <strong>Fan out</strong>. Signals come back merged with per-agent latency + source tags.</div></div></div>
+          </div>
+        </div>
+        <div class="lab-panel lab-panel-full" style="margin-top:14px">
+          <div class="lab-panel-title">Capability matrix <button class="btn-secondary" id="orch-matrix-run" style="margin-left:8px;font-size:11px;padding:4px 10px">Build matrix</button></div>
+          <div id="orch-matrix"><div class="empty-state"><div class="empty-desc">Click <strong>Build matrix</strong> to compare every live agent's tool surface side-by-side. Each row is a tool name; columns are agents; cells mark which agents declare that tool.</div></div></div>
         </div>
       </section>
 
@@ -3893,6 +3938,101 @@ textarea.lab-input { resize: vertical; line-height: 1.5; }
 .holdout-stats .k { font-size: 10.5px; color: var(--text-mut); text-transform: uppercase; letter-spacing: 0.04em; }
 .holdout-stats .v { font-size: 15px; margin-top: 2px; }
 
+/* ── Sec-48: Multi-Agent Orchestrator ─────────────────────────────────── */
+.orch-summary {
+  margin-bottom: 12px;
+}
+.orch-summary-cards {
+  display: grid; grid-template-columns: repeat(auto-fit, minmax(130px, 1fr)); gap: 10px;
+}
+.orch-summary-card {
+  background: var(--bg-surface); border: 1px solid var(--border); border-radius: 6px;
+  padding: 8px 12px;
+}
+.orch-summary-card.orch-summary-ok { border-left: 3px solid var(--success); }
+.orch-summary-card .k { font-size: 10px; color: var(--text-mut); text-transform: uppercase; letter-spacing: 0.04em; }
+.orch-summary-card .v { font-size: 16px; margin-top: 2px; font-weight: 500; }
+
+.orch-stage-section { margin-bottom: 14px; }
+.orch-stage-label {
+  font-size: 11px; text-transform: uppercase; letter-spacing: 0.05em;
+  color: var(--text-mut); margin-bottom: 8px;
+}
+.orch-agent-grid {
+  display: grid; grid-template-columns: repeat(auto-fill, minmax(260px, 1fr)); gap: 10px;
+}
+.orch-agent-card {
+  background: var(--bg-surface); border: 1px solid var(--border); border-left-width: 3px;
+  border-radius: 6px; padding: 10px 12px;
+  display: flex; flex-direction: column; gap: 6px;
+  transition: border-color 0.15s;
+}
+.orch-agent-card.orch-agent-alive { border-left-color: var(--success); }
+.orch-agent-card.orch-agent-down { border-left-color: var(--error); opacity: 0.85; }
+.orch-agent-card.orch-agent-issue { border-left-color: var(--warning); opacity: 0.7; }
+.orch-agent-card.orch-agent-roadmap { border-left-color: var(--text-mut); opacity: 0.6; }
+.orch-agent-card.orch-agent-unknown { border-left-color: var(--text-mut); }
+.orch-agent-head { display: flex; justify-content: space-between; align-items: flex-start; gap: 6px; }
+.orch-agent-name { font-size: 12.5px; font-weight: 500; line-height: 1.2; }
+.orch-agent-meta { display: flex; gap: 8px; align-items: center; }
+.orch-role-badge {
+  display: inline-block; font-size: 9.5px; text-transform: uppercase; letter-spacing: 0.05em;
+  padding: 2px 6px; border-radius: 3px; font-weight: 600;
+}
+.orch-role-signals { background: rgba(79, 142, 255, 0.18); color: var(--accent); }
+.orch-role-buying { background: rgba(79, 195, 127, 0.15); color: var(--success); }
+.orch-role-creative { background: rgba(255, 204, 92, 0.18); color: var(--warning); }
+.orch-role-unclassified { background: var(--bg-soft, var(--bg-base)); color: var(--text-mut); }
+.orch-agent-url { font-size: 10.5px; color: var(--text-mut); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.orch-agent-stats { display: grid; grid-template-columns: 1fr 1fr; gap: 8px; }
+.orch-agent-stats .k { font-size: 9.5px; color: var(--text-mut); text-transform: uppercase; letter-spacing: 0.04em; }
+.orch-agent-stats .v { font-size: 13px; font-family: var(--font-mono); margin-top: 1px; }
+.orch-small { font-size: 10px; color: var(--text-mut); }
+.orch-agent-server { font-size: 10.5px; color: var(--text-mut); }
+.orch-agent-tools { font-size: 10.5px; color: var(--text-mut); line-height: 1.3; }
+.orch-agent-error { font-size: 10px; color: var(--error); line-height: 1.3; }
+
+.orch-fanout-summary { display: grid; grid-template-columns: repeat(auto-fit, minmax(160px, 1fr)); gap: 8px; margin-bottom: 10px; }
+.orch-fanout-card {
+  background: var(--bg-surface); border: 1px solid var(--border); border-left-width: 3px;
+  border-radius: 5px; padding: 8px 10px;
+}
+.orch-fanout-card.orch-fanout-ok { border-left-color: var(--success); }
+.orch-fanout-card.orch-fanout-err { border-left-color: var(--error); opacity: 0.85; }
+.orch-fanout-name { font-size: 12px; font-weight: 500; margin-bottom: 4px; }
+.orch-fanout-stats { display: flex; gap: 10px; font-size: 11px; color: var(--text-mut); }
+.orch-fanout-err-msg { font-size: 10px; color: var(--error); margin-top: 4px; }
+.orch-fanout-totals {
+  font-size: 12px; color: var(--text-mut); padding: 8px 12px;
+  background: var(--bg-soft, var(--bg-surface)); border-radius: 5px;
+}
+.orch-signals-table {
+  width: 100%; border-collapse: collapse; font-size: 11.5px;
+}
+.orch-signals-table th {
+  text-align: left; padding: 6px 8px; font-size: 10px; text-transform: uppercase;
+  letter-spacing: 0.04em; color: var(--text-mut); border-bottom: 1px solid var(--border);
+  white-space: nowrap;
+}
+.orch-signals-table td { padding: 6px 8px; border-bottom: 1px solid var(--border); }
+
+.orch-matrix-table {
+  border-collapse: collapse; font-size: 11.5px; margin: 0;
+}
+.orch-matrix-table th, .orch-matrix-table td {
+  padding: 5px 8px; border: 1px solid var(--border); text-align: center;
+}
+.orch-matrix-table .orch-matrix-tool-header { text-align: left; font-size: 10px; text-transform: uppercase; color: var(--text-mut); }
+.orch-matrix-tool { text-align: left; font-size: 11px; white-space: nowrap; background: var(--bg-surface); }
+.orch-matrix-agent {
+  vertical-align: top; font-weight: 500; min-width: 80px;
+}
+.orch-matrix-agent-name { font-size: 11px; }
+.orch-matrix-agent-meta { font-size: 9.5px; color: var(--text-mut); margin-top: 2px; }
+.orch-matrix-yes { color: var(--success); font-size: 14px; background: rgba(79, 195, 127, 0.08); }
+.orch-matrix-no { color: var(--border); }
+.orch-matrix-unique-row { padding: 4px 0; font-size: 11px; }
+
 /* ── Sec-47: Expression Tree Builder ──────────────────────────────────── */
 .expr-counters {
   display: inline-flex; align-items: center; gap: 8px;
@@ -4237,6 +4377,8 @@ const state = {
   journey: { stages: [], lastResult: null, loaded: false, cumulative: true },
   // Sec-47: boolean expression AST builder. Tree is null until ensureExpression seeds it.
   expression: { tree: null, lastResult: null, loaded: false, nextId: 1, draggedNodeId: null, pickingLeafId: null },
+  // Sec-48: multi-agent orchestrator state.
+  orchestrator: { directory: [], probe: null, orchestrate: null, matrix: null, loaded: false, probing: false, matrixing: false, orchestrating: false },
   // Sec-44: Scenario Planner — current / add / remove pools.
   planner: { cur: [], add: [], rem: [], lastResult: null, loaded: false },
   // Sec-44: Snapshots — fetched index + diff selection.
@@ -4476,6 +4618,7 @@ function switchTab(name) {
     journey: "Journey", planner: "Scenario", snapshots: "Snapshots",
     freshness: "Freshness",
     seasonality: "Seasonality", federation: "Federation",
+    orchestrator: "Orchestrator",
   };
   document.getElementById("crumb-current").textContent = crumbMap[name] || name;
 
@@ -4499,6 +4642,7 @@ function switchTab(name) {
   if (name === "freshness") ensureFreshness();
   if (name === "seasonality") ensureSeasonality();
   if (name === "federation") ensureFederation();
+  if (name === "orchestrator") ensureOrchestrator();
 
   // Activations tab: start polling when visible, stop when hidden
   if (name === "activations") startActivationsPolling();
@@ -10793,6 +10937,261 @@ async function saveExpressionSnapshot() {
   } catch (e) {
     showToast(e.message, true);
   }
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Sec-48: Multi-Agent Orchestrator — live view + fan-out + capability matrix
+// across every AdCP agent in our curated directory.
+// ─────────────────────────────────────────────────────────────────────────
+var _orchLoaded = false;
+
+async function ensureOrchestrator() {
+  if (_orchLoaded) return;
+  _orchLoaded = true;
+  document.getElementById("orch-refresh").addEventListener("click", runOrchProbeAll);
+  document.getElementById("orch-run").addEventListener("click", runOrchFanout);
+  document.getElementById("orch-matrix-run").addEventListener("click", runOrchMatrix);
+  // Load static directory first, then kick off probe in parallel.
+  await loadOrchDirectory();
+  runOrchProbeAll();
+}
+
+async function loadOrchDirectory() {
+  var host = document.getElementById("orch-agents");
+  try {
+    var r = await fetch("/agents/directory");
+    var data = await r.json();
+    state.orchestrator.directory = data.agents || [];
+    var countEl = document.getElementById("orch-agents-count");
+    if (countEl) countEl.textContent = data.count;
+    _orchRenderAgentGrid();
+  } catch (e) {
+    host.innerHTML = '<div class="empty-state" style="border-color:var(--error)"><div class="empty-title" style="color:var(--error)">' + escapeHtml(e.message) + '</div></div>';
+  }
+}
+
+async function runOrchProbeAll() {
+  if (state.orchestrator.probing) return;
+  state.orchestrator.probing = true;
+  var btn = document.getElementById("orch-refresh");
+  var label = btn ? btn.querySelector("span") : null;
+  var origText = label ? label.textContent : "";
+  if (label) label.textContent = "Probing\u2026";
+  if (btn) btn.disabled = true;
+  try {
+    var r = await fetch("/agents/probe-all?timeout_ms=10000");
+    var data = await r.json();
+    if (!r.ok || data.error) throw new Error(data.error || "HTTP " + r.status);
+    state.orchestrator.probe = data;
+    _orchRenderAgentGrid();
+    _orchRenderSummary();
+  } catch (e) {
+    showToast("Probe failed: " + e.message, true);
+  } finally {
+    state.orchestrator.probing = false;
+    if (label) label.textContent = origText;
+    if (btn) btn.disabled = false;
+  }
+}
+
+function _orchRenderSummary() {
+  var host = document.getElementById("orch-summary");
+  if (!host) return;
+  var probe = state.orchestrator.probe;
+  if (!probe) { host.innerHTML = ""; return; }
+  host.innerHTML =
+    '<div class="orch-summary-cards">' +
+      '<div class="orch-summary-card"><div class="k">Probed</div><div class="v mono">' + probe.count + '</div></div>' +
+      '<div class="orch-summary-card orch-summary-ok"><div class="k">Alive</div><div class="v mono">' + probe.alive_count + '</div></div>' +
+      '<div class="orch-summary-card"><div class="k">Down</div><div class="v mono">' + (probe.count - probe.alive_count) + '</div></div>' +
+      '<div class="orch-summary-card"><div class="k">Avg latency</div><div class="v mono">' + probe.avg_latency_ms + ' ms</div></div>' +
+      '<div class="orch-summary-card"><div class="k">Probed at</div><div class="v mono" style="font-size:11px">' + escapeHtml(probe.probed_at) + '</div></div>' +
+    '</div>';
+}
+
+function _orchRenderAgentGrid() {
+  var host = document.getElementById("orch-agents");
+  if (!host) return;
+  var agents = state.orchestrator.directory || [];
+  if (agents.length === 0) {
+    host.innerHTML = '<div class="empty-state"><div class="empty-title">No agents in directory</div></div>';
+    return;
+  }
+  // Build per-agent probe lookup.
+  var probeByUrl = {};
+  if (state.orchestrator.probe) {
+    (state.orchestrator.probe.results || []).forEach(function (r) { probeByUrl[r.mcp_url] = r; });
+  }
+  // Group by role + stage for grid layout.
+  var groups = { signals: [], buying: [], creative: [], unclassified: [] };
+  var byStage = { live: [], known_issue: [], roadmap: [] };
+  agents.forEach(function (a) {
+    byStage[a.stage] = byStage[a.stage] || [];
+    byStage[a.stage].push(a);
+  });
+  function renderAgent(a) {
+    var probe = a.mcp_url ? probeByUrl[a.mcp_url] : null;
+    var probeInfo = probe ? probe.probe : null;
+    var alive = probeInfo && probeInfo.alive;
+    var status = a.stage === "roadmap" ? "roadmap" :
+                 a.stage === "known_issue" ? "issue" :
+                 !probeInfo ? "unknown" :
+                 alive ? "alive" : "down";
+    var statusClass = "orch-agent-" + status;
+    var pillClass = status === "alive" ? "pill-success" :
+                    status === "down" ? "pill-error" :
+                    status === "issue" ? "pill-warning" :
+                    status === "roadmap" ? "pill-muted" : "pill-muted";
+    var pillLabel = status === "alive" ? "alive" : status === "down" ? "down" :
+                    status === "issue" ? "issues" : status === "roadmap" ? "roadmap" : "unknown";
+    var toolCount = probeInfo && probeInfo.tools ? probeInfo.tools.length : (a.directory_tool_count != null ? a.directory_tool_count : "—");
+    var toolSource = probeInfo && probeInfo.tools ? "live" : "dir";
+    var latency = probeInfo ? probeInfo.latency_ms + " ms" : "—";
+    var serverInfo = probeInfo && probeInfo.server_info ? (probeInfo.server_info.name || "") + (probeInfo.server_info.version ? " " + probeInfo.server_info.version : "") : "";
+    var roleBadge = '<span class="orch-role-badge orch-role-' + a.role + '">' + escapeHtml(a.role) + '</span>';
+    var urlShort = a.mcp_url ? a.mcp_url.replace(/^https?:\/\//, "").slice(0, 50) : "no endpoint";
+    var errorLine = probeInfo && probeInfo.error && !alive
+      ? '<div class="orch-agent-error mono">' + escapeHtml(String(probeInfo.error).slice(0, 80)) + '</div>'
+      : '';
+    var firstTools = probeInfo && probeInfo.tools ? probeInfo.tools.slice(0, 3).map(function (t) { return t.name; }).join(", ") : "";
+    return '<div class="orch-agent-card ' + statusClass + '">' +
+      '<div class="orch-agent-head">' +
+        '<div class="orch-agent-name">' + escapeHtml(a.name) + '</div>' +
+        '<span class="pill ' + pillClass + ' mono" style="font-size:10px">' + pillLabel + '</span>' +
+      '</div>' +
+      '<div class="orch-agent-meta">' + roleBadge +
+        '<span class="mono" style="color:var(--text-mut);font-size:10.5px">' + escapeHtml(a.vendor) + '</span>' +
+      '</div>' +
+      '<div class="orch-agent-url mono" title="' + escapeHtml(a.mcp_url || "") + '">' + escapeHtml(urlShort) + '</div>' +
+      '<div class="orch-agent-stats">' +
+        '<div><div class="k">Tools</div><div class="v">' + toolCount + ' <span class="orch-small mono">(' + toolSource + ')</span></div></div>' +
+        '<div><div class="k">Latency</div><div class="v">' + latency + '</div></div>' +
+      '</div>' +
+      (serverInfo ? '<div class="orch-agent-server mono">' + escapeHtml(serverInfo) + '</div>' : '') +
+      (firstTools ? '<div class="orch-agent-tools mono">' + escapeHtml(firstTools) + (probeInfo.tools.length > 3 ? " +" + (probeInfo.tools.length - 3) : "") + '</div>' : '') +
+      errorLine +
+    '</div>';
+  }
+  var html = "";
+  ["live", "known_issue", "roadmap"].forEach(function (stage) {
+    var list = byStage[stage] || [];
+    if (list.length === 0) return;
+    var stageLabel = stage === "live" ? "Live" : stage === "known_issue" ? "Known Issues" : "Roadmap";
+    html +=
+      '<div class="orch-stage-section">' +
+        '<div class="orch-stage-label">' + stageLabel + ' <span class="mono" style="color:var(--text-mut);font-weight:400;margin-left:6px">' + list.length + '</span></div>' +
+        '<div class="orch-agent-grid">' + list.map(renderAgent).join("") + '</div>' +
+      '</div>';
+  });
+  host.innerHTML = html;
+  void groups;
+}
+
+async function runOrchFanout() {
+  if (state.orchestrator.orchestrating) return;
+  var briefEl = document.getElementById("orch-brief");
+  var maxEl = document.getElementById("orch-max");
+  var brief = (briefEl.value || "").trim();
+  if (!brief) { showToast("Brief required.", true); return; }
+  var maxResults = Number(maxEl.value) || 10;
+  state.orchestrator.orchestrating = true;
+  var host = document.getElementById("orch-results");
+  host.innerHTML = '<div class="empty-state"><span class="spinner"></span><div class="empty-title">Fanning out\u2026</div></div>';
+  try {
+    var r = await fetch("/agents/orchestrate", {
+      method: "POST", headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ brief: brief, max_results_per_agent: maxResults, timeout_ms: 15000 }),
+    });
+    var data = await r.json();
+    if (!r.ok || data.error) throw new Error(data.error || "HTTP " + r.status);
+    state.orchestrator.orchestrate = data;
+    _orchRenderFanoutResult(data);
+  } catch (e) {
+    host.innerHTML = '<div class="empty-state" style="border-color:var(--error)"><div class="empty-title" style="color:var(--error)">' + escapeHtml(e.message) + '</div></div>';
+  } finally {
+    state.orchestrator.orchestrating = false;
+  }
+}
+
+function _orchRenderFanoutResult(data) {
+  var host = document.getElementById("orch-results");
+  var summaryCards = (data.per_agent || []).map(function (p) {
+    var cls = p.ok ? "orch-fanout-ok" : "orch-fanout-err";
+    return '<div class="orch-fanout-card ' + cls + '">' +
+      '<div class="orch-fanout-name">' + escapeHtml(p.name) + ' <span class="mono" style="color:var(--text-mut);font-size:10px">· ' + escapeHtml(p.vendor) + '</span></div>' +
+      '<div class="orch-fanout-stats">' +
+        '<span class="mono">' + (p.ok ? p.signal_count + " signals" : "failed") + '</span>' +
+        '<span class="mono">' + p.latency_ms + ' ms</span>' +
+      '</div>' +
+      (p.error ? '<div class="orch-fanout-err-msg mono">' + escapeHtml(String(p.error).slice(0, 80)) + '</div>' : '') +
+    '</div>';
+  }).join("");
+  var signals = data.signals || [];
+  var signalRows = signals.slice(0, 50).map(function (s) {
+    var sourceAgent = s.source_agent || "?";
+    var badgeCls = sourceAgent === "evgeny_signals" ? "pill-success" : sourceAgent === "dstillery" ? "pill-info" : "pill-muted";
+    return '<tr>' +
+      '<td><span class="pill ' + badgeCls + ' mono" style="font-size:10px">' + escapeHtml(sourceAgent) + '</span></td>' +
+      '<td>' + escapeHtml(s.name || "(unnamed)") + '</td>' +
+      '<td class="mono">' + escapeHtml(s.signal_agent_segment_id || "") + '</td>' +
+      '<td class="mono">' + (s.coverage_percentage != null ? (s.coverage_percentage * 100).toFixed(1) + "%" : "—") + '</td>' +
+      '<td class="mono">' + (s.pricing && s.pricing.cpm != null ? "$" + s.pricing.cpm : "—") + '</td>' +
+    '</tr>';
+  }).join("");
+  host.innerHTML =
+    '<div class="orch-fanout-summary">' + summaryCards + '</div>' +
+    '<div class="orch-fanout-totals mono">' +
+      'Total: <strong>' + signals.length + '</strong> signals across <strong>' + data.agents_succeeded.length + '/' + data.agents_queried.length + '</strong> agents' +
+    '</div>' +
+    (signals.length > 0
+      ? '<div style="overflow:auto;margin-top:10px"><table class="orch-signals-table"><thead><tr><th>Source</th><th>Name</th><th>Segment ID</th><th>Coverage</th><th>CPM</th></tr></thead><tbody>' + signalRows + '</tbody></table>' + (signals.length > 50 ? '<div style="color:var(--text-mut);font-size:11px;padding:6px 0">Showing first 50 of ' + signals.length + '.</div>' : '') + '</div>'
+      : '<div class="empty-state" style="margin-top:10px"><div class="empty-desc">No signals returned from any agent. Check the per-agent summary above for per-agent errors.</div></div>');
+}
+
+async function runOrchMatrix() {
+  if (state.orchestrator.matrixing) return;
+  state.orchestrator.matrixing = true;
+  var host = document.getElementById("orch-matrix");
+  host.innerHTML = '<div class="empty-state"><span class="spinner"></span><div class="empty-title">Building capability matrix\u2026</div></div>';
+  try {
+    var r = await fetch("/agents/capability-matrix?timeout_ms=10000");
+    var data = await r.json();
+    if (!r.ok || data.error) throw new Error(data.error || "HTTP " + r.status);
+    state.orchestrator.matrix = data;
+    _orchRenderMatrix(data);
+  } catch (e) {
+    host.innerHTML = '<div class="empty-state" style="border-color:var(--error)"><div class="empty-title" style="color:var(--error)">' + escapeHtml(e.message) + '</div></div>';
+  } finally {
+    state.orchestrator.matrixing = false;
+  }
+}
+
+function _orchRenderMatrix(data) {
+  var host = document.getElementById("orch-matrix");
+  var agents = data.agents || [];
+  var tools = data.tools || [];
+  if (agents.length === 0 || tools.length === 0) {
+    host.innerHTML = '<div class="empty-state"><div class="empty-title">No tools discovered</div><div class="empty-desc">All agents either failed to probe or exposed no tools/list.</div></div>';
+    return;
+  }
+  var headerCells = agents.map(function (a) {
+    var title = escapeHtml(a.name) + " — " + (a.alive ? "alive" : "down");
+    return '<th class="orch-matrix-agent" title="' + title + '"><div class="orch-matrix-agent-name">' + escapeHtml(a.id) + '</div><div class="orch-matrix-agent-meta mono">' + a.tool_count + ' tools</div></th>';
+  }).join("");
+  var rows = tools.map(function (t) {
+    var cells = agents.map(function (a) {
+      var supported = t.supported_by.indexOf(a.id) >= 0;
+      return '<td class="' + (supported ? "orch-matrix-yes" : "orch-matrix-no") + '">' + (supported ? "●" : "") + '</td>';
+    }).join("");
+    return '<tr><td class="orch-matrix-tool mono">' + escapeHtml(t.tool) + '</td>' + cells + '</tr>';
+  }).join("");
+  var uniqueSummary = agents.filter(function (a) { return a.unique_tools && a.unique_tools.length > 0; }).map(function (a) {
+    return '<div class="orch-matrix-unique-row"><span class="pill pill-accent mono" style="font-size:10px">' + escapeHtml(a.id) + '</span> <span class="mono" style="font-size:11px">' + escapeHtml(a.unique_tools.join(", ").slice(0, 100)) + '</span></div>';
+  }).join("");
+  host.innerHTML =
+    '<div style="overflow:auto"><table class="orch-matrix-table"><thead><tr><th class="orch-matrix-tool-header">Tool</th>' + headerCells + '</tr></thead><tbody>' + rows + '</tbody></table></div>' +
+    (uniqueSummary ? '<div style="margin-top:10px"><div class="lab-label">Unique tools per agent</div>' + uniqueSummary + '</div>' : '') +
+    '<div style="font-size:11px;color:var(--text-mut);margin-top:8px">' + tools.length + ' tools across ' + agents.length + ' agents.</div>';
 }
 
 // ─── Federation (partial — more in Part 3) ───────────────────────────────


### PR DESCRIPTION
## Summary

Turns the demo into an ecosystem-scale view. Every active AdCP directory agent is probed in parallel; a single brief fans out to every live signals agent at once; tool surfaces compare side-by-side.

Addresses the user's "full multi a2a workflow, deep and cool capabilities" ask.

## Backend

- **[genericMcpClient.ts](src/federation/genericMcpClient.ts)** — factored Streamable-HTTP + SSE MCP client. Per-URL session cache, one-shot retry on session errors. Exports `probeAgent`, `probeAgents`, `callAgentTool`.
- **[agentRegistry.ts](src/domain/agentRegistry.ts)** — 17 agents from adcp directory as of 2026-04-24: 12 live, 4 known-issue, 3 roadmap. Role classification (signals/buying/creative).
- **[agentsEndpoints.ts](src/routes/agentsEndpoints.ts)** — 4 new endpoints:
  - `GET /agents/directory`
  - `GET /agents/probe-all` (parallel + tool-count-diff vs baseline)
  - `POST /agents/orchestrate` (fan-out signals brief)
  - `GET /agents/capability-matrix` (tools×agents + unique-tools-per-agent)

Capabilities v20 → v21 with `federation.multi_agent_orchestrator` experimental flag.

## UI — new "Orchestrator" tab

- Summary cards: probed / alive / down / avg latency / probed_at
- Agent grid grouped by stage, color-coded (green=alive, red=down, amber=issue, grey=roadmap)
- Fan-out panel + per-agent result cards + merged signals table
- Capability matrix (on-demand)

## Test plan

- `curl /agents/directory` — 17 agents across 3 stages
- `curl /agents/probe-all` — parallel probe of 12 live agents, ~10s
- `curl -X POST /agents/orchestrate -d '{"brief":"travel"}'` — fan-out to signals agents
- `curl /agents/capability-matrix` — tool surface comparison

Backend suite: 369 passed / 12 skipped (no new pure-math tests; the new code is network-transport).

🤖 Generated with [Claude Code](https://claude.com/claude-code)