### PR TITLE
Registry integration: agents + policies + DTS attestations + SWR (Phases A-D)

### DIFF
--- a/.github/adcp-watch-config.json
+++ b/.github/adcp-watch-config.json
@@ -11,12 +11,6 @@
       "number": 2916,
       "kind": "issue",
       "context": "Q3 systemic FAIL→SKIP applicability bug — runner conflates 'media-buy agent' with 'any agent'. Deferred to adcp 3.1.0; resurfaces when capability-derived skip_if grammar lands runner-side in @adcp/client. Until then, error_handling / validation / schema_compliance stay skipped on signals-only agents."
-    },
-    {
-      "repo": "adcontextprotocol/adcp-client",
-      "number": 1036,
-      "kind": "pr",
-      "context": "Governance advisory JSON-parse fix surfaced during triage of our Q1/Q2 issues. Informational; does not affect our compliance numbers."
     }
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "zod": "^3.23.8"
       },
       "devDependencies": {
-        "@adcp/client": "^5.21.1",
+        "@adcp/client": "^5.23.0",
         "@cloudflare/workers-types": "^4.20241022.0",
         "@vitest/coverage-v8": "^2.0.0",
         "typescript": "^5.5.0",
@@ -20,9 +20,9 @@
       }
     },
     "node_modules/@a2a-js/sdk": {
-      "version": "0.3.10",
-      "resolved": "https://registry.npmjs.org/@a2a-js/sdk/-/sdk-0.3.10.tgz",
-      "integrity": "sha512-t6w5ctnwJkSOMRl6M9rn95C1FTHCPqixxMR0yWXtzhZXEnF6mF1NAK0CfKlG3cz+tcwTxkmn287QZC3t9XPgrA==",
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@a2a-js/sdk/-/sdk-0.3.13.tgz",
+      "integrity": "sha512-BZr0f9JVNQs3GKOM9xINWCh6OKIJWZFPyqqVqTym5mxO2Eemc6I/0zL7zWnljHzGdaf5aZQyQN5xa6PSH62q+A==",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true,
@@ -50,11 +50,29 @@
       }
     },
     "node_modules/@adcp/client": {
-      "version": "5.21.1",
-      "resolved": "https://registry.npmjs.org/@adcp/client/-/client-5.21.1.tgz",
-      "integrity": "sha512-6/bATc7xCv4QCBSTeyTgCtdMrr8w/eSC2dB76rXgyJ6Ovecwc6LJN5AwBhcrt7cXNotC5C7xMETJlxWNdR1YDg==",
+      "version": "5.23.0",
+      "resolved": "https://registry.npmjs.org/@adcp/client/-/client-5.23.0.tgz",
+      "integrity": "sha512-tn/sV51bHuKjQjKbT7kcJRPhdNxRrLOqllmm8wU6UQyVcdn0Da6WScnrF83EHO2GzbSghprOrj2ratL1PdiRNA==",
+      "deprecated": "version",
       "dev": true,
       "license": "Apache-2.0",
+      "dependencies": {
+        "@adcp/sdk": "^5.23.0"
+      },
+      "bin": {
+        "adcp": "bin/adcp.js"
+      }
+    },
+    "node_modules/@adcp/sdk": {
+      "version": "5.23.0",
+      "resolved": "https://registry.npmjs.org/@adcp/sdk/-/sdk-5.23.0.tgz",
+      "integrity": "sha512-xy80zuP/navsMZuNs4OJQC717eO40ai3rJbOBG4EPR3+9885udhhxPfiaZ8acd67Cpf9cQHuNug0GS6JIkVSig==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "workspaces": [
+        ".",
+        "packages/*"
+      ],
       "dependencies": {
         "ajv": "^8.18.0",
         "ajv-formats": "^3.0.1",
@@ -85,7 +103,7 @@
         }
       }
     },
-    "node_modules/@adcp/client/node_modules/undici": {
+    "node_modules/@adcp/sdk/node_modules/undici": {
       "version": "6.25.0",
       "resolved": "https://registry.npmjs.org/undici/-/undici-6.25.0.tgz",
       "integrity": "sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==",
@@ -762,9 +780,9 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.11",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.11.tgz",
-      "integrity": "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==",
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -1381,9 +1399,9 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.27.1",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.27.1.tgz",
-      "integrity": "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==",
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -2014,9 +2032,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
-      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2242,9 +2260,9 @@
       "license": "MIT"
     },
     "node_modules/content-disposition": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
-      "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -2557,9 +2575,9 @@
       }
     },
     "node_modules/eventsource-parser": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
-      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.8.tgz",
+      "integrity": "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -2623,9 +2641,9 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.0.tgz",
-      "integrity": "sha512-KJzBawY6fB9FiZGdE/0aftepZ91YlaGIrV8vgblRM3J8X+dHx/aiowJWwkx6LIGyuqGiANsjSwwrbb8mifOJ4Q==",
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.4.1.tgz",
+      "integrity": "sha512-NGVYwQSAyEQgzxX1iCM978PP9AdO/hW93gMcF6ZwQCm+rFvLsBH6w4xcXWTcliS8La5EPRN3p9wzItqBwJrfNw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -2912,9 +2930,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -2926,9 +2944,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.5",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.5.tgz",
-      "integrity": "sha512-3qq+FUBtlTHhtYxbxheZgY8NIFnkkC/MR8u5TTsr7YZ3wixryQ3cCwn3iZbg8p8B88iDBBAYSfZDS75t8MN7Vg==",
+      "version": "4.12.15",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.15.tgz",
+      "integrity": "sha512-qM0jDhFEaCBb4TxoW7f53Qrpv9RBiayUHo0S52JudprkhvpjIrGoU1mnnr29Fvd1U335ZFPZQY1wlkqgfGXyLg==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -3109,9 +3127,9 @@
       }
     },
     "node_modules/jose": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
-      "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -3543,9 +3561,9 @@
       "license": "MIT"
     },
     "node_modules/qs": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
-      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
       "dev": true,
       "license": "BSD-3-Clause",
       "peer": true,
@@ -3661,9 +3679,9 @@
       }
     },
     "node_modules/router/node_modules/path-to-regexp": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
-      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -3840,15 +3858,15 @@
       }
     },
     "node_modules/side-channel-list": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
