### PR TITLE
Sec-48p: surface vendor rejection reason + honest fire-button copy

### DIFF
--- a/src/routes/agentsEndpoints.ts
+++ b/src/routes/agentsEndpoints.ts
@@ -955,6 +955,10 @@ export async function handleWorkflowRunStream(request: Request, env: Env, logger
               fired: true,
               payload_preview: payload,
               result: res.structured_content ?? null,
+              // Sec-48p: surface content too so the UI can show vendor
+              // rejection messages (most agents that return isError:true
+              // put the reason in content[0].text, not in structured).
+              content: res.content ?? null,
             },
           });
         }));

--- a/src/routes/demo.ts
+++ b/src/routes/demo.ts
@@ -11353,6 +11353,7 @@ async function _wfFireBuy(agentId, btn) {
         fired: true,
         payload_preview: data.payload_preview,
         result: data.result,
+        content: data.content,
       },
     });
   } catch (e) {
@@ -12032,22 +12033,68 @@ function _wfPaintAgentComplete(ev) {
       ? (ev.ok ? '<span class="pill pill-success mono" style="font-size:10px">fired \u2713</span>'
                : '<span class="pill pill-error mono" style="font-size:10px">fired \u2717</span>')
       : '<span class="pill pill-muted mono" style="font-size:10px">dry run</span>';
-    // Sec-48n: Fire button appears only on dry-run cards. Clicking it posts
-    // to /agents/workflow/fire-buy with the current pick state.
+    // Sec-48n: fire button appears only on dry-run cards. Clicking it
+    // posts to /agents/workflow/fire-buy with the current pick.
+    // Sec-48p: honest copy. We do actually call the vendor with our
+    // synthesized payload; the payload satisfies the required-field
+    // union but not each vendor's business-logic validation (real
+    // brand IDs, authorized properties, PO numbers, inventory
+    // windows, ...). Rename from "Fire this buy (live)" to signal that.
     var fireBtn = !sum.fired
       ? '<button class="btn-primary wf-refire-btn" ' +
                'data-wf-refire-agent="' + escapeHtml(ev.agent_id) + '" ' +
+               'title="Calls create_media_buy on the agent with our synthesized payload. Vendors typically reject on validation; response body is surfaced below." ' +
                'style="margin-top:8px;width:100%;justify-content:center;padding:6px 10px;font-size:11px">' +
           '<svg class="ico"><use href="#icon-bolt"/></svg>' +
-          '<span>Fire this buy (live)</span>' +
+          '<span>Simulate live fire</span>' +
         '</button>'
       : '';
+    // Sec-48p: always surface vendor response when fired, not just on
+    // success. Failed calls are the interesting case — the vendor's
+    // error message tells us what they reject and why. Auto-open on
+    // err so the user sees the reason without clicking.
+    var responseBlock = "";
+    if (sum.fired) {
+      var hasResult = sum.result !== undefined && sum.result !== null;
+      var hasContent = Array.isArray(sum.content) && sum.content.length > 0;
+      var autoOpen = !ev.ok ? ' open' : '';
+      if (hasResult) {
+        responseBlock +=
+          '<details class="wf-result-details"' + autoOpen + '>' +
+            '<summary class="orch-small">' + (ev.ok ? 'vendor response' : 'vendor rejection \u2014 result') + '</summary>' +
+            '<pre class="wf-json mono">' + escapeHtml(JSON.stringify(sum.result, null, 2)) + '</pre>' +
+          '</details>';
+      }
+      if (hasContent) {
+        // MCP content blocks — prefer the first text block's content,
+        // fall back to the whole array serialized.
+        var textBlock = null;
+        for (var ci = 0; ci < sum.content.length; ci++) {
+          var blk = sum.content[ci];
+          if (blk && typeof blk === "object" && blk.type === "text" && typeof blk.text === "string") {
+            textBlock = blk.text; break;
+          }
+        }
+        var display = textBlock !== null ? textBlock : JSON.stringify(sum.content, null, 2);
+        responseBlock +=
+          '<details class="wf-result-details"' + autoOpen + '>' +
+            '<summary class="orch-small">' + (ev.ok ? 'vendor content' : 'vendor rejection \u2014 content') + '</summary>' +
+            '<pre class="wf-json mono">' + escapeHtml(display) + '</pre>' +
+          '</details>';
+      }
+      if (!hasResult && !hasContent && !ev.ok && !ev.error) {
+        responseBlock +=
+          '<div class="orch-small" style="margin-top:6px;color:var(--text-mut);font-style:italic">' +
+            'vendor returned no body or error message (isError:true, empty content)' +
+          '</div>';
+      }
+    }
     body = '<div class="wf-stage-count mono" style="display:flex;justify-content:space-between;align-items:center">' + fireBadge + '</div>' +
       '<details class="wf-payload-details"' + (sum.fired ? '' : ' open') + '>' +
         '<summary class="orch-small">create_media_buy payload</summary>' +
         '<pre class="wf-json mono" id="wf-payload-pre-' + escapeHtml(ev.agent_id) + '">' + escapeHtml(payloadJson) + '</pre>' +
       '</details>' +
-      (sum.fired && sum.result ? '<details class="wf-result-details"><summary class="orch-small">view agent response</summary><pre class="wf-json mono">' + escapeHtml(JSON.stringify(sum.result, null, 2)) + '</pre></details>' : '') +
+      responseBlock +
       fireBtn;
   }
   var headHTML = '<div class="wf-agent-head">' +


### PR DESCRIPTION
## Summary

Screenshot from production showed all 3 stage-4 cards fire with `err` and nothing explaining why. The fire-buy endpoint already captures the vendor's response — the UI just wasn't rendering it on failure. Also renaming the button to match what the call actually does.

## 1 — vendor response always shown on fired

**Before:** `view agent response` details only rendered when `sum.fired && sum.result`. Failures had `result: null` AND the MCP `content[0].text` where every isError rejection reason actually lives was never shown.

**Now:** on any fired card, render `result` AND `content` side by side, **auto-open on failure** (`!ev.ok`) so the reason is visible without clicking. MCP content prefers the first text block's `.text` for display; falls back to serialized JSON. Labels switch between \"vendor response / content\" on success and \"vendor rejection — result / content\" on failure.

If the vendor returned nothing (plain `isError:true` with empty body + no error message), show an italicized `vendor returned no body or error message` line so the card isn't visually empty.

### Threading

- `handleWorkflowRunStream` media_buy stage now emits `content: res.content ?? null` in the summary.
- `handleWorkflowFireBuy` already returned content; no change.
- `_wfFireBuy` client threads `data.content` into the synthesized `agent_complete` event.

## 3 — button copy

\"Fire this buy (live)\" → **\"Simulate live fire\"** with a tooltip:

> Calls `create_media_buy` on the agent with our synthesized payload. Vendors typically reject on validation; response body is surfaced below.

The label is honest without being scary. Long explanation in tooltip.

## Also confirmed

**Celtra's 79 formats is correct** — verified via stage_complete total + preview sample. Vendor normalizes every size variant (160x600, 300x250, 300x600, 320x100, 320x50, …) as a separate format entry. Not a bug.

## Pre-flight (new memory rule)

Per the `feedback_script_tag_template_trap` memory I just saved — grepped the `demo.ts` diff for backslash-escape sequences inside SCRIPT_TAG and literal backticks. Zero hits. Full suite 406 / 12 skip.

## Test plan

- [x] Type check clean, tests pass.
- [x] Pre-flight escape audit clean.
- [ ] Post-merge + deploy: run workflow, click \"Simulate live fire\" on any dry-run card, expect the card to morph to fired state with the vendor's rejection reason auto-expanded below the payload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)