### PR TITLE
Sec-48r5: Claire top-level brand (BrandReference) + auth-required UI explainer

### DIFF
--- a/src/domain/workflowOrchestration.ts
+++ b/src/domain/workflowOrchestration.ts
@@ -225,15 +225,29 @@ export function applyVendorAdapter(agentId: string, payload: MediaBuyPayload): M
   const isSwivel = agentId === "swivel";
   const isKnownBuying = isAdzymic || isClaire || isContentIgnite || isSwivel;
 
-  // ── brand_manifest ────────────────────────────────────────────────────
-  // Adzymic + Swivel: lenient, extra fields OK. Just need `name` present.
-  // Claire + Content Ignite: narrow — rejected {name, categories} live
-  // too (Sec-48r3 probe), so we OMIT brand_manifest entirely. The field
-  // is optional in their schema (only buyer_ref is required at top level).
+  // ── brand_manifest vs top-level brand ─────────────────────────────────
+  // Sec-48r4 dropped brand_manifest for Claire — revealed in Sec-48r5
+  // probe that Claire actually uses a DIFFERENT field name at the top
+  // level: `brand: BrandReference` (not `brand_manifest: BrandManifest`).
+  // Full error was:
+  //   VALIDATION_ERROR: brand: Input should be a valid dictionary or
+  //                     instance of BrandReference
+  // So for Claire/Content Ignite we swap brand_manifest → brand (with a
+  // minimal BrandReference-shaped dict). Adzymic + Swivel keep the
+  // original brand_manifest contract.
+  //
+  // BrandReference schema isn't public to us but {id, name} is the
+  // standard AdCP BrandReference surface. If rejected, the next probe
+  // will surface the required keys.
   if (isAdzymic || isSwivel) {
     (p.brand_manifest as unknown as Record<string, unknown>).name = p.brand_manifest.brand;
   } else if (isClaire || isContentIgnite) {
+    const name = p.brand_manifest?.brand ?? "Demo Brand";
     delete (p as unknown as Record<string, unknown>).brand_manifest;
+    (p as unknown as Record<string, unknown>).brand = {
+      id: "demo_brand",
+      name,
+    };
   }
 
   // ── packages[].buyer_ref ──────────────────────────────────────────────

--- a/src/routes/demo.ts
+++ b/src/routes/demo.ts
@@ -4286,6 +4286,23 @@ textarea.lab-input { resize: vertical; line-height: 1.5; }
 
 .wf-chosen-empty { opacity: 0.7; font-style: italic; }
 
