### PR TITLE
Sec-48n: interactive product picks + per-agent fire-buy

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -44,6 +44,7 @@ import {
   handleAgentsCapabilityMatrix,
   handleWorkflowRun,
   handleWorkflowRunStream,
+  handleWorkflowFireBuy,
 } from "./routes/agentsEndpoints";
 import {
   handleAudienceCompose,
@@ -218,6 +219,7 @@ export default {
             "/agents/capability-matrix",
             "/agents/workflow/run",
             "/agents/workflow/run/stream",
+            "/agents/workflow/fire-buy",
             "/taxonomy/reverse",
             // Sec-43: audience composer + activation-planning analytics.
             // Read-only — same posture as /portfolio/* and /analytics/*.
@@ -373,6 +375,8 @@ export default {
                 response = await handleWorkflowRun(request, env, logger);
             } else if (method === "POST" && path === "/agents/workflow/run/stream") {
                 response = await handleWorkflowRunStream(request, env, logger);
+            } else if (method === "POST" && path === "/agents/workflow/fire-buy") {
+                response = await handleWorkflowFireBuy(request, env, logger);
 
                 // ── Sec-43: Audience Composer + activation analytics ────────────────
             } else if (method === "POST" && path === "/audience/compose") {

--- a/src/routes/agentsEndpoints.ts
+++ b/src/routes/agentsEndpoints.ts
@@ -391,7 +391,18 @@ export async function handleAgentsCapabilityMatrix(request: Request, env: Env, l
 //     timeout_ms?:         number  default 15000
 //   }
 
-const DEFAULT_BUYING_TRIO = ["adzymic_apx", "claire_pub", "swivel"] as const;
+// Sec-48n: default trio picked for live-demo completeness. Ground-truth
+// probe 2026-04-24 across all 8 live buying agents with the same brief:
+//   adzymic_apx        → ok, 2 products   ✓
+//   claire_scope3      → ok, 1 product    ✓
+//   swivel             → ok, 0 (legit)    ✓ (workflow still advances)
+//   adzymic_{sph,tsl,mediacorp} → isError:true, vendor-side (Sec-48m
+//                                  diagnostic unwraps the cause)
+//   claire_pub         → isError:true
+//   content_ignite     → isError:true
+// Claire-Scope3 is the most product-diverse of the Claire fleet; swapping
+// claire_pub out of the default makes stage 3 land 3/3 OK in the demo.
+const DEFAULT_BUYING_TRIO = ["adzymic_apx", "claire_scope3", "swivel"] as const;
 const DEFAULT_CREATIVE_PAIR = ["advertible", "celtra"] as const;
 
 interface WorkflowRunBody {
@@ -979,6 +990,95 @@ export async function handleWorkflowRunStream(request: Request, env: Env, logger
       "X-Accel-Buffering": "no",
       "Access-Control-Allow-Origin": "*",
     },
+  });
+}
+
+// ── POST /agents/workflow/fire-buy ──────────────────────────────────────────
+// Sec-48n: fire a single create_media_buy against one buying agent after
+// the user has re-picked a product (or the chosen signals) in the UI.
+// Complements the dry-run-by-default /agents/workflow/run: lets the
+// operator inspect the full workflow result, swap in a different product,
+// and THEN fire the buy — without re-running the whole 4-stage fan-out.
+//
+// Request body:
+//   {
+//     agent_id:    string   required  — must be a live buying agent
+//     product_id:  string   required  — target product (from stage 3)
+//     signal_ids:  string[]           — targeting signals (from stage 1)
+//     brief:       string   required
+//     workflow_id?: string            — reused in buyer_ref + po_number if present
+//     timeout_ms?: number
+//   }
+//
+// Returns the full create_media_buy result body (including the synthesized
+// payload we sent, for transparency) so the UI can render it as a drop-in
+// replacement for the stage-4 dry-run card.
+
+interface FireBuyBody {
+  agent_id?: string;
+  product_id?: string;
+  signal_ids?: string[];
+  brief?: string;
+  workflow_id?: string;
+  timeout_ms?: number;
+}
+
+export async function handleWorkflowFireBuy(request: Request, env: Env, logger: Logger): Promise<Response> {
+  ensureSelfHooksInstalled(env, logger);
+  const parsed = await readJsonBody<FireBuyBody>(request);
+  if (parsed.kind === "invalid") return errorResponse("INVALID_JSON", parsed.reason, 400);
+  const body: FireBuyBody = parsed.kind === "parsed" ? parsed.data : {};
+
+  if (!body.agent_id) return errorResponse("INVALID_INPUT", "agent_id required", 400);
+  if (!body.brief || body.brief.trim().length === 0) return errorResponse("INVALID_INPUT", "brief required", 400);
+  if (body.brief.length > 500) return errorResponse("INVALID_INPUT", "brief max 500 chars", 400);
+
+  const agent = findAgent(body.agent_id);
+  if (!agent) return errorResponse("UNKNOWN_AGENT", `agent ${body.agent_id} not in registry`, 400);
+  if (agent.role !== "buying") return errorResponse("INVALID_AGENT_ROLE", `agent ${agent.id} is ${agent.role}, not buying`, 400);
+  if (agent.stage !== "live" || !agent.mcp_url) return errorResponse("AGENT_NOT_LIVE", `agent ${agent.id} is not live`, 400);
+
+  const timeoutMs = Math.max(1000, Math.min(30_000, body.timeout_ms ?? 15_000));
+  const workflowId = body.workflow_id && /^wf_[a-z0-9]+$/i.test(body.workflow_id)
+    ? body.workflow_id
+    : newWorkflowId();
+
+  const payload = buildCreateMediaBuyPayload({
+    workflowId,
+    agentId: agent.id,
+    brief: body.brief,
+    chosenProductId: body.product_id ?? null,
+    chosenSignalIds: Array.isArray(body.signal_ids) ? body.signal_ids.filter((s) => typeof s === "string") : [],
+  });
+
+  const start = Date.now();
+  const res = await callAgentTool(
+    agent.mcp_url,
+    "create_media_buy",
+    payload as unknown as Record<string, unknown>,
+    { timeoutMs },
+  );
+  const latency = Date.now() - start;
+
+  logger.info("agents_workflow_fire_buy", {
+    workflow_id: workflowId,
+    agent_id: agent.id,
+    ok: res.ok,
+    latency_ms: latency,
+    has_product: !!body.product_id,
+    signal_count: Array.isArray(body.signal_ids) ? body.signal_ids.length : 0,
+  });
+
+  return jsonResponse({
+    workflow_id: workflowId,
+    agent_id: agent.id,
+    vendor: agent.vendor,
+    ok: res.ok,
+    ...(res.error ? { error: res.error } : {}),
+    latency_ms: res.latency_ms ?? latency,
+    payload_preview: payload,
+    ...(res.structured_content !== undefined ? { result: res.structured_content } : {}),
+    ...(res.content !== undefined ? { content: res.content } : {}),
   });
 }
 

--- a/src/routes/demo.ts
+++ b/src/routes/demo.ts
@@ -4261,6 +4261,28 @@ textarea.lab-input { resize: vertical; line-height: 1.5; }
   transition: background-color 0.25s;
 }
 
+/* Sec-48n: pickable product rows + fire-buy button. */
+.wf-product-pickable { cursor: pointer; border-radius: 3px; }
+.wf-product-pickable:hover {
+  background: var(--bg-hover);
+  outline: 1px solid var(--accent-border);
+}
+.wf-product-pickable:hover .wf-product-name { color: var(--accent); }
+.wf-refire-btn {
+  display: inline-flex; align-items: center; gap: 4px; justify-content: center;
+  background: var(--accent); color: #000; border: 1px solid var(--accent);
+  border-radius: 4px; padding: 6px 10px; font-size: 11px; font-weight: 500;
+  cursor: pointer; transition: background-color 0.15s, opacity 0.15s;
+}
+.wf-refire-btn:hover:not(:disabled) { background: var(--accent-hover, var(--accent)); filter: brightness(1.1); }
+.wf-refire-btn:disabled { opacity: 0.6; cursor: wait; }
+.wf-refire-btn .ico { width: 11px; height: 11px; }
+.wf-refire-btn .spinner {
+  display: inline-block; border: 1.5px solid rgba(0,0,0,0.2);
+  border-top-color: #000; border-radius: 50%;
+  animation: wf-spinner-rotate 0.7s linear infinite;
+}
+
 .orch-fanout-summary { display: grid; grid-template-columns: repeat(auto-fit, minmax(160px, 1fr)); gap: 8px; margin-bottom: 10px; }
 .orch-fanout-card {
   background: var(--bg-surface); border: 1px solid var(--border); border-left-width: 3px;
@@ -11222,9 +11244,122 @@ async function ensureOrchestrator() {
   document.getElementById("orch-matrix-run").addEventListener("click", runOrchMatrix);
   var wfRunBtn = document.getElementById("wf-run");
   if (wfRunBtn) wfRunBtn.addEventListener("click", runWorkflow);
+  // Sec-48n: delegated click handler for workflow interactivity — product
+  // re-pick + per-card "Fire this buy". Attached once per tab-load, picks
+  // up future dynamic content in #wf-results.
+  var wfResults = document.getElementById("wf-results");
+  if (wfResults) wfResults.addEventListener("click", _wfOnClick);
   // Load static directory first, then kick off probe in parallel.
   await loadOrchDirectory();
   runOrchProbeAll();
+}
+
+function _wfOnClick(ev) {
+  var target = ev.target;
+  if (!target) return;
+  // Walk up to find an actionable wrapper.
+  var pickRow = target.closest ? target.closest(".wf-product-pickable") : null;
+  if (pickRow) {
+    var agentId = pickRow.getAttribute("data-wf-pick-agent");
+    var productId = pickRow.getAttribute("data-wf-pick-product");
+    if (agentId && productId) _wfPickProduct(agentId, productId);
+    return;
+  }
+  var fireBtn = target.closest ? target.closest(".wf-refire-btn") : null;
+  if (fireBtn) {
+    var fa = fireBtn.getAttribute("data-wf-refire-agent");
+    if (fa) _wfFireBuy(fa, fireBtn);
+    return;
+  }
+}
+
+function _wfPickProduct(agentId, productId) {
+  if (!_wfState) return;
+  var previous = (_wfState.stages.products.chosen_per_agent || {})[agentId];
+  if (previous === productId) return; // no-op
+  _wfState.stages.products.chosen_per_agent[agentId] = productId;
+
+  // Swap the visual "chosen" marker across rows within the same agent card.
+  var card = document.getElementById("wf-agent-products-" + agentId);
+  if (card) {
+    card.querySelectorAll(".wf-product-row").forEach(function (row) {
+      row.classList.remove("wf-product-chosen");
+      row.classList.remove("wf-chosen-pulse");
+    });
+    var newRow = card.querySelector('.wf-product-row[data-product-id="' + productId + '"]');
+    if (newRow) {
+      newRow.classList.add("wf-product-chosen", "wf-chosen-pulse");
+      setTimeout(function () { newRow.classList.remove("wf-chosen-pulse"); }, 900);
+    }
+  }
+
+  // Live-rewrite the stage-4 payload JSON for that agent. Mutate the cached
+  // payload object, re-serialize, fade in the new text.
+  var payload = (_wfState.stages.media_buy.payload_by_agent || {})[agentId];
+  if (payload && Array.isArray(payload.packages) && payload.packages.length > 0) {
+    payload.packages[0].product_id = productId;
+    var pre = document.getElementById("wf-payload-pre-" + agentId);
+    if (pre) {
+      try {
+        pre.textContent = JSON.stringify(payload, null, 2);
+        pre.classList.remove("wf-body-anim");
+        // Force reflow so the animation restarts cleanly on repeated picks.
+        void pre.offsetWidth;
+        pre.classList.add("wf-body-anim");
+      } catch (e) { /* noop */ }
+    }
+  }
+}
+
+async function _wfFireBuy(agentId, btn) {
+  if (!_wfState) return;
+  if (btn.disabled) return;
+  var origHTML = btn.innerHTML;
+  btn.disabled = true;
+  btn.innerHTML = '<span class="spinner" style="width:10px;height:10px;margin-right:6px"></span><span>Firing\u2026</span>';
+  var chosenProduct = (_wfState.stages.products.chosen_per_agent || {})[agentId] || null;
+  var signalIds = _wfState.stages.signals.chosen || [];
+  try {
+    var r = await fetch("/agents/workflow/fire-buy", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        agent_id: agentId,
+        product_id: chosenProduct,
+        signal_ids: signalIds,
+        brief: _wfState.brief,
+        workflow_id: _wfState.workflow_id,
+        timeout_ms: 20000,
+      }),
+    });
+    var data = await r.json();
+    if (!r.ok) {
+      btn.innerHTML = origHTML;
+      btn.disabled = false;
+      showToast((data && (data.error || data.message)) || ("HTTP " + r.status), true);
+      return;
+    }
+    // Synthesize an agent_complete-like event so the existing renderer
+    // re-paints the card as a fired result.
+    _wfApplyEvent({
+      type: "agent_complete",
+      stage: "media_buy",
+      agent_id: agentId,
+      ok: !!data.ok,
+      error: data.error,
+      latency_ms: data.latency_ms || 0,
+      summary: {
+        dry_run: false,
+        fired: true,
+        payload_preview: data.payload_preview,
+        result: data.result,
+      },
+    });
+  } catch (e) {
+    btn.innerHTML = origHTML;
+    btn.disabled = false;
+    showToast(String((e && e.message) || e), true);
+  }
 }
 
 async function loadOrchDirectory() {
@@ -11874,8 +12009,15 @@ function _wfPaintAgentComplete(ev) {
   } else if (ev.stage === "products") {
     var previewP = (ev.summary && ev.summary.preview) || [];
     body = '<div class="wf-stage-count mono">' + (ev.summary && ev.summary.count || 0) + ' products</div>' +
+      (previewP.length > 1 ? '<div class="orch-small" style="margin-bottom:2px">click a row to pick</div>' : '') +
       previewP.map(function (p) {
-        return '<div class="wf-product-row" data-product-id="' + escapeHtml(p.id || '') + '">' +
+        // Sec-48n: clickable product rows. data-wf-pick-agent + product
+        // attrs let the delegated handler on #wf-results identify the
+        // target without re-querying the card hierarchy.
+        return '<div class="wf-product-row wf-product-pickable" ' +
+                 'data-wf-pick-agent="' + escapeHtml(ev.agent_id) + '" ' +
+                 'data-wf-pick-product="' + escapeHtml(p.id || '') + '" ' +
+                 'data-product-id="' + escapeHtml(p.id || '') + '">' +
           '<span class="mono wf-product-id">' + escapeHtml(p.id || '-') + '</span>' +
           '<span class="wf-product-name">' + escapeHtml(p.name) + '</span>' +
         '</div>';
@@ -11883,18 +12025,33 @@ function _wfPaintAgentComplete(ev) {
   } else if (ev.stage === "media_buy") {
     var sum = ev.summary || {};
     var payload = sum.payload_preview || {};
+    // Preserve the server-emitted payload on state so re-picks can mutate it
+    // locally without re-calling /run/stream.
+    if (!_wfState.stages.media_buy.payload_by_agent) _wfState.stages.media_buy.payload_by_agent = {};
+    _wfState.stages.media_buy.payload_by_agent[ev.agent_id] = payload;
     var payloadJson = "";
     try { payloadJson = JSON.stringify(payload, null, 2); } catch (e) { payloadJson = String(e); }
     var fireBadge = sum.fired
       ? (ev.ok ? '<span class="pill pill-success mono" style="font-size:10px">fired \u2713</span>'
                : '<span class="pill pill-error mono" style="font-size:10px">fired \u2717</span>')
       : '<span class="pill pill-muted mono" style="font-size:10px">dry run</span>';
+    // Sec-48n: Fire button appears only on dry-run cards. Clicking it posts
+    // to /agents/workflow/fire-buy with the current pick state.
+    var fireBtn = !sum.fired
+      ? '<button class="btn-primary wf-refire-btn" ' +
+               'data-wf-refire-agent="' + escapeHtml(ev.agent_id) + '" ' +
+               'style="margin-top:8px;width:100%;justify-content:center;padding:6px 10px;font-size:11px">' +
+          '<svg class="ico"><use href="#icon-bolt"/></svg>' +
+          '<span>Fire this buy (live)</span>' +
+        '</button>'
+      : '';
     body = '<div class="wf-stage-count mono" style="display:flex;justify-content:space-between;align-items:center">' + fireBadge + '</div>' +
       '<details class="wf-payload-details"' + (sum.fired ? '' : ' open') + '>' +
         '<summary class="orch-small">create_media_buy payload</summary>' +
-        '<pre class="wf-json mono">' + escapeHtml(payloadJson) + '</pre>' +
+        '<pre class="wf-json mono" id="wf-payload-pre-' + escapeHtml(ev.agent_id) + '">' + escapeHtml(payloadJson) + '</pre>' +
       '</details>' +
-      (sum.fired && sum.result ? '<details class="wf-result-details"><summary class="orch-small">view agent response</summary><pre class="wf-json mono">' + escapeHtml(JSON.stringify(sum.result, null, 2)) + '</pre></details>' : '');
+      (sum.fired && sum.result ? '<details class="wf-result-details"><summary class="orch-small">view agent response</summary><pre class="wf-json mono">' + escapeHtml(JSON.stringify(sum.result, null, 2)) + '</pre></details>' : '') +
+      fireBtn;
   }
   var headHTML = '<div class="wf-agent-head">' +
     '<span class="wf-agent-name mono">' + escapeHtml(ev.agent_id) + '</span>' +


### PR DESCRIPTION
## Summary

Closes the loop on the workflow demo: one click runs everything, all three buying agents land ok, user can click a different product row to re-pick — payload updates live — and hit \"Fire this buy (live)\" to actually activate against just that one agent.

## Default trio swap

2026-04-24 live probe across all 8 live buying agents on the same brief:

| Agent | Status | Products |
|---|---|---|
| adzymic_apx | ok | 2 |
| claire_scope3 | ok | 1 |
| swivel | ok | 0 (legit empty) |
| adzymic_sph | isError | — |
| adzymic_tsl | isError | — |
| adzymic_mediacorp | isError | — |
| claire_pub | isError | — |
| content_ignite | isError | — |

Swapped `DEFAULT_BUYING_TRIO`: `claire_pub` → `claire_scope3`. Now 3/3 agents in the default demo return ok; two return non-empty products; workflow always has something to render.

## New endpoint

`POST /agents/workflow/fire-buy` — targeted single-agent activation for use after the /run/stream view. Takes `{agent_id, product_id, signal_ids, brief, workflow_id?}`, synthesizes the same `create_media_buy` payload via `buildCreateMediaBuyPayload`, fires once, returns the full result. Validates agent is a live buying agent.

## UI — interactivity

- **Clickable product rows.** Hover highlights; click re-picks:
  1. Swaps `wf-product-chosen` + plays 900ms pulse on the new row
  2. Mutates cached stage-4 payload (`packages[0].product_id`)
  3. Re-serializes the JSON in the stage-4 `<pre>` with a fade-in
  4. Persists on state for subsequent fire
- **Fire this buy (live)** button per dry-run stage-4 card. Clicking POSTs to fire-buy, synthesizes an `agent_complete` event, reuses `_wfApplyEvent` so the card morphs in-place with the fired-state style + agent response drawer.
- Delegated click handler attached once in `ensureOrchestrator`, picks up re-renders.

## Test plan

- [x] Full suite 406 / 12 skip.
- [x] Type check clean (pre-existing queryResolver.test.ts errors noise).
- [ ] Post-merge + deploy:
  - Run workflow with default trio — expect adzymic_apx (2 products), claire_scope3 (1 product), swivel (0 legit).
  - Click a non-chosen product row on adzymic_apx — expect pulse animation + stage-4 payload JSON for adzymic_apx to update live with the new product_id.
  - Click \"Fire this buy (live)\" on one card — expect spinner, then card morphs to fired state with agent response expandable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)