### PR TITLE
Bump @adcp/client 5.13 → 5.21.1 + truth up compliance declaration

### DIFF
--- a/README.md
+++ b/README.md
@@ -590,15 +590,16 @@ staleness under 1 hour.
 
 ### Upgrading `@adcp/client`
 
-`@adcp/client` is pinned to an exact version (`"5.6.0"`, not `^5.6.0`)
-so compliance-runner behavior can't drift under us silently. Before
-bumping:
+`@adcp/client` is pinned with a caret range (current: `^5.21.1`).
+Compliance-runner behavior can drift under us on `npm install`, so
+the discipline is to re-run compliance whenever the lockfile shifts.
+Before bumping the floor:
 
 1. Read the upstream release notes:
    `https://github.com/adcontextprotocol/adcp-client/releases`.
 2. Re-run `npm run compliance` before merging the bump — any storyboard
    regression on a version bump is usually new spec / new probe
-   behavior, not our code. Two historical examples:
+   behavior, not our code. Three historical examples:
    - 5.2.0 → 5.6.0 (adcp#2535): the `validateErrorCode` extractor
      tightened to read `data.errors[0].code` only when
      `taskResult.success === false`. That requires the agent's MCP
@@ -606,6 +607,20 @@ bumping:
      envelopes — which `callCreateMediaBuy` already does. An agent
      returning errors[] with the default `isError: false` would
      silently regress on this bump.
+   - 5.6.0 → 5.13.0: the `comply()` API was renamed to
+     `testAllScenarios()` (with `formatSuiteResults*` formatters)
+     and the suite restructured from track-based (core/signals/
+     error_handling) to 24 tool-gated scenarios. Any harness script
+     using the old import shape breaks silently with
+     `SyntaxError: Named export 'comply' not found`.
+   - 5.13.0 → 5.21.1: scenario count expanded 24 → 48 (governance,
+     brand-rights, SI, creative-lifecycle, error-codes split into
+     codes/structure/transport). The signals_flow scenario also
+     fixed two long-standing storyboard bugs: it used to send
+     `signal_id` (object) and `destination` (singular) to
+     `activate_signal`; 5.21 sends `signal_agent_segment_id`
+     (string) and `destinations` (array) per 3.0 GA. Agents pinned
+     on 5.13 will see signals_flow 3/5 from those bugs alone.
    - Any bump that adds a new storyboard track (e.g. 5.2.0 added
      security_baseline + signals_baseline) will surface new probes
      as either advisory items or real failures.

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "zod": "^3.23.8"
       },
       "devDependencies": {
-        "@adcp/client": "^5.13.0",
+        "@adcp/client": "^5.21.1",
         "@cloudflare/workers-types": "^4.20241022.0",
         "@vitest/coverage-v8": "^2.0.0",
         "typescript": "^5.5.0",
@@ -50,9 +50,9 @@
       }
     },
     "node_modules/@adcp/client": {
-      "version": "5.13.0",
-      "resolved": "https://registry.npmjs.org/@adcp/client/-/client-5.13.0.tgz",
-      "integrity": "sha512-SKRX0nsNZTImCVICQuv+/WWbt+BA5tgJ6S94SBZI+eFIEj3uSaO069/tuN/Zv8ZCoY/hPkJoLZJJ48caMuw9tQ==",
+      "version": "5.21.1",
+      "resolved": "https://registry.npmjs.org/@adcp/client/-/client-5.21.1.tgz",
+      "integrity": "sha512-6/bATc7xCv4QCBSTeyTgCtdMrr8w/eSC2dB76rXgyJ6Ovecwc6LJN5AwBhcrt7cXNotC5C7xMETJlxWNdR1YDg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "lint": "eslint src --ext .ts"
   },
   "devDependencies": {
-    "@adcp/client": "^5.13.0",
+    "@adcp/client": "^5.21.1",
     "@cloudflare/workers-types": "^4.20241022.0",
     "@vitest/coverage-v8": "^2.0.0",
     "typescript": "^5.5.0",

--- a/scripts/run-compliance.mjs
+++ b/scripts/run-compliance.mjs
@@ -1,16 +1,23 @@
 // scripts/run-compliance.mjs
-// Drives @adcp/client `comply()` programmatically so we can pass a `test_kit`
-// — something the CLI (`npx @adcp/client storyboard run`) has no flag for.
-// Without the test_kit, security_baseline/oauth_discovery fires and needs RFC
-// 9728 protected-resource metadata we don't serve. With `auth.api_key` +
-// `probe_task: get_signals`, the runner takes the api-key path and verifies
-// our existing Bearer auth: valid key → 200 on get_signals; invalid key → 401.
+// Drives @adcp/client's compliance suite programmatically so we can pass a
+// `test_kit` — something the CLI (`npx @adcp/client storyboard run`) has no
+// flag for. Without the test_kit, security_baseline/oauth_discovery fires and
+// needs RFC 9728 protected-resource metadata we don't serve. With
+// `auth.api_key` + `probe_task: get_signals`, the runner takes the api-key
+// path and verifies our existing Bearer auth: valid key → 200 on get_signals;
+// invalid key → 401.
+//
+// API note: pre-5.13 used `comply()` + `formatComplianceResults*`; 5.13
+// renamed this to `testAllScenarios()` + `formatSuiteResults*` and split the
+// suite into 24 tool-gated scenarios. Default-export destructure is needed
+// because the published bundle is CJS without named ESM re-exports.
 //
 // Usage:
 //   API_KEY=demo-key-adcp-signals-v1 npm run compliance
 //   API_KEY=... AGENT_URL=https://... node scripts/run-compliance.mjs --json
 
-import { comply, formatComplianceResults, formatComplianceResultsJSON } from "@adcp/client/testing";
+import pkg from "@adcp/client/testing";
+const { testAllScenarios, formatSuiteResults, formatSuiteResultsJSON } = pkg;
 
 const AGENT_URL = process.env.AGENT_URL ?? "https://adcp-signals-adaptor.evgeny-193.workers.dev/mcp";
 const API_KEY = process.env.API_KEY ?? process.env.DEMO_API_KEY;
@@ -26,11 +33,10 @@ const testOptions = {
   auth: { type: "bearer", token: API_KEY },
   test_kit: {
     auth: {
-      // Drives security_baseline/api_key_path. Must be in PROBE_TASK_ALLOWLIST
-      // at dist/lib/testing/storyboard/test-kit.js — `get_signals` is listed
-      // because it's auth-gated, read-only, and accepts an empty request body
-      // (our callGetSignals at src/mcp/server.ts:332 defaults to limit=20,
-      //  offset=0 when no args are supplied).
+      // Drives security_baseline/api_key_path. `get_signals` is auth-gated,
+      // read-only, and accepts an empty request body (callGetSignals at
+      // src/mcp/server.ts defaults to limit=20, offset=0 when no args
+      // are supplied).
       probe_task: "get_signals",
       api_key: API_KEY,
     },
@@ -38,13 +44,13 @@ const testOptions = {
 };
 
 try {
-  const result = await comply(AGENT_URL, testOptions);
+  const result = await testAllScenarios(AGENT_URL, testOptions);
   if (jsonOutput) {
-    process.stdout.write(JSON.stringify(formatComplianceResultsJSON(result), null, 2) + "\n");
+    process.stdout.write(JSON.stringify(formatSuiteResultsJSON(result), null, 2) + "\n");
   } else {
-    console.log(formatComplianceResults(result));
+    console.log(formatSuiteResults(result));
   }
-  process.exit(result.summary.tracks_failed > 0 ? 3 : 0);
+  process.exit(result.failed_count > 0 ? 3 : 0);
 } catch (err) {
   console.error(`compliance run failed: ${err?.message ?? err}`);
   if (process.env.DEBUG) console.error(err?.stack ?? err);

--- a/src/domain/capabilityService.ts
+++ b/src/domain/capabilityService.ts
@@ -35,7 +35,7 @@
 // self-fetch short-circuit, URL corrections for content_ignite + claire_scope3).
 // The key version must be bumped any time the SHAPE of the capability response
 // changes, so clients that cache by key pick up the new fields.
-const CACHE_KEY = "adcp_capabilities_v22";
+const CACHE_KEY = "adcp_capabilities_v23";
 const CACHE_TTL_SECONDS = 3600;
 
 import { buildUcpCapability, type UcpCapabilityEnv } from "../ucp/vacDeclaration";
@@ -336,25 +336,28 @@ function buildStaticCapabilities(env: UcpCapabilityEnv): AdcpCapabilities {
       // Updated manually after each `npm run compliance` against prod.
       compliance: {
         spec_version: "adcp_3.0",
-        client_runner: "@adcp/client@5.13.0",
-        last_run: "2026-04-23",
+        client_runner: "@adcp/client@5.21.1",
+        last_run: "2026-04-27",
+        // 5.21 runner restructured into 48 tool-gated scenarios. A
+        // signals-only agent has 4 applicable; the rest skip because they
+        // require get_products / create_media_buy / sync_creatives /
+        // build_creative / si_* / governance / brand-rights tools we do
+        // not (and should not) advertise.
         results: {
-          core: { pass: 25, total: 26 },
-          signals: { pass: 3, total: 3 },
-          error_handling: { pass: 5, total: 5 },
-          aggregate: { pass: 33, total: 34 },
+          applicable: 4,
+          passed: 4,
+          failed: 0,
+          skipped: 35,
+          scenarios_run: ["health_check", "discovery", "capability_discovery", "signals_flow"],
         },
         non_applicable_scenarios: [
           {
-            scenario: "schema_validation/past_start_enforcement",
-            track: "core",
-            reason: "Tests create_media_buy with a past start_time. Tool is in the media_buy protocol, which we do not implement (supported_protocols: ['signals'] only). The runner has no applies_to primitive to skip the scenario when media_buy isn't declared, so the aggregate fails despite both individual paths being structurally inapplicable.",
+            scenario: "error_handling / validation / schema_compliance",
+            reason: "5.21 runner gates these behind get_products, conflating 'media-buy agent' with 'any agent' in applicability logic. Signals-only agents lose error/schema track entirely — regression vs the 5.6-era track structure where these ran on every protocol.",
             upstream_issue: "https://github.com/adcontextprotocol/adcp/issues/2916",
-            upstream_status: "filed",
-            workaround: "stub-only-rejection of create_media_buy would yield a vanity 26/26 but pollutes the protocol surface with a tool we do not actually support — declined.",
+            upstream_status: "deferred → adcp 3.1.0 (capability-derived skip_if grammar lands runner-side first)",
           },
         ],
-        structural_ceiling_for_signals_only_agents: "25/26 core (pending adcp#2916)",
         report: "docs/SEC42_ADCP_30_GA_COMPLIANCE.md",
         reproduce: "API_KEY=$DEMO_API_KEY AGENT_URL=https://adcp-signals-adaptor.evgeny-193.workers.dev/mcp npm run compliance",
       },

--- a/src/routes/demo.ts
+++ b/src/routes/demo.ts
@@ -179,7 +179,7 @@ ${STYLES}
 
     <div class="sidebar-footer">
       <div class="kv"><span class="k">Version</span><span class="v mono">3.0 GA</span></div>
-      <div class="kv"><span class="k">Client</span><span class="v mono">@adcp/5.13</span></div>
+      <div class="kv"><span class="k">Client</span><span class="v mono">@adcp/5.21</span></div>
       <div class="kv"><span class="k">Status</span><span class="v"><span class="status-dot ok"></span>live</span></div>
       <div class="kv"><span class="k">Conformance</span><span class="v"><span class="pill pill-success">3 / 3</span></span></div>
     </div>


### PR DESCRIPTION
## Summary

- Bump `@adcp/client` `^5.13.0` → `^5.21.1` (lockfile resolves to 5.21.1)
- Port `scripts/run-compliance.mjs` from the removed `comply()` API to `testAllScenarios()` (broken since the Sec-42 dep bump)
- Restructure the `/capabilities` compliance block from the 5.6-era track shape (Core 25/26 / Signals 3/3 / Error 5/5) to 5.21's scenario shape (4/4 applicable, all pass); cache key v22 → v23
- README: drop the stale "exact version pin" claim and add 5.6→5.13 + 5.13→5.21 to the upgrade-discipline historical examples

## Why

The dep was at `^5.13.0` since Sec-42. Two storyboard bugs in 5.13's `signals_flow` — sending `signal_id` instead of `signal_agent_segment_id`, and the full SignalID object instead of the string — caused `signals_flow` to fail 3/5 on `npm run compliance`. After triage by Addy + ad-tech-protocol-expert + code-reviewer, both bugs were confirmed already fixed in 5.21.1. Our adapter has been spec-correct all along, just running against a stale compliance runner. The fix is a dep bump, not a handler change.

## Verification

- `npm run compliance`: ✅ 4/4 applicable scenarios pass, `signals_flow` 8/8 (was 3/5 on 5.13)
- `npm run test`: ✅ 428 passed, 0 failed
- `npm run type-check`: no new errors (79 pre-existing test errors, unchanged)

## Outstanding

bokelley triaged adcp#2916 (the systemic media-buy/any-agent applicability conflation in the runner) as deferred → adcp 3.1.0. The capability-derived `skip_if` grammar has to land runner-side in `@adcp/client` first; storyboard YAML and spec note ride downstream. Until then, `error_handling` / `validation` / `schema_compliance` stay skipped on signals-only agents. The compliance block notes this.

## Test plan

- [ ] `npm run compliance` shows all-green (4/4 applicable scenarios)
- [ ] `/capabilities` endpoint reports `client_runner: "@adcp/client@5.21.1"` and the 4-scenario `results` shape after deploy
- [ ] Demo footer shows `@adcp/5.21`
- [ ] Capabilities cache key bump (v22 → v23) means discovery clients re-fetch within KV TTL

🤖 Generated with [Claude Code](https://claude.com/claude-code)