### PR TITLE
Sec-48l: prefix-tolerant JSON extraction from MCP text blocks (Celtra fix)

### DIFF
--- a/src/domain/workflowOrchestration.ts
+++ b/src/domain/workflowOrchestration.ts
@@ -291,13 +291,42 @@ export function extractMcpToolArray<T = unknown>(
     if (!block || typeof block !== "object") continue;
     const b = block as { type?: string; text?: string };
     if (b.type !== "text" || typeof b.text !== "string") continue;
-    try {
-      const parsed = JSON.parse(b.text);
-      const fromText = extractArrayPayload<T>(parsed, preferredKeys);
-      if (fromText.length > 0) return fromText;
-    } catch { /* not JSON; try next block */ }
+    for (const candidate of jsonCandidatesFromText(b.text)) {
+      try {
+        const parsed = JSON.parse(candidate);
+        const fromText = extractArrayPayload<T>(parsed, preferredKeys);
+        if (fromText.length > 0) return fromText;
+      } catch { /* candidate didn't parse; try next */ }
+    }
   }
   return fromStructured;
+}
+
+/** Produce JSON-parse candidates from a text block. Tries the whole
+ *  text first (happy path for pure-JSON responses), then falls back
+ *  to sliced ranges starting at the first `{`/`[` and ending at the
+ *  last matching bracket.
+ *
+ *  Celtra (and other MCP servers that prioritize human readability)
+ *  emit "Available Creative Formats:\n\n{...}" — a prefix followed
+ *  by JSON. A plain JSON.parse on that fails. Slicing from the first
+ *  `{` to the matching `}` (or `[`/`]`) recovers the payload without
+ *  needing vendor-specific parsers. */
+function jsonCandidatesFromText(text: string): string[] {
+  const out: string[] = [text];
+  const firstBrace = text.indexOf("{");
+  const firstBracket = text.indexOf("[");
+  // Pick whichever opener appears first (and exists).
+  let start = -1;
+  if (firstBrace >= 0 && firstBracket >= 0) start = Math.min(firstBrace, firstBracket);
+  else if (firstBrace >= 0) start = firstBrace;
+  else if (firstBracket >= 0) start = firstBracket;
+  if (start < 0 || start === 0) return out; // nothing to slice, or already pure JSON
+  const opener = text[start];
+  const closer = opener === "{" ? "}" : "]";
+  const end = text.lastIndexOf(closer);
+  if (end > start) out.push(text.slice(start, end + 1));
+  return out;
 }
 
 export function extractArrayPayload<T = unknown>(

--- a/tests/workflowOrchestration.test.ts
+++ b/tests/workflowOrchestration.test.ts
@@ -287,6 +287,61 @@ describe("extractMcpToolArray", () => {
     );
     expect(out).toEqual([{ id: "nested" }]);
   });
+
+  // Sec-48l: Celtra-style human-prefix + JSON text. Direct JSON.parse
+  // fails on "Available Creative Formats:\n\n{...}". Fallback slices
+  // from the first opener to the last matching closer.
+  it("recovers JSON from a text block with a human-readable prefix", () => {
+    const out = extractMcpToolArray(
+      {},
+      [{
+        type: "text",
+        text:
+          "Available Creative Formats:\n\n" +
+          JSON.stringify({ formats: [{ id: "f1" }, { id: "f2" }] }),
+      }],
+      ["formats"],
+    );
+    expect(out).toEqual([{ id: "f1" }, { id: "f2" }]);
+  });
+
+  it("recovers an array payload with a human-readable prefix", () => {
+    const out = extractMcpToolArray(
+      {},
+      [{
+        type: "text",
+        text: "Results:\n\n" + JSON.stringify([{ id: "a" }, { id: "b" }]),
+      }],
+      ["formats"], // no preferred key matches an array at top level
+    );
+    // extractArrayPayload's generic fallback takes the first array-valued
+    // key — but the parsed JSON is itself an array, not an object. That
+    // doesn't match any of the lookup rules, so we expect empty.
+    // This test documents the current behavior: we recover arrays only
+    // when they're inside an object under a preferred or any key.
+    expect(out).toEqual([]);
+  });
+
+  it("handles the Celtra-observed payload shape end-to-end", () => {
+    // Real shape captured 2026-04-24 via /agents/workflow/run/stream
+    // diagnostic: structured_content null/other, content[0].text starts
+    // with "Available Creative Formats:\n\n{\"formats\":[...]}".
+    const text =
+      "Available Creative Formats:\n\n" +
+      JSON.stringify({
+        formats: [
+          { format_id: { agent_url: "...", id: "ed4e8559" }, name: "2 Images Display 160x600" },
+          { format_id: { agent_url: "...", id: "abc12345" }, name: "Video 16:9" },
+        ],
+      });
+    const out = extractMcpToolArray(
+      null,
+      [{ type: "text", text }],
+      ["formats", "creative_formats", "items"],
+    );
+    expect(out).toHaveLength(2);
+    expect((out[0] as { name: string }).name).toBe("2 Images Display 160x600");
+  });
 });
 
 describe("newWorkflowId", () => {


### PR DESCRIPTION
## Summary

Fixes Celtra's \"0 formats\" for real. Sec-48k's diagnostic revealed the exact shape:

\`\`\`json
{
  \"structured_content\": \"(empty / other)\",
  \"content\": [{
    \"type\": \"text\",
    \"text\": \"Available Creative Formats:\n\n{\\\"formats\\\":[...]}\"
  }]
}
\`\`\`

A plain `JSON.parse` on that text fails because of the human-readable prefix + newlines. Yet the JSON is fully there, just wrapped. Sec-48j's extractor gave up on the first parse failure.

## Change

New helper `jsonCandidatesFromText(text)` produces two parse candidates:

1. The whole text (happy path — works for every other vendor)
2. A sliced range from the first `{` / `[` to the last matching closer

No vendor-specific logic. `extractMcpToolArray` now tries both candidates on each text block.

For Celtra: slice starts at index 27 (after `\"Available Creative Formats:\n\n\"`), recovers `{\"formats\":[...]}`, parses cleanly, preferred-keys walk finds `formats` at depth 0.

## Swivel note

Swivel's zero-products was verified via the same Sec-48k diagnostic as a **genuine zero** — `structured_content.products = []`. The agent returned no matches for the brief, not a parsing bug. Not fixed here because there's nothing to fix.

## Test plan

- [x] 3 new tests: prefix-wrapped object (happy path for Celtra), prefix-wrapped bare array (documents current limitation: bare-array payloads not recovered), end-to-end using the exact Celtra shape.
- [x] Full suite 406 / 12 skip.
- [x] Type check clean.
- [ ] Post-merge + deploy: rerun workflow, expect Celtra's stage-2 card to show a non-zero format count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)