### PR TITLE
Canvas Phase 1 hotfix: drop onerror= from brand-logo (4th SCRIPT_TAG escape trap)

### DIFF
--- a/src/routes/demo.ts
+++ b/src/routes/demo.ts
@@ -12757,7 +12757,11 @@ function _canvasRenderBrandCard(data) {
   card.innerHTML =
     '<div class="canvas-brand-card">' +
       '<div class="canvas-brand-head">' +
-        (logoUrl ? '<img class="canvas-brand-logo" src="' + escapeHtml(logoUrl) + '" alt="' + escapeHtml(data.brand_name) + '" onerror="this.style.display=\'none\'"/>' : '<div class="canvas-brand-logo canvas-brand-logo-placeholder">' + escapeHtml((data.brand_name || "?").slice(0, 1)) + '</div>') +
+        // Note: no inline onerror attribute. Inside SCRIPT_TAG, \\' in
+        // source collapses to a raw apostrophe which terminates the
+        // outer single-quoted JS string. See feedback_script_tag_template_trap.
+        // Native broken-image rendering is fine for the demo.
+        (logoUrl ? '<img class="canvas-brand-logo" src="' + escapeHtml(logoUrl) + '" alt="' + escapeHtml(data.brand_name) + '"/>' : '<div class="canvas-brand-logo canvas-brand-logo-placeholder">' + escapeHtml((data.brand_name || "?").slice(0, 1)) + '</div>') +
         '<div class="canvas-brand-head-text">' +
           '<div class="canvas-brand-name">' + escapeHtml(data.brand_name || "(no name)") + '</div>' +
           '<div class="canvas-brand-domain mono">' + escapeHtml(data.canonical_domain || "") + '</div>' +


### PR DESCRIPTION
## Summary

Fixes the live JS error on `(index):12712`. **Same trap class as Sec-48o** — fourth time we've hit this.

## Root cause

```js
onerror=\"this.style.display=\'none\'\"
```

In source: `\'` was actually written as single-backslash-apostrophe (`\'` in TS source, looking like `\'` per char). Inside the SCRIPT_TAG template literal, a single backslash before any character collapses at emission time. The escape disappears, leaving raw `'` inside the outer single-quoted JS string, which terminates mid-attribute.

## Fix

Drop the `onerror` attribute. Native browser broken-image rendering shows the alt text. One-line change.

## Memory rule strengthened

`feedback_script_tag_template_trap.md` updated:

- Added Canvas Phase 1 as the 4th incident
- **Reframed rule**: there is NO single-backslash escape that survives the template literal. ANY `\` + char in source must be doubled (`\\`) for the served JS to see the escape.
- Replaced the narrow grep pre-flight with a **structural Python audit script** that programmatically flags single-backslash-before-apostrophe (extensible to other chars) inside the SCRIPT_TAG region. Ran on this diff: **zero traps remain**.
- Audit script lives in the memory file — copy + run on every demo.ts edit.

## Test plan

- [x] Type check clean.
- [x] Structural audit script: zero traps in entire SCRIPT_TAG region.
- [ ] Post-merge + deploy: reload demo, no console error, Canvas tab renders, brand resolution works (logo loads if URL valid; gracefully blank if 404 — instead of breaking the whole script).

🤖 Generated with [Claude Code](https://claude.com/claude-code)