### PR TITLE
Sec-48r4: adapter round 3 — pricing_option_id, Swivel budget, drop Claire brand_manifest

### DIFF
--- a/src/domain/workflowOrchestration.ts
+++ b/src/domain/workflowOrchestration.ts
@@ -223,25 +223,32 @@ export function applyVendorAdapter(agentId: string, payload: MediaBuyPayload): M
   const isClaire = agentId.startsWith("claire_");
   const isContentIgnite = agentId === "content_ignite";
   const isSwivel = agentId === "swivel";
+  const isKnownBuying = isAdzymic || isClaire || isContentIgnite || isSwivel;
 
-  // brand_manifest.name — required by adzymic + swivel; for claire/ci we
-  // rebuild the object entirely below with only name + categories.
+  // ── brand_manifest ────────────────────────────────────────────────────
+  // Adzymic + Swivel: lenient, extra fields OK. Just need `name` present.
+  // Claire + Content Ignite: narrow — rejected {name, categories} live
+  // too (Sec-48r3 probe), so we OMIT brand_manifest entirely. The field
+  // is optional in their schema (only buyer_ref is required at top level).
   if (isAdzymic || isSwivel) {
     (p.brand_manifest as unknown as Record<string, unknown>).name = p.brand_manifest.brand;
+  } else if (isClaire || isContentIgnite) {
+    delete (p as unknown as Record<string, unknown>).brand_manifest;
   }
 
