### PR TITLE
Sec-48c hotfix: escape regex slashes in Orchestrator tab

### DIFF
--- a/src/routes/demo.ts
+++ b/src/routes/demo.ts
@@ -11049,7 +11049,12 @@ function _orchRenderAgentGrid() {
     var latency = probeInfo ? probeInfo.latency_ms + " ms" : "—";
     var serverInfo = probeInfo && probeInfo.server_info ? (probeInfo.server_info.name || "") + (probeInfo.server_info.version ? " " + probeInfo.server_info.version : "") : "";
     var roleBadge = '<span class="orch-role-badge orch-role-' + a.role + '">' + escapeHtml(a.role) + '</span>';
-    var urlShort = a.mcp_url ? a.mcp_url.replace(/^https?:\/\//, "").slice(0, 50) : "no endpoint";
+    // Double-escape the slashes: the SCRIPT_TAG body is a TS template
+    // literal, so single-backslash-slash collapses to a plain slash at
+    // emission and the regex becomes /^https?:/// which JS reads as a
+    // regex followed by a line comment — missing ) after argument list.
+    // Using \\/\\/ here so the served JS sees \/\/.
+    var urlShort = a.mcp_url ? a.mcp_url.replace(/^https?:\\/\\//, "").slice(0, 50) : "no endpoint";
     var errorLine = probeInfo && probeInfo.error && !alive
       ? '<div class="orch-agent-error mono">' + escapeHtml(String(probeInfo.error).slice(0, 80)) + '</div>'
       : '';


### PR DESCRIPTION
## Summary

Fixes the live-breaking syntax error reported on the demo page:

> Uncaught SyntaxError: missing ) after argument list (at (index):11004:50)

### Root cause

The Orchestrator tab's URL-shortener uses a regex:

```js
a.mcp_url.replace(/^https?:\/\//, "")
```

That code lives inside the `SCRIPT_TAG` template literal. JavaScript template literals treat `\/` as an invalid escape and drop the backslash at emission time, so the *served* JS looks like:

```js
a.mcp_url.replace(/^https?:///, "")
```

JS parses `/^https?:/` as a complete regex literal. The remaining `//, "").slice(0, 50) : "no endpoint";` is then a line comment, which eats the closing `)`. The whole `<script type="module">` fails to parse — taking the entire demo page with it, not just the Orchestrator tab.

### Fix

Double-escape in source as `\/\/` so the emitted JS contains `\/\/`. One-line change in `src/routes/demo.ts` plus a comment explaining the trap (the next person to add a regex here will hit it too otherwise).

## Test plan

- [x] Type check: no errors.
- [x] Full test suite: 369 / 12 skip — baseline unchanged (no test files touched).
- [ ] Post-merge + deploy: open `/`, confirm no console error, navigate to Orchestrator tab, verify agent cards render with shortened URLs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)