### PR TITLE
Sec-48o hotfix: strip string-escape sequences from SCRIPT_TAG comments

### DIFF
--- a/src/routes/demo.ts
+++ b/src/routes/demo.ts
@@ -11753,12 +11753,9 @@ async function runWorkflow() {
       if (chunk.done) break;
       buf += dec.decode(chunk.value, { stream: true });
       var nl;
-      // Double-escape: SCRIPT_TAG is a template literal, so the source
-      // "\\n" collapses to "\n" (2 chars, backslash+n) when emitted,
-      // which the browser parses as the newline escape. A single "\n"
-      // in source becomes a raw newline inside the string literal —
-      // a multi-line "..." is a SyntaxError at parse time. See Sec-48c
-      // for the same trap with a regex.
+      // See Sec-48c / Sec-48h. This SCRIPT_TAG body is a template
+      // literal, so string-literal escapes must be doubled at source.
+      // Split NDJSON frames on the newline escape.
       while ((nl = buf.indexOf("\\n")) >= 0) {
         var line = buf.slice(0, nl).trim();
         buf = buf.slice(nl + 1);


### PR DESCRIPTION
## Summary

Fixes the live-breaking syntax error at line 11710:

> Uncaught SyntaxError: Invalid or unexpected token (at (index):11710:...)

### Root cause

Sec-48h landed a fix for a newline-escape trap AND added an explanatory comment that embedded literal `\"\n\"` to illustrate the fix. But the SCRIPT_TAG template literal evaluator doesn't know the difference between code and comments — it processes the whole string. The `\n` inside the explanatory comment got collapsed to a raw newline, which left an unclosed string literal inside the comment, which cascaded into a parse error for the whole `<script type=\"module\">`.

So an explanatory comment about an escape trap recursed into the same trap. Third-order bug.

### Fix

Rewrote the comment in plain English with no string-escape sequences at all. Just a cross-reference to Sec-48c and Sec-48h. The actual code path is unchanged — `indexOf` still uses the correctly-doubled `\\n` in source.

### Rule for the future

**Never embed string-literal escape sequences (`\n`, `\t`, `\r`, etc.) inside comments inside the SCRIPT_TAG template literal.** Template literal processing is oblivious to comment boundaries.

## Test plan

- [x] Type check clean.
- [x] grep audit: no remaining `\[nrt]` in comments inside SCRIPT_TAG.
- [ ] Post-merge + deploy: reload demo, no console error; Orchestrator tab renders; workflow runs cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)