-  // packages[].buyer_ref — required by every known vendor except bare
-  // adzymic_apx (which tolerates its absence; harmless to add).
-  if (isAdzymic || isClaire || isContentIgnite || isSwivel) {
+  // ── packages[].buyer_ref ──────────────────────────────────────────────
+  // All known buying vendors require this at package level.
+  if (isKnownBuying) {
     for (const pkg of p.packages) {
       (pkg as unknown as Record<string, unknown>).buyer_ref = `${p.buyer_ref}_${pkg.package_ref}`;
     }
   }
 
-  // Budget + total_budget as scalar number — required by adzymic + claire
-  // + content_ignite. Swivel's pydantic is lenient here so we leave the
-  // object form in place for it.
-  if (isAdzymic || isClaire || isContentIgnite) {
+  // ── budget + total_budget as scalar number ────────────────────────────
+  // Sec-48r3 exempted swivel thinking it was lenient. Live fire-buy showed
+  // swivel ALSO rejects: "INVALID_FIELD_VALUE, Expected number, received
+  // object, field: packages.0.budget". So all four vendor families flatten.
+  if (isKnownBuying) {
     for (const pkg of p.packages) {
       const b = pkg.budget;
       if (b && typeof b === "object" && typeof b.amount === "number") {
@@ -253,16 +260,14 @@ export function applyVendorAdapter(agentId: string, payload: MediaBuyPayload): M
     }
   }
 
-  // claire_* + content_ignite: rebuild brand_manifest to their narrow
-  // contract (rejects `brand` and `advertiser` as unexpected keyword
-  // arguments), and add a placeholder pricing_option_id on each package.
-  if (isClaire || isContentIgnite) {
-    const origName = p.brand_manifest.brand ?? "Demo Brand";
-    const origCats = p.brand_manifest.categories ?? [];
-    (p as unknown as Record<string, unknown>).brand_manifest = {
-      name: origName,
-      categories: origCats,
-    };
+  // ── packages[].pricing_option_id ──────────────────────────────────────
+  // Claire needed this (known in Sec-48r3). Sec-48r4 probe revealed Adzymic
+  // also requires it ("1 validation error ... pricing_option_id missing").
+  // Safest to add to all known buying vendors; unknown agents still pass
+  // through identity. "default" is a placeholder — the real value sources
+  // from the product's pricing_options array (follow-up to thread that
+  // through fire-buy).
+  if (isKnownBuying) {
     for (const pkg of p.packages) {
       (pkg as unknown as Record<string, unknown>).pricing_option_id = "default";
     }

--- a/tests/workflowOrchestration.test.ts
+++ b/tests/workflowOrchestration.test.ts
@@ -502,7 +502,7 @@ describe("applyVendorAdapter (Sec-48r)", () => {
     nowMs: NOW,
   });
 
-  it("adzymic_*: brand_manifest.name + package buyer_ref + budgets flattened", () => {
+  it("adzymic_*: brand_manifest.name + buyer_ref + scalar budgets + pricing_option_id", () => {
     const out = applyVendorAdapter("adzymic_apx", base) as unknown as {
       brand_manifest: Record<string, unknown>;
       packages: Array<Record<string, unknown>>;
@@ -512,10 +512,11 @@ describe("applyVendorAdapter (Sec-48r)", () => {
     expect(out.brand_manifest.name).toBe("AdCP Workflow Demo");
     expect(out.packages[0]!.buyer_ref).toContain("pkg_1");
     expect(out.packages[0]!.budget).toBe(1000);
+    expect(out.packages[0]!.pricing_option_id).toBe("default");
     expect(out.total_budget).toBe(1000);
   });
 
-  it("swivel: brand_manifest.name + package buyer_ref, but budget stays object", () => {
+  it("swivel: same as adzymic (budget also flattened — Sec-48r4)", () => {
     const out = applyVendorAdapter("swivel", base) as unknown as {
       brand_manifest: Record<string, unknown>;
       packages: Array<Record<string, unknown>>;
@@ -523,37 +524,34 @@ describe("applyVendorAdapter (Sec-48r)", () => {
     };
     expect(out.brand_manifest.name).toBeDefined();
     expect(out.packages[0]!.buyer_ref).toContain(base.buyer_ref);
-    // Swivel's pydantic is lenient on budget shape — object form preserved.
-    expect(out.packages[0]!.budget).toEqual({ amount: 1000, currency: "USD" });
-    expect(out.total_budget).toEqual({ amount: 1000, currency: "USD" });
+    // Sec-48r4: swivel's pydantic is NOT lenient on budget. Same error
+    // format as adzymic; flatten to scalar.
+    expect(out.packages[0]!.budget).toBe(1000);
+    expect(out.total_budget).toBe(1000);
+    expect(out.packages[0]!.pricing_option_id).toBe("default");
   });
 
-  it("claire_*: narrow brand_manifest, buyer_ref, scalar budget, pricing_option_id", () => {
+  it("claire_*: OMITS brand_manifest (not just narrowed); other fields present", () => {
     const out = applyVendorAdapter("claire_scope3", base) as unknown as {
-      brand_manifest: Record<string, unknown>;
+      brand_manifest?: unknown;
       packages: Array<Record<string, unknown>>;
       total_budget: unknown;
     };
-    // Narrow brand_manifest — no `brand`, no `advertiser`.
-    expect(out.brand_manifest).toEqual({
-      name: "AdCP Workflow Demo",
-      categories: base.brand_manifest.categories,
-    });
-    expect(out.brand_manifest.brand).toBeUndefined();
-    expect(out.brand_manifest.advertiser).toBeUndefined();
+    // Sec-48r4: claire rejected {name, categories} too — omit entirely.
+    expect(out.brand_manifest).toBeUndefined();
     expect(out.packages[0]!.buyer_ref).toBeDefined();
     expect(out.packages[0]!.budget).toBe(1000);
     expect(out.packages[0]!.pricing_option_id).toBe("default");
     expect(out.total_budget).toBe(1000);
   });
 
-  it("content_ignite follows claire rules", () => {
+  it("content_ignite follows claire rules (including brand_manifest omit)", () => {
     const out = applyVendorAdapter("content_ignite", base) as unknown as {
-      brand_manifest: Record<string, unknown>;
+      brand_manifest?: unknown;
       packages: Array<Record<string, unknown>>;
       total_budget: unknown;
     };
-    expect(out.brand_manifest.brand).toBeUndefined();
+    expect(out.brand_manifest).toBeUndefined();
     expect(out.packages[0]!.buyer_ref).toBeDefined();
     expect(out.packages[0]!.budget).toBe(1000);
     expect(out.packages[0]!.pricing_option_id).toBe("default");


### PR DESCRIPTION
## Summary

Post-Sec-48r3 live probe exposed three more per-vendor quirks. Consolidating the rule set.

## What live fire-buy returned after Sec-48r3

**adzymic_apx**: 4 errors → **1 error** after Sec-48r3.
\`\`\`
packages.0.pricing_option_id — Field required
\`\`\`
pricing_option_id isn't Claire-only; Adzymic needs it too.

**claire_scope3**: 2 errors → **1 error** after Sec-48r3.
\`\`\`
brand_manifest — Unexpected keyword argument (input: {name, categories})
\`\`\`
Even the narrow `{name, categories}` shape was rejected. Claire's Pydantic rejects ANY key.

**swivel**: new error format (structured JSON), new error body we hadn't seen:
\`\`\`
{\"errors\":[{\"code\":\"INVALID_FIELD_VALUE\",\"message\":\"Expected number, received object\",\"field\":\"packages.0.budget\"...}]}
\`\`\`
Swivel is NOT lenient on budget shape. Sec-48r3's swivel exemption was wrong.

## Consolidated rules

| Transform | adzymic_* | swivel | claire_* | content_ignite |
|---|---|---|---|---|
| `brand_manifest.name = .brand` | ✓ | ✓ | **omit entirely** | **omit entirely** |
| `packages[].buyer_ref` | ✓ | ✓ | ✓ | ✓ |
| `packages[].budget` scalar | ✓ | **✓ (new)** | ✓ | ✓ |
| `total_budget` scalar | ✓ | **✓ (new)** | ✓ | ✓ |
| `packages[].pricing_option_id: \"default\"` | **✓ (new)** | **✓ (new)** | ✓ | ✓ |

Unknown vendor_id → identity clone.

## pricing_option_id note

\"default\" is still a placeholder. Real value sources from `product.pricing_options[0].id` per AdCP buying spec. Wiring that through requires re-threading product data into fire-buy — tracked as follow-up. The placeholder surfaces a different vendor error which is still more demo-informative than the current rejection.

## Test plan

- [x] Suite 428 / 12 skip unchanged (test expectations updated).
- [ ] Post-merge + deploy:
  - adzymic_apx fire-buy: expect error count to drop to 0 OR shift to \"pricing_option_id 'default' not recognized\".
  - claire_scope3: expect brand_manifest error gone; likely surface the pricing_option_id error.
  - swivel: expect budget error gone; next layer error surfaces (likely product-id related since \"prod_test\" is fake).

🤖 Generated with [Claude Code](https://claude.com/claude-code)