+/* Sec-48r5: auth-gated callout on fire-buy cards. Used when the vendor
+   rejection text matches known auth idioms. Teaches the room that the
+   payload shape passed; the wall is auth. */
+.wf-auth-callout {
+  display: flex; gap: 8px; align-items: flex-start;
+  margin-top: 8px; padding: 8px 10px;
+  background: rgba(255, 183, 77, 0.08);
+  border: 1px solid rgba(255, 183, 77, 0.4);
+  border-left: 3px solid #ffb74d;
+  border-radius: 4px;
+  font-size: 11px;
+}
+.wf-auth-icon { color: #ffb74d; font-size: 14px; flex-shrink: 0; line-height: 1.3; }
+.wf-auth-title { color: #ffb74d; font-weight: 600; font-size: 11.5px; margin-bottom: 2px; }
+.wf-auth-body { color: var(--text-dim); line-height: 1.45; }
+.wf-auth-body em { color: var(--text); font-style: italic; }
+
 /* Sec-48n: pickable product rows + fire-buy button. */
 .wf-product-pickable { cursor: pointer; border-radius: 3px; }
 .wf-product-pickable:hover {
@@ -12268,6 +12285,39 @@ function _wfPaintAgentComplete(ev) {
         responseBlock +=
           '<div class="orch-small" style="margin-top:6px;color:var(--text-mut);font-style:italic">' +
             'vendor returned no body or error message (isError:true, empty content)' +
+          '</div>';
+      }
+      // Sec-48r5: detect auth-gated rejections and surface a callout. The
+      // demo's story: payload shape passed; auth is the ceiling. We scan
+      // the serialized content for known auth-rejection idioms seen in
+      // the Sec-48r4 live probe across all three default-trio vendors.
+      var allText = "";
+      if (hasContent) {
+        for (var ti = 0; ti < sum.content.length; ti++) {
+          var tb = sum.content[ti];
+          if (tb && typeof tb === "object" && typeof tb.text === "string") allText += tb.text + " ";
+        }
+      }
+      if (hasResult) {
+        try { allText += JSON.stringify(sum.result); } catch (e2) { /* noop */ }
+      }
+      // Word-boundary in regex needs double-escape per SCRIPT_TAG rule
+      // (single-backslash-b would collapse to backspace char in the
+      // served JS). Using \\b so the emitted regex has \b.
+      var authPatterns = /principal id not found|authentication required|auth_token_invalid|unauthorized|\\b401\\b|tenant policy/i;
+      if (authPatterns.test(allText)) {
+        responseBlock +=
+          '<div class="wf-auth-callout">' +
+            '<span class="wf-auth-icon">\u26a0</span>' +
+            '<div>' +
+              '<div class="wf-auth-title">Auth-gated vendor</div>' +
+              '<div class="wf-auth-body">' +
+                'Payload shape passed vendor validation. The wall is auth \u2014 ' +
+                'this vendor requires credentials we don\'t have in this public demo. ' +
+                'Not a protocol bug, a protocol <em>gap</em>: AdCP has no shared ' +
+                'auth-posture contract across signals / creative / buying agents.' +
+              '</div>' +
+            '</div>' +
           '</div>';
       }
     }

--- a/tests/workflowOrchestration.test.ts
+++ b/tests/workflowOrchestration.test.ts
@@ -531,31 +531,33 @@ describe("applyVendorAdapter (Sec-48r)", () => {
     expect(out.packages[0]!.pricing_option_id).toBe("default");
   });
 
-  it("claire_*: OMITS brand_manifest (not just narrowed); other fields present", () => {
+  it("claire_*: swap brand_manifest for top-level brand BrandReference (Sec-48r5)", () => {
     const out = applyVendorAdapter("claire_scope3", base) as unknown as {
       brand_manifest?: unknown;
+      brand?: Record<string, unknown>;
       packages: Array<Record<string, unknown>>;
       total_budget: unknown;
     };
-    // Sec-48r4: claire rejected {name, categories} too — omit entirely.
+    // Sec-48r5: Claire expects top-level `brand: BrandReference`, not
+    // `brand_manifest: BrandManifest`. Different schema family.
     expect(out.brand_manifest).toBeUndefined();
+    expect(out.brand).toEqual({ id: "demo_brand", name: "AdCP Workflow Demo" });
     expect(out.packages[0]!.buyer_ref).toBeDefined();
     expect(out.packages[0]!.budget).toBe(1000);
     expect(out.packages[0]!.pricing_option_id).toBe("default");
     expect(out.total_budget).toBe(1000);
   });
 
-  it("content_ignite follows claire rules (including brand_manifest omit)", () => {
+  it("content_ignite follows claire rules (brand swap, not brand_manifest)", () => {
     const out = applyVendorAdapter("content_ignite", base) as unknown as {
       brand_manifest?: unknown;
+      brand?: Record<string, unknown>;
       packages: Array<Record<string, unknown>>;
-      total_budget: unknown;
     };
     expect(out.brand_manifest).toBeUndefined();
-    expect(out.packages[0]!.buyer_ref).toBeDefined();
-    expect(out.packages[0]!.budget).toBe(1000);
+    expect(out.brand).toBeDefined();
+    expect(out.brand!.name).toBe("AdCP Workflow Demo");
     expect(out.packages[0]!.pricing_option_id).toBe("default");
-    expect(out.total_budget).toBe(1000);
   });
 
   it("unknown agent passes through as identity", () => {


### PR DESCRIPTION
## Summary

Final Sec-48r iteration. Addresses two things revealed in the Sec-48r4 live probe:

1. **Claire uses a different schema family, not just different shape.** Top-level `brand: BrandReference`, not `brand_manifest: BrandManifest`.
2. **Auth is the actual ceiling** for all three default-trio vendors. The UI should teach the audience this at a glance.

## 1. Claire top-level `brand` adapter

Live error from Sec-48r4 deploy:

\`\`\`
VALIDATION_ERROR: brand: Input should be a valid dictionary or
                  instance of BrandReference
\`\`\`

Claire/Content Ignite now get:
- `brand_manifest` deleted
- top-level `brand: { id: \"demo_brand\", name: \"...\" }` (minimal BrandReference)

Adzymic + Swivel keep their original `brand_manifest` contract untouched. This IS the headline gap-list finding: AdCP lacks a single canonical brand-context primitive.

## 2. Auth-gated callout on stage-4 cards

When a fire-buy response matches known auth-rejection idioms (`principal id not found`, `authentication required`, `auth_token_invalid`, `unauthorized`, `401`, `tenant policy`), the card renders an amber callout:

> ⚠ **Auth-gated vendor**
> Payload shape passed vendor validation. The wall is auth — this vendor requires credentials we don't have in this public demo. Not a protocol bug, a protocol *gap*: AdCP has no shared auth-posture contract across signals / creative / buying agents.

Teaches the workshop audience the right lesson at a glance.

## Pre-flight (escape-trap memory)

- Diff scan: zero bare `\n` / `\t` / `\r` in new demo.ts code
- Regex `\b401\b` correctly double-escaped in source
- Zero literal backticks added

## Test plan

- [x] Suite 428 / 12 skip (test updates for brand_manifest → brand swap).
- [ ] Post-merge + deploy:
  - claire_scope3 fire-buy: expect `brand: ...BrandReference` error gone. Next layer is likely `pricing_option_id \"default\"` not recognized OR an auth check.
  - All three cards: auth-gated callout should appear on the Adzymic + Swivel fires (they both hit auth), teaching the room that the shape story is solved and auth is the gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)