### PR TITLE
Registry diff: URL normalization + backfill 3 net-new vendors

### DIFF
--- a/src/domain/agentRegistry.ts
+++ b/src/domain/agentRegistry.ts
@@ -175,6 +175,45 @@ export const AGENT_REGISTRY: RegisteredAgent[] = [
     protocols: ["adcp_3.0", "mcp_streamable_http"],
     directory_tool_count: 8,
   },
+  // ── Backfilled from /api/registry/agents diff (2026-04-29) ──────────
+  // Three vendors that appeared upstream after our hardcoded snapshot
+  // froze. Marked stage="live" because registry-side metadata says so;
+  // not yet probed live by us — first orchestrator run will discover
+  // their actual tool surface. Specialties are best-guess from vendor
+  // domain reputation; refine when a probe response comes back.
+  {
+    id: "setupad_gatavocom",
+    name: "Setupad — Gatavo.com deployment",
+    vendor: "Setupad",
+    mcp_url: "https://gatavocom.sales-agent.setupad.ai",
+    stage: "live",
+    role: "buying",
+    protocols: ["adcp_3.0", "mcp_streamable_http"],
+    specialties: ["programmatic_yield_management", "header_bidding"],
+    notes: "Backfilled from registry diff 2026-04-29 (added_date 2026-04-28). Tool count TBD — discovery on first orchestrator run.",
+  },
+  {
+    id: "setupad_wheelrandom",
+    name: "Setupad — WheelRandom deployment",
+    vendor: "Setupad",
+    mcp_url: "https://wheelrandom.sales-agent.setupad.ai",
+    stage: "live",
+    role: "buying",
+    protocols: ["adcp_3.0", "mcp_streamable_http"],
+    specialties: ["programmatic_yield_management", "header_bidding"],
+    notes: "Backfilled from registry diff 2026-04-29 (added_date 2026-04-28). Same Setupad platform as gatavocom; second tenant.",
+  },
+  {
+    id: "mamamia",
+    name: "Mamamia",
+    vendor: "Mamamia",
+    mcp_url: "https://agent.mamamia.com.au",
+    stage: "live",
+    role: "buying",
+    protocols: ["adcp_3.0", "mcp_streamable_http"],
+    specialties: ["womens_media", "publisher_direct", "au_market"],
+    notes: "Backfilled from registry diff 2026-04-29 (added_date 2026-04-28). Australian publisher direct sales agent.",
+  },
   // ── Known-issue agents (skipped on probe-all) ─────────────────────────
   {
     id: "bidcliq",

--- a/src/routes/demo.ts
+++ b/src/routes/demo.ts
@@ -3135,12 +3135,19 @@ svg.ico path, svg.ico circle, svg.ico rect, svg.ico line { vector-effect: non-sc
 .dts-v { color: var(--text-dim); font-family: var(--font-mono); font-size: 11.5px; word-break: break-word; }
 .dts-v a { color: var(--accent); }
 
-/* Phase D: policy_attestations chips inside the DTS panel.
-   Visual layer below the IAB DTS v1.2 fields, surfacing the
-   provider's compliance claims against agentic-advertising
-   registry policies. Color-codes by claim type. */
-.dts-attest-group { border-color: var(--accent); }
-.dts-attest-list { display: flex; flex-direction: column; gap: 6px; }
+/* Phase D: policy_attestations sub-section nested INSIDE the
+   Privacy & compliance group. Separated from the IAB kv-list above
+   by a faint divider + subhead, so the two layers (IAB DTS v1.2
+   fields + agentic-advertising registry attestations) read as one
+   coherent compliance block instead of two redundant siblings. */
+.dts-attest-subhead {
+  margin-top: 12px; padding-top: 10px;
+  border-top: 1px dashed var(--border);
+  font-size: 10.5px; color: var(--accent);
+  text-transform: uppercase; letter-spacing: 0.06em;
+  font-weight: 600;
+}
+.dts-attest-list { display: flex; flex-direction: column; gap: 6px; margin-top: 8px; }
 .dts-attest-row {
   display: grid; grid-template-columns: 220px 90px 1fr;
   gap: 10px; padding: 4px 0; align-items: center;
@@ -8599,14 +8606,6 @@ function renderDtsLabel(dts) {
       ],
     },
     {
-      title: "Privacy & compliance",
-      rows: [
-        ["Privacy mechanisms", Array.isArray(dts.privacy_compliance_mechanisms) ? dts.privacy_compliance_mechanisms.join(", ") : null],
-        ["Privacy policy", dts.privacy_policy_url ? '<a href="' + escapeHtml(dts.privacy_policy_url) + '" target="_blank" rel="noopener">' + escapeHtml(dts.privacy_policy_url) + "</a>" : null],
-        ["IAB Tech Lab compliant", dts.iab_techlab_compliant],
-      ],
-    },
-    {
       title: "Onboarder (offline sources)",
       rows: [
         ["Match keys", dts.onboarder_match_keys],
@@ -8617,14 +8616,22 @@ function renderDtsLabel(dts) {
     },
   ];
 
-  // Phase D: optional policy_attestations row, rendered as a chip block
-  // BELOW the standard DTS groups. Each chip = one policy claim. Color
-  // codes by claim type so a buyer can read trust posture at a glance.
+  // Phase D refinement: the IAB DTS "Privacy & compliance" group AND the
+  // policy_attestations are the same conceptual layer (provider's
+  // compliance posture) — just at different granularities. The IAB
+  // fields describe HOW consent is honored (TCF / GPP / MSPA channels);
+  // attestations describe WHICH agentic-advertising registry policies
+  // the signal claims compliance with. Rendered as one group with the
+  // attestations as a sub-section, instead of two sibling blocks
+  // (which read as redundant).
   var attestations = Array.isArray(dts.policy_attestations) ? dts.policy_attestations : [];
-  var attestBlock = "";
+  var attestSubBlock = "";
   if (attestations.length > 0) {
-    attestBlock = '<div class="dts-group dts-attest-group">' +
-      '<div class="dts-group-title">Policy attestations <span class="pill pill-muted mono" style="font-size:9px;margin-left:6px">DTS v1.3 proposal</span></div>' +
+    attestSubBlock =
+      '<div class="dts-attest-subhead">' +
+        'Policy attestations ' +
+        '<span class="pill pill-muted mono" style="font-size:9px;margin-left:6px">DTS v1.3 proposal · agentic-advertising registry</span>' +
+      '</div>' +
       '<div class="dts-attest-list">' +
         attestations.map(function (a) {
           var cls = "dts-attest-" + (a.claim || "unknown").replace(/_/g, "-");
@@ -8635,9 +8642,32 @@ function renderDtsLabel(dts) {
             notes +
           '</div>';
         }).join("") +
-      '</div>' +
-    '</div>';
+      '</div>';
   }
+
+  // Privacy + compliance group is rendered manually so we can interleave
+  // the IAB kv-list with the attestation sub-block underneath it.
+  var privacyKv = [
+    ["Privacy mechanisms", Array.isArray(dts.privacy_compliance_mechanisms) ? dts.privacy_compliance_mechanisms.join(", ") : null],
+    ["Privacy policy", dts.privacy_policy_url ? '<a href="' + escapeHtml(dts.privacy_policy_url) + '" target="_blank" rel="noopener">' + escapeHtml(dts.privacy_policy_url) + "</a>" : null],
+    ["IAB Tech Lab compliant", dts.iab_techlab_compliant],
+  ].filter(function (r) { return r[1] != null && r[1] !== ""; });
+
+  var privacyBlock = (privacyKv.length || attestSubBlock)
+    ? '<div class="dts-group">' +
+        '<div class="dts-group-title">Privacy &amp; compliance</div>' +
+        (privacyKv.length
+          ? '<div class="dts-kv-list">' +
+              privacyKv.map(function (r) {
+                var k = r[0], v = r[1];
+                var val = typeof v === "string" && v.indexOf("<a ") === 0 ? v : escapeHtml(String(v));
+                return '<div class="dts-kv"><span class="dts-k">' + escapeHtml(k) + '</span><span class="dts-v">' + val + '</span></div>';
+              }).join("") +
+            '</div>'
+          : '') +
+        attestSubBlock +
+      '</div>'
+    : '';
 
   return '<div class="dts-groups">' +
     groups.map((g) => {
@@ -8654,7 +8684,7 @@ function renderDtsLabel(dts) {
           '</div>' +
         '</div>';
     }).join("") +
-    attestBlock +
+    privacyBlock +
     '</div>';
 }
 

--- a/src/routes/registryRoutes.ts
+++ b/src/routes/registryRoutes.ts
@@ -72,25 +72,40 @@ export async function handleRegistryAgents(
     return errorResponse("UPSTREAM_ERROR", "Registry unreachable", 502);
   }
 
+  // Normalize URLs so trailing-slash drift doesn't show as a diff.
+  // Registry sometimes lists "/mcp" and "/mcp/" as separate entries
+  // (e.g. Claire scope3 appears under BOTH variants); we don't want
+  // to flag them as 2 missing agents when we already have one entry.
+  const normalize = (u: string | undefined): string => {
+    if (!u) return "";
+    let v = u.trim().replace(/\/+$/, "");           // drop trailing slash(es)
+    v = v.replace(/\/mcp$/, "");                     // drop /mcp suffix for canonical compare
+    return v.toLowerCase();
+  };
+
   const remote = payload.agents ?? [];
   const remoteByMcp = new Map<string, RegistryAgentEntry>();
   for (const a of remote) {
-    const key = (a.mcp_endpoint || a.url || "").trim();
-    if (key) remoteByMcp.set(key, a);
+    const key = normalize(a.mcp_endpoint || a.url);
+    if (key && !remoteByMcp.has(key)) remoteByMcp.set(key, a);
   }
 
   // Diff: agents in registry that we don't have, agents we have that the
   // registry doesn't list. Used by the Canvas to render a freshness badge.
   const localMcpSet = new Set(
-    AGENT_REGISTRY.map((a) => a.mcp_url).filter((u): u is string => !!u),
+    AGENT_REGISTRY.map((a) => normalize(a.mcp_url ?? undefined)).filter((u) => !!u),
   );
-  const onlyInRegistry = remote.filter((a) => {
-    const key = (a.mcp_endpoint || a.url || "").trim();
-    return key && !localMcpSet.has(key);
-  }).map((a) => ({ name: a.name, mcp_url: a.mcp_endpoint || a.url, added_date: a.added_date }));
+  const seenInRegistry = new Set<string>();
+  const onlyInRegistry: Array<{ name: string; mcp_url: string | undefined; added_date: string | undefined }> = [];
+  for (const a of remote) {
+    const key = normalize(a.mcp_endpoint || a.url);
+    if (!key || localMcpSet.has(key) || seenInRegistry.has(key)) continue;
+    seenInRegistry.add(key);
+    onlyInRegistry.push({ name: a.name, mcp_url: a.mcp_endpoint || a.url, added_date: a.added_date });
+  }
 
   const onlyInLocal = AGENT_REGISTRY
-    .filter((a) => a.mcp_url && !remoteByMcp.has(a.mcp_url))
+    .filter((a) => a.mcp_url && !remoteByMcp.has(normalize(a.mcp_url)))
     .map((a) => ({ id: a.id, name: a.name, mcp_url: a.mcp_url, role: a.role, stage: a.stage }));
 
   const out = {


### PR DESCRIPTION
## Summary

The \`/registry/agents\` diff was over-reporting: 7 \"only_in_registry\" entries broke down as **4 URL drift + 3 genuine new vendors**.

### URL drift (now collapsed via normalization)
- Celtra: registry has \`/mcp/\`, we have \`/mcp\`
- Claire scope3: registry lists BOTH \`/\` and \`/mcp\` variants (we have one)
- Content Ignite: registry has bare root, we have \`/mcp/\` (intentional — bare root doesn't respond)

Fix: strip trailing slashes + \`/mcp\` suffix before set comparison; dedupe within the registry side.

### Genuine new vendors (now backfilled into \`AGENT_REGISTRY\`)
- **Setupad — gatavocom** (\`https://gatavocom.sales-agent.setupad.ai\`)
- **Setupad — wheelrandom** (same platform, second tenant)
- **Mamamia** (AU publisher direct sales — \`https://agent.mamamia.com.au\`)

All marked \`stage: \"live\"\`, best-guess specialties from vendor reputation, notes documenting backfill provenance. Tool surface TBD until first orchestrator probe.

## Effect on Canvas
Registry-sync bar should now read **22 / 22 / 0 new** instead of 22 / 19 / +7 — matches reality (registry and our directory are in sync; the 7 was URL-noise + missed entries).

## Test plan
- [x] Type-check clean
- [x] 428/428 tests pass
- [ ] Smoke after deploy: \`/registry/agents\` returns \`only_in_registry: 0\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)