### PR TITLE
Sec-48k: zero-count diagnostic on workflow stream events

### DIFF
--- a/src/domain/workflowOrchestration.ts
+++ b/src/domain/workflowOrchestration.ts
@@ -204,6 +204,65 @@ export function newWorkflowId(): string {
  * we add an explicit preferred-key entry rather than making this walk
  * the whole object graph.
  */
+/** Describe the shape of a tool-call result for diagnostic purposes.
+ *  Used in stream events when the extractor returns an empty array so
+ *  we can see live what the vendor's response looked like without
+ *  dumping the full payload. */
+export interface ToolResultDiagnostic {
+  structured_type: "object" | "array" | "null" | "other";
+  structured_keys: string[];        // top-level keys if object, empty otherwise
+  content_count: number;             // number of content blocks
+  content_types: string[];           // unique types seen ("text", "image", ...)
+  text_preview?: string;             // first 300 chars of first text block
+  text_is_json: boolean;             // whether that preview parsed as JSON
+  text_json_keys: string[];          // top-level keys of that JSON, if any
+}
+
+export function describeToolResult(structuredContent: unknown, content: unknown): ToolResultDiagnostic {
+  const out: ToolResultDiagnostic = {
+    structured_type: "other",
+    structured_keys: [],
+    content_count: 0,
+    content_types: [],
+    text_is_json: false,
+    text_json_keys: [],
+  };
+  if (structuredContent === null) out.structured_type = "null";
+  else if (Array.isArray(structuredContent)) out.structured_type = "array";
+  else if (structuredContent && typeof structuredContent === "object") {
+    out.structured_type = "object";
+    out.structured_keys = Object.keys(structuredContent as Record<string, unknown>).slice(0, 20);
+  }
+  if (Array.isArray(content)) {
+    out.content_count = content.length;
+    const seen = new Set<string>();
+    for (const block of content) {
+      if (block && typeof block === "object") {
+        const t = (block as { type?: unknown }).type;
+        if (typeof t === "string") seen.add(t);
+      }
+    }
+    out.content_types = Array.from(seen);
+    const firstText = content.find((b) => b && typeof b === "object" && (b as { type?: unknown }).type === "text");
+    if (firstText) {
+      const text = (firstText as { text?: unknown }).text;
+      if (typeof text === "string") {
+        out.text_preview = text.slice(0, 300);
+        try {
+          const parsed = JSON.parse(text);
+          out.text_is_json = true;
+          if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+            out.text_json_keys = Object.keys(parsed as Record<string, unknown>).slice(0, 20);
+          } else if (Array.isArray(parsed)) {
+            out.text_json_keys = ["(array:" + parsed.length + ")"];
+          }
+        } catch { /* leave text_is_json false */ }
+      }
+    }
+  }
+  return out;
+}
+
 /** Extract an array from an MCP tools/call result, trying both the
  *  structured-content and text-content paths.
  *

--- a/src/routes/agentsEndpoints.ts
+++ b/src/routes/agentsEndpoints.ts
@@ -42,6 +42,7 @@ import {
   productId as productIdOf,
   signalId as signalIdOf,
   extractMcpToolArray,
+  describeToolResult,
   type SignalLite,
   type ProductLite,
   type MediaBuyPayload,
@@ -845,6 +846,12 @@ export async function handleWorkflowRunStream(request: Request, env: Env, logger
                 const fo = f as { name?: string; format_id?: string; id?: string } | null;
                 return fo ? (fo.name ?? fo.format_id ?? fo.id ?? "(format)") : "(format)";
               }),
+              // Sec-48k: when the extractor finds nothing, attach a shape
+              // diagnostic so the UI (and we) can see why. Cheap — runs
+              // only on the zero-count path.
+              ...(formats.length === 0 && res.ok
+                ? { diagnostic: describeToolResult(res.structured_content, res.content) }
+                : {}),
             },
           });
           return out;
@@ -887,6 +894,9 @@ export async function handleWorkflowRunStream(request: Request, env: Env, logger
                 id: productIdOf(p),
                 name: p.name ?? "(unnamed product)",
               })),
+              ...(products.length === 0 && res.ok
+                ? { diagnostic: describeToolResult(res.structured_content, res.content) }
+                : {}),
             },
           });
           return out;


### PR DESCRIPTION
## Summary

Sec-48j still didn't fix Celtra's zero formats live. Rather than keep guessing at response shape, instrument the stream: when the extractor returns zero items but the call was ok, emit a compact shape diagnostic in the agent_complete event's summary.

## Change

New helper [`describeToolResult(structured, content)`](src/domain/workflowOrchestration.ts) returns:

- `structured_type`: object/array/null/other
- `structured_keys`: top-level keys (first 20)
- `content_count`: number of content blocks
- `content_types`: unique \"type\" values seen
- `text_preview`: first 300 chars of first text block
- `text_is_json`: whether it parsed as JSON
- `text_json_keys`: keys of that parsed JSON

Wired into the streaming **creative + products** stages. Zero overhead on happy path (only runs when count is 0 AND ok). Permanent infrastructure — every new vendor with an unexpected shape surfaces here without a debug build.

Not wired into signals (both our signals agents always return `structured_content.signals`; zero there means \"no matches\" not shape mismatch).

## Test plan

- [x] Full suite 403 / 12 skip.
- [x] Type check clean.
- [ ] Post-merge + deploy: rerun workflow, curl the stream, pull the Celtra `diagnostic` block — use that shape to ship a targeted Sec-48l fix to the extractor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)