### PR TITLE
fix: adcp-watcher empty AGENT_URL falls through to default

### DIFF
--- a/scripts/adcp-watch.mjs
+++ b/scripts/adcp-watch.mjs
@@ -48,8 +48,11 @@ const config = JSON.parse(readFileSync(CONFIG_PATH, "utf8"));
 const repo =
   process.env.GITHUB_REPOSITORY ??
   execSync("gh repo view --json nameWithOwner -q .nameWithOwner").toString().trim();
+// `||` not `??` because GHA passes unset workflow envs as empty strings,
+// not undefined — `??` would keep "" and discovery would silently fail
+// against an empty URL, producing scenarios_run: [] with no error to grep.
 const agentUrl =
-  process.env.AGENT_URL ?? "https://adcp-signals-adaptor.evgeny-193.workers.dev/mcp";
+  process.env.AGENT_URL || "https://adcp-signals-adaptor.evgeny-193.workers.dev/mcp";
 
 function gh(args) {
   return execSync(`gh ${args}`, { encoding: "utf8" });


### PR DESCRIPTION
## Summary

Watcher's first successful run reported `compliance: { applicable: 0, passed: 0, scenarios_run: [] }` even though `npm run compliance` works fine locally. Discovery silently returned an empty profile, no error to grep.

## Root cause

Workflow declares `AGENT_URL: \${{ vars.AGENT_URL }}` (intended as an optional override for non-prod deploys). User hasn't set that repo variable, so the env var arrives as **empty string** — GHA passes unset workflow envs as `""`, not `undefined`.

Script used `??`, which only short-circuits on null/undefined:

```js
const agentUrl =
  process.env.AGENT_URL ?? "https://adcp-signals-adaptor.evgeny-193.workers.dev/mcp";
```

So `agentUrl` resolved to `""`, `testAllScenarios("", ...)` ran discovery against an empty URL, and the runner returned the no-discovery shape (`scenarios_run: []`) without throwing.

## Fix

`||` instead of `??`, with a comment so nobody re-introduces the trap:

```js
const agentUrl =
  process.env.AGENT_URL || "https://adcp-signals-adaptor.evgeny-193.workers.dev/mcp";
```

## Verification

Locally with `AGENT_URL=` explicitly empty: compliance bucket fills with the real 4/4-scenario result instead of zeros.

## Post-merge

Re-trigger watcher → next comment will show `compliance.applicable: 0 → 4`, `compliance.passed: 0 → 4`, `compliance.scenarios_run: [] → [...]`. After that, daily runs are silent unless something actually moves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)