### PR TITLE
AdCP 3.0.1 alignment: governance mode badge + paginated max_results + SDK bump

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "zod": "^3.23.8"
       },
       "devDependencies": {
-        "@adcp/client": "^5.21.1",
+        "@adcp/client": "^5.23.0",
         "@cloudflare/workers-types": "^4.20241022.0",
         "@vitest/coverage-v8": "^2.0.0",
         "typescript": "^5.5.0",
@@ -20,9 +20,9 @@
       }
     },
     "node_modules/@a2a-js/sdk": {
-      "version": "0.3.10",
-      "resolved": "https://registry.npmjs.org/@a2a-js/sdk/-/sdk-0.3.10.tgz",
-      "integrity": "sha512-t6w5ctnwJkSOMRl6M9rn95C1FTHCPqixxMR0yWXtzhZXEnF6mF1NAK0CfKlG3cz+tcwTxkmn287QZC3t9XPgrA==",
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@a2a-js/sdk/-/sdk-0.3.13.tgz",
+      "integrity": "sha512-BZr0f9JVNQs3GKOM9xINWCh6OKIJWZFPyqqVqTym5mxO2Eemc6I/0zL7zWnljHzGdaf5aZQyQN5xa6PSH62q+A==",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true,
@@ -50,11 +50,29 @@
       }
     },
     "node_modules/@adcp/client": {
-      "version": "5.21.1",
-      "resolved": "https://registry.npmjs.org/@adcp/client/-/client-5.21.1.tgz",
-      "integrity": "sha512-6/bATc7xCv4QCBSTeyTgCtdMrr8w/eSC2dB76rXgyJ6Ovecwc6LJN5AwBhcrt7cXNotC5C7xMETJlxWNdR1YDg==",
+      "version": "5.23.0",
+      "resolved": "https://registry.npmjs.org/@adcp/client/-/client-5.23.0.tgz",
+      "integrity": "sha512-tn/sV51bHuKjQjKbT7kcJRPhdNxRrLOqllmm8wU6UQyVcdn0Da6WScnrF83EHO2GzbSghprOrj2ratL1PdiRNA==",
+      "deprecated": "version",
       "dev": true,
       "license": "Apache-2.0",
+      "dependencies": {
+        "@adcp/sdk": "^5.23.0"
+      },
+      "bin": {
+        "adcp": "bin/adcp.js"
+      }
+    },
+    "node_modules/@adcp/sdk": {
+      "version": "5.23.0",
+      "resolved": "https://registry.npmjs.org/@adcp/sdk/-/sdk-5.23.0.tgz",
+      "integrity": "sha512-xy80zuP/navsMZuNs4OJQC717eO40ai3rJbOBG4EPR3+9885udhhxPfiaZ8acd67Cpf9cQHuNug0GS6JIkVSig==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "workspaces": [
+        ".",
+        "packages/*"
+      ],
       "dependencies": {
         "ajv": "^8.18.0",
         "ajv-formats": "^3.0.1",
@@ -85,7 +103,7 @@
         }
       }
     },
-    "node_modules/@adcp/client/node_modules/undici": {
+    "node_modules/@adcp/sdk/node_modules/undici": {
       "version": "6.25.0",
       "resolved": "https://registry.npmjs.org/undici/-/undici-6.25.0.tgz",
       "integrity": "sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==",
@@ -762,9 +780,9 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.11",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.11.tgz",
-      "integrity": "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==",
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -1381,9 +1399,9 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.27.1",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.27.1.tgz",
-      "integrity": "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==",
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -2014,9 +2032,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
-      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2242,9 +2260,9 @@
       "license": "MIT"
     },
     "node_modules/content-disposition": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
-      "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -2557,9 +2575,9 @@
       }
     },
     "node_modules/eventsource-parser": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
