### PR TITLE
Sec-48f: end-to-end multi-role workflow (2 signals + 2 creative + 3 buying)

### DIFF
--- a/src/domain/workflowOrchestration.ts
+++ b/src/domain/workflowOrchestration.ts
@@ -1,0 +1,185 @@
+// src/domain/workflowOrchestration.ts
+// Sec-48f: pure helpers for the 4-stage end-to-end workflow that
+// fans a single brief across signals → creative → products →
+// media_buy, using live AdCP directory agents at every stage.
+//
+// All functions here are deterministic and don't touch the network.
+// Transport + fan-out live in agentsEndpoints.ts; schema synth lives
+// here so it's unit-testable.
+//
+// Payload synthesis targets the UNION of required fields across the
+// three buying agents we ship with by default (adzymic_apx, claire_pub,
+// swivel). Union = buyer_ref + brand_manifest + packages + start_time
+// + end_time. Claire accepts less but doesn't reject the extras.
+//
+// Live probe data 2026-04-24 informs the field list:
+//   adzymic_apx.create_media_buy   — 22 props, 5 required
+//   claire_pub.create_media_buy    — 24 props, 1 required
+//   swivel.create_media_buy        — 10 props, 5 required
+
+export interface SignalLite {
+  source_agent?: string;
+  signal_agent_segment_id?: string;
+  id?: string;
+  name?: string;
+  description?: string;
+  coverage_percentage?: number;
+  estimated_audience_size?: number;
+  [k: string]: unknown;
+}
+
+export interface ProductLite {
+  product_id?: string;
+  id?: string;
+  name?: string;
+  description?: string;
+  [k: string]: unknown;
+}
+
+/** Identify a signal with a single stable string ID regardless of
+ *  vendor variations. Dstillery uses signal_agent_segment_id; our
+ *  own signals may surface under `id`. */
+export function signalId(s: SignalLite): string | null {
+  if (typeof s.signal_agent_segment_id === "string") return s.signal_agent_segment_id;
+  if (typeof s.id === "string") return s.id;
+  return null;
+}
+
+/** Identify a product. `product_id` is AdCP canonical; some vendors
+ *  surface plain `id`. */
+export function productId(p: ProductLite): string | null {
+  if (typeof p.product_id === "string") return p.product_id;
+  if (typeof p.id === "string") return p.id;
+  return null;
+}
+
+/** Pick top-N signals from a merged multi-agent list. Ranking is
+ *  coverage-desc; ties broken by appearance order. Returns just the
+ *  IDs — downstream stages don't need the full signal object. */
+export function pickTopSignals(merged: SignalLite[], n: number): string[] {
+  const scored = merged
+    .map((s, i) => ({ id: signalId(s), cov: typeof s.coverage_percentage === "number" ? s.coverage_percentage : -1, idx: i }))
+    .filter((x): x is { id: string; cov: number; idx: number } => x.id !== null);
+  scored.sort((a, b) => b.cov - a.cov || a.idx - b.idx);
+  const out: string[] = [];
+  const seen = new Set<string>();
+  for (const s of scored) {
+    if (seen.has(s.id)) continue;
+    seen.add(s.id);
+    out.push(s.id);
+    if (out.length >= n) break;
+  }
+  return out;
+}
+
+/** Pick the first product per agent (deterministic). Returns a map
+ *  of agent_id → product_id (or null when the agent returned no
+ *  products). */
+export function pickProductPerAgent(
+  perAgent: Array<{ id: string; products: ProductLite[] }>,
+): Record<string, string | null> {
+  const out: Record<string, string | null> = {};
+  for (const a of perAgent) {
+    const first = a.products.find((p) => productId(p) !== null);
+    out[a.id] = first ? productId(first) : null;
+  }
+  return out;
+}
+
+export interface MediaBuyPayloadInput {
+  workflowId: string;
+  agentId: string;
+  brief: string;
+  chosenProductId: string | null;
+  chosenSignalIds: string[];
+  /** Optional override for the demo budget. Default: $1000 USD for 7d. */
+  totalBudgetUsd?: number;
+  /** Optional override for start delay. Default: +24h from now. */
+  startDelayHours?: number;
+  /** Optional campaign duration in days. Default: 7. */
+  durationDays?: number;
+  /** Optional reference clock — injected for testability. Defaults to Date.now(). */
+  nowMs?: number;
+}
+
+export interface MediaBuyPayload {
+  buyer_ref: string;
+  brand_manifest: {
+    brand: string;
+    advertiser: string;
+    categories: string[];
+  };
+  packages: Array<{
+    package_ref: string;
+    product_id: string | null;
+    budget: { amount: number; currency: "USD" };
+  }>;
+  start_time: string;
+  end_time: string;
+  total_budget: { amount: number; currency: "USD" };
+  targeting_overlay?: {
+    required_axe_signals?: string[];
+  };
+  po_number: string;
+}
+
+/** Synthesize a create_media_buy payload that satisfies the union of
+ *  required fields across Adzymic / Claire / Swivel. Same payload is
+ *  emitted for every agent in the workflow — any per-vendor tailoring
+ *  happens at the transport layer. */
+export function buildCreateMediaBuyPayload(input: MediaBuyPayloadInput): MediaBuyPayload {
+  const now = input.nowMs ?? Date.now();
+  const startDelayMs = (input.startDelayHours ?? 24) * 60 * 60 * 1000;
+  const durationMs = (input.durationDays ?? 7) * 24 * 60 * 60 * 1000;
+  const startIso = new Date(now + startDelayMs).toISOString();
+  const endIso = new Date(now + startDelayMs + durationMs).toISOString();
+  const totalBudget = input.totalBudgetUsd ?? 1000;
+
+  const payload: MediaBuyPayload = {
+    buyer_ref: `wf_${input.workflowId}_${input.agentId}`,
+    brand_manifest: {
+      brand: "AdCP Workflow Demo",
+      advertiser: "AdCP Workflow Demo",
+      categories: extractCategories(input.brief),
+    },
+    packages: [
+      {
+        package_ref: "pkg_1",
+        product_id: input.chosenProductId,
+        budget: { amount: totalBudget, currency: "USD" },
+      },
+    ],
+    start_time: startIso,
+    end_time: endIso,
+    total_budget: { amount: totalBudget, currency: "USD" },
+    po_number: `demo_${input.workflowId}`,
+  };
+
+  if (input.chosenSignalIds.length > 0) {
+    payload.targeting_overlay = { required_axe_signals: input.chosenSignalIds };
+  }
+
+  return payload;
+}
+
+/** Shallow category extraction for the brand_manifest. Just tokenizes
+ *  the brief on whitespace + punctuation and keeps the first 3 alpha
+ *  tokens of length ≥4. Good enough to populate the field without
+ *  triggering "categories[] required" validators. */
+export function extractCategories(brief: string): string[] {
+  const tokens = brief.toLowerCase().split(/[^a-z]+/).filter((t) => t.length >= 4);
+  const uniq: string[] = [];
+  for (const t of tokens) {
+    if (!uniq.includes(t)) uniq.push(t);
+    if (uniq.length >= 3) break;
+  }
+  return uniq.length > 0 ? uniq : ["general"];
+}
+
+/** Create a reasonably unique + human-recognizable workflow id.
+ *  Format: wf_<base36-ms><6-random>. Called once per POST. */
+export function newWorkflowId(): string {
+  const t = Date.now().toString(36);
+  const rand = Math.random().toString(36).slice(2, 8);
+  return `wf_${t}${rand}`;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,6 +42,7 @@ import {
   handleAgentsProbeAll,
   handleAgentsOrchestrate,
   handleAgentsCapabilityMatrix,
+  handleWorkflowRun,
 } from "./routes/agentsEndpoints";
 import {
   handleAudienceCompose,
@@ -214,6 +215,7 @@ export default {
             "/agents/probe-all",
             "/agents/orchestrate",
             "/agents/capability-matrix",
+            "/agents/workflow/run",
             "/taxonomy/reverse",
             // Sec-43: audience composer + activation-planning analytics.
             // Read-only — same posture as /portfolio/* and /analytics/*.
@@ -365,6 +367,8 @@ export default {
                 response = await handleAgentsOrchestrate(request, env, logger);
             } else if (method === "GET" && path === "/agents/capability-matrix") {
                 response = await handleAgentsCapabilityMatrix(request, env, logger);
+            } else if (method === "POST" && path === "/agents/workflow/run") {
+                response = await handleWorkflowRun(request, env, logger);
 
                 // ── Sec-43: Audience Composer + activation analytics ────────────────
             } else if (method === "POST" && path === "/audience/compose") {

--- a/src/routes/agentsEndpoints.ts
+++ b/src/routes/agentsEndpoints.ts
@@ -34,6 +34,17 @@ import {
 } from "../federation/genericMcpClient";
 import { searchSignalsService } from "../domain/signalService";
 import { getDb } from "../storage/db";
+import {
+  pickTopSignals,
+  pickProductPerAgent,
+  buildCreateMediaBuyPayload,
+  newWorkflowId,
+  productId as productIdOf,
+  signalId as signalIdOf,
+  type SignalLite,
+  type ProductLite,
+  type MediaBuyPayload,
+} from "../domain/workflowOrchestration";
 
 // Sec-48b: hook the generic MCP client with a self-detector. When the orchestrator
 // probes or fans-out to our own URL, Cloudflare Workers refuse self-fetch; we
@@ -338,6 +349,338 @@ export async function handleAgentsCapabilityMatrix(request: Request, env: Env, l
     tools: matrix,
     tool_count: toolList.length,
     note: "Matrix rows = tool names (union across probed agents), columns = supported_by list. Summary shows each agent's tool count + tools unique to it.",
+  });
+}
+
+// ── POST /agents/workflow/run ───────────────────────────────────────────────
+// Sec-48f: four-stage end-to-end orchestration across 2+ signals agents,
+// 2+ creative agents, and 3+ buying agents. Stages 1-3 always fire live
+// (read-only tools). Stage 4 always emits a dry-run payload preview
+// per buying agent; any agent ID listed in `activate_agents` also gets
+// its create_media_buy fired for real.
+//
+// Default target fleet (demo diversity by design):
+//   signals  → evgeny_signals + dstillery           (2)
+//   creative → advertible + celtra                  (2)
+//   buying   → adzymic_apx + claire_pub + swivel    (3 — one per fleet)
+//
+// Request shape (POST body, JSON):
+//   {
+//     brief:               string   required
+//     signal_agent_ids?:   string[] default = live signals agents
+//     creative_agent_ids?: string[] default = live creative agents
+//     buying_agent_ids?:   string[] default = 3 diverse buying agents
+//     max_signals_per_agent?:   number  default 5
+//     max_products_per_agent?:  number  default 3
+//     activate_agents?:    string[] buying agents to ACTUALLY fire
+//                                   create_media_buy on (default = []
+//                                   = dry-run preview only)
+//     timeout_ms?:         number  default 15000
+//   }
+
+const DEFAULT_BUYING_TRIO = ["adzymic_apx", "claire_pub", "swivel"] as const;
+const DEFAULT_CREATIVE_PAIR = ["advertible", "celtra"] as const;
+
+interface WorkflowRunBody {
+  brief?: string;
+  signal_agent_ids?: string[];
+  creative_agent_ids?: string[];
+  buying_agent_ids?: string[];
+  max_signals_per_agent?: number;
+  max_products_per_agent?: number;
+  activate_agents?: string[];
+  timeout_ms?: number;
+}
+
+interface StageAgentResult<TPayload> {
+  id: string;
+  name: string;
+  vendor: string;
+  url: string;
+  ok: boolean;
+  error?: string;
+  latency_ms: number;
+  payload: TPayload;
+}
+
+type SignalsStageAgent = StageAgentResult<{ signals: SignalLite[]; count: number }>;
+type CreativeStageAgent = StageAgentResult<{ formats: unknown[]; count: number }>;
+type ProductsStageAgent = StageAgentResult<{ products: ProductLite[]; count: number }>;
+
+interface MediaBuyStageAgent {
+  id: string;
+  name: string;
+  vendor: string;
+  url: string;
+  dry_run: boolean;
+  payload_preview: MediaBuyPayload;
+  fired: boolean;
+  ok?: boolean;
+  error?: string;
+  latency_ms?: number;
+  result?: unknown;
+}
+
+function resolveAgents(ids: string[] | undefined, fallback: readonly string[]): RegisteredAgent[] {
+  const candidateIds = (ids && ids.length > 0 ? ids : fallback.slice()) as string[];
+  const out: RegisteredAgent[] = [];
+  for (const id of candidateIds) {
+    const a = findAgent(id);
+    if (a && a.stage === "live" && a.mcp_url) out.push(a);
+  }
+  return out;
+}
+
+async function runSignalsStage(
+  agents: RegisteredAgent[],
+  brief: string,
+  maxResults: number,
+  timeoutMs: number,
+): Promise<SignalsStageAgent[]> {
+  return Promise.all(agents.map(async (a): Promise<SignalsStageAgent> => {
+    const res = await callAgentTool(
+      a.mcp_url!,
+      "get_signals",
+      { signal_spec: brief, max_results: maxResults },
+      { timeoutMs },
+    );
+    const structured = res.structured_content as { signals?: SignalLite[] } | undefined;
+    const signals = (structured?.signals ?? []).map((s) => ({ source_agent: a.id, ...s }));
+    const out: SignalsStageAgent = {
+      id: a.id, name: a.name, vendor: a.vendor, url: a.mcp_url!,
+      ok: res.ok, latency_ms: res.latency_ms,
+      payload: { signals, count: signals.length },
+    };
+    if (res.error) out.error = res.error;
+    return out;
+  }));
+}
+
+async function runCreativeStage(
+  agents: RegisteredAgent[],
+  timeoutMs: number,
+): Promise<CreativeStageAgent[]> {
+  return Promise.all(agents.map(async (a): Promise<CreativeStageAgent> => {
+    // list_creative_formats is a directory scan — no args required across
+    // Advertible, Celtra, and the buying-agent implementations.
+    const res = await callAgentTool(a.mcp_url!, "list_creative_formats", {}, { timeoutMs });
+    const structured = res.structured_content as { formats?: unknown[]; creative_formats?: unknown[] } | undefined;
+    const formats = structured?.formats ?? structured?.creative_formats ?? [];
+    const out: CreativeStageAgent = {
+      id: a.id, name: a.name, vendor: a.vendor, url: a.mcp_url!,
+      ok: res.ok, latency_ms: res.latency_ms,
+      payload: { formats, count: formats.length },
+    };
+    if (res.error) out.error = res.error;
+    return out;
+  }));
+}
+
+async function runProductsStage(
+  agents: RegisteredAgent[],
+  brief: string,
+  maxResults: number,
+  timeoutMs: number,
+): Promise<ProductsStageAgent[]> {
+  return Promise.all(agents.map(async (a): Promise<ProductsStageAgent> => {
+    // Across the 3 default buying agents, `brief` is the only universally-
+    // accepted arg. Max_results is nonstandard on these endpoints so we
+    // rely on server-side paging defaults.
+    const res = await callAgentTool(a.mcp_url!, "get_products", { brief }, { timeoutMs });
+    const structured = res.structured_content as { products?: ProductLite[] } | undefined;
+    const products = (structured?.products ?? []).slice(0, maxResults);
+    const out: ProductsStageAgent = {
+      id: a.id, name: a.name, vendor: a.vendor, url: a.mcp_url!,
+      ok: res.ok, latency_ms: res.latency_ms,
+      payload: { products, count: products.length },
+    };
+    if (res.error) out.error = res.error;
+    return out;
+  }));
+}
+
+async function runMediaBuyStage(
+  workflowId: string,
+  agents: RegisteredAgent[],
+  brief: string,
+  chosenProductByAgent: Record<string, string | null>,
+  chosenSignalIds: string[],
+  activateSet: Set<string>,
+  timeoutMs: number,
+): Promise<MediaBuyStageAgent[]> {
+  return Promise.all(agents.map(async (a): Promise<MediaBuyStageAgent> => {
+    const chosenProductId = chosenProductByAgent[a.id] ?? null;
+    const payload = buildCreateMediaBuyPayload({
+      workflowId,
+      agentId: a.id,
+      brief,
+      chosenProductId,
+      chosenSignalIds,
+    });
+    const base: MediaBuyStageAgent = {
+      id: a.id, name: a.name, vendor: a.vendor, url: a.mcp_url!,
+      dry_run: !activateSet.has(a.id),
+      payload_preview: payload,
+      fired: false,
+    };
+    if (!activateSet.has(a.id)) return base;
+    // User opted to fire on this agent.
+    const res = await callAgentTool(
+      a.mcp_url!,
+      "create_media_buy",
+      payload as unknown as Record<string, unknown>,
+      { timeoutMs },
+    );
+    base.fired = true;
+    base.ok = res.ok;
+    base.latency_ms = res.latency_ms;
+    if (res.error) base.error = res.error;
+    if (res.structured_content !== undefined) base.result = res.structured_content;
+    return base;
+  }));
+}
+
+export async function handleWorkflowRun(request: Request, env: Env, logger: Logger): Promise<Response> {
+  ensureSelfHooksInstalled(env, logger);
+  const parsed = await readJsonBody<WorkflowRunBody>(request);
+  if (parsed.kind === "invalid") return errorResponse("INVALID_JSON", parsed.reason, 400);
+  const body: WorkflowRunBody = parsed.kind === "parsed" ? parsed.data : {};
+
+  if (!body.brief || body.brief.trim().length === 0) return errorResponse("INVALID_INPUT", "brief required", 400);
+  if (body.brief.length > 500) return errorResponse("INVALID_INPUT", "brief max 500 chars", 400);
+
+  const maxSignals = Math.max(1, Math.min(50, body.max_signals_per_agent ?? 5));
+  const maxProducts = Math.max(1, Math.min(20, body.max_products_per_agent ?? 3));
+  const timeoutMs = Math.max(1000, Math.min(30_000, body.timeout_ms ?? 15_000));
+
+  // Resolve targets. Fall back to default demo diversity when not specified.
+  const signalsAgents = resolveAgents(
+    body.signal_agent_ids,
+    getAgentsByRole("signals").filter((a) => a.stage === "live" && a.mcp_url).map((a) => a.id),
+  );
+  const creativeAgents = resolveAgents(body.creative_agent_ids, DEFAULT_CREATIVE_PAIR);
+  const buyingAgents = resolveAgents(body.buying_agent_ids, DEFAULT_BUYING_TRIO);
+
+  if (signalsAgents.length === 0) return errorResponse("NO_TARGETS", "No live signals agents matched.", 400);
+  if (buyingAgents.length === 0) return errorResponse("NO_TARGETS", "No live buying agents matched.", 400);
+
+  // Activation list — only buying agents can be activated. Anything else
+  // in the list is ignored with a soft warning surfaced in the response.
+  const activateSet = new Set<string>();
+  const activateWarnings: string[] = [];
+  for (const id of body.activate_agents ?? []) {
+    if (buyingAgents.find((a) => a.id === id)) activateSet.add(id);
+    else activateWarnings.push(`ignored_non_buying_activate_target:${id}`);
+  }
+
+  const workflowId = newWorkflowId();
+  const t0 = Date.now();
+
+  // Stage 1 + Stage 2 in parallel (independent).
+  const [signalsResults, creativeResults] = await Promise.all([
+    runSignalsStage(signalsAgents, body.brief, maxSignals, timeoutMs),
+    creativeAgents.length > 0 ? runCreativeStage(creativeAgents, timeoutMs) : Promise.resolve([]),
+  ]);
+
+  // Stage 3 depends on the brief only — could have run in parallel with
+  // stages 1/2 but sequencing it after signals gives the UI a clear
+  // "step arrow" between "I know the audience" and "I know the inventory"
+  // moments. Cheap to re-order later.
+  const productsResults = await runProductsStage(buyingAgents, body.brief, maxProducts, timeoutMs);
+
+  // Pick downstream targeting.
+  const mergedSignals = signalsResults.flatMap((r) => r.payload.signals);
+  const chosenSignalIds = pickTopSignals(mergedSignals, 3);
+  const chosenProductByAgent = pickProductPerAgent(productsResults.map((r) => ({ id: r.id, products: r.payload.products })));
+
+  // Stage 4 — payload synth + optional fire.
+  const mediaBuyResults = await runMediaBuyStage(
+    workflowId,
+    buyingAgents,
+    body.brief,
+    chosenProductByAgent,
+    chosenSignalIds,
+    activateSet,
+    timeoutMs,
+  );
+
+  const totalTimeMs = Date.now() - t0;
+  const allActivatedOk = mediaBuyResults.filter((r) => r.fired).every((r) => r.ok === true);
+  const anyActivated = mediaBuyResults.some((r) => r.fired);
+
+  logger.info("agents_workflow_run", {
+    workflow_id: workflowId,
+    brief_chars: body.brief.length,
+    signals_agents: signalsAgents.length,
+    creative_agents: creativeAgents.length,
+    buying_agents: buyingAgents.length,
+    activated: activateSet.size,
+    total_time_ms: totalTimeMs,
+  });
+
+  // Normalize into a compact response. The full per-agent products +
+  // signals are preserved on the stage objects so the UI can render
+  // everything without follow-up calls.
+  return jsonResponse({
+    workflow_id: workflowId,
+    brief: body.brief,
+    mode: activateSet.size === 0 ? "dry_run" : activateSet.size === buyingAgents.length ? "all_live" : "partial_live",
+    total_time_ms: totalTimeMs,
+    stages: {
+      signals: {
+        agents_queried: signalsAgents.map((a) => a.id),
+        per_agent: signalsResults.map((r) => ({
+          id: r.id, name: r.name, vendor: r.vendor,
+          ok: r.ok, latency_ms: r.latency_ms,
+          signal_count: r.payload.count,
+          ...(r.error ? { error: r.error } : {}),
+          signals: r.payload.signals.map((s) => ({
+            source_agent: r.id,
+            id: signalIdOf(s),
+            name: s.name ?? "(unnamed)",
+            description: typeof s.description === "string" ? s.description.slice(0, 200) : "",
+            coverage_percentage: s.coverage_percentage,
+            estimated_audience_size: s.estimated_audience_size,
+          })),
+        })),
+        total_signals: mergedSignals.length,
+        chosen_signal_ids: chosenSignalIds,
+      },
+      creative: {
+        agents_queried: creativeAgents.map((a) => a.id),
+        per_agent: creativeResults.map((r) => ({
+          id: r.id, name: r.name, vendor: r.vendor,
+          ok: r.ok, latency_ms: r.latency_ms,
+          format_count: r.payload.count,
+          ...(r.error ? { error: r.error } : {}),
+          formats: r.payload.formats.slice(0, 10),
+        })),
+      },
+      products: {
+        agents_queried: buyingAgents.map((a) => a.id),
+        per_agent: productsResults.map((r) => ({
+          id: r.id, name: r.name, vendor: r.vendor,
+          ok: r.ok, latency_ms: r.latency_ms,
+          product_count: r.payload.count,
+          ...(r.error ? { error: r.error } : {}),
+          products: r.payload.products.map((p) => ({
+            id: productIdOf(p),
+            name: p.name ?? "(unnamed product)",
+            description: typeof p.description === "string" ? p.description.slice(0, 200) : "",
+          })),
+        })),
+        chosen_product_per_agent: chosenProductByAgent,
+      },
+      media_buy: {
+        agents_queried: buyingAgents.map((a) => a.id),
+        activated: Array.from(activateSet),
+        all_activated_ok: anyActivated ? allActivatedOk : null,
+        per_agent: mediaBuyResults,
+      },
+    },
+    warnings: activateWarnings,
+    method: "sec48f_parallel_multi_role_fanout",
+    note: "Stages 1+2 run in parallel. Products sequential after signals to give the UI a clean step. Stage 4 is payload-synth + optional create_media_buy firing per `activate_agents`. Dry-run default: preview only, zero side effects on buying agents.",
   });
 }
 

--- a/src/routes/demo.ts
+++ b/src/routes/demo.ts
@@ -1256,6 +1256,39 @@ ${STYLES}
             <div id="orch-results"><div class="empty-state"><div class="empty-desc">Enter a brief, hit <strong>Fan out</strong>. Signals come back merged with per-agent latency + source tags.</div></div></div>
           </div>
         </div>
+        <!-- ── End-to-end multi-role workflow (Sec-48f) ──────────────── -->
+        <div class="lab-panel lab-panel-full" style="margin-top:14px">
+          <div class="lab-panel-title">
+            End-to-end workflow
+            <span class="pill pill-accent mono" style="margin-left:8px;font-size:10px">Sec-48f</span>
+            <span style="margin-left:8px;color:var(--text-mut);font-weight:400;font-size:11px">signals \u2192 creative \u2192 products \u2192 media buy</span>
+          </div>
+          <div class="wf-controls">
+            <div class="wf-control-row">
+              <label class="lab-label">Brief</label>
+              <textarea id="wf-brief" class="lab-input" rows="2" placeholder="luxury travelers in-market for APAC trips"></textarea>
+            </div>
+            <div class="wf-control-row wf-activate-row">
+              <div class="wf-activate-label">Stage 4 activation <span class="orch-small">(default: dry-run only)</span></div>
+              <div class="wf-activate-toggles" id="wf-activate-toggles">
+                <label class="wf-toggle"><input type="checkbox" value="adzymic_apx" class="wf-activate-cb"/><span>adzymic_apx</span></label>
+                <label class="wf-toggle"><input type="checkbox" value="claire_pub" class="wf-activate-cb"/><span>claire_pub</span></label>
+                <label class="wf-toggle"><input type="checkbox" value="swivel" class="wf-activate-cb"/><span>swivel</span></label>
+              </div>
+            </div>
+            <button class="btn-primary" id="wf-run" style="width:100%;justify-content:center;margin-top:6px">
+              <svg class="ico"><use href="#icon-bolt"/></svg><span>Run workflow</span>
+            </button>
+            <div style="font-size:11px;color:var(--text-mut);margin-top:8px">
+              Fans out to <strong>2 signals</strong> + <strong>2 creative</strong> + <strong>3 buying</strong> agents via <code>/agents/workflow/run</code>.
+              Stage 4 always returns a payload preview per buying agent; checked agents also fire <code>create_media_buy</code> for real.
+            </div>
+          </div>
+          <div id="wf-results" style="margin-top:14px">
+            <div class="empty-state"><div class="empty-desc">Run the workflow to see all four stages fan out live. Each stage's per-agent results render below as cards.</div></div>
+          </div>
+        </div>
+
         <div class="lab-panel lab-panel-full" style="margin-top:14px">
           <div class="lab-panel-title">Capability matrix <button class="btn-secondary" id="orch-matrix-run" style="margin-left:8px;font-size:11px;padding:4px 10px">Build matrix</button></div>
           <div id="orch-matrix"><div class="empty-state"><div class="empty-desc">Click <strong>Build matrix</strong> to compare every live agent's tool surface side-by-side. Each row is a tool name; columns are agents; cells mark which agents declare that tool.</div></div></div>
@@ -4022,6 +4055,122 @@ textarea.lab-input { resize: vertical; line-height: 1.5; }
 .orch-tool-preq { white-space: nowrap; }
 .orch-tool-pdesc { color: var(--text-mut); line-height: 1.4; }
 .orch-tool-enum { color: var(--text-dim); font-size: 10px; }
+
+/* Sec-48f: end-to-end workflow UI. */
+.wf-controls { display: flex; flex-direction: column; gap: 8px; }
+.wf-control-row { display: flex; flex-direction: column; gap: 4px; }
+.wf-activate-row { flex-direction: row; align-items: center; gap: 12px; flex-wrap: wrap; }
+.wf-activate-label { font-size: 11px; color: var(--text-mut); font-weight: 500; }
+.wf-activate-toggles { display: flex; gap: 8px; flex-wrap: wrap; }
+.wf-toggle {
+  display: inline-flex; align-items: center; gap: 4px; font-size: 11px;
+  padding: 3px 8px; background: var(--bg-raised); border: 1px solid var(--border);
+  border-radius: 4px; cursor: pointer; color: var(--text-mut);
+}
+.wf-toggle:hover { color: var(--text); }
+.wf-toggle input[type=checkbox] { width: 12px; height: 12px; margin: 0; }
+.wf-toggle input[type=checkbox]:checked + span { color: var(--accent); font-weight: 500; }
+
+.wf-header {
+  display: flex; justify-content: space-between; align-items: center;
+  padding: 8px 12px; background: var(--bg-raised);
+  border: 1px solid var(--border); border-radius: 5px; margin-bottom: 10px;
+}
+.wf-header-id { font-size: 11px; color: var(--text-mut); }
+.wf-header-brief { font-size: 13px; color: var(--text); margin-top: 2px; }
+.wf-header-right { display: flex; align-items: center; }
+
+.wf-timeline {
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 10px; background: var(--bg-surface);
+  border: 1px solid var(--border); border-radius: 5px;
+  margin-bottom: 12px; gap: 6px;
+}
+.wf-timeline-cell {
+  flex: 1; text-align: center; padding: 4px 8px;
+  background: var(--bg-raised); border-radius: 4px;
+  border: 1px solid var(--border);
+}
+.wf-timeline-label { font-size: 11px; color: var(--text); font-weight: 500; }
+.wf-timeline-count { font-size: 10px; color: var(--text-mut); margin-top: 2px; }
+.wf-timeline-arrow { color: var(--accent); font-size: 16px; }
+
+.wf-stage {
+  background: var(--bg-surface); border: 1px solid var(--border);
+  border-left-width: 3px; border-radius: 5px;
+  padding: 10px 12px; margin-bottom: 10px;
+}
+.wf-stage-signals   { border-left-color: #64b5f6; }
+.wf-stage-creative  { border-left-color: #ba68c8; }
+.wf-stage-products  { border-left-color: #ffb74d; }
+.wf-stage-media-buy { border-left-color: var(--accent); }
+
+.wf-stage-head {
+  display: flex; align-items: center; gap: 10px; margin-bottom: 8px;
+  padding-bottom: 6px; border-bottom: 1px solid var(--border);
+}
+.wf-stage-num {
+  display: inline-flex; align-items: center; justify-content: center;
+  width: 22px; height: 22px; border-radius: 50%; background: var(--bg-raised);
+  border: 1px solid var(--border); font-size: 11px; color: var(--text);
+}
+.wf-stage-title { font-size: 13px; font-weight: 500; color: var(--text); }
+
+.wf-stage-agents {
+  display: grid; grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 8px;
+}
+.wf-agent-card {
+  background: var(--bg-raised); border: 1px solid var(--border);
+  border-left-width: 2px; border-radius: 4px;
+  padding: 8px 10px;
+}
+.wf-agent-ok  { border-left-color: var(--success); }
+.wf-agent-err { border-left-color: var(--error); }
+.wf-agent-dry { border-left-color: var(--text-mut); opacity: 0.9; }
+
+.wf-agent-head { display: flex; align-items: center; gap: 6px; flex-wrap: wrap; margin-bottom: 4px; }
+.wf-agent-name { font-size: 11.5px; font-weight: 500; color: var(--text); }
+.wf-agent-vendor { font-size: 10.5px; color: var(--text-mut); flex: 1; }
+.wf-agent-error {
+  font-size: 10.5px; color: var(--error); margin-top: 4px;
+  background: rgba(239,83,80,0.06); padding: 4px 6px; border-radius: 3px;
+  word-break: break-word;
+}
+
+.wf-stage-body { font-size: 11px; color: var(--text-mut); margin-top: 4px; }
+.wf-stage-count { font-size: 10px; color: var(--text-dim); margin-bottom: 4px; }
+.wf-signal-row, .wf-product-row {
+  display: flex; align-items: center; gap: 6px;
+  padding: 3px 0; border-top: 1px solid var(--border);
+  font-size: 11px;
+}
+.wf-signal-row:first-child, .wf-product-row:first-child { border-top: none; }
+.wf-signal-id, .wf-product-id { color: var(--text-dim); font-size: 10px; white-space: nowrap; max-width: 120px; overflow: hidden; text-overflow: ellipsis; }
+.wf-signal-name, .wf-product-name { flex: 1; color: var(--text); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.wf-product-chosen { background: var(--accent-dim); padding: 3px 6px; margin: 2px -4px; border-radius: 3px; }
+
+.wf-formats-list { display: flex; flex-wrap: wrap; gap: 3px; align-items: center; }
+
+.wf-chosen {
+  margin-top: 8px; padding: 6px 10px;
+  background: var(--accent-dim); border: 1px solid var(--accent);
+  border-radius: 4px; font-size: 11px;
+}
+.wf-chosen-label { color: var(--text-mut); margin-right: 6px; }
+.wf-chosen code { margin-right: 4px; font-size: 10.5px; }
+
+.wf-payload-details, .wf-result-details { margin-top: 6px; }
+.wf-payload-details summary, .wf-result-details summary {
+  cursor: pointer; font-size: 10.5px; color: var(--text-mut);
+  padding: 2px 0;
+}
+.wf-payload-details summary:hover, .wf-result-details summary:hover { color: var(--accent); }
+.wf-json {
+  font-size: 10.5px; background: var(--bg-surface);
+  padding: 6px 8px; border-radius: 4px; overflow: auto; max-height: 280px;
+  color: var(--text-dim); line-height: 1.45;
+}
 
 .orch-fanout-summary { display: grid; grid-template-columns: repeat(auto-fit, minmax(160px, 1fr)); gap: 8px; margin-bottom: 10px; }
 .orch-fanout-card {
@@ -10982,6 +11131,8 @@ async function ensureOrchestrator() {
   document.getElementById("orch-refresh").addEventListener("click", runOrchProbeAll);
   document.getElementById("orch-run").addEventListener("click", runOrchFanout);
   document.getElementById("orch-matrix-run").addEventListener("click", runOrchMatrix);
+  var wfRunBtn = document.getElementById("wf-run");
+  if (wfRunBtn) wfRunBtn.addEventListener("click", runWorkflow);
   // Load static directory first, then kick off probe in parallel.
   await loadOrchDirectory();
   runOrchProbeAll();
@@ -11314,6 +11465,192 @@ function _orchRenderMatrix(data) {
     '<div style="overflow:auto"><table class="orch-matrix-table"><thead><tr><th class="orch-matrix-tool-header">Tool</th>' + headerCells + '</tr></thead><tbody>' + rows + '</tbody></table></div>' +
     (uniqueSummary ? '<div style="margin-top:10px"><div class="lab-label">Unique tools per agent</div>' + uniqueSummary + '</div>' : '') +
     '<div style="font-size:11px;color:var(--text-mut);margin-top:8px">' + tools.length + ' tools across ' + agents.length + ' agents.</div>';
+}
+
+// ─── Workflow (Sec-48f: signals → creative → products → media_buy) ───────
+var _wfRunning = false;
+
+async function runWorkflow() {
+  if (_wfRunning) return;
+  var host = document.getElementById("wf-results");
+  var briefEl = document.getElementById("wf-brief");
+  var brief = (briefEl.value || "").trim();
+  if (!brief) { showToast("Workflow brief required.", true); return; }
+  var activateIds = Array.prototype.slice
+    .call(document.querySelectorAll(".wf-activate-cb"))
+    .filter(function (cb) { return cb.checked; })
+    .map(function (cb) { return cb.value; });
+  var mode = activateIds.length === 0 ? "dry-run" : "live (" + activateIds.length + " agent" + (activateIds.length === 1 ? "" : "s") + ")";
+  _wfRunning = true;
+  host.innerHTML = '<div class="empty-state"><span class="spinner"></span><div class="empty-title">Running 4-stage workflow\u2026 <span class="orch-small">(' + escapeHtml(mode) + ')</span></div></div>';
+  try {
+    var r = await fetch("/agents/workflow/run", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ brief: brief, activate_agents: activateIds, timeout_ms: 20000 }),
+    });
+    var data = await r.json();
+    if (!r.ok || data.error) throw new Error(data.error || data.message || "HTTP " + r.status);
+    _wfRenderResults(data);
+  } catch (e) {
+    host.innerHTML = '<div class="empty-state" style="border-color:var(--error)"><div class="empty-title" style="color:var(--error)">' + escapeHtml(e.message) + '</div></div>';
+  } finally {
+    _wfRunning = false;
+  }
+}
+
+function _wfRenderResults(data) {
+  var host = document.getElementById("wf-results");
+  var st = data.stages || {};
+  var header =
+    '<div class="wf-header">' +
+      '<div class="wf-header-left">' +
+        '<div class="wf-header-id mono">' + escapeHtml(data.workflow_id) + '</div>' +
+        '<div class="wf-header-brief">' + escapeHtml(data.brief) + '</div>' +
+      '</div>' +
+      '<div class="wf-header-right">' +
+        '<span class="pill ' + (data.mode === "dry_run" ? "pill-muted" : "pill-accent") + ' mono" style="font-size:10px">' + escapeHtml(data.mode) + '</span>' +
+        '<span class="orch-small mono" style="margin-left:8px">' + (data.total_time_ms || 0) + ' ms</span>' +
+      '</div>' +
+    '</div>';
+  var timeline = _wfRenderTimeline(st);
+  var s1 = _wfRenderSignalsStage(st.signals || {});
+  var s2 = _wfRenderCreativeStage(st.creative || {});
+  var s3 = _wfRenderProductsStage(st.products || {});
+  var s4 = _wfRenderMediaBuyStage(st.media_buy || {});
+  host.innerHTML = header + timeline + s1 + s2 + s3 + s4;
+}
+
+function _wfRenderTimeline(stages) {
+  var items = [
+    { key: "signals",   label: "Signals",   agents: (stages.signals  || {}).agents_queried || [] },
+    { key: "creative",  label: "Creative",  agents: (stages.creative || {}).agents_queried || [] },
+    { key: "products",  label: "Products",  agents: (stages.products || {}).agents_queried || [] },
+    { key: "media_buy", label: "Media buy", agents: (stages.media_buy|| {}).agents_queried || [] },
+  ];
+  var cells = items.map(function (it, i) {
+    var arrow = i < items.length - 1 ? '<span class="wf-timeline-arrow">\u2192</span>' : '';
+    return '<div class="wf-timeline-cell">' +
+      '<div class="wf-timeline-label">' + escapeHtml(it.label) + '</div>' +
+      '<div class="wf-timeline-count mono">' + it.agents.length + ' agent' + (it.agents.length === 1 ? '' : 's') + '</div>' +
+    '</div>' + arrow;
+  }).join("");
+  return '<div class="wf-timeline">' + cells + '</div>';
+}
+
+function _wfRenderStageAgentCard(kind, r, extra) {
+  var statusClass = r.ok ? "wf-agent-ok" : "wf-agent-err";
+  var statusPill = r.ok
+    ? '<span class="pill pill-success mono" style="font-size:10px">ok</span>'
+    : '<span class="pill pill-error mono" style="font-size:10px">err</span>';
+  return '<div class="wf-agent-card ' + statusClass + '">' +
+    '<div class="wf-agent-head"><span class="wf-agent-name mono">' + escapeHtml(r.id) + '</span>' +
+      '<span class="wf-agent-vendor">' + escapeHtml(r.vendor || '') + '</span>' +
+      statusPill + '<span class="orch-small mono" style="margin-left:6px">' + (r.latency_ms || 0) + ' ms</span>' +
+    '</div>' +
+    (r.error ? '<div class="wf-agent-error mono">' + escapeHtml(r.error.slice(0, 200)) + '</div>' : '') +
+    (extra || '') +
+  '</div>';
+}
+
+function _wfRenderSignalsStage(stage) {
+  var perAgent = (stage.per_agent || []).map(function (r) {
+    var signals = r.signals || [];
+    var rows = signals.slice(0, 5).map(function (s) {
+      var cov = typeof s.coverage_percentage === "number" ? (Math.round(s.coverage_percentage * 100) + "%") : "";
+      var reach = typeof s.estimated_audience_size === "number" ? ((s.estimated_audience_size / 1e6).toFixed(1) + "M") : "";
+      return '<div class="wf-signal-row"><span class="mono wf-signal-id">' + escapeHtml(s.id || '-') + '</span>' +
+        '<span class="wf-signal-name">' + escapeHtml(s.name) + '</span>' +
+        (cov ? '<span class="pill pill-muted mono" style="font-size:9.5px">cov ' + cov + '</span>' : '') +
+        (reach ? '<span class="pill pill-muted mono" style="font-size:9.5px">' + reach + '</span>' : '') +
+      '</div>';
+    }).join("");
+    var more = signals.length > 5 ? '<div class="orch-small" style="margin-top:4px">+ ' + (signals.length - 5) + ' more</div>' : '';
+    var extra = '<div class="wf-stage-body"><div class="wf-stage-count mono">' + r.signal_count + ' signals</div>' + rows + more + '</div>';
+    return _wfRenderStageAgentCard("signals", r, extra);
+  }).join("");
+  var chosen = (stage.chosen_signal_ids || []).map(function (s) { return '<code class="mono">' + escapeHtml(s) + '</code>'; }).join(" ");
+  var chosenLine = chosen ? '<div class="wf-chosen"><span class="wf-chosen-label">Chosen for targeting \u2192</span> ' + chosen + '</div>' : '';
+  return '<div class="wf-stage wf-stage-signals">' +
+    '<div class="wf-stage-head"><span class="wf-stage-num mono">1</span><span class="wf-stage-title">Signals</span><span class="orch-small mono">' + (stage.total_signals || 0) + ' total</span></div>' +
+    '<div class="wf-stage-agents">' + perAgent + '</div>' + chosenLine +
+  '</div>';
+}
+
+function _wfRenderCreativeStage(stage) {
+  var perAgent = (stage.per_agent || []).map(function (r) {
+    var formats = r.formats || [];
+    var names = formats.slice(0, 5).map(function (f) {
+      var n = (f && (f.name || f.format_id || f.id)) || "(format)";
+      return '<span class="pill pill-muted mono" style="font-size:10px">' + escapeHtml(String(n).slice(0, 40)) + '</span>';
+    }).join(" ");
+    var more = formats.length > 5 ? '<span class="orch-small" style="margin-left:4px">+ ' + (formats.length - 5) + '</span>' : '';
+    var extra = '<div class="wf-stage-body"><div class="wf-stage-count mono">' + r.format_count + ' formats</div><div class="wf-formats-list">' + names + more + '</div></div>';
+    return _wfRenderStageAgentCard("creative", r, extra);
+  }).join("");
+  return '<div class="wf-stage wf-stage-creative">' +
+    '<div class="wf-stage-head"><span class="wf-stage-num mono">2</span><span class="wf-stage-title">Creative</span></div>' +
+    '<div class="wf-stage-agents">' + perAgent + '</div>' +
+  '</div>';
+}
+
+function _wfRenderProductsStage(stage) {
+  var chosenMap = stage.chosen_product_per_agent || {};
+  var perAgent = (stage.per_agent || []).map(function (r) {
+    var prods = r.products || [];
+    var rows = prods.slice(0, 3).map(function (p) {
+      var chosen = chosenMap[r.id] && chosenMap[r.id] === p.id;
+      return '<div class="wf-product-row' + (chosen ? ' wf-product-chosen' : '') + '">' +
+        '<span class="mono wf-product-id">' + escapeHtml(p.id || '-') + '</span>' +
+        '<span class="wf-product-name">' + escapeHtml(p.name) + '</span>' +
+        (chosen ? '<span class="pill pill-accent mono" style="font-size:9.5px">chosen</span>' : '') +
+      '</div>';
+    }).join("");
+    var more = prods.length > 3 ? '<div class="orch-small" style="margin-top:4px">+ ' + (prods.length - 3) + ' more</div>' : '';
+    var extra = '<div class="wf-stage-body"><div class="wf-stage-count mono">' + r.product_count + ' products</div>' + rows + more + '</div>';
+    return _wfRenderStageAgentCard("products", r, extra);
+  }).join("");
+  return '<div class="wf-stage wf-stage-products">' +
+    '<div class="wf-stage-head"><span class="wf-stage-num mono">3</span><span class="wf-stage-title">Products</span></div>' +
+    '<div class="wf-stage-agents">' + perAgent + '</div>' +
+  '</div>';
+}
+
+function _wfRenderMediaBuyStage(stage) {
+  var activated = stage.activated || [];
+  var perAgent = (stage.per_agent || []).map(function (r) {
+    var headClass = r.fired ? (r.ok ? "wf-agent-ok" : "wf-agent-err") : "wf-agent-dry";
+    var fireBadge = r.fired
+      ? (r.ok ? '<span class="pill pill-success mono" style="font-size:10px">fired \u2713</span>'
+              : '<span class="pill pill-error mono" style="font-size:10px">fired \u2717</span>')
+      : '<span class="pill pill-muted mono" style="font-size:10px">dry run</span>';
+    var payload = r.payload_preview || {};
+    var payloadJson = "";
+    try { payloadJson = JSON.stringify(payload, null, 2); } catch (e) { payloadJson = String(e); }
+    var resultBlock = r.fired && r.result
+      ? '<details class="wf-result-details"><summary class="orch-small">view agent response</summary><pre class="wf-json mono">' + escapeHtml(JSON.stringify(r.result, null, 2)) + '</pre></details>'
+      : '';
+    return '<div class="wf-agent-card ' + headClass + '">' +
+      '<div class="wf-agent-head"><span class="wf-agent-name mono">' + escapeHtml(r.id) + '</span>' +
+        '<span class="wf-agent-vendor">' + escapeHtml(r.vendor || '') + '</span>' +
+        fireBadge +
+        (typeof r.latency_ms === "number" ? '<span class="orch-small mono" style="margin-left:6px">' + r.latency_ms + ' ms</span>' : '') +
+      '</div>' +
+      (r.error ? '<div class="wf-agent-error mono">' + escapeHtml(r.error.slice(0, 200)) + '</div>' : '') +
+      '<details class="wf-payload-details"' + (r.fired ? '' : ' open') + '>' +
+        '<summary class="orch-small">create_media_buy payload preview</summary>' +
+        '<pre class="wf-json mono">' + escapeHtml(payloadJson) + '</pre>' +
+      '</details>' +
+      resultBlock +
+    '</div>';
+  }).join("");
+  var summary = activated.length === 0
+    ? 'Dry run \u2014 no agents fired. Check boxes above to activate per-agent.'
+    : activated.length + ' agent' + (activated.length === 1 ? '' : 's') + ' fired: ' + activated.map(function (id) { return '<code>' + escapeHtml(id) + '</code>'; }).join(" ");
+  return '<div class="wf-stage wf-stage-media-buy">' +
+    '<div class="wf-stage-head"><span class="wf-stage-num mono">4</span><span class="wf-stage-title">Media buy</span><span class="orch-small">' + summary + '</span></div>' +
+    '<div class="wf-stage-agents">' + perAgent + '</div>' +
+  '</div>';
 }
 
 // ─── Federation (partial — more in Part 3) ───────────────────────────────

--- a/tests/workflowOrchestration.test.ts
+++ b/tests/workflowOrchestration.test.ts
@@ -1,0 +1,161 @@
+// tests/workflowOrchestration.test.ts
+// Unit coverage for Sec-48f workflow helpers. These are pure functions
+// (no network, no Env binding) so the tests are deterministic.
+
+import { describe, it, expect } from "vitest";
+import {
+  signalId,
+  productId,
+  pickTopSignals,
+  pickProductPerAgent,
+  buildCreateMediaBuyPayload,
+  extractCategories,
+  newWorkflowId,
+} from "../src/domain/workflowOrchestration";
+
+describe("signalId / productId", () => {
+  it("signalId prefers signal_agent_segment_id, falls back to id", () => {
+    expect(signalId({ signal_agent_segment_id: "seg_1" })).toBe("seg_1");
+    expect(signalId({ id: "abc" })).toBe("abc");
+    expect(signalId({ name: "no id" })).toBeNull();
+  });
+
+  it("productId prefers product_id over id", () => {
+    expect(productId({ product_id: "p1" })).toBe("p1");
+    expect(productId({ id: "alt" })).toBe("alt");
+    expect(productId({ name: "no id" })).toBeNull();
+  });
+});
+
+describe("pickTopSignals", () => {
+  it("ranks by coverage_percentage desc, ties broken by input order", () => {
+    const merged = [
+      { signal_agent_segment_id: "low",   coverage_percentage: 0.2 },
+      { signal_agent_segment_id: "high",  coverage_percentage: 0.9 },
+      { signal_agent_segment_id: "mid_a", coverage_percentage: 0.5 },
+      { signal_agent_segment_id: "mid_b", coverage_percentage: 0.5 },
+    ];
+    expect(pickTopSignals(merged, 3)).toEqual(["high", "mid_a", "mid_b"]);
+  });
+
+  it("deduplicates by id across source agents", () => {
+    const merged = [
+      { signal_agent_segment_id: "seg1", coverage_percentage: 0.7, source_agent: "a" },
+      { signal_agent_segment_id: "seg1", coverage_percentage: 0.7, source_agent: "b" },
+      { signal_agent_segment_id: "seg2", coverage_percentage: 0.5 },
+    ];
+    expect(pickTopSignals(merged, 5)).toEqual(["seg1", "seg2"]);
+  });
+
+  it("skips signals without any id", () => {
+    const merged = [
+      { name: "no id",  coverage_percentage: 0.9 },
+      { id: "seg_alt", coverage_percentage: 0.3 },
+    ];
+    expect(pickTopSignals(merged, 2)).toEqual(["seg_alt"]);
+  });
+
+  it("returns empty array when no signals", () => {
+    expect(pickTopSignals([], 5)).toEqual([]);
+  });
+});
+
+describe("pickProductPerAgent", () => {
+  it("picks the first product with an id per agent", () => {
+    const out = pickProductPerAgent([
+      { id: "agent_a", products: [{ product_id: "p_a1" }, { product_id: "p_a2" }] },
+      { id: "agent_b", products: [{ id: "p_b1" }] },
+    ]);
+    expect(out).toEqual({ agent_a: "p_a1", agent_b: "p_b1" });
+  });
+
+  it("returns null for agents with no products or no ids", () => {
+    const out = pickProductPerAgent([
+      { id: "empty",  products: [] },
+      { id: "no_ids", products: [{ name: "untagged" }] },
+    ]);
+    expect(out).toEqual({ empty: null, no_ids: null });
+  });
+});
+
+describe("buildCreateMediaBuyPayload", () => {
+  const NOW = Date.UTC(2026, 3, 24, 12, 0, 0); // 2026-04-24T12:00:00Z
+
+  it("emits buyer_ref + all union-required fields", () => {
+    const p = buildCreateMediaBuyPayload({
+      workflowId: "wf_abc",
+      agentId: "claire_pub",
+      brief: "luxury travelers APAC",
+      chosenProductId: "prod_123",
+      chosenSignalIds: ["sig_1", "sig_2"],
+      nowMs: NOW,
+    });
+    expect(p.buyer_ref).toBe("wf_wf_abc_claire_pub");
+    expect(p.brand_manifest.categories).toContain("luxury");
+    expect(p.packages).toHaveLength(1);
+    expect(p.packages[0]!.product_id).toBe("prod_123");
+    expect(p.packages[0]!.budget.currency).toBe("USD");
+    expect(p.start_time).toBe("2026-04-25T12:00:00.000Z");
+    expect(p.end_time).toBe("2026-05-02T12:00:00.000Z");
+    expect(p.total_budget.amount).toBe(1000);
+    expect(p.po_number).toBe("demo_wf_abc");
+    expect(p.targeting_overlay?.required_axe_signals).toEqual(["sig_1", "sig_2"]);
+  });
+
+  it("omits targeting_overlay when no signals chosen", () => {
+    const p = buildCreateMediaBuyPayload({
+      workflowId: "w", agentId: "a", brief: "t",
+      chosenProductId: "p", chosenSignalIds: [], nowMs: NOW,
+    });
+    expect(p.targeting_overlay).toBeUndefined();
+  });
+
+  it("honors custom budget + duration overrides", () => {
+    const p = buildCreateMediaBuyPayload({
+      workflowId: "w", agentId: "a", brief: "t",
+      chosenProductId: "p", chosenSignalIds: [],
+      totalBudgetUsd: 5000, startDelayHours: 48, durationDays: 14, nowMs: NOW,
+    });
+    expect(p.total_budget.amount).toBe(5000);
+    expect(p.packages[0]!.budget.amount).toBe(5000);
+    expect(p.start_time).toBe("2026-04-26T12:00:00.000Z");
+    expect(p.end_time).toBe("2026-05-10T12:00:00.000Z");
+  });
+
+  it("handles null product id (agent returned no products)", () => {
+    const p = buildCreateMediaBuyPayload({
+      workflowId: "w", agentId: "a", brief: "t",
+      chosenProductId: null, chosenSignalIds: [], nowMs: NOW,
+    });
+    expect(p.packages[0]!.product_id).toBeNull();
+  });
+});
+
+describe("extractCategories", () => {
+  it("keeps the first 3 unique alpha tokens length >= 4", () => {
+    expect(extractCategories("luxury travelers planning APAC trips")).toEqual(["luxury", "travelers", "planning"]);
+  });
+
+  it("deduplicates repeated tokens", () => {
+    expect(extractCategories("travel travel travel luxury")).toEqual(["travel", "luxury"]);
+  });
+
+  it("falls back to ['general'] when no tokens match", () => {
+    expect(extractCategories("a b c")).toEqual(["general"]);
+    expect(extractCategories("")).toEqual(["general"]);
+  });
+
+  it("lowercases and strips punctuation", () => {
+    expect(extractCategories("LUXURY! travel_segments (APAC)")).toEqual(["luxury", "travel", "segments"]);
+  });
+});
+
+describe("newWorkflowId", () => {
+  it("starts with wf_ and is unique on repeated calls", () => {
+    const a = newWorkflowId();
+    const b = newWorkflowId();
+    expect(a.startsWith("wf_")).toBe(true);
+    expect(b.startsWith("wf_")).toBe(true);
+    expect(a).not.toEqual(b);
+  });
+});


### PR DESCRIPTION
## Summary

The headline demo feature. One brief fans across four stages, hitting **7 live AdCP agents** in parallel with role-specific tools. Stage 4 stops at a dry-run payload preview by default; per-agent activation is opt-in via checkboxes.

Default fleet (chosen for diversity by design):

| Stage | Agents | Tool | What you see |
|---|---|---|---|
| 1. Signals | `evgeny_signals` + `dstillery` | `get_signals` | Top-5 signals per agent + "chosen for targeting" footer |
| 2. Creative | `advertible` + `celtra` | `list_creative_formats` | Format pills per vendor (Advertible previews vs Celtra builds) |
| 3. Products | `adzymic_apx` + `claire_pub` + `swivel` | `get_products` | Product list per agent with chosen one accent-highlighted |
| 4. Media buy | same 3 buying agents | `create_media_buy` | Full payload preview as collapsible JSON; fired agents show the response |

All overridable via request body (`signal_agent_ids`, `creative_agent_ids`, `buying_agent_ids`, `activate_agents`).

## Backend

- **New endpoint `POST /agents/workflow/run`** in [src/routes/agentsEndpoints.ts](src/routes/agentsEndpoints.ts). Stages 1+2 run in parallel; stage 3 sequences after to give the UI a clean \"audience first, then inventory\" beat; stage 4 always emits payload preview + fires only for IDs in `activate_agents`.
- **Payload synth** targets the UNION of required fields across the three default buying agents — live schemas captured 2026-04-24:
  - `adzymic_apx.create_media_buy`: 22 props, 5 required (`buyer_ref`, `brand_manifest`, `packages`, `start_time`, `end_time`)
  - `claire_pub.create_media_buy`: 24 props, 1 required (`buyer_ref`) — but accepts the extras
  - `swivel.create_media_buy`: 10 props, 5 required (same as Adzymic)
  
  One synthesized payload satisfies all three. Signals from stage 1 are carried into stage 4 as `targeting_overlay.required_axe_signals`. Chosen product from stage 3 fills `packages[0].product_id`.
- **Pure helpers** in new [src/domain/workflowOrchestration.ts](src/domain/workflowOrchestration.ts): signal/product ID extraction, top-N signal picker (coverage desc + dedup), per-agent first-product picker, payload builder with injectable clock, category extractor, workflow-ID generator.

## UI

New \"End-to-end workflow\" section on the Orchestrator tab, between the existing fan-out panel and the capability matrix.

- Header ribbon: workflow_id, brief, mode pill (`dry_run` / `partial_live` / `all_live`), total round-trip ms.
- 4-cell timeline showing agents-per-stage.
- Four stage sections color-coded by role (blue/purple/amber/accent). Per-agent cards show ok/err status + latency + top results.
- Stage 4 cards show the full `create_media_buy` payload as a collapsible JSON preview (open by default for dry-runs). Fired agents additionally expose the agent's raw response under a second `<details>`.

Activation defaults to empty — click a checkbox to fire that specific agent, or all three for the full go-live run.

## Test plan

- [x] 17 unit tests covering the pure helpers (signal/product ID, pickers, payload builder with overrides + null product, category extraction, workflow-ID uniqueness).
- [x] Full suite 386 / 12 skip — baseline + 17 new tests.
- [x] Type check: no errors.
- [ ] Post-merge + deploy:
  - `curl -X POST /agents/workflow/run -d '{\"brief\":\"luxury travel APAC\"}'` → dry-run, expect stages 1–3 alive, stage 4 payloads for all three buying agents, `mode: \"dry_run\"`.
  - Run the workflow from the UI with no checkboxes ticked — verify dry-run UI + payload previews.
  - Check one box + run — verify `mode: \"partial_live\"` and that `create_media_buy` actually fires on that one agent (expect real buy_id or a human-readable vendor error).
  - Check all three + run — verify `mode: \"all_live\"` and per-agent response blocks render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)