### PR TITLE
Brand industry enrichment: pattern overrides for coarse registry taxonomy

### DIFF
--- a/src/domain/brandIndustryOverrides.ts
+++ b/src/domain/brandIndustryOverrides.ts
@@ -1,0 +1,145 @@
+// src/domain/brandIndustryOverrides.ts
+//
+// The agentic-advertising registry's industry taxonomy is COARSE.
+// Many brands miss obvious tags:
+//   - Pfizer  → tagged "Heavy Industry and Engineering" (no "pharma")
+//   - Heineken→ tagged "Food and Drink" (no "alcohol" or "beer")
+//   - DraftKings, lego, etc. — frequently absent from search
+//
+// This drops policy-matching (Phase C), governance preview (MVP #2),
+// and brand-rights inference (Refinement C) at the catch-all level
+// for brands that should clearly trigger industry-specific must/should
+// policies.
+//
+// Solution: pattern-derived enrichment keyed on `brand_name`. The
+// overrides are MERGED with registry industries (not replaced); a
+// provenance field records what we added so the UI can flag it.
+//
+// When upstream registry adds finer-grained tags, this file becomes
+// redundant — at worst, harmless duplication. The override layer is
+// purely additive and idempotent.
+
+export interface BrandIndustryEnrichment {
+  /** Merged list: registry industries + override additions, in that order. */
+  industries: string[];
+  /** What we added beyond registry — empty = no override applied. */
+  added_by_override: string[];
+  /** Brief ID of the matched pattern, for UI provenance display. */
+  matched_pattern_id?: string;
+}
+
+interface OverridePattern {
+  /** Stable identifier shown in the UI as provenance. */
+  id: string;
+  /** Regex against lowercased brand_name. First-match-wins. */
+  pattern: RegExp;
+  /** Industry slugs to add. Lowercased. Match policyRegistry's
+   *  industries_inferred conventions where possible. */
+  add: string[];
+}
+
+// First-match-wins. Order matters when patterns overlap.
+const OVERRIDES: OverridePattern[] = [
+  // Alcohol — beer / wine / spirits / brewers / distillers
+  {
+    id: "alcohol",
+    pattern: /\b(heineken|anheuser|budweiser|coors|miller|corona|stella|guinness|pernod|diageo|bacardi|absolut|smirnoff|jack\s*daniel|jim\s*beam|johnnie\s*walker|jose\s*cuervo|patron|barefoot|yellow\s*tail|crown\s*royal|captain\s*morgan|ketel\s*one|grey\s*goose|hennessy|jagermeister|jameson|chivas|maker.?s\s*mark|tequila|whisky|whiskey|vodka|\brum\b|\bgin\b|cognac|champagne|wine|brewing|brewery|spirits|distillery|distilleries|liquor|cellars?|vineyard)/i,
+    add: ["alcohol", "beer", "wine", "spirits"],
+  },
+  // Tobacco / nicotine / vaping
+  {
+    id: "tobacco",
+    pattern: /\b(philip\s*morris|altria|reynolds\s*american|british\s*american\s*tobacco|imperial\s*brands|jt\s*international|tobacco|cigarette|marlboro|\bcamel\b|newport|juul|vape|vaping|nicotine)/i,
+    add: ["tobacco", "vaping", "nicotine"],
+  },
+  // Cannabis
+  {
+    id: "cannabis",
+    pattern: /\b(curaleaf|cresco|trulieve|green\s*thumb|tilray|aurora\s*cannabis|canopy\s*growth|cronos|cannabis|marijuana|\bcbd\b|dispensary|dispensaries)/i,
+    add: ["cannabis"],
+  },
+  // Gambling / sportsbook / lottery
+  {
+    id: "gambling",
+    pattern: /\b(draftkings|fanduel|mgm\s*resorts|caesars|wynn|las\s*vegas\s*sands|penn\s*entertainment|flutter|bet365|pokerstars|gambling|casino|sportsbook|lottery|sports\s*bett?ing)/i,
+    add: ["gambling", "sports_betting", "lottery"],
+  },
+  // Pharma / healthcare / medical
+  {
+    id: "pharma",
+    pattern: /\b(pfizer|merck|gsk|glaxo|astrazeneca|roche|novartis|johnson\s*&\s*johnson|johnson\s+and\s+johnson|j&j|abbvie|bristol[-\s]*myers|sanofi|eli\s*lilly|\blilly\b|amgen|gilead|biogen|moderna|biontech|regeneron|takeda|bayer|teva|mylan|viatris|cvs\s*health|caremark|walgreens|pharmaceutic|pharma|biotech|hospital|clinic|medical\s*device|healthcare)/i,
+    add: ["pharma", "healthcare", "medical_devices"],
+  },
+  // Children / toys / education / family-targeted
+  {
+    id: "children",
+    pattern: /\b(lego|mattel|hasbro|fisher[-\s]*price|barbie|hot\s*wheels|playmobil|crayola|nintendo|playstation|xbox|disney(\s*kids)?|nickelodeon|cartoon\s*network|pbs\s*kids|kids?|toddler|toys?|preschool|kindergarten|elementary|montessori)/i,
+    add: ["children", "toys", "education"],
+  },
+  // Financial services / banking / insurance / fintech
+  {
+    id: "financial",
+    pattern: /\b(visa|mastercard|amex|american\s*express|\bchase\b|citi(\s*bank)?|bank\s*of\s*america|wells\s*fargo|jpmorgan|goldman|morgan\s*stanley|capital\s*one|\bdiscover\b|paypal|stripe|\bsquare\b|robinhood|fidelity|charles\s*schwab|vanguard|blackrock|allianz|\baig\b|metlife|prudential|geico|progressive|state\s*farm|liberty\s*mutual|farmers\s*insurance|intuit|turbotax|quickbooks|\bbank|insurance|loan|mortgage|credit|fintech|investment|brokerage|wealth\s*management)/i,
+    add: ["financial", "banking", "insurance", "lending", "fintech"],
+  },
+  // Fast food / HFSS-relevant — UK HFSS regulation triggers on these
+  {
+    id: "fast_food",
+    pattern: /\b(mcdonald|burger\s*king|wendy|kfc|taco\s*bell|pizza\s*hut|domino|subway|chipotle|popeyes|chick[-\s]*fil[-\s]*a|arby|sonic\s*drive|five\s*guys|in[-\s]*n[-\s]*out|whataburger|fast\s*food|quick\s*service)/i,
+    add: ["fast_food", "food_beverage"],
+  },
+  // Confectionery / snacks (HFSS-relevant)
+  {
+    id: "confectionery",
+    pattern: /\b(hershey|mars|mondelez|nestl[ée]|ferrero|cadbury|oreo|kit\s*kat|snickers|reese|m&m|gummy|chocolate|candy|confectionery|snack|chip|cookie|biscuit|cereal)/i,
+    add: ["confectionery", "food_beverage"],
+  },
+  // Political / advocacy
+  {
+    id: "political",
+    pattern: /\b(political|campaign\s*committee|democratic|republican|partisan|advocacy|super\s*pac|\bpac\b|nonprofit\s*advocacy)/i,
+    add: ["political", "advocacy"],
+  },
+  // AI-generated content / generative AI vendors
+  {
+    id: "ai_generated",
+    pattern: /\b(openai|anthropic|midjourney|stability\s*ai|runway\s*ml|elevenlabs|synthesia|generative\s*ai|ai[-\s]*generated|deepfake)/i,
+    add: ["ai_generated_content"],
+  },
+];
+
+/**
+ * Given a brand_name and the registry-supplied industries, return the
+ * merged list with override-added entries appended. Idempotent: re-running
+ * on already-enriched output yields the same result. First-pattern-wins.
+ */
+export function enrichIndustries(
+  brandName: string | undefined | null,
+  registryIndustries: readonly string[],
+): BrandIndustryEnrichment {
+  const name = (brandName || "").toLowerCase();
+  const lowerRegistry = new Set(registryIndustries.map((s) => s.toLowerCase()));
+  if (!name) {
+    return { industries: registryIndustries.slice(), added_by_override: [] };
+  }
+  for (const p of OVERRIDES) {
+    if (p.pattern.test(name)) {
+      const additions = p.add.filter((a) => !lowerRegistry.has(a.toLowerCase()));
+      if (additions.length === 0) {
+        // Pattern matched but every tag already present — return as-is,
+        // mark the match for UI provenance ("registry already has this").
+        return {
+          industries: registryIndustries.slice(),
+          added_by_override: [],
+          matched_pattern_id: p.id,
+        };
+      }
+      return {
+        industries: [...registryIndustries, ...additions],
+        added_by_override: additions,
+        matched_pattern_id: p.id,
+      };
+    }
+  }
+  return { industries: registryIndustries.slice(), added_by_override: [] };
+}