-      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.8.tgz",
+      "integrity": "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -2623,9 +2641,9 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.0.tgz",
-      "integrity": "sha512-KJzBawY6fB9FiZGdE/0aftepZ91YlaGIrV8vgblRM3J8X+dHx/aiowJWwkx6LIGyuqGiANsjSwwrbb8mifOJ4Q==",
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.4.1.tgz",
+      "integrity": "sha512-NGVYwQSAyEQgzxX1iCM978PP9AdO/hW93gMcF6ZwQCm+rFvLsBH6w4xcXWTcliS8La5EPRN3p9wzItqBwJrfNw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -2912,9 +2930,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -2926,9 +2944,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.5",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.5.tgz",
-      "integrity": "sha512-3qq+FUBtlTHhtYxbxheZgY8NIFnkkC/MR8u5TTsr7YZ3wixryQ3cCwn3iZbg8p8B88iDBBAYSfZDS75t8MN7Vg==",
+      "version": "4.12.15",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.15.tgz",
+      "integrity": "sha512-qM0jDhFEaCBb4TxoW7f53Qrpv9RBiayUHo0S52JudprkhvpjIrGoU1mnnr29Fvd1U335ZFPZQY1wlkqgfGXyLg==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -3109,9 +3127,9 @@
       }
     },
     "node_modules/jose": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
-      "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -3543,9 +3561,9 @@
       "license": "MIT"
     },
     "node_modules/qs": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
-      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
       "dev": true,
       "license": "BSD-3-Clause",
       "peer": true,
@@ -3661,9 +3679,9 @@
       }
     },
     "node_modules/router/node_modules/path-to-regexp": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
-      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -3840,15 +3858,15 @@
       }
     },
     "node_modules/side-channel-list": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
