### PR TITLE
Sec-48b hotfix: stateless MCP + self-fetch short-circuit + URL fixes

### DIFF
--- a/src/domain/agentRegistry.ts
+++ b/src/domain/agentRegistry.ts
@@ -137,7 +137,8 @@ export const AGENT_REGISTRY: RegisteredAgent[] = [
     id: "content_ignite",
     name: "Content Ignite",
     vendor: "Content Ignite",
-    mcp_url: "https://sales-agent.contentignite.com",
+    // Sec-48b: directory listed bare root URL; real endpoint is /mcp/ (trailing slash).
+    mcp_url: "https://sales-agent.contentignite.com/mcp/",
     stage: "live",
     role: "buying",
     protocols: ["adcp_3.0", "mcp_streamable_http"],
@@ -157,7 +158,8 @@ export const AGENT_REGISTRY: RegisteredAgent[] = [
     id: "claire_scope3",
     name: "Claire (Scope3 deployment)",
     vendor: "Philippe Giendaj",
-    mcp_url: "https://6138516b.sales-agent.scope3.com/mcp",
+    // Sec-48b: directory shows both /mcp and /mcp/; only /mcp/ responds.
+    mcp_url: "https://6138516b.sales-agent.scope3.com/mcp/",
     stage: "live",
     role: "buying",
     protocols: ["adcp_3.0", "mcp_streamable_http"],

--- a/src/domain/capabilityService.ts
+++ b/src/domain/capabilityService.ts
@@ -30,9 +30,12 @@
 // v21: Sec-48 adds agent-syndication endpoints (/agents/directory, /agents/probe-all,
 // /agents/orchestrate, /agents/capability-matrix) + federation.multi_agent_orchestrator
 // experimental feature flag.
+// v22: Sec-48b — no surface change, but bump so the capability-discovery cache
+// invalidates alongside the probe-handshake fixes (stateless MCP support,
+// self-fetch short-circuit, URL corrections for content_ignite + claire_scope3).
 // The key version must be bumped any time the SHAPE of the capability response
 // changes, so clients that cache by key pick up the new fields.
-const CACHE_KEY = "adcp_capabilities_v21";
+const CACHE_KEY = "adcp_capabilities_v22";
 const CACHE_TTL_SECONDS = 3600;
 
 import { buildUcpCapability, type UcpCapabilityEnv } from "../ucp/vacDeclaration";

--- a/src/federation/genericMcpClient.ts
+++ b/src/federation/genericMcpClient.ts
@@ -21,6 +21,9 @@
 // frequently; this is best-effort, we renew on every cold start.
 
 const SESSION_TTL_MS = 9 * 60 * 1000;
+/** Sentinel used for agents that negotiate stateless MCP (no mcp-session-id header
+ * on initialize). Subsequent calls for these agents don't send the header. */
+const STATELESS_SESSION = "__stateless__";
 const _sessions = new Map<string, { id: string; atMs: number }>();
 
 /** Parse an SSE response body and return the last `data:` payload as JSON. */
@@ -63,7 +66,7 @@ async function initializeSession(url: string, opts: InitOptions = {}): Promise<{
       const body = await res.text().catch(() => "");
       return { sessionId: null, error: `HTTP ${res.status}: ${body.slice(0, 200)}` };
     }
-    const sessionId = res.headers.get("mcp-session-id");
+    const headerSessionId = res.headers.get("mcp-session-id");
     const bodyText = await res.text();
     const parsed = parseSSELastData(bodyText) as {
       result?: {
@@ -72,6 +75,13 @@ async function initializeSession(url: string, opts: InitOptions = {}): Promise<{
       };
       error?: { code: number; message: string };
     } | null;
+    // Sec-48b: an initialize response with a successful `result` body means the
+    // server is live MCP. If it also returned a session id header, the server
+    // is stateful; otherwise it negotiated stateless transport (call each
+    // method independently, no session header). Treat both as success.
+    let sessionId: string | null = null;
+    if (headerSessionId) sessionId = headerSessionId;
+    else if (parsed?.result && !parsed.error) sessionId = STATELESS_SESSION;
     const result: {
       sessionId: string | null;
       serverInfo?: { name: string; version?: string };
@@ -81,16 +91,18 @@ async function initializeSession(url: string, opts: InitOptions = {}): Promise<{
     if (parsed?.result?.serverInfo) result.serverInfo = parsed.result.serverInfo;
     if (parsed?.result?.protocolVersion) result.protocolVersion = parsed.result.protocolVersion;
     if (parsed?.error) result.error = parsed.error.message;
-    // Post-initialize notification (best-effort — many servers require it before tool calls)
+    // Post-initialize notification (best-effort — many stateful servers require
+    // it before tool calls; stateless servers accept it as a no-op).
     if (sessionId) {
       try {
+        const headers: Record<string, string> = {
+          "Content-Type": "application/json",
+          "Accept": "application/json, text/event-stream",
+        };
+        if (sessionId !== STATELESS_SESSION) headers["mcp-session-id"] = sessionId;
         await fetch(url, {
           method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            "Accept": "application/json, text/event-stream",
-            "mcp-session-id": sessionId,
-          },
+          headers,
           body: JSON.stringify({ jsonrpc: "2.0", method: "notifications/initialized" }),
           signal: AbortSignal.timeout(5_000),
         });
@@ -130,9 +142,32 @@ export interface ProbeResult {
   tools?: Array<{ name: string; description?: string }>;
 }
 
+/** Sec-48b: caller-installed hook to short-circuit probes of our own URL.
+ * Cloudflare Workers block a Worker from fetching its own public hostname
+ * (Cloudflare error 1042 / 522). When we know the URL is us, return the
+ * canonical tool list without hitting the network. The hook accepts a URL
+ * and returns a synth ProbeResult payload if the URL is self, null otherwise. */
+type SelfProbeHook = (url: string) => { server_info?: { name: string; version?: string }; tools?: Array<{ name: string; description?: string }> } | null;
+let SELF_PROBE_HOOK: SelfProbeHook | null = null;
+export function installSelfProbeHook(hook: SelfProbeHook | null): void { SELF_PROBE_HOOK = hook; }
+
 export async function probeAgent(url: string, opts?: { timeoutMs?: number }): Promise<ProbeResult> {
   const start = Date.now();
   const timeoutMs = opts?.timeoutMs ?? 10_000;
+  // Sec-48b: short-circuit self-probe. Cloudflare Workers block a Worker from
+  // calling its own public hostname (returns Cloudflare error 1042). We know
+  // our own tools from the self-registry — synthesize a probe result from
+  // that instead of hitting the network.
+  if (SELF_PROBE_HOOK && SELF_PROBE_HOOK(url)) {
+    const synth = SELF_PROBE_HOOK(url);
+    return {
+      url,
+      alive: true,
+      latency_ms: Date.now() - start,
+      ...(synth?.server_info ? { server_info: synth.server_info } : {}),
+      ...(synth?.tools ? { tools: synth.tools } : {}),
+    };
+  }
   const init = await initializeSession(url, { timeoutMs });
   if (!init.sessionId) {
     return {
@@ -146,13 +181,14 @@ export async function probeAgent(url: string, opts?: { timeoutMs?: number }): Pr
   _sessions.set(url, { id: init.sessionId, atMs: start });
   // tools/list
   try {
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+      "Accept": "application/json, text/event-stream",
+    };
+    if (init.sessionId !== STATELESS_SESSION) headers["mcp-session-id"] = init.sessionId;
     const res = await fetch(url, {
       method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        "Accept": "application/json, text/event-stream",
-        "mcp-session-id": init.sessionId,
-      },
+      headers,
       body: JSON.stringify({ jsonrpc: "2.0", id: 2, method: "tools/list", params: {} }),
       signal: AbortSignal.timeout(timeoutMs),
     });
@@ -200,13 +236,14 @@ export interface ToolCallResult {
 
 async function callToolOnce(url: string, sessionId: string, name: string, args: Record<string, unknown>, timeoutMs: number): Promise<ToolCallResult> {
   const start = Date.now();
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    "Accept": "application/json, text/event-stream",
+  };
+  if (sessionId !== STATELESS_SESSION) headers["mcp-session-id"] = sessionId;
   const res = await fetch(url, {
     method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      "Accept": "application/json, text/event-stream",
-      "mcp-session-id": sessionId,
-    },
+    headers,
     body: JSON.stringify({
       jsonrpc: "2.0", id: Date.now(), method: "tools/call",
       params: { name, arguments: args },
@@ -239,9 +276,25 @@ async function callToolOnce(url: string, sessionId: string, name: string, args: 
   return out;
 }
 
+/** Sec-48b: caller-installed hook for self-tool-calls. When the URL is us,
+ * the caller supplies a direct-dispatch function that runs the tool in-process
+ * (bypassing the HTTP round-trip that Cloudflare Workers would block anyway). */
+type SelfToolHook = (url: string, name: string, args: Record<string, unknown>) => Promise<ToolCallResult> | null;
+let SELF_TOOL_HOOK: SelfToolHook | null = null;
+export function installSelfToolHook(hook: SelfToolHook | null): void { SELF_TOOL_HOOK = hook; }
+
 export async function callAgentTool(url: string, name: string, args: Record<string, unknown>, opts?: { timeoutMs?: number }): Promise<ToolCallResult> {
   const timeoutMs = opts?.timeoutMs ?? 20_000;
   const start = Date.now();
+  // Sec-48b: if this is a call against our own URL, use the in-process hook
+  // to avoid Cloudflare Workers' self-fetch restriction.
+  if (SELF_TOOL_HOOK) {
+    const selfResult = SELF_TOOL_HOOK(url, name, args);
+    if (selfResult) {
+      try { return await selfResult; }
+      catch (e) { return { ok: false, error: String((e as Error).message || e), latency_ms: Date.now() - start }; }
+    }
+  }
   try {
     let session = await ensureSession(url, { timeoutMs });
     if (!session) {

--- a/src/routes/agentsEndpoints.ts
+++ b/src/routes/agentsEndpoints.ts
@@ -20,9 +20,81 @@ import {
   getLiveAgents,
   getAgentsByRole,
   findAgent,
+  SELF_URL,
+  SELF_AGENT_ID,
   type RegisteredAgent,
 } from "../domain/agentRegistry";
-import { probeAgents, callAgentTool, type ProbeResult } from "../federation/genericMcpClient";
+import {
+  probeAgents,
+  callAgentTool,
+  installSelfProbeHook,
+  installSelfToolHook,
+  type ProbeResult,
+  type ToolCallResult,
+} from "../federation/genericMcpClient";
+import { searchSignalsService } from "../domain/signalService";
+import { getDb } from "../storage/db";
+
+// Sec-48b: hook the generic MCP client with a self-detector. When the orchestrator
+// probes or fans-out to our own URL, Cloudflare Workers refuse self-fetch; we
+// short-circuit and return our real tool list / dispatch the call in-process.
+let _envHookInstalled = false;
+function ensureSelfHooksInstalled(env: Env, logger: Logger): void {
+  if (_envHookInstalled) return;
+  _envHookInstalled = true;
+  installSelfProbeHook((url) => {
+    if (!isSelfUrl(url)) return null;
+    const self = AGENT_REGISTRY.find((a) => a.id === SELF_AGENT_ID);
+    return {
+      server_info: { name: self?.name ?? "evgeny-signals", version: "48.0" },
+      tools: (self?.tools_exposed ?? []).map((name) => ({ name })),
+    };
+  });
+  installSelfToolHook((url, name, args) => {
+    if (!isSelfUrl(url)) return null;
+    return selfToolDispatch(name, args, env, logger);
+  });
+}
+
+function isSelfUrl(url: string): boolean {
+  const a = url.replace(/\/+$/, "");
+  const b = (SELF_URL + "/mcp").replace(/\/+$/, "");
+  return a === b || a === SELF_URL.replace(/\/+$/, "");
+}
+
+/** Direct-dispatch our own signals tools without the HTTP roundtrip.
+ * Covers get_signals (the only tool orchestrate currently fans to); other
+ * tools fall through to "tool_not_self_dispatchable" so a bug can be caught
+ * rather than silently returning empty. */
+async function selfToolDispatch(name: string, args: Record<string, unknown>, env: Env, logger: Logger): Promise<ToolCallResult> {
+  const start = Date.now();
+  void logger;
+  try {
+    if (name === "get_signals") {
+      const brief = String(args.signal_spec ?? args.brief ?? "");
+      const maxResults = Math.max(1, Math.min(50, Number(args.max_results) || 10));
+      const db = getDb(env);
+      // searchSignalsService needs a KVNamespace; env.SIGNALS_CACHE is the
+      // operator-scoped KV used elsewhere in the codebase.
+      const result = await searchSignalsService(db, env.SIGNALS_CACHE, {
+        brief,
+        limit: maxResults,
+      });
+      return {
+        ok: true,
+        latency_ms: Date.now() - start,
+        structured_content: { signals: result.signals, count: result.count },
+      };
+    }
+    return {
+      ok: false,
+      error: `tool_not_self_dispatchable: ${name}`,
+      latency_ms: Date.now() - start,
+    };
+  } catch (e) {
+    return { ok: false, error: String((e as Error).message || e), latency_ms: Date.now() - start };
+  }
+}
 
 // ── GET /agents/directory ───────────────────────────────────────────────────
 
@@ -45,7 +117,8 @@ export function handleAgentsDirectory(): Response {
 
 // ── GET /agents/probe-all ───────────────────────────────────────────────────
 
-export async function handleAgentsProbeAll(request: Request, _env: Env, logger: Logger): Promise<Response> {
+export async function handleAgentsProbeAll(request: Request, env: Env, logger: Logger): Promise<Response> {
+  ensureSelfHooksInstalled(env, logger);
   const url = new URL(request.url);
   const roleFilter = url.searchParams.get("role");
   const timeoutMs = Math.max(1000, Math.min(30_000, Number(url.searchParams.get("timeout_ms")) || 8000));
@@ -123,7 +196,8 @@ interface OrchestratePerAgent {
   signals: unknown[];
 }
 
-export async function handleAgentsOrchestrate(request: Request, _env: Env, logger: Logger): Promise<Response> {
+export async function handleAgentsOrchestrate(request: Request, env: Env, logger: Logger): Promise<Response> {
+  ensureSelfHooksInstalled(env, logger);
   const parsed = await readJsonBody<OrchestrateBody>(request);
   if (parsed.kind === "invalid") return errorResponse("INVALID_JSON", parsed.reason, 400);
   const body: OrchestrateBody = parsed.kind === "parsed" ? parsed.data : {};
@@ -202,7 +276,8 @@ export async function handleAgentsOrchestrate(request: Request, _env: Env, logge
 // shows whether the agent declares it (from probe-all). Useful to see
 // which agents cluster on the same tool set.
 
-export async function handleAgentsCapabilityMatrix(request: Request, _env: Env, logger: Logger): Promise<Response> {
+export async function handleAgentsCapabilityMatrix(request: Request, env: Env, logger: Logger): Promise<Response> {
+  ensureSelfHooksInstalled(env, logger);
   const url = new URL(request.url);
   const timeoutMs = Math.max(1000, Math.min(30_000, Number(url.searchParams.get("timeout_ms")) || 8000));
   const roleFilter = url.searchParams.get("role");


### PR DESCRIPTION
Post-deploy verification of PR #73 caught 4 real bugs. This hotfix:

1. **Self-probe failure** — Cloudflare Workers block a Worker from fetching its own public hostname. Added `installSelfProbeHook` / `installSelfToolHook` — route layer registers an in-process short-circuit so probes of our own URL return our tool list from the registry and tool calls dispatch via `searchSignalsService` directly.
2. **Stateless MCP** — Swivel + others succeed on initialize but return no `mcp-session-id` header. New `STATELESS_SESSION` sentinel; tools/list + tools/call skip the session header when stateless.
3. **content_ignite URL** — needed trailing slash `/mcp/`.
4. **claire_scope3 URL** — same, needed trailing slash.

Cache key bumped v21 → v22.

### Expected after merge
```
evgeny_signals  alive (via in-process dispatch)
swivel          alive (via stateless handshake)
content_ignite  alive (via /mcp/)
claire_scope3   alive (via /mcp/)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)