--- a/src/routes/brandRegistry.ts
+++ b/src/routes/brandRegistry.ts
@@ -19,6 +19,7 @@
 import type { Env } from "../types/env";
 import type { Logger } from "../utils/logger";
 import { jsonResponse, errorResponse } from "./shared";
+import { enrichIndustries } from "../domain/brandIndustryOverrides";
 
 const REGISTRY_BASE = "https://agenticadvertising.org/api";
 const SEARCH_TTL_SEC = 600;       // 10 min — search results change with new brand additions
@@ -48,6 +49,37 @@ async function fetchWithTimeout(url: string, timeoutMs: number): Promise<Respons
     signal: AbortSignal.timeout(timeoutMs),
     headers: { "Accept": "application/json" },
   });
+}
+
+// Industry enrichment: server-side merge of pattern-derived industry
+// tags with the registry's coarse taxonomy. Mutates a copy of the
+// brand_manifest.company.industries; adds a parallel `industries_meta`
+// object inside brand_manifest carrying provenance (which entries
+// were registry-original vs override-added). Idempotent — safe to
+// re-run on already-enriched bodies.
+function applyIndustryEnrichment(brand: BrandResolved): BrandResolved {
+  if (!brand || !brand.brand_manifest) return brand;
+  const bm = brand.brand_manifest as Record<string, unknown>;
+  const company = (bm.company || {}) as Record<string, unknown>;
+  const original = Array.isArray(company.industries)
+    ? (company.industries as unknown[]).filter((s) => typeof s === "string") as string[]
+    : [];
+  const enr = enrichIndustries(brand.brand_name, original);
+  if (enr.added_by_override.length === 0 && !enr.matched_pattern_id) {
+    return brand;
+  }
+  // Clone shallowly so the cached/returned object reflects the merge.
+  const newCompany: Record<string, unknown> = { ...company, industries: enr.industries };
+  const newBm: Record<string, unknown> = {
+    ...bm,
+    company: newCompany,
+    industries_meta: {
+      registry_original: original,
+      added_by_override: enr.added_by_override,
+      ...(enr.matched_pattern_id ? { matched_pattern_id: enr.matched_pattern_id } : {}),
+    },
+  };
+  return { ...brand, brand_manifest: newBm };
 }
 
 // Phase A: conditional fetch with If-None-Match. Returns the upstream
