### PR TITLE
Sec-48e: self-probe emits real tool schemas (not just names)

### DIFF
--- a/src/routes/agentsEndpoints.ts
+++ b/src/routes/agentsEndpoints.ts
@@ -46,6 +46,7 @@ import {
   type ProductLite,
   type MediaBuyPayload,
 } from "../domain/workflowOrchestration";
+import { ADCP_TOOLS } from "../mcp/tools";
 
 // Sec-48b: hook the generic MCP client with a self-detector. When the orchestrator
 // probes or fans-out to our own URL, Cloudflare Workers refuse self-fetch; we
@@ -57,9 +58,19 @@ function ensureSelfHooksInstalled(env: Env, logger: Logger): void {
   installSelfProbeHook((url) => {
     if (!isSelfUrl(url)) return null;
     const self = AGENT_REGISTRY.find((a) => a.id === SELF_AGENT_ID);
+    // Sec-48e: emit the same shape as a real tools/list — every external
+    // agent's probe returns description + inputSchema, and the Orchestrator
+    // UI renders a params table from those. Without this, the self card
+    // showed 8 tools with "No parameter schema advertised" while Claire and
+    // Adzymic rendered full schemas. Source ADCP_TOOLS is the single tool
+    // registry also served at POST /mcp tools/list.
     return {
       server_info: { name: self?.name ?? "evgeny-signals", version: "48.0" },
-      tools: (self?.tools_exposed ?? []).map((name) => ({ name })),
+      tools: ADCP_TOOLS.map((t) => ({
+        name: t.name,
+        description: t.description,
+        inputSchema: t.inputSchema,
+      })),
     };
   });
   installSelfToolHook((url, name, args) => {


### PR DESCRIPTION
## Summary

Consistency fix for the Orchestrator tab. Our own agent card was rendering 8 tools with \"No parameter schema advertised\" while every external agent showed full descriptions + parameter tables. The data already exists — our /capabilities page surfaces it today, and POST /mcp tools/list returns it from the same `ADCP_TOOLS` registry — just wasn't being threaded into the self-probe hook.

## Change

One call site in [src/routes/agentsEndpoints.ts](src/routes/agentsEndpoints.ts): the `installSelfProbeHook` callback now emits `{name, description, inputSchema}` per tool, sourced from `ADCP_TOOLS`. External agents already carry these through from the MCP wire after Sec-48d widened `ProbeResult.tools`.

## Test plan

- [x] Type check: no errors.
- [x] Full suite: 369 / 12 skip — baseline unchanged.
- [ ] Post-merge + deploy: expand the Evgeny Signals card on the Orchestrator tab — expect 8 tools with description + parameter table (matching what /capabilities already shows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)