### PR TITLE
Sec-48i: depth-1 nested fallback in extractArrayPayload (Celtra fix)

### DIFF
--- a/src/domain/workflowOrchestration.ts
+++ b/src/domain/workflowOrchestration.ts
@@ -186,16 +186,23 @@ export function newWorkflowId(): string {
 
 /** Extract an array from an MCP tool's `structured_content` payload.
  *
- * Different vendors return their results under different top-level keys:
+ * Different vendors return their results under different top-level keys,
+ * and some nest them one level deeper inside a wrapper object:
  *   - Our get_signals:              { signals: [...] }
  *   - Adzymic get_products:         { products: [...] }
- *   - Swivel get_products:          { items: [...] }  (observed)
  *   - Advertible list_formats:      { formats: [...] }
- *   - Celtra list_formats:          { creative_formats: [...] }  (observed)
+ *   - Celtra list_formats:          { formats: [...] } nested under a
+ *                                     wrapper (Sec-48i: depth-1 search)
  *
- * We try the caller's preferred keys first, then fall back to the first
- * array-valued top-level key. This keeps the workflow extractor tolerant
- * of vendor drift without needing per-vendor code.
+ * Lookup priority:
+ *   1. preferredKeys at depth 0 — the fast path
+ *   2. preferredKeys at depth 1 — wrapper envelopes like {result:{…}}
+ *   3. any array at depth 0 — generic fallback
+ *   4. any array at depth 1 — last-resort for deeply-wrapped responses
+ *
+ * Bounded to depth 1. If a future vendor nests the array at depth 2+,
+ * we add an explicit preferred-key entry rather than making this walk
+ * the whole object graph.
  */
 export function extractArrayPayload<T = unknown>(
   structured: unknown,
@@ -203,13 +210,42 @@ export function extractArrayPayload<T = unknown>(
 ): T[] {
   if (!structured || typeof structured !== "object") return [];
   const obj = structured as Record<string, unknown>;
+
+  // 1. preferred keys at top level
   for (const k of preferredKeys) {
     const v = obj[k];
     if (Array.isArray(v)) return v as T[];
   }
+
+  // 2. preferred keys inside any object-valued top-level key
+  for (const k of Object.keys(obj)) {
+    const v = obj[k];
+    if (v && typeof v === "object" && !Array.isArray(v)) {
+      const inner = v as Record<string, unknown>;
+      for (const pk of preferredKeys) {
+        const nv = inner[pk];
+        if (Array.isArray(nv)) return nv as T[];
+      }
+    }
+  }
+
+  // 3. first array-valued top-level key
   for (const k of Object.keys(obj)) {
     const v = obj[k];
     if (Array.isArray(v)) return v as T[];
   }
+
+  // 4. first array-valued key inside any object-valued top-level key
+  for (const k of Object.keys(obj)) {
+    const v = obj[k];
+    if (v && typeof v === "object" && !Array.isArray(v)) {
+      const inner = v as Record<string, unknown>;
+      for (const nk of Object.keys(inner)) {
+        const nv = inner[nk];
+        if (Array.isArray(nv)) return nv as T[];
+      }
+    }
+  }
+
   return [];
 }

--- a/tests/workflowOrchestration.test.ts
+++ b/tests/workflowOrchestration.test.ts
@@ -176,6 +176,50 @@ describe("extractArrayPayload", () => {
     expect(extractArrayPayload("string", ["products"])).toEqual([]);
     expect(extractArrayPayload(42, ["products"])).toEqual([]);
   });
+
+  // Sec-48i: depth-1 nested search for vendors that wrap in an envelope.
+  it("finds a preferred key nested one level deep in a wrapper object", () => {
+    const out = extractArrayPayload(
+      { result: { formats: [{ id: "f1" }, { id: "f2" }] } },
+      ["formats", "creative_formats"],
+    );
+    expect(out).toEqual([{ id: "f1" }, { id: "f2" }]);
+  });
+
+  it("prefers a top-level preferred key over a nested one", () => {
+    const out = extractArrayPayload(
+      { formats: ["top"], result: { formats: ["nested"] } },
+      ["formats"],
+    );
+    expect(out).toEqual(["top"]);
+  });
+
+  it("prefers a nested preferred key over a top-level generic-array fallback", () => {
+    const out = extractArrayPayload(
+      { meta: [1, 2, 3], data: { products: [{ id: "p" }] } },
+      ["products"],
+    );
+    expect(out).toEqual([{ id: "p" }]);
+  });
+
+  it("falls back to the first nested array when no preferred key matches", () => {
+    const out = extractArrayPayload(
+      { output: { unknown_key: [{ id: "x" }] } },
+      ["products"],
+    );
+    expect(out).toEqual([{ id: "x" }]);
+  });
+
+  it("does not dive into array-valued top-level keys when looking nested", () => {
+    // Arrays of objects at top-level that themselves contain arrays
+    // should not confuse the nested search. Here no preferred key is
+    // present, so the top-level array wins via rule 3.
+    const out = extractArrayPayload(
+      { items: [{ sub: [1] }, { sub: [2] }] },
+      ["products"],
+    );
+    expect(out).toEqual([{ sub: [1] }, { sub: [2] }]);
+  });
 });
 
 describe("newWorkflowId", () => {


### PR DESCRIPTION
## Summary

Fixes the \"Celtra returns 0 formats\" issue we parked after the Sec-48g ship. Their \`list_creative_formats\` response wraps the array one level deeper than the previous extractor walked, so the helper found nothing despite \`tools/list\` reporting 5 tools advertised.

## Change

[src/domain/workflowOrchestration.ts](src/domain/workflowOrchestration.ts) — extend \`extractArrayPayload\` from a single-level pass to a **bounded depth-1 walk**. Lookup priority:

1. preferred keys at depth 0 — fast path (unchanged)
2. preferred keys at depth 1 — wrapper envelopes like \`{result: {formats: [...]}}\`
3. any array at depth 0 — generic fallback (unchanged)
4. any array at depth 1 — last-resort for new vendors

Capped at depth 1. If a future vendor nests deeper, we add an explicit preferred-key entry rather than growing an unbounded recursive walk (which could latch onto unrelated nested arrays).

## Test plan

- [x] 5 new unit tests covering the nested paths: top-level wins over nested, nested preferred wins over top-level generic, nested generic falls through, arrays of objects at top level don't confuse nested search.
- [x] Full suite: 396 / 12 skip.
- [x] Type check: no errors.
- [ ] Post-merge + deploy: rerun the workflow with brief \"luxury travel APAC\" — expect the Celtra card in stage 2 to show a non-zero format count (was 0 before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)