### PR TITLE
Sec-48r6: Claire BrandReference {domain, name} + apostrophe escape hotfix

### DIFF
--- a/src/domain/workflowOrchestration.ts
+++ b/src/domain/workflowOrchestration.ts
@@ -242,10 +242,17 @@ export function applyVendorAdapter(agentId: string, payload: MediaBuyPayload): M
   if (isAdzymic || isSwivel) {
     (p.brand_manifest as unknown as Record<string, unknown>).name = p.brand_manifest.brand;
   } else if (isClaire || isContentIgnite) {
+    // Sec-48r6: live probe of Sec-48r5 deploy revealed the actual
+    // BrandReference shape Claire validates against. Errors:
+    //   brand.domain — Required field is missing
+    //   brand.id     — Extra field not allowed by AdCP spec
+    // So Claire's BrandReference is {domain, name} — NOT {id, name}.
+    // The error explicitly cited "AdCP spec", so this is canonical:
+    //   https://adcontextprotocol.org/schemas/v1/
     const name = p.brand_manifest?.brand ?? "Demo Brand";
     delete (p as unknown as Record<string, unknown>).brand_manifest;
     (p as unknown as Record<string, unknown>).brand = {
-      id: "demo_brand",
+      domain: "demo.example.com",
       name,
     };
   }

--- a/src/routes/demo.ts
+++ b/src/routes/demo.ts
@@ -12313,7 +12313,7 @@ function _wfPaintAgentComplete(ev) {
               '<div class="wf-auth-title">Auth-gated vendor</div>' +
               '<div class="wf-auth-body">' +
                 'Payload shape passed vendor validation. The wall is auth \u2014 ' +
-                'this vendor requires credentials we don\'t have in this public demo. ' +
+                'this vendor requires credentials we do not have in this public demo. ' +
                 'Not a protocol bug, a protocol <em>gap</em>: AdCP has no shared ' +
                 'auth-posture contract across signals / creative / buying agents.' +
               '</div>' +

--- a/tests/workflowOrchestration.test.ts
+++ b/tests/workflowOrchestration.test.ts
@@ -541,7 +541,8 @@ describe("applyVendorAdapter (Sec-48r)", () => {
     // Sec-48r5: Claire expects top-level `brand: BrandReference`, not
     // `brand_manifest: BrandManifest`. Different schema family.
     expect(out.brand_manifest).toBeUndefined();
-    expect(out.brand).toEqual({ id: "demo_brand", name: "AdCP Workflow Demo" });
+    // Sec-48r6: AdCP spec BrandReference is {domain, name} (not {id, name}).
+    expect(out.brand).toEqual({ domain: "demo.example.com", name: "AdCP Workflow Demo" });
     expect(out.packages[0]!.buyer_ref).toBeDefined();
     expect(out.packages[0]!.budget).toBe(1000);
     expect(out.packages[0]!.pricing_option_id).toBe("default");


### PR DESCRIPTION
## Summary

Two final closeouts on the Sec-48r adapter arc. **Includes a live JS-error hotfix** so this should land soon.

## 1. Claire's BrandReference shape (canonical)

Sec-48r5 sent `{id, name}`. Live response was unusually explicit:

\`\`\`
VALIDATION_ERROR: Invalid request: The following fields do not match the AdCP specification:
  • brand.domain: Required field is missing
  • brand.id: Extra field not allowed by AdCP spec.
    Received value: \"demo_brand\"
  ...
  https://adcontextprotocol.org/schemas/v1/
\`\`\`

So AdCP's `BrandReference` is `{domain, name}`. Adapter now emits:

\`\`\`json
\"brand\": { \"domain\": \"demo.example.com\", \"name\": \"...\" }
\`\`\`

## 2. Apostrophe escape hotfix (live JS error)

> Uncaught SyntaxError on (index):12268

Sec-48r5 wrote the auth callout as `'... we don\'t have ...'`. Inside the SCRIPT_TAG template literal, `\'` is an unknown escape — JS drops the backslash. Served JS got an unescaped apostrophe inside a single-quoted string, terminating it mid-sentence.

**Same trap class as Sec-48c/h/o.** The `feedback_script_tag_template_trap` rule covers `\n`/`\t`/`\r` — but it ALSO applies to `\'`. Fixed by rewriting without the contraction (\"we do not have\"). Bypass the escape question.

Memory rule implicitly extended: pre-flight grep should also catch `[a-z]'[a-z]` patterns inside single-quoted JS string literals, not just backslash escapes.

## Memory closeout

Updated `recent_shipped_2026_04.md` with:
- Full Sec-48r1..r6 PR timeline
- Canonical 6-gap workshop list (auth posture as #1 finding, schema-family split for brand context as #2)
- Adapter rules table

## Test plan

- [x] Suite 428/12, type check clean.
- [ ] Post-merge + deploy:
  - Page loads without console error (apostrophe fix).
  - claire_scope3 fire-buy: expect `brand.domain` / `brand.id` errors gone. Next layer likely auth or another field tweak.
  - Auth callout still renders for adzymic + swivel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)