### PR TITLE
Sec-48r3: expanded vendor adapter — Adzymic budget/buyer_ref, Claire narrow brand_manifest

### DIFF
--- a/src/domain/workflowOrchestration.ts
+++ b/src/domain/workflowOrchestration.ts
@@ -188,44 +188,60 @@ export function extractCategories(brief: string): string[] {
   return uniq.length > 0 ? uniq : ["general"];
 }
 
-/** Sec-48r: per-vendor transform applied to the synthesized media-buy
- *  payload JUST before the create_media_buy tool call. Compensates for
- *  schema drift across live implementations observed during Sec-48
- *  interop probing.
+/** Sec-48r (expanded in Sec-48r3): per-vendor transform applied to the
+ *  synthesized media-buy payload just before the `create_media_buy`
+ *  tool call. Compensates for validation drift across live
+ *  implementations observed via the Sec-48k/p diagnostic probes.
  *
- *  Rules discovered via Sec-48k/p diagnostic probes:
+ *  Rules after iterating against live responses:
  *
- *    adzymic_*    — brand_manifest requires `name` (we emit `brand`).
- *                   Claire-style `buyer_ref` on the package is harmless.
- *    claire_*     — packages[].buyer_ref is required; budget must be a
- *                   number (not {amount, currency}).
- *    swivel       — wants packages[].buyer_ref. Also validates more
- *                   strictly than others; keep payload minimal.
- *    content_ignite — similar to claire shape.
+ *    adzymic_*      — brand_manifest.name required (synth emits brand);
+ *                     packages[].buyer_ref required; budget + total_budget
+ *                     must be scalar numbers, not {amount, currency} objects.
+ *    swivel         — brand_manifest.name required; packages[].buyer_ref
+ *                     required. Budget shape lenient (keep object).
+ *    claire_*       — packages[].buyer_ref required; budget + total_budget
+ *                     scalar numbers; brand_manifest narrower — accepts
+ *                     ONLY `name` + `categories` (rejects `brand` and
+ *                     `advertiser` as unexpected keyword arguments);
+ *                     packages[].pricing_option_id required.
+ *    content_ignite — same as claire_*.
  *
- *  Unknown vendor_ids fall through to the identity transform (base
- *  payload unchanged). This keeps new-vendor support additive. */
+ *  Unknown vendor_ids fall through to identity (base payload unchanged).
+ *
+ *  The `packages[].pricing_option_id` default is a known-bad placeholder —
+ *  Claire's real schema expects a value sourced from the product's
+ *  pricing_options array. Wiring that through requires re-threading the
+ *  product result into fire-buy; tracked as follow-up. For now the
+ *  placeholder surfaces as a different vendor error message, which is
+ *  still better than the current outright rejection. */
 export function applyVendorAdapter(agentId: string, payload: MediaBuyPayload): MediaBuyPayload {
   // Deep-clone so callers can still inspect the pre-transform shape.
   const p: MediaBuyPayload = JSON.parse(JSON.stringify(payload));
 
-  if (agentId.startsWith("adzymic_") || agentId === "swivel") {
-    // brand_manifest.name alongside brand (Pydantic accepts extra fields
-    // but a missing `name` is a hard reject).
+  const isAdzymic = agentId.startsWith("adzymic_");
+  const isClaire = agentId.startsWith("claire_");
+  const isContentIgnite = agentId === "content_ignite";
+  const isSwivel = agentId === "swivel";
+
+  // brand_manifest.name — required by adzymic + swivel; for claire/ci we
+  // rebuild the object entirely below with only name + categories.
+  if (isAdzymic || isSwivel) {
     (p.brand_manifest as unknown as Record<string, unknown>).name = p.brand_manifest.brand;
   }
 
-  if (agentId.startsWith("claire_") || agentId === "content_ignite" || agentId === "swivel") {
-    // Package-level buyer_ref required. Reuse the top-level buyer_ref
-    // as the seed + append the package_ref for uniqueness.
+  // packages[].buyer_ref — required by every known vendor except bare
+  // adzymic_apx (which tolerates its absence; harmless to add).
+  if (isAdzymic || isClaire || isContentIgnite || isSwivel) {
     for (const pkg of p.packages) {
       (pkg as unknown as Record<string, unknown>).buyer_ref = `${p.buyer_ref}_${pkg.package_ref}`;
     }
   }
 
-  if (agentId.startsWith("claire_") || agentId === "content_ignite") {
-    // Their Pydantic wants budget as a scalar number, not an object. Also
-    // propagate at package level (same lib validates both).
+  // Budget + total_budget as scalar number — required by adzymic + claire
+  // + content_ignite. Swivel's pydantic is lenient here so we leave the
+  // object form in place for it.
+  if (isAdzymic || isClaire || isContentIgnite) {
     for (const pkg of p.packages) {
       const b = pkg.budget;
       if (b && typeof b === "object" && typeof b.amount === "number") {
@@ -234,6 +250,21 @@ export function applyVendorAdapter(agentId: string, payload: MediaBuyPayload): M
     }
     if (p.total_budget && typeof p.total_budget === "object" && typeof p.total_budget.amount === "number") {
       (p as unknown as Record<string, unknown>).total_budget = p.total_budget.amount;
+    }
+  }
+
+  // claire_* + content_ignite: rebuild brand_manifest to their narrow
+  // contract (rejects `brand` and `advertiser` as unexpected keyword
+  // arguments), and add a placeholder pricing_option_id on each package.
+  if (isClaire || isContentIgnite) {
+    const origName = p.brand_manifest.brand ?? "Demo Brand";
+    const origCats = p.brand_manifest.categories ?? [];
+    (p as unknown as Record<string, unknown>).brand_manifest = {
+      name: origName,
+      categories: origCats,
+    };
+    for (const pkg of p.packages) {
+      (pkg as unknown as Record<string, unknown>).pricing_option_id = "default";
     }
   }
 

--- a/tests/workflowOrchestration.test.ts
+++ b/tests/workflowOrchestration.test.ts
@@ -502,39 +502,61 @@ describe("applyVendorAdapter (Sec-48r)", () => {
     nowMs: NOW,
   });
 
-  it("adzymic_* gets brand_manifest.name alongside .brand", () => {
-    const out = applyVendorAdapter("adzymic_apx", base) as unknown as { brand_manifest: Record<string, unknown> };
-    expect(out.brand_manifest.brand).toBe("AdCP Workflow Demo");
-    expect(out.brand_manifest.name).toBe("AdCP Workflow Demo");
-  });
-
-  it("swivel also gets brand_manifest.name AND package buyer_ref", () => {
-    const out = applyVendorAdapter("swivel", base) as unknown as {
+  it("adzymic_*: brand_manifest.name + package buyer_ref + budgets flattened", () => {
+    const out = applyVendorAdapter("adzymic_apx", base) as unknown as {
       brand_manifest: Record<string, unknown>;
-      packages: Array<Record<string, unknown>>;
-    };
-    expect(out.brand_manifest.name).toBeDefined();
-    expect(out.packages[0]!.buyer_ref).toContain(base.buyer_ref);
-    expect(out.packages[0]!.buyer_ref).toContain("pkg_1");
-  });
-
-  it("claire_* gets package buyer_ref + budget flattened to number", () => {
-    const out = applyVendorAdapter("claire_scope3", base) as unknown as {
       packages: Array<Record<string, unknown>>;
       total_budget: unknown;
     };
+    expect(out.brand_manifest.brand).toBe("AdCP Workflow Demo");
+    expect(out.brand_manifest.name).toBe("AdCP Workflow Demo");
+    expect(out.packages[0]!.buyer_ref).toContain("pkg_1");
+    expect(out.packages[0]!.budget).toBe(1000);
+    expect(out.total_budget).toBe(1000);
+  });
+
+  it("swivel: brand_manifest.name + package buyer_ref, but budget stays object", () => {
+    const out = applyVendorAdapter("swivel", base) as unknown as {
+      brand_manifest: Record<string, unknown>;
+      packages: Array<Record<string, unknown>>;
+      total_budget: unknown;
+    };
+    expect(out.brand_manifest.name).toBeDefined();
+    expect(out.packages[0]!.buyer_ref).toContain(base.buyer_ref);
+    // Swivel's pydantic is lenient on budget shape — object form preserved.
+    expect(out.packages[0]!.budget).toEqual({ amount: 1000, currency: "USD" });
+    expect(out.total_budget).toEqual({ amount: 1000, currency: "USD" });
+  });
+
+  it("claire_*: narrow brand_manifest, buyer_ref, scalar budget, pricing_option_id", () => {
+    const out = applyVendorAdapter("claire_scope3", base) as unknown as {
+      brand_manifest: Record<string, unknown>;
+      packages: Array<Record<string, unknown>>;
+      total_budget: unknown;
+    };
+    // Narrow brand_manifest — no `brand`, no `advertiser`.
+    expect(out.brand_manifest).toEqual({
+      name: "AdCP Workflow Demo",
+      categories: base.brand_manifest.categories,
+    });
+    expect(out.brand_manifest.brand).toBeUndefined();
+    expect(out.brand_manifest.advertiser).toBeUndefined();
     expect(out.packages[0]!.buyer_ref).toBeDefined();
     expect(out.packages[0]!.budget).toBe(1000);
+    expect(out.packages[0]!.pricing_option_id).toBe("default");
     expect(out.total_budget).toBe(1000);
   });
 
   it("content_ignite follows claire rules", () => {
     const out = applyVendorAdapter("content_ignite", base) as unknown as {
+      brand_manifest: Record<string, unknown>;
       packages: Array<Record<string, unknown>>;
       total_budget: unknown;
     };
+    expect(out.brand_manifest.brand).toBeUndefined();
     expect(out.packages[0]!.buyer_ref).toBeDefined();
     expect(out.packages[0]!.budget).toBe(1000);
+    expect(out.packages[0]!.pricing_option_id).toBe("default");
     expect(out.total_budget).toBe(1000);
   });
 


### PR DESCRIPTION
## Summary

Post-deploy of Sec-48r2 revealed the adapter rules were scoped too narrowly. Live diagnostic against the default trio:

**adzymic_apx** (my earlier adapter only set `brand_manifest.name`):
\`\`\`
4 validation errors for call[create_media_buy]
packages.0.budget — should be a valid number [input {'amount': 1000, 'currency': 'USD'}]
packages.0.buyer_ref — Field required
\`\`\`

**claire_scope3** (my earlier adapter added `buyer_ref` + flattened budget but didn't touch brand_manifest):
\`\`\`
2 validation errors for call[create_media_buy]
packages.0.pricing_option_id — Field required
brand_manifest — Unexpected keyword argument
\`\`\`

## Expanded rules

| Vendor | brand_manifest | package.buyer_ref | budget shape | pricing_option_id |
|---|---|---|---|---|
| `adzymic_*` | add `name` alongside `brand` | **add** (new) | **scalar number** (new) | — |
| `swivel` | add `name` | add | object (lenient) | — |
| `claire_*` | **rebuild narrow `{name, categories}`** (strips `brand` + `advertiser`) | add | scalar number | **add placeholder** `\"default\"` |
| `content_ignite` | same as claire | add | scalar number | add placeholder |

The `pricing_option_id: \"default\"` placeholder is deliberate — the real value sources from the product's `pricing_options` array, which requires re-threading product data into fire-buy. Surfacing a different vendor error is still more demo-informative than outright rejection. Tracked as follow-up.

## Also surfaced: 5 \"failing\" agents were actually auth-gated

Triage of adzymic_sph/tsl/mediacorp + claire_pub + content_ignite: all reject with
\`AUTH_TOKEN_INVALID: Authentication required by tenant policy\`. Credentials we don't have. Not a shape gap — a **credentials gap**. Our default trio (apx + claire_scope3 + swivel) remains the open set. Worth calling out at the workshop as \"AdCP has no auth-posture standard\" gap.

## Tests

Adapter tests expanded to lock in the rules per vendor (adzymic gets budget-flatten, swivel doesn't, claire strips brand + pricing_option_id, etc.). **Full suite 428 / 12 skip** unchanged (test names rewritten, count unchanged).

## Pre-flight

No `demo.ts` changes this PR. Pure backend + tests.

## Test plan

- [x] Type check, suite.
- [ ] Post-merge + deploy: fire-buy on adzymic_apx — expect the budget+buyer_ref errors to disappear (replaced by whatever the next validation layer rejects on, if anything). Fire-buy on claire_scope3 — expect brand_manifest error gone, pricing_option_id error likely remaining with a \"pricing_option_id 'default' not recognized\" shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)