+        "object-inspect": "^1.13.4"
       },
       "engines": {
         "node": ">= 0.4"
@@ -4228,9 +4246,9 @@
       }
     },
     "node_modules/uuid": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
       "dev": true,
       "funding": [
         "https://github.com/sponsors/broofa",
@@ -5117,14 +5135,14 @@
       }
     },
     "node_modules/zod-to-json-schema": {
-      "version": "3.25.1",
-      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.1.tgz",
-      "integrity": "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==",
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
       "dev": true,
       "license": "ISC",
       "peer": true,
       "peerDependencies": {
-        "zod": "^3.25 || ^4"
+        "zod": "^3.25.28 || ^4"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "lint": "eslint src --ext .ts"
   },
   "devDependencies": {
-    "@adcp/client": "^5.21.1",
+    "@adcp/client": "^5.23.0",
     "@cloudflare/workers-types": "^4.20241022.0",
     "@vitest/coverage-v8": "^2.0.0",
     "typescript": "^5.5.0",

--- a/src/domain/policyRegistry.ts
+++ b/src/domain/policyRegistry.ts
@@ -1,0 +1,220 @@
+// src/domain/policyRegistry.ts
+//
+// Local snapshot of the agentic-advertising registry policy table.
+// As of 2026-04-29 the public site renders the policies tab from
+// internal data, but `/api/registry/policies` returns 404 (the
+// brand-side `/api/brands/resolve` and the agent-side
+// `/api/registry/agents` are both live; policies API has not landed).
+//
+// We mirror the 14 published entries here so:
+//   1. Our DTS `policy_attestations` extension (Phase D) has real
+//      stable policy_ids to point at, NOT placeholder strings.
+//   2. The Canvas brand-anchored view can match brand industries to
+//      applicable policies *today* — no upstream blocker.
+//   3. When `/api/registry/policies` ships, this file becomes a
+//      cached/seed copy and a daily worker can keep it fresh.
+//      Migration: replace `POLICIES` with a `loadPolicies()` that
+//      hits the live API + falls back to this snapshot on error.
+//
+// Source: agenticadvertising.org/registry/?tab=policies
+// Snapshotted: 2026-04-29
+
+export type PolicyCategory = "regulation" | "standard";
+export type PolicyEnforcement = "must" | "should" | "may";
+
+export interface RegistryPolicy {
+  policy_id: string;          // slug, e.g. "ca_sb_942"
+  name: string;               // human-readable
+  category: PolicyCategory;   // regulation | standard
+  enforcement: PolicyEnforcement;
+  description: string;
+  region: string;             // ISO-2 or "EU" or "Global"
+  effective_date: string;     // ISO date
+  authority: string;          // e.g. "California State Legislature"
+  // Industries this policy is relevant to. Not in the registry's published
+  // schema yet — we infer from the policy name/description so the
+  // Canvas-side brand→policy matcher (Phase C) has something to chew on.
+  // When the upstream schema adds an explicit industries field, replace.
+  industries_inferred: string[];
+}
+
+export const POLICIES: RegistryPolicy[] = [
+  {
+    policy_id: "ca_sb_942",
+    name: "California AI Transparency Act",
+    category: "regulation",
+    enforcement: "must",
+    description: "California requirements for labeling AI-generated content on large platforms.",
+    region: "US",
+    effective_date: "2026-01-01",
+    authority: "California State Legislature",
+    industries_inferred: ["ai_generated_content"],
+  },
+  {
+    policy_id: "eu_ai_act_article_50",
+    name: "EU AI Act Transparency Obligations",
+    category: "regulation",
+    enforcement: "must",
+    description: "EU AI Act requirements for AI-generated advertising content disclosure.",
+    region: "EU",
+    effective_date: "2026-08-02",
+    authority: "European Parliament and Council",
+    industries_inferred: ["ai_generated_content"],
+  },
+  {
+    policy_id: "eu_gdpr_advertising",
+    name: "EU GDPR Advertising Requirements",
+    category: "regulation",
+    enforcement: "must",
+    description: "GDPR requirements for personal data processing in advertising.",
+    region: "EU",
+    effective_date: "2018-05-25",
+    authority: "European Parliament and Council",
+    industries_inferred: ["all"],
+  },
+  {
+    policy_id: "political_advertising",
+    name: "Political advertising transparency",
+    category: "regulation",
+    enforcement: "must",
+    description: "Transparency and disclosure requirements for political advertising across jurisdictions.",
+    region: "EU",
+    effective_date: "2024-02-17",
+    authority: "European Union / Various national authorities",
+    industries_inferred: ["political", "advocacy"],
+  },
+  {
+    policy_id: "tobacco_nicotine",
+    name: "Tobacco and nicotine advertising restrictions",
+    category: "regulation",
+    enforcement: "must",
+    description: "Tobacco and nicotine advertising restrictions across jurisdictions. Most markets ban tobacco advertising entirely.",
+    region: "Global",
+    effective_date: "2024-01-01",
+    authority: "World Health Organization",
+    industries_inferred: ["tobacco", "vaping", "nicotine"],
+  },
+  {
+    policy_id: "uk_hfss",
+    name: "UK HFSS Advertising Restrictions",
+    category: "regulation",
+    enforcement: "must",
+    description: "UK ban on paid online advertising of less healthy food and drink products.",
+    region: "GB",
+    effective_date: "2025-10-01",
+    authority: "UK Parliament",
+    industries_inferred: ["food_beverage", "fast_food", "confectionery"],
+  },
+  {
+    policy_id: "us_cannabis",
+    name: "US Cannabis Advertising Restrictions",
+    category: "regulation",
+    enforcement: "must",
+    description: "Cannabis advertising compliance requirements across US jurisdictions.",
+    region: "US",
+    effective_date: "2024-01-01",
+    authority: "National Conference of State Legislatures",
+    industries_inferred: ["cannabis"],
+  },
+  {
+    policy_id: "us_coppa",
+    name: "US COPPA",
+    category: "regulation",
+    enforcement: "must",
+    description: "Children's Online Privacy Protection Act requirements for advertising.",
+    region: "US",
+    effective_date: "2000-04-21",
+    authority: "US Federal Trade Commission",
+    industries_inferred: ["children", "toys", "education"],
+  },
+  {
+    policy_id: "alcohol_advertising",
+    name: "Alcohol Advertising Standards",
+    category: "standard",
+    enforcement: "should",
+    description: "Industry best practices for responsible alcohol advertising.",
+    region: "Global",
+    effective_date: "2024-01-01",
+    authority: "International Alliance for Responsible Drinking",
+    industries_inferred: ["alcohol", "beer", "wine", "spirits"],
+  },
+  {
+    policy_id: "childrens_advertising",
+    name: "Children's advertising standards",
+    category: "standard",
+    enforcement: "should",
+    description: "Global standards for advertising directed at or likely to be seen by children, covering protections beyond US COPPA.",
+    region: "Global",
+    effective_date: "2025-01-01",
+    authority: "Multiple: UK ASA/CAP, EU AVMSD, ICC, UNICEF",
+    industries_inferred: ["children", "toys", "education"],
+  },
+  {
+    policy_id: "csbs",
+    name: "Common Sense Brand Standards",
+    category: "standard",
+    enforcement: "must",
+    description: "Common Sense Brand Standards (CSBS) — content adjacency standard governed by AgenticAdvertising.org.",
+    region: "Global",
+    effective_date: "2026-01-01",
+    authority: "AgenticAdvertising.org",
+    industries_inferred: ["all"],
+  },
+  {
+    policy_id: "financial_services",
+    name: "Financial Services Advertising Standards",
+    category: "standard",
+    enforcement: "should",
+    description: "Best practices for financial product and services advertising.",
+    region: "Global",
+    effective_date: "2024-01-01",
+    authority: "Consumer Financial Protection Bureau",
+    industries_inferred: ["financial", "banking", "insurance", "lending", "fintech"],
+  },
+  {
+    policy_id: "gambling_advertising",
+    name: "Gambling Advertising Standards",
+    category: "standard",
+    enforcement: "should",
+    description: "Industry best practices for responsible gambling advertising.",
+    region: "Global",
+    effective_date: "2024-01-01",
+    authority: "International Comparative Legal Guides",
+    industries_inferred: ["gambling", "lottery", "sports_betting"],
+  },
+  {
+    policy_id: "pharma_us_fda",
+    name: "US Pharmaceutical Advertising Standards",
+    category: "standard",
+    enforcement: "should",
+    description: "FDA-aligned best practices for pharmaceutical and healthcare advertising.",
+    region: "US",
+    effective_date: "2024-01-01",
+    authority: "US Food and Drug Administration",
+    industries_inferred: ["pharma", "healthcare", "medical_devices"],
+  },
+];
+
+/**
+ * Look up a policy by its slug. Returns undefined if not found.
+ */
+export function getPolicy(policyId: string): RegistryPolicy | undefined {
+  return POLICIES.find((p) => p.policy_id === policyId);
+}
+
+/**
+ * Find all policies whose `industries_inferred` list overlaps with the
+ * supplied brand industry slugs. The "all" sentinel matches every brand.
+ *
+ * Brand-anchored Canvas view (Phase C) uses this. Phase D's
+ * `policy_attestations` emission is provider-side and doesn't strictly
+ * need brand context — it declares which policies our SIGNAL data
+ * complies with regardless of campaign target.
+ */
+export function policiesForIndustries(industries: readonly string[]): RegistryPolicy[] {
+  const norm = industries.map((i) => i.toLowerCase());
+  return POLICIES.filter((p) => {
+    if (p.industries_inferred.includes("all")) return true;
+    return p.industries_inferred.some((ind) => norm.includes(ind.toLowerCase()));
+  });
+}

--- a/src/federation/dstilleryClient.ts
+++ b/src/federation/dstilleryClient.ts
@@ -123,7 +123,9 @@ async function callGetSignalsOnce(
       method: "tools/call",
       params: {
         name: "get_signals",
-        arguments: { signal_spec: brief, max_results: maxResults },
+        // AdCP 3.0.1: paginated form preferred; top-level kept for back-compat
+        // with 3.0.0-era agents (drop top-level on 4.0 cutover).
+        arguments: { signal_spec: brief, max_results: maxResults, pagination: { max_results: maxResults } },
       },
     }),
     signal: AbortSignal.timeout(15_000),

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,6 +52,10 @@ import {
   handleBrandLogo,
 } from "./routes/brandRegistry";
 import {
+  handleRegistryAgents,
+  handleRegistryPolicies,
+} from "./routes/registryRoutes";
+import {
   handleAudienceCompose,
   handleAudienceSaturation,
   handleAffinityAudit,
@@ -230,6 +234,10 @@ export default {
             "/brands/search",
             "/brands/resolve",
             "/brands/logo",
+            // Phase B + C: agents-registry passthrough + policies snapshot.
+            // Public — informational views over the agentic-advertising registry.
+            "/registry/agents",
+            "/registry/policies",
             "/taxonomy/reverse",
             // Sec-43: audience composer + activation-planning analytics.
             // Read-only — same posture as /portfolio/* and /analytics/*.
@@ -395,6 +403,12 @@ export default {
                 response = await handleBrandResolve(request, env, logger);
             } else if (method === "GET" && path === "/brands/logo") {
                 response = await handleBrandLogo(request, env, logger);
+
+                // ── Phase B + C: agents-registry passthrough + policies snapshot ────
+            } else if (method === "GET" && path === "/registry/agents") {
+                response = await handleRegistryAgents(request, env, logger);
+            } else if (method === "GET" && path === "/registry/policies") {
+                response = await handleRegistryPolicies(request, env, logger);
 
                 // ── Sec-43: Audience Composer + activation analytics ────────────────
             } else if (method === "POST" && path === "/audience/compose") {

--- a/src/mappers/signalMapper.ts
+++ b/src/mappers/signalMapper.ts
@@ -20,6 +20,7 @@ import type {
   DtsDataSource,
   DtsInclusionMethodology,
   DtsRefreshCadence,
+  PolicyAttestation,
 } from "../types/api";
 
 const DATA_PROVIDER = "AdCP Signals Adaptor - Demo Provider (Evgeny)";
@@ -180,6 +181,53 @@ function buildAudienceCriteria(signal: CanonicalSignal): string {
 }
 
 /**
+ * Build the Phase D `policy_attestations` set for our demo provider.
+ *
+ * The provider attests against the agentic-advertising registry's
+ * `must`-enforcement regulations + the Common Sense Brand Standards
+ * (csbs). Our signals are first-party / partner-derived US household
+ * audiences; the attestations declare:
+ *   - GDPR / GDPR-advertising — out_of_scope (no EU processing)
+ *   - COPPA — compliant (we filter children's data per attestor process)
+ *   - Cannabis / Tobacco / Political / AI-Transparency — out_of_scope
+ *     (we don't source from those category surfaces)
+ *   - HFSS — not_applicable (UK; we're US-only)
+ *   - CSBS — compliant (Common Sense Brand Standards adherence)
+ *
+ * Workshop angle: this is the SIGNAL's claim, separate from
+ * `check_governance` (plan-level) and IAB DTS (audience attributes).
+ * A buyer who needs `gambling_advertising` compliance can see we're
+ * silent on it (no attestation present) and route to a different
+ * signal provider, OR call `check_governance` for the authoritative
+ * answer at plan-time. The attestation is a low-cost pre-filter.
+ *
+ * Static for the demo; in production this would be assembled per-
+ * signal based on data lineage + active compliance program.
+ */
+function buildPolicyAttestations(): PolicyAttestation[] {
+  const now = new Date().toISOString();
+  const evidence = `https://${PROVIDER_DOMAIN}/compliance`;
+  return [
+    { policy_id: "us_coppa", claim: "compliant", attested_at: now, attestor: DATA_PROVIDER, evidence_url: evidence,
+      notes: "Children's data filtered at ingestion per documented process." },
+    { policy_id: "csbs", claim: "compliant", attested_at: now, attestor: DATA_PROVIDER, evidence_url: evidence,
+      notes: "Common Sense Brand Standards adherence." },
+    { policy_id: "eu_gdpr_advertising", claim: "out_of_scope", attested_at: now, attestor: DATA_PROVIDER,
+      notes: "Provider does not process EU resident data." },
+    { policy_id: "uk_hfss", claim: "not_applicable", attested_at: now, attestor: DATA_PROVIDER,
+      notes: "US-only addressable; no UK ad surface." },
+    { policy_id: "ca_sb_942", claim: "out_of_scope", attested_at: now, attestor: DATA_PROVIDER,
+      notes: "No AI-generated content in signal payloads." },
+    { policy_id: "tobacco_nicotine", claim: "out_of_scope", attested_at: now, attestor: DATA_PROVIDER,
+      notes: "Tobacco / nicotine excluded at source." },
+    { policy_id: "us_cannabis", claim: "out_of_scope", attested_at: now, attestor: DATA_PROVIDER,
+      notes: "Cannabis excluded at source." },
+    { policy_id: "political_advertising", claim: "out_of_scope", attested_at: now, attestor: DATA_PROVIDER,
+      notes: "Political segments not sourced." },
+  ];
+}
+
+/**
  * Build full DTS v1.2 label from CanonicalSignal.
  */
 export function buildDtsLabel(signal: CanonicalSignal): DtsV12Label {
@@ -225,6 +273,10 @@ export function buildDtsLabel(signal: CanonicalSignal): DtsV12Label {
     onboarder_audience_expansion: hasOfflineSource ? "No" : "N/A",
     onboarder_device_expansion: hasOfflineSource ? "No" : "N/A",
     onboarder_audience_precision_level: hasOfflineSource ? "Geography" : "N/A",
+
+    // Phase D: agentic-advertising registry policy attestations.
+    // Static for the demo; production would key off signal lineage.
+    policy_attestations: buildPolicyAttestations(),
   };
 }
 

--- a/src/routes/agentsEndpoints.ts
+++ b/src/routes/agentsEndpoints.ts
@@ -250,9 +250,15 @@ export async function handleAgentsOrchestrate(request: Request, env: Env, logger
   if (targets.length === 0) return errorResponse("NO_TARGETS", "No live signals agents matched filters.", 400);
 
   const perAgent: OrchestratePerAgent[] = await Promise.all(targets.map(async (a): Promise<OrchestratePerAgent> => {
+    // AdCP 3.0.1: send both top-level + pagination.max_results.
+    // Spec says agents honor `pagination.max_results` when both are present
+    // (top-level deprecated, removed in 4.0); we keep the top-level form
+    // for back-compat with 3.0.0-era agents that don't read the paginated
+    // form. Drop the top-level on the 4.0 cutover.
     const res = await callAgentTool(a.mcp_url!, tool, {
       signal_spec: body.brief,
       max_results: maxResults,
+      pagination: { max_results: maxResults },
     }, { timeoutMs });
     const structured = res.structured_content as { signals?: unknown[] } | undefined;
     const signals = structured?.signals ?? [];
@@ -511,7 +517,8 @@ async function runSignalsStage(
     const res = await callAgentTool(
       a.mcp_url!,
       "get_signals",
-      { signal_spec: brief, max_results: maxResults },
+      // AdCP 3.0.1 paginated form + top-level back-compat (see comment above).
+      { signal_spec: brief, max_results: maxResults, pagination: { max_results: maxResults } },
       { timeoutMs },
     );
     const signals = extractMcpToolArray<SignalLite>(res.structured_content, res.content, ["signals"])
@@ -877,7 +884,8 @@ export async function handleWorkflowRunStream(request: Request, env: Env, logger
           const res = await callAgentTool(
             a.mcp_url!,
             "get_signals",
-            { signal_spec: body.brief, max_results: maxSignals },
+            // AdCP 3.0.1 paginated form + top-level back-compat.
+            { signal_spec: body.brief, max_results: maxSignals, pagination: { max_results: maxSignals } },
             { timeoutMs },
           );
           const signals = extractMcpToolArray<SignalLite>(res.structured_content, res.content, ["signals"])

--- a/src/routes/brandRegistry.ts
+++ b/src/routes/brandRegistry.ts
@@ -21,8 +21,9 @@ import type { Logger } from "../utils/logger";
 import { jsonResponse, errorResponse } from "./shared";
 
 const REGISTRY_BASE = "https://agenticadvertising.org/api";
-const SEARCH_TTL_SEC = 600;     // 10 min — search results change with new brand additions
-const RESOLVE_TTL_SEC = 3600;   // 1 hr — resolved brand manifests change less often
+const SEARCH_TTL_SEC = 600;       // 10 min — search results change with new brand additions
+const RESOLVE_TTL_SEC = 86400;    // 24h hard KV TTL (Phase A: extended for stale-while-revalidate)
+const RESOLVE_FRESH_SEC = 3600;   // 1h soft "fresh" window — past this we revalidate via etag
 const SEARCH_KEY_PREFIX = "brand_search:";
 const RESOLVE_KEY_PREFIX = "brand_resolve:";
 
@@ -46,6 +47,21 @@ async function fetchWithTimeout(url: string, timeoutMs: number): Promise<Respons
   return fetch(url, {
     signal: AbortSignal.timeout(timeoutMs),
     headers: { "Accept": "application/json" },
+  });
+}
+
+// Phase A: conditional fetch with If-None-Match. Returns the upstream
+// Response (which may be 304) so callers can branch on status.
+async function fetchWithEtag(
+  url: string,
+  etag: string | undefined,
+  timeoutMs: number,
+): Promise<Response> {
+  const headers: Record<string, string> = { "Accept": "application/json" };
+  if (etag) headers["If-None-Match"] = etag;
+  return fetch(url, {
+    signal: AbortSignal.timeout(timeoutMs),
+    headers,
   });
 }
 
@@ -118,19 +134,79 @@ export async function handleBrandResolve(
   }
 
   const cacheKey = RESOLVE_KEY_PREFIX + domain;
-  try {
-    const cached = await env.SIGNALS_CACHE.get(cacheKey, "json");
-    if (cached) {
-      return jsonResponse({ ...(cached as object), cache: "hit" });
-    }
-  } catch { /* fall through to fresh fetch */ }
-
+  // Phase A: stale-while-revalidate. The KV entry now lives 24h (was 1h)
+  // and we keep `fetched_at` + `etag` in the metadata. On read:
+  //   - age < 1h        → return as-is (cache: "hit")
+  //   - 1h ≤ age < 24h  → conditional GET upstream with If-None-Match.
+  //                       304 → bump fetched_at, return body (cache: "swr-validated")
+  //                       200 → write fresh, return (cache: "swr-refresh")
+  //                       error → return stale body (cache: "swr-stale-fallback")
+  //   - age ≥ 24h       → KV entry is gone; full fetch (cache: "miss")
   const upstream = REGISTRY_BASE + "/brands/resolve?domain=" + encodeURIComponent(domain);
+  let cached: { value: string | null; metadata: { fetched_at?: string; etag?: string } | null } = { value: null, metadata: null };
+  try {
+    cached = await env.SIGNALS_CACHE.getWithMetadata<{ fetched_at?: string; etag?: string }>(cacheKey, "text");
+  } catch { /* treat as full miss */ }
+
+  if (cached.value) {
+    const cachedBody = JSON.parse(cached.value) as Record<string, unknown>;
+    const fetchedAt = cached.metadata?.fetched_at;
+    const ageSec = fetchedAt
+      ? (Date.now() - Date.parse(fetchedAt)) / 1000
+      : Number.POSITIVE_INFINITY;
+
+    if (ageSec < RESOLVE_FRESH_SEC) {
+      return jsonResponse({ ...cachedBody, cache: "hit" });
+    }
+
+    // Soft-stale: revalidate via etag.
+    try {
+      const res = await fetchWithEtag(upstream, cached.metadata?.etag, 8000);
+      if (res.status === 304) {
+        // Body unchanged. Re-write KV with same body but bumped fetched_at
+        // so we don't keep re-validating on every request inside the
+        // 24h window.
+        const refreshedAt = new Date().toISOString();
+        try {
+          await env.SIGNALS_CACHE.put(cacheKey, cached.value, {
+            expirationTtl: RESOLVE_TTL_SEC,
+            metadata: { fetched_at: refreshedAt, etag: cached.metadata?.etag },
+          });
+        } catch { /* non-fatal */ }
+        return jsonResponse({ ...cachedBody, fetched_at: refreshedAt, cache: "swr-validated" });
+      }
+      if (res.status === 404) {
+        // Brand was removed upstream — fast-fail and let the KV expire naturally.
+        return errorResponse("BRAND_NOT_FOUND", `No brand found for domain '${domain}'`, 404);
+      }
+      if (res.ok) {
+        const body = (await res.json()) as BrandResolved;
+        const out = { ...body, fetched_at: new Date().toISOString(), cache: "swr-refresh" };
+        try {
+          const { cache: _c, ...store } = out;
+          void _c;
+          await env.SIGNALS_CACHE.put(cacheKey, JSON.stringify(store), {
+            expirationTtl: RESOLVE_TTL_SEC,
+            metadata: { fetched_at: out.fetched_at, etag: res.headers.get("etag") || undefined },
+          });
+        } catch { /* non-fatal */ }
+        return jsonResponse(out);
+      }
+      // Upstream non-ok during revalidation → fall through to stale fallback.
+      logger.warn("brand_resolve_revalidate_status", { status: res.status });
+    } catch (e) {
+      logger.warn("brand_resolve_revalidate_error", { error: String((e as Error).message || e) });
+    }
+    // Stale fallback — upstream had a problem, we still have a body.
+    return jsonResponse({ ...cachedBody, cache: "swr-stale-fallback" });
+  }
+
+  // Full miss path.
   let body: BrandResolved | null = null;
+  let etag: string | undefined;
   try {
     const res = await fetchWithTimeout(upstream, 8000);
     if (res.status === 404) {
-      // Don't cache 404s — brand might be added later. Fast-fail.
       return errorResponse("BRAND_NOT_FOUND", `No brand found for domain '${domain}'`, 404);
     }
     if (!res.ok) {
@@ -138,21 +214,19 @@ export async function handleBrandResolve(
       return errorResponse("UPSTREAM_ERROR", "Registry resolve failed: " + res.status, 502);
     }
     body = (await res.json()) as BrandResolved;
+    etag = res.headers.get("etag") || undefined;
   } catch (e) {
     logger.warn("brand_resolve_upstream_error", { error: String((e as Error).message || e) });
     return errorResponse("UPSTREAM_ERROR", "Registry unreachable", 502);
   }
 
-  const out = {
-    ...body,
-    fetched_at: new Date().toISOString(),
-    cache: "miss",
-  };
+  const out = { ...body, fetched_at: new Date().toISOString(), cache: "miss" };
   try {
     const { cache: _c, ...store } = out;
     void _c;
     await env.SIGNALS_CACHE.put(cacheKey, JSON.stringify(store), {
       expirationTtl: RESOLVE_TTL_SEC,
+      metadata: { fetched_at: out.fetched_at, etag },
     });
   } catch { /* non-fatal */ }
 

--- a/src/routes/demo.ts
+++ b/src/routes/demo.ts
@@ -1384,6 +1384,24 @@ ${STYLES}
              tool surface explicitly so the gap is visible by design.
              Three stacked cards mirror the spec's three task families. -->
         <div id="canvas-bottom" class="canvas-bottom" style="display:none">
+          <!-- Phase B: registry health strip. Live counts of registry
+               agents vs our hardcoded directory; flags new agents the
+               registry has that we don't yet have entries for. -->
+          <div class="canvas-registry-bar" id="canvas-registry-bar">
+            <span class="canvas-registry-label">Registry sync</span>
+            <span class="canvas-registry-stat" id="canvas-registry-agents">
+              <span class="orch-small">…</span>
+            </span>
+            <span class="canvas-registry-stat" id="canvas-registry-policies">
+              <span class="orch-small">…</span>
+            </span>
+            <span class="canvas-registry-stat" id="canvas-registry-brands">
+              <span class="orch-small">brands: passthrough</span>
+            </span>
+            <span class="canvas-registry-stat canvas-registry-stat-href">
+              <a class="orch-small" href="https://agenticadvertising.org/registry/" target="_blank" rel="noopener">agenticadvertising.org/registry ↗</a>
+            </span>
+          </div>
           <div class="canvas-spec-block">
             <div class="canvas-spec-header">
               <span class="canvas-spec-label">Governance + brand rights</span>
@@ -3117,6 +3135,31 @@ svg.ico path, svg.ico circle, svg.ico rect, svg.ico line { vector-effect: non-sc
 .dts-v { color: var(--text-dim); font-family: var(--font-mono); font-size: 11.5px; word-break: break-word; }
 .dts-v a { color: var(--accent); }
 
+/* Phase D: policy_attestations chips inside the DTS panel.
+   Visual layer below the IAB DTS v1.2 fields, surfacing the
+   provider's compliance claims against agentic-advertising
+   registry policies. Color-codes by claim type. */
+.dts-attest-group { border-color: var(--accent); }
+.dts-attest-list { display: flex; flex-direction: column; gap: 6px; }
+.dts-attest-row {
+  display: grid; grid-template-columns: 220px 90px 1fr;
+  gap: 10px; padding: 4px 0; align-items: center;
+  border-bottom: 1px dashed var(--border); font-size: 11.5px;
+}
+.dts-attest-row:last-child { border-bottom: none; }
+.dts-attest-id { color: var(--text-dim); }
+.dts-attest-claim {
+  font-size: 9.5px; padding: 1px 6px; border-radius: 3px;
+  border: 1px solid currentColor; text-align: center;
+  text-transform: uppercase; letter-spacing: 0.04em;
+}
+.dts-attest-compliant      { color: var(--success); background: rgba(102,187,106,0.10); }
+.dts-attest-exempt         { color: var(--text-dim); background: var(--bg-input); }
+.dts-attest-out-of-scope   { color: var(--text-mut); background: var(--bg-input); }
+.dts-attest-not-applicable { color: var(--text-mut); background: var(--bg-input); }
+.dts-attest-unknown        { color: var(--warning, #d4a017); background: rgba(212,160,23,0.08); }
+.dts-attest-note { color: var(--text-mut); font-size: 11px; line-height: 1.35; }
+
 /* ── Activations ─────────────────────────────────────────────────────── */
 .activations-controls { display: flex; gap: 8px; align-items: center; }
 .status-dot.submitted { background: var(--text-mut); }
@@ -4699,6 +4742,64 @@ textarea.lab-input { resize: vertical; line-height: 1.5; }
   color: var(--warning, #d4a017); border-top-color: var(--warning, #d4a017);
   display: flex; align-items: flex-start; gap: 5px;
 }
+
+/* Phase C: policy hits row on the brand card. Each chip = one
+   applicable policy from the agentic-advertising registry,
+   matched on brand industries. Color codes: red = must
+   regulation, amber = must standard, muted = should. */
+.canvas-policy-row {
+  margin-top: 10px; padding: 8px 0;
+  border-top: 1px solid var(--border);
+  border-bottom: 1px solid var(--border);
+}
+.canvas-policy-chips {
+  display: flex; flex-wrap: wrap; gap: 6px; margin-top: 4px;
+}
+.canvas-policy-chip {
+  display: inline-flex; align-items: center; gap: 5px;
+  padding: 3px 7px; border-radius: 4px; font-size: 11px;
+  background: var(--bg-raised); border: 1px solid var(--border);
+  cursor: help;
+}
+.canvas-policy-chip.canvas-policy-must  { border-color: var(--error); }
+.canvas-policy-chip.canvas-policy-should { border-color: var(--warning, #d4a017); }
+.canvas-policy-cat {
+  font-size: 8.5px; padding: 1px 4px; border-radius: 2px;
+  font-weight: 600; letter-spacing: 0.04em;
+}
+.canvas-policy-cat.canvas-policy-reg { background: var(--error); color: #000; }
+.canvas-policy-cat.canvas-policy-std { background: var(--accent); color: #000; }
+.canvas-policy-name { color: var(--text); }
+.canvas-policy-enf {
+  font-size: 9px; color: var(--text-mut);
+  text-transform: uppercase; letter-spacing: 0.05em;
+}
+
+/* Phase B: registry health bar. Strip across canvas-bottom showing
+   how stale our local view of the registry is (agents + policies
+   + brands). Click-through to upstream registry. */
+.canvas-registry-bar {
+  display: flex; align-items: center; gap: 14px; flex-wrap: wrap;
+  padding: 8px 12px; margin-bottom: 8px;
+  background: var(--bg-input); border: 1px solid var(--border);
+  border-radius: 5px; font-size: 11px;
+}
+.canvas-registry-label {
+  font-size: 10px; color: var(--text-mut);
+  text-transform: uppercase; letter-spacing: 0.06em;
+}
+.canvas-registry-stat { color: var(--text-dim); }
+.canvas-registry-stat .registry-pill {
+  display: inline-block; padding: 1px 6px; border-radius: 3px;
+  background: var(--bg-raised); border: 1px solid var(--border);
+  font-family: var(--font-mono); font-size: 10.5px;
+  margin-left: 4px;
+}
+.canvas-registry-stat .registry-pill-new {
+  border-color: var(--accent); color: var(--accent);
+}
+.canvas-registry-stat-href { margin-left: auto; }
+.canvas-registry-stat-href a { color: var(--accent); }
 
 .canvas-brand-actions {
   display: flex; align-items: center; gap: 12px; flex-wrap: wrap;
@@ -8516,6 +8617,28 @@ function renderDtsLabel(dts) {
     },
   ];
 
+  // Phase D: optional policy_attestations row, rendered as a chip block
+  // BELOW the standard DTS groups. Each chip = one policy claim. Color
+  // codes by claim type so a buyer can read trust posture at a glance.
+  var attestations = Array.isArray(dts.policy_attestations) ? dts.policy_attestations : [];
+  var attestBlock = "";
+  if (attestations.length > 0) {
+    attestBlock = '<div class="dts-group dts-attest-group">' +
+      '<div class="dts-group-title">Policy attestations <span class="pill pill-muted mono" style="font-size:9px;margin-left:6px">DTS v1.3 proposal</span></div>' +
+      '<div class="dts-attest-list">' +
+        attestations.map(function (a) {
+          var cls = "dts-attest-" + (a.claim || "unknown").replace(/_/g, "-");
+          var notes = a.notes ? '<span class="dts-attest-note">' + escapeHtml(a.notes) + '</span>' : '';
+          return '<div class="dts-attest-row">' +
+            '<span class="mono dts-attest-id">' + escapeHtml(a.policy_id || "?") + '</span>' +
+            '<span class="dts-attest-claim ' + escapeHtml(cls) + ' mono">' + escapeHtml(a.claim || "unknown") + '</span>' +
+            notes +
+          '</div>';
+        }).join("") +
+      '</div>' +
+    '</div>';
+  }
+
   return '<div class="dts-groups">' +
     groups.map((g) => {
       const rows = g.rows.filter(([, v]) => v != null && v !== "");
@@ -8531,6 +8654,7 @@ function renderDtsLabel(dts) {
           '</div>' +
         '</div>';
     }).join("") +
+    attestBlock +
     '</div>';
 }
 
@@ -13008,6 +13132,8 @@ async function _canvasResolveBrand(domain) {
     if (bottom) bottom.style.display = "";
     var loopArrow = document.getElementById("canvas-loop-arrow");
     if (loopArrow) loopArrow.style.display = "";
+    // Phase B: hydrate registry-status bar (lazy, only on first canvas open).
+    _canvasFillRegistryBar();
   } catch (e) {
     card.innerHTML = '<div class="empty-state" style="border-color:var(--error)"><div class="empty-title" style="color:var(--error)">' + escapeHtml(String(e.message || e)) + '</div></div>';
   }
@@ -13116,6 +13242,17 @@ function _canvasRenderBrandCard(data) {
         '</div>' +
       '</div>' +
       classNote +
+      // Phase C: applicable policies, matched on brand industries.
+      // Slot is filled async after /registry/policies resolves —
+      // until then it shows a "loading" placeholder.
+      '<div class="canvas-policy-row" id="canvas-policy-row" data-industries="' +
+        escapeHtml(uniqInd.join(",")) +
+      '">' +
+        '<div class="canvas-brand-label">Policy hits</div>' +
+        '<div class="canvas-policy-chips" id="canvas-policy-chips">' +
+          '<span class="orch-small">checking applicable policies…</span>' +
+        '</div>' +
+      '</div>' +
       // Phase 2: Run workflow button. Auto-derives a brief from the brand.
       '<div class="canvas-brand-actions">' +
         '<button class="btn-primary canvas-run-btn" id="canvas-run-btn">' +
@@ -13146,6 +13283,89 @@ function _canvasRenderBrandCard(data) {
     logoImg.addEventListener("error", function () {
       logoImg.style.display = "none";
       logoFallback.style.display = "";
+    });
+  }
+
+  // Phase C: hydrate the policy-hits row. Fetch /registry/policies once
+  // (snapshot is small, ~14 entries) and match on brand industries.
+  _canvasFillPolicyHits(uniqInd);
+}
+
+// Phase C: in-page policy cache + hits resolver.
+var _canvasPoliciesCache = null;
+
+async function _canvasFillPolicyHits(industries) {
+  var chips = document.getElementById("canvas-policy-chips");
+  if (!chips) return;
+  try {
+    if (!_canvasPoliciesCache) {
+      var r = await fetch("/registry/policies");
+      var data = await r.json();
+      _canvasPoliciesCache = Array.isArray(data.policies) ? data.policies : [];
+    }
+  } catch (e) {
+    chips.innerHTML = '<span class="orch-small" style="color:var(--text-mut)">policy registry unreachable</span>';
+    return;
+  }
+  // Match: brand industry overlaps policy.industries_inferred,
+  // OR policy is industries_inferred=["all"] (catch-alls like GDPR, CSBS).
+  var indNorm = (industries || []).map(function (i) { return String(i || "").toLowerCase(); });
+  var hits = _canvasPoliciesCache.filter(function (p) {
+    var inf = (p.industries_inferred || []).map(function (s) { return String(s).toLowerCase(); });
+    if (inf.indexOf("all") >= 0) return true;
+    return inf.some(function (i) { return indNorm.indexOf(i) >= 0; });
+  });
+  if (hits.length === 0) {
+    chips.innerHTML = '<span class="orch-small" style="color:var(--text-mut)">no specific industry policies; CSBS + GDPR baseline still applies</span>';
+    return;
+  }
+  // Sort: must regulations > must standards > should
+  hits.sort(function (a, b) {
+    var sa = (a.enforcement === "must" ? 0 : a.enforcement === "should" ? 1 : 2)
+           + (a.category === "regulation" ? 0 : 0.5);
+    var sb = (b.enforcement === "must" ? 0 : b.enforcement === "should" ? 1 : 2)
+           + (b.category === "regulation" ? 0 : 0.5);
+    return sa - sb;
+  });
+  chips.innerHTML = hits.map(function (p) {
+    var enfClass = "canvas-policy-" + p.enforcement;
+    var catBadge = p.category === "regulation"
+      ? '<span class="canvas-policy-cat canvas-policy-reg mono">REG</span>'
+      : '<span class="canvas-policy-cat canvas-policy-std mono">STD</span>';
+    return '<span class="canvas-policy-chip ' + enfClass + '" title="' + escapeHtml(p.description) + ' (' + escapeHtml(p.region) + ')">' +
+      catBadge +
+      '<span class="canvas-policy-name">' + escapeHtml(p.name) + '</span>' +
+      '<span class="canvas-policy-enf mono">' + escapeHtml(p.enforcement) + '</span>' +
+    '</span>';
+  }).join("");
+}
+
+// Phase B: hydrate registry-status bar. One-shot, idempotent — silently
+// no-ops if the bar element isn't on the page (Orchestrator tab, etc.).
+var _canvasRegistryBarFilled = false;
+async function _canvasFillRegistryBar() {
+  if (_canvasRegistryBarFilled) return;
+  _canvasRegistryBarFilled = true;
+  var agentsEl = document.getElementById("canvas-registry-agents");
+  var policiesEl = document.getElementById("canvas-registry-policies");
+  if (agentsEl) {
+    fetch("/registry/agents").then(function (r) { return r.json(); }).then(function (d) {
+      var c = d.counts || {};
+      var newCount = c.only_in_registry || 0;
+      agentsEl.innerHTML =
+        'agents: <span class="registry-pill">' + (c.registry || 0) + ' upstream</span>' +
+        ' <span class="registry-pill">' + (c.local || 0) + ' local</span>' +
+        (newCount > 0 ? ' <span class="registry-pill registry-pill-new">+' + newCount + ' new</span>' : '');
+    }).catch(function () {
+      agentsEl.innerHTML = '<span class="orch-small">agents: registry unreachable</span>';
+    });
+  }
+  if (policiesEl) {
+    fetch("/registry/policies").then(function (r) { return r.json(); }).then(function (d) {
+      policiesEl.innerHTML =
+        'policies: <span class="registry-pill">' + (d.count || 0) + ' (local snapshot)</span>';
+    }).catch(function () {
+      policiesEl.innerHTML = '<span class="orch-small">policies: snapshot read failed</span>';
     });
   }
 }

--- a/src/routes/demo.ts
+++ b/src/routes/demo.ts
@@ -1387,13 +1387,19 @@ ${STYLES}
           <div class="canvas-spec-block">
             <div class="canvas-spec-header">
               <span class="canvas-spec-label">Governance + brand rights</span>
-              <span class="pill pill-warning mono" style="font-size:10px">AdCP 3.0 spec'd · no live impl</span>
+              <span class="pill pill-warning mono" style="font-size:10px">AdCP 3.0.1 spec'd · no live impl</span>
             </div>
             <div class="canvas-spec-body">
               <div class="canvas-spec-card">
                 <div class="canvas-spec-card-name mono">check_governance</div>
-                <div class="canvas-spec-card-shape orch-small">in: <code>{plan, brand: BrandRef}</code> · out: <code>{decision, audit_log_url, requires_human_review?}</code></div>
+                <div class="canvas-spec-card-shape orch-small">in: <code>{plan, brand: BrandRef}</code> · out: <code>{decision, mode, audit_log_url, requires_human_review?}</code></div>
                 <div class="canvas-spec-card-note orch-small">would gate alcohol / pharma / lending / housing for regulated brands. Runs BEFORE create_media_buy.</div>
+                <div class="canvas-gov-mode-row" title="enforcement posture surfaced via the mode field on check-governance-response (added in AdCP 3.0.1)">
+                  <span class="canvas-gov-mode-label orch-small">mode:</span>
+                  <span class="canvas-gov-mode-pill canvas-gov-mode-enforce mono" title="check is active and BLOCKS non-compliant plans">enforce</span>
+                  <span class="canvas-gov-mode-pill canvas-gov-mode-advisory mono" title="check returns a recommendation but does NOT block">advisory</span>
+                  <span class="canvas-gov-mode-pill canvas-gov-mode-audit mono" title="check is logged for audit only — no decision returned">audit</span>
+                </div>
               </div>
               <div class="canvas-spec-card">
                 <div class="canvas-spec-card-name mono">get_rights · acquire_rights · update_rights</div>
@@ -4760,6 +4766,26 @@ textarea.lab-input { resize: vertical; line-height: 1.5; }
 }
 .canvas-spec-card-note { color: var(--text-mut); line-height: 1.4; }
 .canvas-spec-card-note strong { color: var(--text); }
+
+/* AdCP 3.0.1: mode swatch on check_governance card.
+   Visual strawman of the enforcement-posture options surfaced by the
+   new mode response field. Workshop trust-contract teaching moment:
+   is your governance call actually gating, or just telemetry? */
+.canvas-gov-mode-row {
+  display: flex; align-items: center; gap: 6px; flex-wrap: wrap;
+  margin-top: 6px; padding-top: 6px;
+  border-top: 1px dashed var(--border);
+}
+.canvas-gov-mode-label {
+  color: var(--text-mut); font-size: 10px;
+}
+.canvas-gov-mode-pill {
+  font-size: 9.5px; padding: 1px 6px; border-radius: 3px;
+  border: 1px solid currentColor; cursor: help;
+}
+.canvas-gov-mode-enforce  { color: var(--error); background: rgba(239,83,80,0.08); }
+.canvas-gov-mode-advisory { color: var(--warning, #d4a017); background: rgba(212,160,23,0.08); }
+.canvas-gov-mode-audit    { color: var(--text-dim); background: var(--bg-input); }
 
 /* Phase 4: view-mode toggle (Pattern C/B/A). */
 .canvas-viewmodes {

--- a/src/routes/registryRoutes.ts
+++ b/src/routes/registryRoutes.ts
@@ -1,0 +1,138 @@
+// src/routes/registryRoutes.ts
+//
+// Phase B + C of the agentic-advertising registry integration:
+//
+//   GET  /registry/agents    — passthrough + KV cache of /api/registry/agents
+//                              (no live policy applied; the orchestrator still
+//                              uses src/domain/agentRegistry.ts as the source
+//                              of truth — this view is informational, used by
+//                              the Canvas to surface "what does the registry
+//                              actually have today vs what we know")
+//
+//   GET  /registry/policies  — serves the local snapshot from
+//                              src/domain/policyRegistry.ts. As of 2026-04-29
+//                              the upstream `/api/registry/policies` endpoint
+//                              returns 404; when it ships, this handler
+//                              becomes a passthrough (and the snapshot
+//                              becomes a fallback / seed).
+//
+// Both endpoints are unauth — same posture as the public registry.
+
+import type { Env } from "../types/env";
+import type { Logger } from "../utils/logger";
+import { jsonResponse, errorResponse } from "./shared";
+import { POLICIES } from "../domain/policyRegistry";
+import { AGENT_REGISTRY } from "../domain/agentRegistry";
+
+const REGISTRY_AGENTS_URL = "https://agenticadvertising.org/api/registry/agents";
+const AGENTS_TTL_SEC = 3600;          // 1 hour — registry doesn't change fast
+const AGENTS_KEY = "registry_agents:v1";
+
+interface RegistryAgentEntry {
+  name: string;
+  url?: string;
+  type?: string;
+  protocol?: string;
+  description?: string;
+  mcp_endpoint?: string;
+  contact?: { name?: string; email?: string; website?: string };
+  added_date?: string;
+  source?: string;
+  member?: { slug?: string; display_name?: string };
+}
+
+// ── /registry/agents ────────────────────────────────────────────────────────
+
+export async function handleRegistryAgents(
+  _request: Request,
+  env: Env,
+  logger: Logger,
+): Promise<Response> {
+  // Try KV first
+  try {
+    const cached = await env.SIGNALS_CACHE.get(AGENTS_KEY, "json");
+    if (cached) {
+      return jsonResponse({ ...(cached as object), cache: "hit" });
+    }
+  } catch { /* fall through */ }
+
+  let payload: { agents?: RegistryAgentEntry[] } = { agents: [] };
+  try {
+    const res = await fetch(REGISTRY_AGENTS_URL, {
+      signal: AbortSignal.timeout(8000),
+      headers: { Accept: "application/json" },
+    });
+    if (!res.ok) {
+      logger.warn("registry_agents_upstream_status", { status: res.status });
+      return errorResponse("UPSTREAM_ERROR", "Registry agents fetch failed: " + res.status, 502);
+    }
+    payload = (await res.json()) as { agents?: RegistryAgentEntry[] };
+  } catch (e) {
+    logger.warn("registry_agents_upstream_error", { error: String((e as Error).message || e) });
+    return errorResponse("UPSTREAM_ERROR", "Registry unreachable", 502);
+  }
+
+  const remote = payload.agents ?? [];
+  const remoteByMcp = new Map<string, RegistryAgentEntry>();
+  for (const a of remote) {
+    const key = (a.mcp_endpoint || a.url || "").trim();
+    if (key) remoteByMcp.set(key, a);
+  }
+
+  // Diff: agents in registry that we don't have, agents we have that the
+  // registry doesn't list. Used by the Canvas to render a freshness badge.
+  const localMcpSet = new Set(
+    AGENT_REGISTRY.map((a) => a.mcp_url).filter((u): u is string => !!u),
+  );
+  const onlyInRegistry = remote.filter((a) => {
+    const key = (a.mcp_endpoint || a.url || "").trim();
+    return key && !localMcpSet.has(key);
+  }).map((a) => ({ name: a.name, mcp_url: a.mcp_endpoint || a.url, added_date: a.added_date }));
+
+  const onlyInLocal = AGENT_REGISTRY
+    .filter((a) => a.mcp_url && !remoteByMcp.has(a.mcp_url))
+    .map((a) => ({ id: a.id, name: a.name, mcp_url: a.mcp_url, role: a.role, stage: a.stage }));
+
+  const out = {
+    fetched_at: new Date().toISOString(),
+    cache: "miss",
+    counts: {
+      registry: remote.length,
+      local: AGENT_REGISTRY.length,
+      only_in_registry: onlyInRegistry.length,
+      only_in_local: onlyInLocal.length,
+    },
+    only_in_registry: onlyInRegistry,
+    only_in_local: onlyInLocal,
+    agents: remote,
+  };
+
+  try {
+    const { cache: _c, ...store } = out;
+    void _c;
+    await env.SIGNALS_CACHE.put(AGENTS_KEY, JSON.stringify(store), {
+      expirationTtl: AGENTS_TTL_SEC,
+    });
+  } catch { /* non-fatal */ }
+
+  return jsonResponse(out);
+}
+
+// ── /registry/policies ──────────────────────────────────────────────────────
+
+export async function handleRegistryPolicies(
+  _request: Request,
+  _env: Env,
+  _logger: Logger,
+): Promise<Response> {
+  // Local snapshot — see src/domain/policyRegistry.ts header for sourcing.
+  // When upstream API lands, switch to passthrough + cache (mirror
+  // brandRegistry.ts pattern) and keep this snapshot as fallback.
+  return jsonResponse({
+    source: "local_snapshot",
+    snapshot_date: "2026-04-29",
+    upstream_status: "404 — /api/registry/policies not yet implemented",
+    count: POLICIES.length,
+    policies: POLICIES,
+  });
+}

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -323,6 +323,41 @@ export interface DtsV12Label {
   onboarder_audience_expansion: "Yes" | "No" | "N/A";
   onboarder_device_expansion: "Yes" | "No" | "N/A";
   onboarder_audience_precision_level: string; // "N/A" for non-offline sources
+
+  // ── Phase D extension: policy attestations ─────────────────────────────
+  // NOT in IAB DTS v1.2; proposed for v1.3 (or out-of-band sidecar).
+  // Bridges the IAB content-trust layer (provenance / consent / freshness /
+  // coverage) into the AdCP governance layer by letting a signal declare
+  // WHICH agentic-advertising registry policies it claims compliance with.
+  // Policy ids match the slugs in src/domain/policyRegistry.ts.
+  policy_attestations?: PolicyAttestation[];
+}
+
+/**
+ * One policy claim by the signal provider. Phase D extension.
+ *
+ * Layering:
+ *   - IAB DTS = "what is this audience, where did it come from"
+ *     (provenance/consent/freshness/coverage)
+ *   - AdCP `check_governance` = "is using this audience for THIS plan
+ *     allowed under THIS brand's policy stack" (3.0.1 added the
+ *     `mode` field for enforcement posture)
+ *   - `PolicyAttestation` = the SIGNAL's own claim about which policies
+ *     it adheres to, regardless of plan/brand. Lets `check_governance`
+ *     short-circuit when the signal pre-attests to relevant policies,
+ *     and lets a buyer reject a signal that's silent on a `must` policy.
+ *
+ * `evidence_url` should point to a stable doc — runbook, audit log,
+ * compliance attestation page. We don't validate the URL contents
+ * here; consumers do.
+ */
+export interface PolicyAttestation {
+  policy_id: string;                        // matches RegistryPolicy.policy_id
+  claim: "compliant" | "exempt" | "out_of_scope" | "not_applicable" | "unknown";
+  attested_at: string;                      // ISO-8601 timestamp
+  attestor: string;                         // who attested (org name)
+  evidence_url?: string;                    // link to attestation evidence
+  notes?: string;                           // free text, ≤ 280 chars
 }
 
 // ── Errors ────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Anchors orchestration on the agentic-advertising registry as a source of truth. Four phases shipped in one PR because they share endpoints, types, and Canvas surfaces.

| Phase | What | Where |
|---|---|---|
| **A** — Brand cache SWR | 1h fresh → 24h hard TTL, conditional GET via \`If-None-Match\`, stale-fallback on upstream error | \`src/routes/brandRegistry.ts\` |
| **B** — Agents passthrough | \`/registry/agents\` proxy + diff vs hardcoded \`AGENT_REGISTRY\`; Canvas "Registry sync" bar with +N new pill | \`src/routes/registryRoutes.ts\`, \`src/routes/demo.ts\` |
| **C** — Policies snapshot + matcher | 14 policies mirrored locally (upstream \`/api/registry/policies\` is still 404); brand→policies matcher; Canvas "Policy hits" chip row | \`src/domain/policyRegistry.ts\`, \`src/routes/registryRoutes.ts\`, \`src/routes/demo.ts\` |
| **D** — DTS \`policy_attestations\[\]\` | Optional v1.3 extension on \`DtsV12Label\`; emits 8 demo claims; rendered as color-coded chips in DTS panel | \`src/types/api.ts\`, \`src/mappers/signalMapper.ts\`, \`src/routes/demo.ts\` |

**Workshop angle (Phase D):** trust contract = DTS coverage *plus* policy attestation. The signal declares its own compliance posture against agentic-advertising registry policies, separate from plan-time \`check_governance\`. A buyer can pre-filter signals on attestation gaps before incurring the governance round-trip.

Also drops \`adcontextprotocol/adcp-client#1036\` from watcher \`tracked_issues\` (merged + closed; was sitting as terminal state).

## Test plan
- [x] \`npm run type-check\` — clean for production src
- [x] \`npm test\` — 428/428 pass
- [x] \`tmp-mining/trap_audit.py\` — 0 SCRIPT_TAG escape traps
- [ ] Smoke: \`/registry/agents\` returns counts + diff
- [ ] Smoke: \`/registry/policies\` returns 14 entries
- [ ] Canvas: brand card shows policy hits row + DTS panel shows attestation chips
- [ ] Canvas: registry-sync bar populated post-brand-resolve
- [ ] SWR: hit \`/brands/resolve?domain=cocacola.com\` twice within 1h (cache: hit), wait 1h+, hit again (cache: swr-validated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)