### PR TITLE
Canvas v2 Phase 3+4 + Refinement: logo proxy, gov/brand-rights cards, BrandRef threading

### DIFF
--- a/src/domain/workflowOrchestration.ts
+++ b/src/domain/workflowOrchestration.ts
@@ -107,6 +107,17 @@ export interface MediaBuyPayloadInputWithCreative extends MediaBuyPayloadInput {
    *  `packages[0].creatives` so the vendor sees a compatible
    *  format declaration alongside the product + targeting. */
   chosenFormatIds?: string[];
+  /** Canvas v2: real brand context lifted from the agentic-advertising
+   *  registry. When provided, the payload's brand fields use the real
+   *  brand domain + name + categories instead of the synthetic
+   *  "AdCP Workflow Demo" defaults. Vendor adapter still routes between
+   *  BrandRef and BrandManifest at call time. */
+  brandContext?: {
+    domain: string;
+    name?: string;
+    brand_id?: string;
+    industries?: string[];
+  } | undefined;
 }
 
 export interface MediaBuyPayload {
@@ -153,12 +164,20 @@ export function buildCreateMediaBuyPayload(input: MediaBuyPayloadInputWithCreati
     pkg.creatives = formats.map((fid) => ({ format_id: fid }));
   }
 
+  // Canvas v2: when brandContext is supplied, use the real brand from
+  // the agentic-advertising registry; otherwise fall back to the demo
+  // defaults. Vendor adapter handles BrandRef vs BrandManifest routing.
+  const brandName = input.brandContext?.name ?? input.brandContext?.domain ?? "AdCP Workflow Demo";
+  const brandCategories = (input.brandContext?.industries && input.brandContext.industries.length > 0)
+    ? input.brandContext.industries.slice(0, 5).map((c) => c.toLowerCase())
+    : extractCategories(input.brief);
+
   const payload: MediaBuyPayload = {
     buyer_ref: `wf_${input.workflowId}_${input.agentId}`,
     brand_manifest: {
-      brand: "AdCP Workflow Demo",
-      advertiser: "AdCP Workflow Demo",
-      categories: extractCategories(input.brief),
+      brand: brandName,
+      advertiser: brandName,
+      categories: brandCategories,
     },
     packages: [pkg],
     start_time: startIso,
@@ -215,7 +234,20 @@ export function extractCategories(brief: string): string[] {
  *  product result into fire-buy; tracked as follow-up. For now the
  *  placeholder surfaces as a different vendor error message, which is
  *  still better than the current outright rejection. */
-export function applyVendorAdapter(agentId: string, payload: MediaBuyPayload): MediaBuyPayload {
+/** Optional brand-domain hint for the BrandRef synthesis. Canvas v2
+ *  passes the canonical brand domain (e.g. cbrands.com) so Claire's
+ *  validator sees a real domain instead of "demo.example.com".
+ *  brandDomain accepts undefined explicitly so callers can pass through
+ *  optional chains directly. */
+export interface VendorAdapterContext {
+  brandDomain?: string | undefined;
+}
+
+export function applyVendorAdapter(
+  agentId: string,
+  payload: MediaBuyPayload,
+  ctx?: VendorAdapterContext,
+): MediaBuyPayload {
   // Deep-clone so callers can still inspect the pre-transform shape.
   const p: MediaBuyPayload = JSON.parse(JSON.stringify(payload));
 
@@ -250,9 +282,10 @@ export function applyVendorAdapter(agentId: string, payload: MediaBuyPayload): M
     // The error explicitly cited "AdCP spec", so this is canonical:
     //   https://adcontextprotocol.org/schemas/v1/
     const name = p.brand_manifest?.brand ?? "Demo Brand";
+    const domain = ctx?.brandDomain ?? "demo.example.com";
     delete (p as unknown as Record<string, unknown>).brand_manifest;
     (p as unknown as Record<string, unknown>).brand = {
-      domain: "demo.example.com",
+      domain,
       name,
     };
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,6 +49,7 @@ import {
 import {
   handleBrandSearch,
   handleBrandResolve,
+  handleBrandLogo,
 } from "./routes/brandRegistry";
 import {
   handleAudienceCompose,
@@ -228,6 +229,7 @@ export default {
             // Public — same posture as the upstream registry itself.
             "/brands/search",
             "/brands/resolve",
+            "/brands/logo",
             "/taxonomy/reverse",
             // Sec-43: audience composer + activation-planning analytics.
             // Read-only — same posture as /portfolio/* and /analytics/*.
@@ -391,6 +393,8 @@ export default {
                 response = await handleBrandSearch(request, env, logger);
             } else if (method === "GET" && path === "/brands/resolve") {
                 response = await handleBrandResolve(request, env, logger);
+            } else if (method === "GET" && path === "/brands/logo") {
+                response = await handleBrandLogo(request, env, logger);
 
                 // ── Sec-43: Audience Composer + activation analytics ────────────────
             } else if (method === "POST" && path === "/audience/compose") {

--- a/src/routes/agentsEndpoints.ts
+++ b/src/routes/agentsEndpoints.ts
@@ -420,6 +420,46 @@ interface WorkflowRunBody {
   max_products_per_agent?: number;
   activate_agents?: string[];
   timeout_ms?: number;
+  // Canvas v2 Refinement: when the caller is the brand-anchored canvas,
+  // it sends a real brand context lifted from agenticadvertising.org.
+  // Threaded into get_products + create_media_buy so vendors with
+  // BrandRef-shaped validators (Claire family) accept the buy. Kept
+  // optional — Sec-48 Orchestrator continues to send brief-only.
+  brand?: BrandContext;
+}
+
+interface BrandContext {
+  domain: string;          // canonical domain (BrandRef.domain)
+  name?: string;           // brand display name
+  brand_id?: string;       // optional: registry id
+  description?: string;
+  // industries[] is included so vendors that don't carry a brand object
+  // can still receive the implied verticals as filter hints.
+  industries?: string[];
+  // brand_manifest fields for Adzymic / Swivel (legacy 2.x BrandManifest).
+  // The vendor adapter routes between BrandRef vs BrandManifest at call time.
+  manifest?: {
+    fonts?: Array<{ name: string; role?: string }>;
+    logos?: Array<{ url: string; tags?: string[] }>;
+    colors?: { accent?: string; primary?: string; secondary?: string };
+  };
+}
+
+/** Compact a BrandContext into the payload-builder shape with optional
+ *  fields stripped when undefined (TS exactOptionalPropertyTypes wants
+ *  the keys absent, not present-with-undefined). */
+function compactBrandContext(b: BrandContext | undefined): {
+  domain: string;
+  name?: string;
+  brand_id?: string;
+  industries?: string[];
+} | undefined {
+  if (!b) return undefined;
+  const out: { domain: string; name?: string; brand_id?: string; industries?: string[] } = { domain: b.domain };
+  if (b.name !== undefined) out.name = b.name;
+  if (b.brand_id !== undefined) out.brand_id = b.brand_id;
+  if (b.industries !== undefined) out.industries = b.industries;
+  return out;
 }
 
 interface StageAgentResult<TPayload> {
@@ -548,6 +588,7 @@ async function runMediaBuyStage(
   chosenFormatIds: string[],
   activateSet: Set<string>,
   timeoutMs: number,
+  brandContext?: BrandContext,
 ): Promise<MediaBuyStageAgent[]> {
   return Promise.all(agents.map(async (a): Promise<MediaBuyStageAgent> => {
     const chosenProductId = chosenProductByAgent[a.id] ?? null;
@@ -558,6 +599,7 @@ async function runMediaBuyStage(
       chosenProductId,
       chosenSignalIds,
       chosenFormatIds,
+      brandContext: compactBrandContext(brandContext),
     });
     const base: MediaBuyStageAgent = {
       id: a.id, name: a.name, vendor: a.vendor, url: a.mcp_url!,
@@ -569,7 +611,10 @@ async function runMediaBuyStage(
     // Sec-48r: apply per-vendor adapter just before firing. The preview
     // above stays in the pre-transform shape so the UI shows the common
     // synthesized payload; the wire call carries vendor-specific tweaks.
-    const wirePayload = applyVendorAdapter(a.id, payload);
+    // Canvas v2: pass brand domain so Claire's BrandRef gets the real domain.
+    const wirePayload = applyVendorAdapter(a.id, payload, {
+      brandDomain: brandContext?.domain,
+    });
     const res = await callAgentTool(
       a.mcp_url!,
       "create_media_buy",
@@ -641,7 +686,10 @@ export async function handleWorkflowRun(request: Request, env: Env, logger: Logg
 
   const chosenProductByAgent = pickProductPerAgent(productsResults.map((r) => ({ id: r.id, products: r.payload.products })));
 
-  // Stage 4 — payload synth + optional fire.
+  // Stage 4 — payload synth + optional fire. Canvas v2 threads brand
+  // context through so the synthesized create_media_buy carries real
+  // brand identity (BrandRef.domain, brand_manifest.brand) instead of
+  // the demo placeholder.
   const mediaBuyResults = await runMediaBuyStage(
     workflowId,
     buyingAgents,
@@ -651,6 +699,7 @@ export async function handleWorkflowRun(request: Request, env: Env, logger: Logg
     chosenFormatIds,
     activateSet,
     timeoutMs,
+    body.brand,
   );
 
   const totalTimeMs = Date.now() - t0;
@@ -981,6 +1030,7 @@ export async function handleWorkflowRunStream(request: Request, env: Env, logger
           const payload = buildCreateMediaBuyPayload({
             workflowId, agentId: a.id, brief: body.brief!,
             chosenProductId, chosenSignalIds, chosenFormatIds,
+            brandContext: compactBrandContext(body.brand),
           });
           if (!activateSet.has(a.id)) {
             send({
@@ -994,7 +1044,9 @@ export async function handleWorkflowRunStream(request: Request, env: Env, logger
             return;
           }
           const start = Date.now();
-          const wirePayload = applyVendorAdapter(a.id, payload);
+          const wirePayload = applyVendorAdapter(a.id, payload, {
+            brandDomain: body.brand?.domain,
+          });
           const res = await callAgentTool(
             a.mcp_url!,
             "create_media_buy",
@@ -1085,6 +1137,8 @@ interface FireBuyBody {
   brief?: string;
   workflow_id?: string;
   timeout_ms?: number;
+  /** Canvas v2 Refinement: real brand context. */
+  brand?: BrandContext;
 }
 
 export async function handleWorkflowFireBuy(request: Request, env: Env, logger: Logger): Promise<Response> {
@@ -1114,12 +1168,15 @@ export async function handleWorkflowFireBuy(request: Request, env: Env, logger: 
     chosenProductId: body.product_id ?? null,
     chosenSignalIds: Array.isArray(body.signal_ids) ? body.signal_ids.filter((s) => typeof s === "string") : [],
     chosenFormatIds: Array.isArray(body.format_ids) ? body.format_ids.filter((f) => typeof f === "string") : [],
+    brandContext: compactBrandContext(body.brand),
   });
 
   // Sec-48r: apply per-vendor adapter just before wire call. payload
   // above stays as the common synthesized shape returned in the
   // response's `payload_preview` — UI shows the base for comparison.
-  const wirePayload = applyVendorAdapter(agent.id, payload);
+  const wirePayload = applyVendorAdapter(agent.id, payload, {
+    brandDomain: body.brand?.domain,
+  });
   const start = Date.now();
   const res = await callAgentTool(
     agent.mcp_url,

--- a/src/routes/brandRegistry.ts
+++ b/src/routes/brandRegistry.ts
@@ -158,3 +158,101 @@ export async function handleBrandResolve(
 
   return jsonResponse(out);
 }
+
+// ── /brands/logo ────────────────────────────────────────────────────────────
+//
+// Phase 2 follow-up: proxy brand-logo image bytes through our worker so the
+// UI doesn't depend on third-party CDN render reliability. Brandfetch.io
+// (the actual host for many registry entries — e.g. Coca-Cola) returns a
+// valid SVG over HTTPS, but browser <img> rendering of that origin can
+// fail silently in our context (suspected hotlink-detect / referrer
+// policy). Proxying through us makes logos render uniformly: we own the
+// response headers, the cache, and the failure-mode (404 fallback).
+//
+// SSRF guard: only allow URLs from a known set of brand-logo origins.
+
+const LOGO_TTL_SEC = 86400;       // 24h — logos rarely change
+const LOGO_KEY_PREFIX = "brand_logo:";
+const LOGO_ALLOWED_HOSTS = new Set<string>([
+  "agenticadvertising.org",
+  "cdn.brandfetch.io",
+  "asset.brandfetch.io",
+  "logos.brandfetch.io",
+]);
+
+export async function handleBrandLogo(
+  request: Request,
+  env: Env,
+  logger: Logger,
+): Promise<Response> {
+  const url = new URL(request.url);
+  const target = url.searchParams.get("u");
+  if (!target) return errorResponse("INVALID_INPUT", "u (target url) required", 400);
+
+  let parsed: URL;
+  try {
+    parsed = new URL(target);
+  } catch {
+    return errorResponse("INVALID_INPUT", "malformed url", 400);
+  }
+  if (parsed.protocol !== "https:") {
+    return errorResponse("INVALID_INPUT", "https only", 400);
+  }
+  if (!LOGO_ALLOWED_HOSTS.has(parsed.hostname)) {
+    return errorResponse("HOST_NOT_ALLOWED", `logo host ${parsed.hostname} not allowlisted`, 403);
+  }
+
+  const cacheKey = LOGO_KEY_PREFIX + target;
+  try {
+    const ctMeta = await env.SIGNALS_CACHE.getWithMetadata<{ ct?: string }>(cacheKey, "stream");
+    if (ctMeta.value) {
+      const contentType = (ctMeta.metadata && ctMeta.metadata.ct) || "image/svg+xml";
+      return new Response(ctMeta.value, {
+        status: 200,
+        headers: {
+          "Content-Type": contentType,
+          "Cache-Control": "public, max-age=" + LOGO_TTL_SEC,
+          "X-Cache": "hit",
+        },
+      });
+    }
+  } catch { /* fall through to fresh fetch */ }
+
+  let upstream: Response;
+  try {
+    upstream = await fetch(target, {
+      signal: AbortSignal.timeout(8000),
+      headers: { "Accept": "image/*" },
+    });
+  } catch (e) {
+    logger.warn("brand_logo_upstream_error", { url: target, error: String((e as Error).message || e) });
+    return errorResponse("UPSTREAM_ERROR", "logo unreachable", 502);
+  }
+  if (!upstream.ok) {
+    logger.warn("brand_logo_upstream_status", { url: target, status: upstream.status });
+    return errorResponse("UPSTREAM_ERROR", "logo upstream " + upstream.status, 502);
+  }
+
+  const contentType = upstream.headers.get("content-type") || "image/svg+xml";
+  const arrayBuf = await upstream.arrayBuffer();
+  if (arrayBuf.byteLength > 1_000_000) {
+    return errorResponse("UPSTREAM_TOO_LARGE", "logo > 1MB; not cached", 413);
+  }
+
+  try {
+    await env.SIGNALS_CACHE.put(cacheKey, arrayBuf, {
+      expirationTtl: LOGO_TTL_SEC,
+      metadata: { ct: contentType },
+    });
+  } catch { /* non-fatal */ }
+
+  return new Response(arrayBuf, {
+    status: 200,
+    headers: {
+      "Content-Type": contentType,
+      "Cache-Control": "public, max-age=" + LOGO_TTL_SEC,
+      "X-Cache": "miss",
+    },
+  });
+}
+

--- a/src/routes/demo.ts
+++ b/src/routes/demo.ts
@@ -1380,28 +1380,79 @@ ${STYLES}
           </div>
         </div>
 
-        <!-- Governance + media-buy + measurement. -->
+        <!-- Governance + brand rights — Phase 3: show the AdCP 3.0 GA
+             tool surface explicitly so the gap is visible by design.
+             Three stacked cards mirror the spec's three task families. -->
         <div id="canvas-bottom" class="canvas-bottom" style="display:none">
-          <div class="canvas-bottom-row canvas-row-governance">
-            <div class="canvas-bottom-label">Governance + brand rights</div>
-            <div class="canvas-bottom-body">
-              <span class="pill pill-warning mono" style="font-size:10px">AdCP 3.0 spec'd</span>
-              <span class="orch-small" style="margin-left:8px">no live agent implementations — phase 3</span>
+          <div class="canvas-spec-block">
+            <div class="canvas-spec-header">
+              <span class="canvas-spec-label">Governance + brand rights</span>
+              <span class="pill pill-warning mono" style="font-size:10px">AdCP 3.0 spec'd · no live impl</span>
+            </div>
+            <div class="canvas-spec-body">
+              <div class="canvas-spec-card">
+                <div class="canvas-spec-card-name mono">check_governance</div>
+                <div class="canvas-spec-card-shape orch-small">in: <code>{plan, brand: BrandRef}</code> · out: <code>{decision, audit_log_url, requires_human_review?}</code></div>
+                <div class="canvas-spec-card-note orch-small">would gate alcohol / pharma / lending / housing for regulated brands. Runs BEFORE create_media_buy.</div>
+              </div>
+              <div class="canvas-spec-card">
+                <div class="canvas-spec-card-name mono">get_rights · acquire_rights · update_rights</div>
+                <div class="canvas-spec-card-shape orch-small">brand-rights lifecycle: discover → negotiate → modify (extend / restrict / revoke)</div>
+                <div class="canvas-spec-card-note orch-small">e.g. asset usage rights for the chosen creatives. None of the live directory agents implement this family.</div>
+              </div>
+              <div class="canvas-spec-card">
+                <div class="canvas-spec-card-name mono">sync_plans · report_plan_outcome · get_plan_audit_logs</div>
+                <div class="canvas-spec-card-shape orch-small">signed <code>governance_context</code> JWS tokens for plan approval + auditability</div>
+                <div class="canvas-spec-card-note orch-small">RFC 9421 HTTP message signatures + idempotency keys per request.</div>
+              </div>
             </div>
           </div>
+
           <div class="canvas-bottom-row canvas-row-mediabuy" id="canvas-lane-mediabuy-row">
             <div class="canvas-bottom-label">Media buy</div>
             <div class="canvas-bottom-body" id="canvas-row-mediabuy-body">
-              <span class="orch-small">click Run above; payload assembled with this brand</span>
+              <span class="orch-small">click Run above; payload assembled with this brand's BrandRef</span>
             </div>
           </div>
-          <div class="canvas-bottom-row canvas-row-measurement">
-            <div class="canvas-bottom-label">In-flight + measurement</div>
-            <div class="canvas-bottom-body">
-              <span class="pill pill-warning mono" style="font-size:10px">closed-loop unspec'd</span>
-              <span class="orch-small" style="margin-left:8px">no measurement-as-role agent type — phase 4</span>
+
+          <!-- Closed-loop measurement: SVG arc back to Audiences + spec card -->
+          <div class="canvas-spec-block">
+            <div class="canvas-spec-header">
+              <span class="canvas-spec-label">In-flight + measurement</span>
+              <span class="pill pill-warning mono" style="font-size:10px">closed-loop unspec'd · no agent type</span>
+            </div>
+            <div class="canvas-spec-body">
+              <div class="canvas-spec-card">
+                <div class="canvas-spec-card-name mono">get_media_buy_delivery</div>
+                <div class="canvas-spec-card-shape orch-small">in-flight pacing, viewability, measurement_windows (Live, C3, C7)</div>
+                <div class="canvas-spec-card-note orch-small">implemented across all 7 buying agents — partial closed loop on the buy side.</div>
+              </div>
+              <div class="canvas-spec-card canvas-spec-card-gap">
+                <div class="canvas-spec-card-name mono">[no spec'd primitive]</div>
+                <div class="canvas-spec-card-shape orch-small">measurement → next-cycle signals query</div>
+                <div class="canvas-spec-card-note orch-small">"these signals underperformed; surface adjacent ones next time." DV / IAS / Comscore / Nielsen positioning. <strong>Whole role unspec'd.</strong></div>
+              </div>
             </div>
           </div>
+        </div>
+
+        <!-- Closed-loop arrow (Phase 4): SVG arc from media-buy back to audiences -->
+        <svg class="canvas-loop-arrow" id="canvas-loop-arrow" style="display:none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" preserveAspectRatio="none">
+          <defs>
+            <marker id="canvas-arrow-head" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto">
+              <path d="M0,0 L10,5 L0,10 z" fill="var(--accent)"/>
+            </marker>
+          </defs>
+          <path d="M 95 92 C 110 50, 110 8, 5 8 L 5 12" stroke="var(--accent)" stroke-width="0.4" fill="none" stroke-dasharray="1.5,1.5" marker-end="url(#canvas-arrow-head)"/>
+          <text x="55" y="55" fill="var(--accent)" font-size="3" font-family="var(--font-mono)" text-anchor="middle">closed loop · phase 4</text>
+        </svg>
+
+        <!-- View-mode toggle (Phase 4): canvas / role-pivot / capability graph -->
+        <div class="canvas-viewmodes">
+          <span class="orch-small" style="color:var(--text-mut);margin-right:8px">view:</span>
+          <button class="canvas-viewmode active" data-mode="canvas" title="Brand-anchored canvas (current)">brand canvas</button>
+          <button class="canvas-viewmode disabled" data-mode="role" title="Pattern B from proposal #98 — coming soon" disabled>role-pivot</button>
+          <button class="canvas-viewmode disabled" data-mode="graph" title="Pattern A from proposal #98 — coming soon" disabled>capability graph</button>
         </div>
       </section>
 
@@ -4639,6 +4690,85 @@ textarea.lab-input { resize: vertical; line-height: 1.5; }
   flex: 1; min-width: 200px;
   color: var(--text-dim);
   font-size: 11px;
+}
+
+/* Phase 3: governance + brand-rights + measurement spec cards.
+   Make the AdCP 3.0 unimplemented-tool surface visible by design. */
+.canvas-spec-block {
+  margin-top: 12px;
+  padding: 10px 12px;
+  background: var(--bg-input);
+  border: 1px solid var(--border);
+  border-left: 3px solid #ffb74d;
+  border-radius: 5px;
+}
+.canvas-spec-header {
+  display: flex; align-items: center; gap: 10px;
+  padding-bottom: 8px; margin-bottom: 8px;
+  border-bottom: 1px solid var(--border);
+}
+.canvas-spec-label {
+  font-size: 12.5px; font-weight: 500; color: var(--text);
+}
+.canvas-spec-body {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 8px;
+}
+.canvas-spec-card {
+  padding: 8px 10px;
+  background: var(--bg-raised);
+  border: 1px dashed var(--border);
+  border-radius: 4px;
+}
+.canvas-spec-card-gap {
+  border-color: var(--error);
+  background: rgba(239,83,80,0.05);
+}
+.canvas-spec-card-name {
+  font-size: 11.5px; font-weight: 500; color: var(--accent);
+  margin-bottom: 3px;
+}
+.canvas-spec-card-shape {
+  font-size: 10.5px; color: var(--text-dim); line-height: 1.45;
+  margin-bottom: 4px;
+}
+.canvas-spec-card-shape code {
+  font-size: 10px; background: var(--bg-input); padding: 1px 4px; border-radius: 3px;
+}
+.canvas-spec-card-note { color: var(--text-mut); line-height: 1.4; }
+.canvas-spec-card-note strong { color: var(--text); }
+
+/* Phase 4: view-mode toggle (Pattern C/B/A). */
+.canvas-viewmodes {
+  display: flex; align-items: center; gap: 6px;
+  margin-top: 10px; padding: 6px 10px;
+  background: var(--bg-input);
+  border: 1px solid var(--border);
+  border-radius: 5px;
+}
+.canvas-viewmode {
+  background: var(--bg-raised); border: 1px solid var(--border);
+  border-radius: 4px; padding: 4px 10px; font-size: 11px;
+  cursor: pointer; color: var(--text-mut);
+  transition: color 0.15s, border-color 0.15s;
+}
+.canvas-viewmode:hover:not(.disabled) { color: var(--accent); border-color: var(--accent-border); }
+.canvas-viewmode.active {
+  color: var(--accent); border-color: var(--accent);
+  background: var(--accent-dim);
+}
+.canvas-viewmode.disabled {
+  opacity: 0.5; cursor: not-allowed;
+}
+
+/* Phase 4: closed-loop arrow. SVG overlay drawn over the bottom region. */
+.canvas-loop-arrow {
+  position: relative;
+  width: 100%; height: 60px;
+  margin: -8px 0 -8px 0;
+  pointer-events: none;
+  opacity: 0.7;
 }
 
 .canvas-bottom { margin-top: 14px; display: flex; flex-direction: column; gap: 8px; }
@@ -12814,6 +12944,8 @@ async function _canvasResolveBrand(domain) {
     if (lanes) lanes.style.display = "";
     var bottom = document.getElementById("canvas-bottom");
     if (bottom) bottom.style.display = "";
+    var loopArrow = document.getElementById("canvas-loop-arrow");
+    if (loopArrow) loopArrow.style.display = "";
   } catch (e) {
     card.innerHTML = '<div class="empty-state" style="border-color:var(--error)"><div class="empty-title" style="color:var(--error)">' + escapeHtml(String(e.message || e)) + '</div></div>';
   }
@@ -12830,9 +12962,13 @@ function _canvasRenderBrandCard(data) {
   var lightLogo = logos.find(function (l) { return (l.tags || []).indexOf("light") >= 0 && (l.tags || []).indexOf("symbol") < 0; });
   var anyLogo = lightLogo || logos[0];
   // Resolve relative URLs to the registry origin.
-  var logoUrl = anyLogo && anyLogo.url
+  // Phase 3: route through /brands/logo proxy. Uniform render path,
+  // bypasses third-party CDN hotlink-detect (e.g. brandfetch.io
+  // silently failing IMG fetches in our origin context).
+  var rawLogoUrl = anyLogo && anyLogo.url
     ? (anyLogo.url.indexOf("http") === 0 ? anyLogo.url : "https://agenticadvertising.org" + anyLogo.url)
     : null;
+  var logoUrl = rawLogoUrl ? ("/brands/logo?u=" + encodeURIComponent(rawLogoUrl)) : null;
 
   var colors = bm.colors || {};
   var palette = ["primary", "accent", "secondary"]
@@ -12964,12 +13100,25 @@ async function _canvasRunWorkflow() {
   // Reset lanes to running state.
   _canvasResetLanes();
 
+  // Refinement: thread the brand BrandRef through to the workflow.
+  // Pulls domain + name + industries from the resolved brand_manifest;
+  // the backend's vendor adapter routes between BrandRef (Claire family)
+  // and brand_manifest.brand (Adzymic + Swivel) at call time.
+  var bm = (brand && brand.brand_manifest) || {};
+  var company = bm.company || {};
+  var brandPayload = {
+    domain: brand.canonical_domain || "",
+    name: brand.brand_name || bm.name || "",
+    description: bm.description || "",
+    industries: Array.isArray(company.industries) ? company.industries : [],
+  };
   try {
     var r = await fetch("/agents/workflow/run/stream", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
         brief: brief,
+        brand: brandPayload,
         timeout_ms: 25000,
       }),
     });


### PR DESCRIPTION
## Summary

Four canvas upgrades bundled together. Closes the orchestration v2 short-list (Phase 3 + Phase 4 + Refinement), plus fixes the logo render issue you flagged in the screenshot.

## 1. Logo proxy fix (the screenshot bug)

Coca-Cola's logo lives on `cdn.brandfetch.io`. Server fetches fine over HTTPS, but the browser `<img>` render fails silently in our origin context (suspected hotlink-detect or referrer policy). Same flavor will bite any third-party CDN logo.

**Fix:** new `GET /brands/logo?u=<encoded>` proxies image bytes through our worker. SSRF-guarded with an allowlist (agenticadvertising.org + brandfetch.io subdomains). KV-cached 24h. UI now resolves all brand-card logos through the proxy.

## 2. Phase 3 — governance + brand-rights spec cards

Replaced the single-row \"AdCP 3.0 spec'd, no impl\" placeholders with two spec-block cards showing the actual unimplemented tool surface, with in/out shapes and notes:

- **Governance + brand rights**: `check_governance`, `get_rights`/`acquire_rights`/`update_rights` lifecycle, `sync_plans`/`report_plan_outcome`/`get_plan_audit_logs`
- **In-flight + measurement**: `get_media_buy_delivery` (implemented across 7 buying agents), plus a red-tinted card for the **measurement → signals feedback** primitive that has no AdCP 3.0 spec at all

Makes the unimplemented protocol surface **visible by design** — workshop point.

## 3. Phase 4 — closed-loop arrow + view-mode toggle stubs

- **SVG arc** from media-buy region back to audiences, labeled \"closed loop · phase 4\", drawn dashed in accent. Cosmetic for now; will animate in Phase 5 once the post-campaign feedback primitive is spec'd.
- **View-mode toggle**: \"brand canvas\" (active) / \"role-pivot\" / \"capability graph\" (both disabled, with proposal-98 references in tooltips). Sets up the Pattern A/B build paths.

## 4. Refinement — BrandRef threaded end-to-end

The Canvas was sending just the derived brief. Now it sends a real `BrandContext` lifted from the resolved `brand_manifest`:

```json
{ \"domain\": \"cbrands.com\", \"name\": \"Constellation Brands\", \"description\": \"...\", \"industries\": [\"Beverages\", \"Food and Drink\"] }
```

Plumbed through WorkflowRunBody → `buildCreateMediaBuyPayload` → `applyVendorAdapter`:

- `brand_manifest.brand` + `categories` use real brand name + industries instead of \"AdCP Workflow Demo\" placeholders
- Claire's `BrandRef.domain` now carries the real domain (`cbrands.com`) instead of `demo.example.com`
- Adzymic + Swivel see real brand name + industries in `brand_manifest`
- `/agents/workflow/fire-buy` accepts `brand` on body — Canvas re-fires honor it

End-to-end: when Canvas runs against Coca-Cola, Claire's `create_media_buy` sees `brand: { domain: \"coke.com\", name: \"Coca-Cola\" }` and Adzymic sees `brand_manifest: { brand: \"Coca-Cola\", categories: [\"food and drink\", \"restaurants and delivery\", \"travel and tourism\"] }`.

## Pre-flight

- Structural audit script (`tmp-mining/trap_audit.py`, lives in the memory file): **zero** single-backslash escapes in the SCRIPT_TAG region
- Type check clean (relaxed two interface fields to accept explicit `undefined` per `exactOptionalPropertyTypes`)
- Suite 428 / 12 skip — unchanged

## Test plan

- [x] Audit + type + tests clean
- [ ] Post-merge + deploy:
  - Logo: pick `coke.com` → Coca-Cola logo renders (via our proxy, not the CDN direct)
  - Phase 3: bottom shows two governance/measurement spec-blocks with in/out shapes + the red \"no spec'd primitive\" card
  - Phase 4: closed-loop SVG arc renders below the canvas; view-mode toggle shows brand canvas active, others tooltip-disabled
  - Refinement: click Run → check the stage-4 dry-run payload → see real brand name in brand_manifest.brand for Adzymic/Swivel, real domain in brand for Claire

🤖 Generated with [Claude Code](https://claude.com/claude-code)