### PR TITLE
Sec-48r1: fire zero-count diagnostic regardless of ok

### DIFF
--- a/src/routes/agentsEndpoints.ts
+++ b/src/routes/agentsEndpoints.ts
@@ -897,7 +897,12 @@ export async function handleWorkflowRunStream(request: Request, env: Env, logger
               // Sec-48k: when the extractor finds nothing, attach a shape
               // diagnostic so the UI (and we) can see why. Cheap — runs
               // only on the zero-count path.
-              ...(formats.length === 0 && res.ok
+              // Sec-48r: fire diagnostic on any zero-count result — success
+              // (interpretation: "genuinely empty") or failure (interpretation:
+              // "isError:true; reason in content[0].text"). The diagnostic is
+              // how we triage vendor-shape mismatches without shipping a debug
+              // build.
+              ...(formats.length === 0
                 ? { diagnostic: describeToolResult(res.structured_content, res.content) }
                 : {}),
             },
@@ -951,7 +956,9 @@ export async function handleWorkflowRunStream(request: Request, env: Env, logger
                 id: productIdOf(p),
                 name: p.name ?? "(unnamed product)",
               })),
-              ...(products.length === 0 && res.ok
+              // Sec-48r: fire on zero-count regardless of ok — see note in
+              // the creative stage above.
+              ...(products.length === 0
                 ? { diagnostic: describeToolResult(res.structured_content, res.content) }
                 : {}),
             },


### PR DESCRIPTION
## Summary

9-line surgical fix. Sec-48m (#86) was closed as superseded by #89, but #89 only touched the media_buy stage — the creative + products zero-count guards still have \`&& res.ok\`. So failed \`get_products\` calls from adzymic_{sph,tsl,mediacorp}, content_ignite, claire_pub emit no diagnostic and we can't see the rejection reason.

## Change

Drop the \`&& res.ok\` guard on both stages in the streaming endpoint. Diagnostic now fires on:
- ok + count=0 → vendor genuinely empty
- !ok + count=0 → vendor rejected, diagnostic shows the rejection text verbatim

## Why now

Unblocks Sec-48r2 (per-vendor \`create_media_buy\` payload adapters + workshop demo script). Can't build adapters without seeing the rejection bodies.

## Test plan

- [x] Type check clean, suite 422/12 unchanged (no test files touched).
- [ ] Post-merge + deploy: curl the stream with \`buying_agent_ids:[\"adzymic_sph\",\"content_ignite\",\"claire_pub\"]\`, expect \`summary.diagnostic\` block present on all three agent_complete events for the products stage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)