### PR TITLE
Sec-48j: extractMcpToolArray — content[].text JSON fallback

### DIFF
--- a/src/domain/workflowOrchestration.ts
+++ b/src/domain/workflowOrchestration.ts
@@ -204,6 +204,43 @@ export function newWorkflowId(): string {
  * we add an explicit preferred-key entry rather than making this walk
  * the whole object graph.
  */
+/** Extract an array from an MCP tools/call result, trying both the
+ *  structured-content and text-content paths.
+ *
+ *  MCP tools can return data two ways:
+ *    1. `result.structuredContent`  — typed JSON, what we mostly get
+ *    2. `result.content[]`          — array of {type:"text"|"image"|...}
+ *                                     blocks. Some servers (Celtra)
+ *                                     return the structured payload as
+ *                                     JSON inside content[0].text.
+ *
+ *  We try structured first (fast path), then scan content[] for any
+ *  text block that parses as JSON and looks for the array under the
+ *  same preferred keys. Designed to replace direct extractArrayPayload
+ *  calls on `res.structured_content` where the caller also has access
+ *  to `res.content`.
+ */
+export function extractMcpToolArray<T = unknown>(
+  structuredContent: unknown,
+  content: unknown,
+  preferredKeys: readonly string[],
+): T[] {
+  const fromStructured = extractArrayPayload<T>(structuredContent, preferredKeys);
+  if (fromStructured.length > 0) return fromStructured;
+  if (!Array.isArray(content)) return fromStructured;
+  for (const block of content) {
+    if (!block || typeof block !== "object") continue;
+    const b = block as { type?: string; text?: string };
+    if (b.type !== "text" || typeof b.text !== "string") continue;
+    try {
+      const parsed = JSON.parse(b.text);
+      const fromText = extractArrayPayload<T>(parsed, preferredKeys);
+      if (fromText.length > 0) return fromText;
+    } catch { /* not JSON; try next block */ }
+  }
+  return fromStructured;
+}
+
 export function extractArrayPayload<T = unknown>(
   structured: unknown,
   preferredKeys: readonly string[],

--- a/src/routes/agentsEndpoints.ts
+++ b/src/routes/agentsEndpoints.ts
@@ -41,7 +41,7 @@ import {
   newWorkflowId,
   productId as productIdOf,
   signalId as signalIdOf,
-  extractArrayPayload,
+  extractMcpToolArray,
   type SignalLite,
   type ProductLite,
   type MediaBuyPayload,
@@ -456,7 +456,7 @@ async function runSignalsStage(
       { signal_spec: brief, max_results: maxResults },
       { timeoutMs },
     );
-    const signals = extractArrayPayload<SignalLite>(res.structured_content, ["signals"])
+    const signals = extractMcpToolArray<SignalLite>(res.structured_content, res.content, ["signals"])
       .map((s) => ({ source_agent: a.id, ...s }));
     const out: SignalsStageAgent = {
       id: a.id, name: a.name, vendor: a.vendor, url: a.mcp_url!,
@@ -476,7 +476,7 @@ async function runCreativeStage(
     // list_creative_formats is a directory scan — no args required across
     // Advertible, Celtra, and the buying-agent implementations.
     const res = await callAgentTool(a.mcp_url!, "list_creative_formats", {}, { timeoutMs });
-    const formats = extractArrayPayload(res.structured_content, ["formats", "creative_formats", "items"]);
+    const formats = extractMcpToolArray(res.structured_content, res.content, ["formats", "creative_formats", "items"]);
     const out: CreativeStageAgent = {
       id: a.id, name: a.name, vendor: a.vendor, url: a.mcp_url!,
       ok: res.ok, latency_ms: res.latency_ms,
@@ -498,8 +498,9 @@ async function runProductsStage(
     // accepted arg. Max_results is nonstandard on these endpoints so we
     // rely on server-side paging defaults.
     const res = await callAgentTool(a.mcp_url!, "get_products", { brief }, { timeoutMs });
-    const products = extractArrayPayload<ProductLite>(
+    const products = extractMcpToolArray<ProductLite>(
       res.structured_content,
+      res.content,
       ["products", "items", "product_list"],
     ).slice(0, maxResults);
     const out: ProductsStageAgent = {
@@ -794,7 +795,7 @@ export async function handleWorkflowRunStream(request: Request, env: Env, logger
             { signal_spec: body.brief, max_results: maxSignals },
             { timeoutMs },
           );
-          const signals = extractArrayPayload<SignalLite>(res.structured_content, ["signals"])
+          const signals = extractMcpToolArray<SignalLite>(res.structured_content, res.content, ["signals"])
             .map((s) => ({ source_agent: a.id, ...s }));
           const out: SignalsStageAgent = {
             id: a.id, name: a.name, vendor: a.vendor, url: a.mcp_url!,
@@ -824,7 +825,7 @@ export async function handleWorkflowRunStream(request: Request, env: Env, logger
 
         const creativePromise = Promise.all(creativeAgents.map(async (a): Promise<CreativeStageAgent> => {
           const res = await callAgentTool(a.mcp_url!, "list_creative_formats", {}, { timeoutMs });
-          const formats = extractArrayPayload(res.structured_content, ["formats", "creative_formats", "items"]);
+          const formats = extractMcpToolArray(res.structured_content, res.content, ["formats", "creative_formats", "items"]);
           const out: CreativeStageAgent = {
             id: a.id, name: a.name, vendor: a.vendor, url: a.mcp_url!,
             ok: res.ok, latency_ms: res.latency_ms,
@@ -862,8 +863,9 @@ export async function handleWorkflowRunStream(request: Request, env: Env, logger
         for (const a of buyingAgents) send({ type: "agent_start", stage: "products", agent_id: a.id });
         const productsResults = await Promise.all(buyingAgents.map(async (a): Promise<ProductsStageAgent> => {
           const res = await callAgentTool(a.mcp_url!, "get_products", { brief: body.brief }, { timeoutMs });
-          const products = extractArrayPayload<ProductLite>(
+          const products = extractMcpToolArray<ProductLite>(
             res.structured_content,
+            res.content,
             ["products", "items", "product_list"],
           ).slice(0, maxProducts);
           const out: ProductsStageAgent = {

--- a/tests/workflowOrchestration.test.ts
+++ b/tests/workflowOrchestration.test.ts
@@ -11,6 +11,7 @@ import {
   buildCreateMediaBuyPayload,
   extractCategories,
   extractArrayPayload,
+  extractMcpToolArray,
   newWorkflowId,
 } from "../src/domain/workflowOrchestration";
 
@@ -219,6 +220,72 @@ describe("extractArrayPayload", () => {
       ["products"],
     );
     expect(out).toEqual([{ sub: [1] }, { sub: [2] }]);
+  });
+});
+
+describe("extractMcpToolArray", () => {
+  it("returns structured_content array when present (fast path)", () => {
+    const out = extractMcpToolArray(
+      { formats: [{ id: "f1" }] },
+      [{ type: "text", text: "ignored" }],
+      ["formats"],
+    );
+    expect(out).toEqual([{ id: "f1" }]);
+  });
+
+  it("falls back to parsing content[].text as JSON when structured is empty", () => {
+    const out = extractMcpToolArray(
+      {},
+      [{ type: "text", text: JSON.stringify({ formats: [{ id: "f1" }, { id: "f2" }] }) }],
+      ["formats"],
+    );
+    expect(out).toEqual([{ id: "f1" }, { id: "f2" }]);
+  });
+
+  it("handles structured_content null with content fallback", () => {
+    const out = extractMcpToolArray(
+      null,
+      [{ type: "text", text: '{"products":[{"id":"p"}]}' }],
+      ["products"],
+    );
+    expect(out).toEqual([{ id: "p" }]);
+  });
+
+  it("picks the first text block that parses as JSON with a matching array", () => {
+    const out = extractMcpToolArray(
+      {},
+      [
+        { type: "text", text: "not json" },
+        { type: "text", text: '{"irrelevant":1}' },
+        { type: "text", text: '{"formats":[{"id":"f"}]}' },
+      ],
+      ["formats"],
+    );
+    expect(out).toEqual([{ id: "f" }]);
+  });
+
+  it("tolerates non-text content blocks without crashing", () => {
+    const out = extractMcpToolArray(
+      {},
+      [{ type: "image", data: "..." }, { type: "text", text: '{"formats":[1]}' }],
+      ["formats"],
+    );
+    expect(out).toEqual([1]);
+  });
+
+  it("returns [] when neither structured nor any text block yields an array", () => {
+    expect(extractMcpToolArray({}, [{ type: "text", text: "hello" }], ["formats"])).toEqual([]);
+    expect(extractMcpToolArray({ meta: 1 }, null, ["formats"])).toEqual([]);
+    expect(extractMcpToolArray(null, null, ["formats"])).toEqual([]);
+  });
+
+  it("uses depth-1 nested search inside text-block JSON too", () => {
+    const out = extractMcpToolArray(
+      {},
+      [{ type: "text", text: JSON.stringify({ result: { formats: [{ id: "nested" }] } }) }],
+      ["formats"],
+    );
+    expect(out).toEqual([{ id: "nested" }]);
   });
 });
 


### PR DESCRIPTION
## Summary

Sec-48i's depth-1 nested search didn't fix Celtra's \"0 formats\" live. Probing confirmed their \`list_creative_formats\` isn't returning anything in \`structuredContent\` at all — they're almost certainly using MCP's alternate return path: text blocks inside \`result.content[]\` containing serialized JSON.

MCP tools can return data two ways per spec:
- \`result.structuredContent\` — typed JSON (what most servers send)
- \`result.content[{type:\"text\", text: \"...\"}]\` — text blocks, which may carry JSON payloads inline

Previous extractor only checked the first path.

## Change

New helper [`extractMcpToolArray(structured, content, preferredKeys)`](src/domain/workflowOrchestration.ts) tries structured first (fast path, covers every other vendor unchanged), then scans content[] for any text block that parses as JSON and runs the existing depth-1 `extractArrayPayload` walk on the parsed result.

All six stage extractors in [src/routes/agentsEndpoints.ts](src/routes/agentsEndpoints.ts) migrated (signals + creative + products × one-shot + streaming endpoints). Removed the now-unused direct `extractArrayPayload` import — the new helper calls it internally.

## Test plan

- [x] 7 new unit tests: structured fast path, content fallback with structured null/empty, multi-block scan with early exit, non-text block tolerance, depth-1 nested search inside text-block JSON, all-empty case.
- [x] Full suite: 403 / 12 skip.
- [x] Type check: no errors.
- [ ] Post-merge + deploy: rerun workflow with brief \"luxury travel APAC\" — expect Celtra's stage-2 card to show a non-zero format count (was 0 before). If still 0, Celtra's response is either at depth ≥2 inside the text block or genuinely empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)