+        "object-inspect": "^1.13.4"
       },
       "engines": {
         "node": ">= 0.4"
@@ -4228,9 +4246,9 @@
       }
     },
     "node_modules/uuid": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
       "dev": true,
       "funding": [
         "https://github.com/sponsors/broofa",
@@ -5117,14 +5135,14 @@
       }
     },
     "node_modules/zod-to-json-schema": {
-      "version": "3.25.1",
-      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.1.tgz",
-      "integrity": "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==",
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
       "dev": true,
       "license": "ISC",
       "peer": true,
       "peerDependencies": {
-        "zod": "^3.25 || ^4"
+        "zod": "^3.25.28 || ^4"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "lint": "eslint src --ext .ts"
   },
   "devDependencies": {
-    "@adcp/client": "^5.21.1",
+    "@adcp/client": "^5.23.0",
     "@cloudflare/workers-types": "^4.20241022.0",
     "@vitest/coverage-v8": "^2.0.0",
     "typescript": "^5.5.0",

--- a/src/federation/dstilleryClient.ts
+++ b/src/federation/dstilleryClient.ts
@@ -123,7 +123,9 @@ async function callGetSignalsOnce(
       method: "tools/call",
       params: {
         name: "get_signals",
-        arguments: { signal_spec: brief, max_results: maxResults },
+        // AdCP 3.0.1: paginated form preferred; top-level kept for back-compat
+        // with 3.0.0-era agents (drop top-level on 4.0 cutover).
+        arguments: { signal_spec: brief, max_results: maxResults, pagination: { max_results: maxResults } },
       },
     }),
     signal: AbortSignal.timeout(15_000),

--- a/src/routes/agentsEndpoints.ts
+++ b/src/routes/agentsEndpoints.ts
@@ -250,9 +250,15 @@ export async function handleAgentsOrchestrate(request: Request, env: Env, logger
   if (targets.length === 0) return errorResponse("NO_TARGETS", "No live signals agents matched filters.", 400);
 
   const perAgent: OrchestratePerAgent[] = await Promise.all(targets.map(async (a): Promise<OrchestratePerAgent> => {
+    // AdCP 3.0.1: send both top-level + pagination.max_results.
+    // Spec says agents honor `pagination.max_results` when both are present
+    // (top-level deprecated, removed in 4.0); we keep the top-level form
+    // for back-compat with 3.0.0-era agents that don't read the paginated
+    // form. Drop the top-level on the 4.0 cutover.
     const res = await callAgentTool(a.mcp_url!, tool, {
       signal_spec: body.brief,
       max_results: maxResults,
+      pagination: { max_results: maxResults },
     }, { timeoutMs });
     const structured = res.structured_content as { signals?: unknown[] } | undefined;
     const signals = structured?.signals ?? [];
@@ -511,7 +517,8 @@ async function runSignalsStage(
     const res = await callAgentTool(
       a.mcp_url!,
       "get_signals",
-      { signal_spec: brief, max_results: maxResults },
+      // AdCP 3.0.1 paginated form + top-level back-compat (see comment above).
+      { signal_spec: brief, max_results: maxResults, pagination: { max_results: maxResults } },
       { timeoutMs },
     );
     const signals = extractMcpToolArray<SignalLite>(res.structured_content, res.content, ["signals"])
@@ -877,7 +884,8 @@ export async function handleWorkflowRunStream(request: Request, env: Env, logger
           const res = await callAgentTool(
             a.mcp_url!,
             "get_signals",
-            { signal_spec: body.brief, max_results: maxSignals },
+            // AdCP 3.0.1 paginated form + top-level back-compat.
+            { signal_spec: body.brief, max_results: maxSignals, pagination: { max_results: maxSignals } },
             { timeoutMs },
           );
           const signals = extractMcpToolArray<SignalLite>(res.structured_content, res.content, ["signals"])

--- a/src/routes/demo.ts
+++ b/src/routes/demo.ts
@@ -1387,13 +1387,19 @@ ${STYLES}
           <div class="canvas-spec-block">
             <div class="canvas-spec-header">
               <span class="canvas-spec-label">Governance + brand rights</span>
-              <span class="pill pill-warning mono" style="font-size:10px">AdCP 3.0 spec'd · no live impl</span>
+              <span class="pill pill-warning mono" style="font-size:10px">AdCP 3.0.1 spec'd · no live impl</span>
             </div>
             <div class="canvas-spec-body">
               <div class="canvas-spec-card">
                 <div class="canvas-spec-card-name mono">check_governance</div>
-                <div class="canvas-spec-card-shape orch-small">in: <code>{plan, brand: BrandRef}</code> · out: <code>{decision, audit_log_url, requires_human_review?}</code></div>
+                <div class="canvas-spec-card-shape orch-small">in: <code>{plan, brand: BrandRef}</code> · out: <code>{decision, mode, audit_log_url, requires_human_review?}</code></div>
                 <div class="canvas-spec-card-note orch-small">would gate alcohol / pharma / lending / housing for regulated brands. Runs BEFORE create_media_buy.</div>
+                <div class="canvas-gov-mode-row" title="enforcement posture surfaced via the mode field on check-governance-response (added in AdCP 3.0.1)">
+                  <span class="canvas-gov-mode-label orch-small">mode:</span>
+                  <span class="canvas-gov-mode-pill canvas-gov-mode-enforce mono" title="check is active and BLOCKS non-compliant plans">enforce</span>
+                  <span class="canvas-gov-mode-pill canvas-gov-mode-advisory mono" title="check returns a recommendation but does NOT block">advisory</span>
+                  <span class="canvas-gov-mode-pill canvas-gov-mode-audit mono" title="check is logged for audit only — no decision returned">audit</span>
+                </div>
               </div>
               <div class="canvas-spec-card">
                 <div class="canvas-spec-card-name mono">get_rights · acquire_rights · update_rights</div>
@@ -4760,6 +4766,26 @@ textarea.lab-input { resize: vertical; line-height: 1.5; }
 }
 .canvas-spec-card-note { color: var(--text-mut); line-height: 1.4; }
 .canvas-spec-card-note strong { color: var(--text); }
+
+/* AdCP 3.0.1: mode swatch on check_governance card.
+   Visual strawman of the enforcement-posture options surfaced by the
+   new mode response field. Workshop trust-contract teaching moment:
+   is your governance call actually gating, or just telemetry? */
+.canvas-gov-mode-row {
+  display: flex; align-items: center; gap: 6px; flex-wrap: wrap;
+  margin-top: 6px; padding-top: 6px;
+  border-top: 1px dashed var(--border);
+}
+.canvas-gov-mode-label {
+  color: var(--text-mut); font-size: 10px;
+}
+.canvas-gov-mode-pill {
+  font-size: 9.5px; padding: 1px 6px; border-radius: 3px;
+  border: 1px solid currentColor; cursor: help;
+}
+.canvas-gov-mode-enforce  { color: var(--error); background: rgba(239,83,80,0.08); }
+.canvas-gov-mode-advisory { color: var(--warning, #d4a017); background: rgba(212,160,23,0.08); }
+.canvas-gov-mode-audit    { color: var(--text-dim); background: var(--bg-input); }
 
 /* Phase 4: view-mode toggle (Pattern C/B/A). */
 .canvas-viewmodes {


### PR DESCRIPTION
## Summary
Three coordinated alignments to AdCP **3.0.1** (released 2026-04-28).

### 1. Governance card: surface the new `mode` field
3.0.1 added a `mode` field on `check-governance-response` recording the **enforcement posture** active at check time — `enforce` / `advisory` / `audit`. Updated the canvas-bottom spec card to:
- Show new response shape: `{decision, mode, audit_log_url, requires_human_review?}`
- Render a 3-pill swatch (red enforce / amber advisory / muted audit) as a workshop teaching aid for the trust-contract block
- Bump the spec-block badge from "AdCP 3.0 spec'd" to "AdCP 3.0.1 spec'd"

This is the workshop's *"is your governance call actually gating, or just telemetry?"* conversation made visible.

### 2. `get_signals`: send paginated form alongside top-level
3.0.1 deprecates top-level `max_results` (removed in 4.0) and formalizes that agents MUST honor `pagination.max_results` when both are present. Sending both forms maximizes back-compat with 3.0.0-era agents that may not read the paginated form yet.

Touched 4 outbound call sites:
- `src/routes/agentsEndpoints.ts` L255, L514, L880 (the three `get_signals` fan-outs)
- `src/federation/dstilleryClient.ts` L126 (the directory-level Dstillery client)

Demo example payloads in `demo.ts` left as-is — they're documentation, not live calls; will update separately if useful.

### 3. `@adcp/client` 5.21.1 → 5.23.0
- **5.22.0** ships AdCP 3.0.1 spec alignment + sandbox-only test-controller scenarios (`force_create_media_buy_arm`, `force_task_completion`, `seed_creative_format`)
- **5.23.0** renames the package to `@adcp/sdk` with a `@adcp/client` shim re-export (non-breaking)

Diffed both releases — additive only, no breaking changes for us. We don't use the codegen-renamed types (`FormatID` → `FormatReferenceStructuredObject`, `RATE_LIMITEDDetails` → `RateLimitedDetails`).

## Watcher confirms
Today's daily AdCP watcher run (15:20 UTC) picked up all three changes:
- `client_sdk.latest_published`: `5.21.1` → `5.23.0`
- `spec_release.latest_tag`: `v3.0.0` → `v3.0.1`
- `adcp-client#1036` merged (governance-advisory JSON-parse fix — folded into 5.22+, so the SDK bump pulls it in)

## Pre-flight
- [x] Structural SCRIPT_TAG audit clean (0 traps); 5th case (raw backticks in CSS comments) added to `feedback_script_tag_template_trap.md`
- [x] Type-check clean for touched files
- [x] 428 tests pass
- [x] `@adcp/client` 5.23.0 installed; lockfile updated

## Test plan
- [ ] After merge: deploy + verify Canvas governance card renders the 3-pill mode swatch
- [ ] Verify `get_signals` outbound calls include both `max_results` and `pagination.max_results` (any of the 8 directory agents will accept either form)
- [ ] Watcher tomorrow: state should be stable, no new diffs

🤖 Generated with [Claude Code](https://claude.com/claude-code)