@@ -180,7 +212,8 @@ export async function handleBrandResolve(
         return errorResponse("BRAND_NOT_FOUND", `No brand found for domain '${domain}'`, 404);
       }
       if (res.ok) {
-        const body = (await res.json()) as BrandResolved;
+        const rawBody = (await res.json()) as BrandResolved;
+        const body = applyIndustryEnrichment(rawBody);
         const out = { ...body, fetched_at: new Date().toISOString(), cache: "swr-refresh" };
         try {
           const { cache: _c, ...store } = out;
@@ -219,6 +252,12 @@ export async function handleBrandResolve(
     logger.warn("brand_resolve_upstream_error", { error: String((e as Error).message || e) });
     return errorResponse("UPSTREAM_ERROR", "Registry unreachable", 502);
   }
+
+  // Apply industry enrichment — registry's industry taxonomy is coarse;
+  // pattern-based overrides supplement so policy/governance/brand-rights
+  // matchers downstream produce useful results even when the registry
+  // misses obvious tags (Heineken → alcohol, Pfizer → pharma, etc.).
+  body = applyIndustryEnrichment(body);
 
   const out = { ...body, fetched_at: new Date().toISOString(), cache: "miss" };
   try {

--- a/src/routes/demo.ts
+++ b/src/routes/demo.ts
@@ -4812,6 +4812,18 @@ textarea.lab-input { resize: vertical; line-height: 1.5; }
 }
 .canvas-mediabuy-pred-icon { color: var(--accent); }
 
+/* Industry-enrichment provenance: chips added by brand-name pattern
+   override (vs registry-original) get a dashed accent border + a "+"
+   prefix so the demo stays honest about which tags we derived. */
+.canvas-industry-augmented {
+  background: rgba(56,182,255,0.08);
+  color: var(--accent);
+  border: 1px dashed var(--accent);
+}
+.canvas-industry-augmented-mark {
+  font-weight: 700; opacity: 0.75; margin-right: 1px;
+}
+
 /* MVP #6: portfolio-rebalance banner. Shows above the media-buy cells
    when N agents auth-gate and at least 1 succeeds. Communicates that
    the workflow is robust to partial failure and the deployable budget
@@ -13525,8 +13537,22 @@ function _canvasRenderBrandCard(data) {
   // Dedupe (the data sometimes repeats)
   var uniqInd = [];
   industries.forEach(function (i) { if (uniqInd.indexOf(i) < 0) uniqInd.push(i); });
+  // Brand industry enrichment provenance: mark override-added chips
+  // visually so the demo stays honest about what came from registry vs
+  // what we derived from brand-name patterns.
+  var indMeta = bm.industries_meta || {};
+  var addedSet = {};
+  (indMeta.added_by_override || []).forEach(function (s) { addedSet[String(s).toLowerCase()] = true; });
   var industryChips = uniqInd.map(function (i) {
-    return '<span class="pill pill-muted mono" style="font-size:10.5px">' + escapeHtml(i) + '</span>';
+    var isAdded = addedSet[String(i).toLowerCase()] === true;
+    var cls = "pill mono " + (isAdded ? "canvas-industry-augmented" : "pill-muted");
+    var title = isAdded
+      ? "added by client-side enrichment (registry industry taxonomy is coarse) — pattern: " + escapeHtml(indMeta.matched_pattern_id || "?")
+      : "from registry";
+    return '<span class="' + cls + '" style="font-size:10.5px" title="' + title + '">' +
+      (isAdded ? '<span class="canvas-industry-augmented-mark">+</span> ' : '') +
+      escapeHtml(i) +
+    '</span>';
   }).join(" ");
 
   var qualityScore = typeof bm.quality_score === "number"


### PR DESCRIPTION
## Summary

The agentic-advertising registry tags brands with a coarse industry taxonomy — many brands miss obvious tags that our policy / governance / brand-rights matchers depend on:

| Brand | Registry industries | Should also include |
|---|---|---|
| Pfizer | \"Heavy Industry and Engineering\" | pharma, healthcare |
| Heineken USA | \"Food and Drink\" | alcohol, beer |
| DraftKings | (often absent) | gambling, sports_betting |
| Lego | (often absent) | children, toys |

Result: governance preview + policy hits row stay at the catch-all level (GDPR + CSBS only) even for brands that should clearly trigger industry-specific must/should policies.

## Fix

**Server-side pattern-derived enrichment** in a new \`src/domain/brandIndustryOverrides.ts\`:

- 11 pattern groups: alcohol · tobacco · cannabis · gambling · pharma · children · financial · fast_food · confectionery · political · ai_generated
- First-pattern-wins, idempotent, **additive only** (never replaces registry)
- Provenance tracked: \`brand_manifest.industries_meta.added_by_override\` lists what we added; \`matched_pattern_id\` cites the rule

**Canvas surface:** override-added chips get a dashed-accent border + \`+\` prefix; hover tooltip explains the enrichment came from brand-name pattern matching, not the registry. Stays honest about provenance.

## Effect on the workshop

Heineken now triggers \`alcohol_advertising\` should-policy; Pfizer triggers \`pharma_us_fda\`; DraftKings triggers \`gambling_advertising\`. The governance preview, brand-rights row, and policy hits row all populate with substantive content.

## Test plan
- [x] Type-check clean
- [x] 428/428 tests pass
- [x] SCRIPT_TAG audit clean
- [ ] Smoke after deploy:
  - [ ] \`/brands/resolve?domain=pfizer.com\` → \`industries\` includes \"pharma\", \"healthcare\"; \`industries_meta.matched_pattern_id\` = \"pharma\"
  - [ ] \`/brands/resolve?domain=heinekenusa.com\` → \`industries\` includes \"alcohol\"; pattern_id = \"alcohol\"
  - [ ] \`/registry/governance-preview?industries=alcohol\` → block/warn on alcohol_advertising
  - [ ] Canvas: brand card shows augmented chips with dashed border + \"+\" prefix

🤖 Generated with [Claude Code](https://claude.com/claude-code)