### PR TITLE
Sec-48h hotfix: double-escape newline in workflow stream reader

### DIFF
--- a/src/routes/demo.ts
+++ b/src/routes/demo.ts
@@ -11618,7 +11618,13 @@ async function runWorkflow() {
       if (chunk.done) break;
       buf += dec.decode(chunk.value, { stream: true });
       var nl;
-      while ((nl = buf.indexOf("\n")) >= 0) {
+      // Double-escape: SCRIPT_TAG is a template literal, so the source
+      // "\\n" collapses to "\n" (2 chars, backslash+n) when emitted,
+      // which the browser parses as the newline escape. A single "\n"
+      // in source becomes a raw newline inside the string literal —
+      // a multi-line "..." is a SyntaxError at parse time. See Sec-48c
+      // for the same trap with a regex.
+      while ((nl = buf.indexOf("\\n")) >= 0) {
         var line = buf.slice(0, nl).trim();
         buf = buf.slice(nl + 1);
         if (!line) continue;


### PR DESCRIPTION
## Summary

Fixes the live-breaking syntax error:

> Uncaught SyntaxError: Invalid or unexpected token (at (index):11573:32)

### Root cause

The workflow stream reader in `runWorkflow` (added in Sec-48g) splits NDJSON events on newline:

\`\`\`js
while ((nl = buf.indexOf(\"\n\")) >= 0) {
\`\`\`

But that code lives inside the \`SCRIPT_TAG\` template literal — so the single-backslash-n got consumed at emission time and the served JS contained:

\`\`\`js
while ((nl = buf.indexOf(\"
\")) >= 0) {
\`\`\`

Browser parser: string literals can't span newlines → SyntaxError → whole \`<script type=\"module\">\` block fails to parse → the entire Workflow tab (and likely other tabs' JS) go dark.

### Fix

Double-escape: source \`\"\\n\"\` → served \`\"\n\"\` → browser parses as newline escape. One-line change at [src/routes/demo.ts:11621](src/routes/demo.ts:11621) plus a comment referencing Sec-48c so the next person adding a string escape inside SCRIPT_TAG knows the convention.

## Test plan

- [x] Type check: no errors.
- [x] Full suite: 391 / 12 skip — unchanged.
- [ ] Post-merge + deploy: reload the demo, no console error, run workflow — expect the NDJSON reader to actually split events (visible as progressive stage reveal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)