### PR TITLE
Sec-48m: fire zero-count diagnostic on errors too

### DIFF
--- a/src/routes/agentsEndpoints.ts
+++ b/src/routes/agentsEndpoints.ts
@@ -849,7 +849,7 @@ export async function handleWorkflowRunStream(request: Request, env: Env, logger
               // Sec-48k: when the extractor finds nothing, attach a shape
               // diagnostic so the UI (and we) can see why. Cheap — runs
               // only on the zero-count path.
-              ...(formats.length === 0 && res.ok
+              ...(formats.length === 0
                 ? { diagnostic: describeToolResult(res.structured_content, res.content) }
                 : {}),
             },
@@ -894,7 +894,10 @@ export async function handleWorkflowRunStream(request: Request, env: Env, logger
                 id: productIdOf(p),
                 name: p.name ?? "(unnamed product)",
               })),
-              ...(products.length === 0 && res.ok
+              // Sec-48m: fire diagnostic on zero-result success AND on
+              // vendor errors (isError:true with no useful error message).
+              // Otherwise the UI shows "err" with nothing explaining why.
+              ...(products.length === 0
                 ? { diagnostic: describeToolResult(res.structured_content, res.content) }
                 : {}),
             },


### PR DESCRIPTION
## Summary

Tiny follow-up to Sec-48k. The diagnostic only fired on `ok && count === 0` so error cases went completely opaque. 5 of 8 live buying agents (adzymic_sph, adzymic_tsl, adzymic_mediacorp, claire_pub, content_ignite) return `isError:true` with no useful error field — we see \"err\" in the UI without any hint why.

## Change

Drop the `ok` guard on the diagnostic block in both creative + products stages. Now fires whenever `count === 0`, regardless of ok/err. One-line change per stage.

Next step after merge + deploy: one curl pull reveals why the five agents fail on `get_products` — likely an argument-shape mismatch we can satisfy with extra payload fields, or auth, or brief-specific empty.

## Test plan

- [x] Type check clean, suite 406/12 unchanged (no test file touched).
- [ ] Post-deploy: rerun workflow with all 8 buying agents via `buying_agent_ids` override, curl the stream, inspect the diagnostic block for each of the 5 failing agents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)