### PR TITLE
Campaign Canvas: buy-side / DSP control-loop visualization (Option B)

### DIFF
--- a/src/domain/dspMock.ts
+++ b/src/domain/dspMock.ts
@@ -1,0 +1,470 @@
+// src/domain/dspMock.ts
+//
+// MVP for the Campaign Canvas (buy-side / DSP control-loop view).
+//
+// AdCP 3.0 GA covers sell-side discovery + plan-level buy:
+//   get_signals · get_products · create_media_buy · activate_signal
+//
+// The buy-side real-time control loop is UNSPECIFIED across the 11
+// directory agents:
+//   - submit_bid_strategy       — declare how to bid
+//   - get_bid_opportunities     — receive bid requests (streaming)
+//   - get_pacing_status         — burn rate vs target
+//   - optimize_strategy         — feedback from delivery → strategy
+//
+// This module mocks all four. Same playbook as governanceMock.ts +
+// brandRightsMock.ts: deterministic synthetic data so the Canvas can
+// render meaningful visuals; swap to live when upstream catches up.
+//
+// Determinism: all generators are seeded from (campaign_id × "salt").
+// Same inputs → same outputs across requests. No real RTB latency.
+
+// ── Campaign templates ──────────────────────────────────────────────────────
+//
+// 3 demo campaigns covering different KPI postures so the Canvas
+// can show meaningful diversity in the control loop.
+
+export type CampaignKpi = "CPM" | "CPA" | "ROAS" | "BRAND_LIFT";
+
+export interface Campaign {
+  campaign_id: string;
+  name: string;
+  brand_name: string;
+  brand_domain: string;
+  kpi: CampaignKpi;
+  kpi_target: number;
+  kpi_unit: string;        // e.g. "$" or "%"
+  budget_total_usd: number;
+  budget_daily_cap_usd: number;
+  freq_cap_per_user: number;
+  flight_start: string;    // ISO date
+  flight_end: string;
+  start_day_offset: number; // For demo: how many days into the flight
+  geo: string[];
+  audience_brief: string;
+}
+
+const CAMPAIGNS: Record<string, Campaign> = {
+  cmp_cocacola_summer: {
+    campaign_id: "cmp_cocacola_summer",
+    name: "Coca-Cola Summer Refresh",
+    brand_name: "Coca-Cola",
+    brand_domain: "coca-cola.com",
+    kpi: "ROAS",
+    kpi_target: 3.5,
+    kpi_unit: "x",
+    budget_total_usd: 250_000,
+    budget_daily_cap_usd: 10_000,
+    freq_cap_per_user: 5,
+    flight_start: "2026-04-15",
+    flight_end: "2026-05-30",
+    start_day_offset: 14,
+    geo: ["US"],
+    audience_brief: "food and drink + beverages buyers in Coca-Cola core markets",
+  },
+  cmp_nike_drop: {
+    campaign_id: "cmp_nike_drop",
+    name: "Nike Air Max Drop",
+    brand_name: "Nike",
+    brand_domain: "nike.com",
+    kpi: "CPM",
+    kpi_target: 8.50,
+    kpi_unit: "$",
+    budget_total_usd: 120_000,
+    budget_daily_cap_usd: 25_000,
+    freq_cap_per_user: 3,
+    flight_start: "2026-04-25",
+    flight_end: "2026-05-02",
+    start_day_offset: 4,
+    geo: ["US-NYC", "US-LA", "US-SF", "US-CHI", "US-MIA"],
+    audience_brief: "sneakerheads + active lifestyle in urban DMAs",
+  },
+  cmp_pfizer_lift: {
+    campaign_id: "cmp_pfizer_lift",
+    name: "Pfizer Brand Lift Study",
+    brand_name: "Pfizer",
+    brand_domain: "pfizer.com",
+    kpi: "BRAND_LIFT",
+    kpi_target: 12.0,
+    kpi_unit: "%",
+    budget_total_usd: 80_000,
+    budget_daily_cap_usd: 4_000,
+    freq_cap_per_user: 2,
+    flight_start: "2026-04-01",
+    flight_end: "2026-05-15",
+    start_day_offset: 28,
+    geo: ["US"],
+    audience_brief: "healthcare-engaged adults; contextual-only, brand-safe inventory",
+  },
+};
+
+export function listCampaigns(): Campaign[] {
+  return Object.values(CAMPAIGNS);
+}
+
+export function getCampaign(id: string): Campaign | null {
+  return CAMPAIGNS[id] ?? null;
+}
+
+// ── Deterministic seed helpers ──────────────────────────────────────────────
+
+function fnv1a(s: string): number {
+  let h = 2166136261;
+  for (let i = 0; i < s.length; i++) {
+    h ^= s.charCodeAt(i);
+    h = Math.imul(h, 16777619);
+  }
+  return h >>> 0;
+}
+
+function lcg(seed: number): () => number {
+  let s = seed;
+  return () => {
+    s = (Math.imul(s, 1664525) + 1013904223) >>> 0;
+    return s / 0xffffffff;
+  };
+}
+
+function rng(campaign_id: string, salt: string): () => number {
+  return lcg(fnv1a(campaign_id + "|" + salt));
+}
+
+// ── Bid strategy ────────────────────────────────────────────────────────────
+
+export interface BidStrategy {
+  campaign_id: string;
+  algorithm: "first_price" | "second_price" | "fixed_cpm";
+  base_bid_usd: number;
+  bid_modifiers: Array<{ name: string; multiplier: number; reason: string }>;
+  floor_strategy: "respect_publisher" | "negotiate_down" | "ignore";
+  pacing_strategy: "even" | "asap" | "weighted";
+  brand_safety_floor: number;  // 0-100; min DV/IAS score to accept
+  viewability_floor: number;   // 0-1; min predicted viewability to bid
+  dayparting: Array<{ hour: number; multiplier: number }>;
+}
+
+export function generateBidStrategy(c: Campaign): BidStrategy {
+  const r = rng(c.campaign_id, "strategy");
+  const algo = c.kpi === "BRAND_LIFT" ? "fixed_cpm" : (r() < 0.6 ? "second_price" : "first_price");
+  const baseBid = c.kpi === "CPM" ? c.kpi_target * (0.85 + r() * 0.20) : 5.50 + r() * 4.00;
+  const modifiers = [
+    { name: "audience_match", multiplier: 1.25, reason: "+25% when audience signal matches" },
+    { name: "contextual_brand_safe", multiplier: 1.10, reason: "+10% on brand-safe pages" },
+    { name: "dayparting_peak", multiplier: 1.15, reason: "+15% during 18:00-22:00 local" },
+    { name: "frequency_decay", multiplier: 0.70, reason: "-30% after 3 impressions/user" },
+  ];
+  if (c.kpi === "BRAND_LIFT") {
+    modifiers.push({ name: "viewability_premium", multiplier: 1.30, reason: "+30% on >75% viewable" });
+  }
+  const dayparting = Array.from({ length: 24 }, (_, h) => {
+    let m = 1.0;
+    if (h >= 18 && h <= 22) m = 1.15;
+    else if (h >= 0 && h <= 5) m = 0.6;
+    else if (h >= 12 && h <= 14) m = 1.05;
+    return { hour: h, multiplier: Math.round(m * 100) / 100 };
+  });
+  return {
+    campaign_id: c.campaign_id,
+    algorithm: algo,
+    base_bid_usd: Math.round(baseBid * 100) / 100,
+    bid_modifiers: modifiers,
+    floor_strategy: c.kpi === "BRAND_LIFT" ? "respect_publisher" : "negotiate_down",
+    pacing_strategy: c.kpi === "CPM" ? "asap" : "even",
+    brand_safety_floor: c.kpi === "BRAND_LIFT" ? 85 : 70,
+    viewability_floor: c.kpi === "BRAND_LIFT" ? 0.75 : 0.50,
+    dayparting,
+  };
+}
+
+// ── Bid stream ──────────────────────────────────────────────────────────────
+
+export interface BidStreamSample {
+  t_offset_sec: number;       // seconds before now
+  bid_requests_per_sec: number;
+  bids_per_sec: number;
+  wins_per_sec: number;
+  avg_winning_cpm_usd: number;
+  latency_p50_ms: number;
+  latency_p95_ms: number;
+}
+
+export function generateBidStream(c: Campaign, samples = 60): BidStreamSample[] {
+  const r = rng(c.campaign_id, "stream");
+  const baseQps = c.budget_daily_cap_usd / 86400 * 1000;  // very rough QPS scaling
+  const out: BidStreamSample[] = [];
+  for (let i = 0; i < samples; i++) {
+    const noise = 0.85 + r() * 0.30;
+    const reqs = Math.round(baseQps * 60 * noise);   // ~per-minute aggregation
+    const bidRate = 0.12 + r() * 0.08;               // 12-20% of requests we bid on
+    const bids = Math.round(reqs * bidRate);
+    const winRate = 0.18 + r() * 0.12;               // 18-30% win on bids
+    const wins = Math.round(bids * winRate);
+    const cpm = (c.kpi === "CPM" ? c.kpi_target : 6.0) * (0.85 + r() * 0.30);
+    out.push({
+      t_offset_sec: (samples - 1 - i) * 60,
+      bid_requests_per_sec: reqs / 60,
+      bids_per_sec: bids / 60,
+      wins_per_sec: wins / 60,
+      avg_winning_cpm_usd: Math.round(cpm * 100) / 100,
+      latency_p50_ms: Math.round(35 + r() * 20),
+      latency_p95_ms: Math.round(70 + r() * 40),
+    });
+  }
+  return out;
+}
+
+// ── Inventory match per SSP ─────────────────────────────────────────────────
+
+export interface SspPerformance {
+  ssp_id: string;
+  ssp_name: string;
+  win_rate_pct: number;
+  avg_winning_cpm_usd: number;
+  audience_match_rate_pct: number;
+  bid_qps: number;
+  latency_p95_ms: number;
+  share_of_spend_pct: number;
+  trend_24h: "up" | "down" | "flat";
+}
+
+const SSP_POOL: Array<{ ssp_id: string; ssp_name: string }> = [
+  { ssp_id: "ssp_pubmatic", ssp_name: "PubMatic" },
+  { ssp_id: "ssp_magnite",  ssp_name: "Magnite" },
+  { ssp_id: "ssp_index",    ssp_name: "Index Exchange" },
+  { ssp_id: "ssp_openx",    ssp_name: "OpenX" },
+  { ssp_id: "ssp_xandr",    ssp_name: "Microsoft Xandr" },
+  { ssp_id: "ssp_ttd_ox",   ssp_name: "The Trade Desk OpenPath" },
+  { ssp_id: "ssp_freewheel", ssp_name: "FreeWheel (CTV)" },
+];
+
+export function generateSspPerformance(c: Campaign): SspPerformance[] {
+  const r = rng(c.campaign_id, "ssps");
+  const out: SspPerformance[] = SSP_POOL.map((s) => {
+    const winRate = 12 + r() * 28;
+    const cpm = (c.kpi === "CPM" ? c.kpi_target : 6.0) * (0.80 + r() * 0.40);
+    const matchRate = 38 + r() * 50;
+    const qps = (c.budget_daily_cap_usd / 86400 * 1000) * (0.05 + r() * 0.20);
+    const trend: SspPerformance["trend_24h"] = r() < 0.4 ? "up" : r() < 0.75 ? "flat" : "down";
+    return {
+      ssp_id: s.ssp_id,
+      ssp_name: s.ssp_name,
+      win_rate_pct: Math.round(winRate * 10) / 10,
+      avg_winning_cpm_usd: Math.round(cpm * 100) / 100,
+      audience_match_rate_pct: Math.round(matchRate * 10) / 10,
+      bid_qps: Math.round(qps * 10) / 10,
+      latency_p95_ms: Math.round(60 + r() * 80),
+      share_of_spend_pct: 0,  // filled below
+      trend_24h: trend,
+    };
+  });
+  // Sort by composite score (win × match) and assign share-of-spend.
+  out.sort((a, b) => (b.win_rate_pct * b.audience_match_rate_pct) - (a.win_rate_pct * a.audience_match_rate_pct));
+  const totalWeight = out.reduce((s, x, i) => s + (out.length - i), 0);
+  out.forEach((x, i) => {
+    x.share_of_spend_pct = Math.round(((out.length - i) / totalWeight) * 1000) / 10;
+  });
+  return out;
+}
+
+// ── Brand safety / pre-bid filter ───────────────────────────────────────────
+
+export interface BrandSafetyStats {
+  total_impressions_evaluated: number;
+  total_blocked: number;
+  block_rate_pct: number;
+  reasons: Array<{ reason: string; count: number; pct: number }>;
+  avg_brand_safety_score: number;       // 0-100
+  avg_predicted_viewability: number;     // 0-1
+  filter_latency_p50_ms: number;
+}
+
+export function generateBrandSafety(c: Campaign): BrandSafetyStats {
+  const r = rng(c.campaign_id, "safety");
+  const impressions = Math.round(c.budget_total_usd / 6 * 1000 * (c.start_day_offset / 30));
+  const blockRate = c.kpi === "BRAND_LIFT" ? 0.18 + r() * 0.06 : 0.06 + r() * 0.04;
+  const blocked = Math.round(impressions * blockRate);
+  const reasons = [
+    { reason: "brand_safety_category_breach", weight: 0.42 },
+    { reason: "viewability_below_floor", weight: 0.28 },
+    { reason: "geo_jurisdiction_excluded", weight: 0.12 },
+    { reason: "frequency_cap_hit", weight: 0.10 },
+    { reason: "page_not_brand_aligned", weight: 0.05 },
+    { reason: "audience_match_fail", weight: 0.03 },
+  ].map(({ reason, weight }) => ({
+    reason,
+    count: Math.round(blocked * weight),
+    pct: Math.round(weight * 1000) / 10,
+  }));
+  return {
+    total_impressions_evaluated: impressions,
+    total_blocked: blocked,
+    block_rate_pct: Math.round(blockRate * 1000) / 10,
+    reasons,
+    avg_brand_safety_score: Math.round(78 + r() * 16),
+    avg_predicted_viewability: Math.round((0.62 + r() * 0.20) * 100) / 100,
+    filter_latency_p50_ms: Math.round(8 + r() * 12),
+  };
+}
+
+// ── Pacing + delivery ───────────────────────────────────────────────────────
+
+export interface PacingPoint {
+  day: number;
+  spend_usd: number;
+  cum_spend_usd: number;
+  target_cum_spend_usd: number;
+  impressions: number;
+  variance_pct: number;        // (actual - target) / target * 100
+}
+
+export interface PacingReport {
+  budget_total_usd: number;
+  spent_to_date_usd: number;
+  remaining_usd: number;
+  days_elapsed: number;
+  days_total: number;
+  pacing_health: "under" | "on_track" | "over";
+  pacing_variance_pct: number;
+  per_day: PacingPoint[];
+  total_impressions: number;
+}
+
+export function generatePacing(c: Campaign): PacingReport {
+  const r = rng(c.campaign_id, "pacing");
+  const flightStart = Date.parse(c.flight_start);
+  const flightEnd = Date.parse(c.flight_end);
+  const daysTotal = Math.max(1, Math.round((flightEnd - flightStart) / 86400000));
+  const daysElapsed = Math.min(daysTotal, c.start_day_offset);
+  const targetPerDay = c.budget_total_usd / daysTotal;
+  let cumActual = 0;
+  let totalImps = 0;
+  const perDay: PacingPoint[] = [];
+  for (let d = 1; d <= daysElapsed; d++) {
+    const dailyTarget = Math.min(targetPerDay, c.budget_daily_cap_usd);
+    const noise = 0.85 + r() * 0.35;
+    const spend = Math.round(dailyTarget * noise * 100) / 100;
+    cumActual += spend;
+    const cumTarget = Math.round((targetPerDay * d) * 100) / 100;
+    const variance = cumTarget > 0 ? Math.round(((cumActual - cumTarget) / cumTarget) * 1000) / 10 : 0;
+    const cpm = (c.kpi === "CPM" ? c.kpi_target : 6.0) * (0.90 + r() * 0.20);
+    const imps = Math.round(spend / cpm * 1000);
+    totalImps += imps;
+    perDay.push({
+      day: d,
+      spend_usd: spend,
+      cum_spend_usd: Math.round(cumActual * 100) / 100,
+      target_cum_spend_usd: cumTarget,
+      impressions: imps,
+      variance_pct: variance,
+    });
+  }
+  const overallVariance = perDay.length > 0 ? perDay[perDay.length - 1]!.variance_pct : 0;
+  const health: PacingReport["pacing_health"] =
+    Math.abs(overallVariance) < 5 ? "on_track" : overallVariance > 0 ? "over" : "under";
+  return {
+    budget_total_usd: c.budget_total_usd,
+    spent_to_date_usd: Math.round(cumActual * 100) / 100,
+    remaining_usd: Math.round((c.budget_total_usd - cumActual) * 100) / 100,
+    days_elapsed: daysElapsed,
+    days_total: daysTotal,
+    pacing_health: health,
+    pacing_variance_pct: overallVariance,
+    per_day: perDay,
+    total_impressions: totalImps,
+  };
+}
+
+// ── Attribution + optimization signals ──────────────────────────────────────
+
+export interface OptimizationSignal {
+  kind: "boost" | "decay" | "shift" | "alert";
+  target: string;          // e.g. "ssp:ssp_pubmatic" or "audience:auto_in_market"
+  metric: string;          // e.g. "+12% lift" or "-8% efficiency"
+  recommendation: string;
+  confidence: number;      // 0-1
+}
+
+export interface AttributionReport {
+  conversions: number;
+  conversion_value_usd: number;
+  realized_kpi: number;
+  realized_kpi_unit: string;
+  kpi_target: number;
+  kpi_status: "above" | "on" | "below";
+  optimization_signals: OptimizationSignal[];
+  feedback_into_strategy: string[];   // human-readable diff vs current strategy
+}
+
+export function generateAttribution(c: Campaign, pacing: PacingReport): AttributionReport {
+  const r = rng(c.campaign_id, "attribution");
+  const imps = pacing.total_impressions;
+  const ctr = 0.0008 + r() * 0.0012;
+  const clicks = Math.round(imps * ctr);
+  const cvr = 0.012 + r() * 0.020;
+  const conversions = Math.round(clicks * cvr);
+  const aov = 24 + r() * 56;
+  const value = Math.round(conversions * aov * 100) / 100;
+  let realized = 0;
+  if (c.kpi === "ROAS") realized = Math.round((value / pacing.spent_to_date_usd) * 100) / 100;
+  else if (c.kpi === "CPM") realized = Math.round((pacing.spent_to_date_usd / imps * 1000) * 100) / 100;
+  else if (c.kpi === "CPA") realized = Math.round((pacing.spent_to_date_usd / Math.max(1, conversions)) * 100) / 100;
+  else realized = Math.round((9 + r() * 6) * 10) / 10;  // BRAND_LIFT %
+
+  let status: AttributionReport["kpi_status"];
+  if (c.kpi === "CPM" || c.kpi === "CPA") {
+    // Lower is better.
+    status = realized < c.kpi_target * 0.95 ? "above" : realized > c.kpi_target * 1.05 ? "below" : "on";
+  } else {
+    // Higher is better.
+    status = realized > c.kpi_target * 1.05 ? "above" : realized < c.kpi_target * 0.95 ? "below" : "on";
+  }
+
+  // Optimization signals — diverse set of recommendation kinds.
+  const signals: OptimizationSignal[] = [
+    {
+      kind: "boost",
+      target: "ssp:ssp_pubmatic",
+      metric: "+" + (Math.round(8 + r() * 12)) + "% efficiency",
+      recommendation: "Increase share-of-spend by 15% — match rate + win rate both top-quartile.",
+      confidence: Math.round((0.78 + r() * 0.18) * 100) / 100,
+    },
+    {
+      kind: "decay",
+      target: "ssp:ssp_openx",
+      metric: "-" + (Math.round(4 + r() * 6)) + "% efficiency",
+      recommendation: "Reduce share-of-spend; CPM trending up while win rate drifts down.",
+      confidence: Math.round((0.62 + r() * 0.20) * 100) / 100,
+    },
+    {
+      kind: "shift",
+      target: "audience:auto_in_market_signals",
+      metric: "+" + (Math.round(10 + r() * 20)) + "% conversion lift",
+      recommendation: "Reallocate frequency cap from broad-targeting to in-market segments.",
+      confidence: Math.round((0.71 + r() * 0.18) * 100) / 100,
+    },
+    {
+      kind: "alert",
+      target: "dayparting:hours_2_5",
+      metric: "low fill, high CPM",
+      recommendation: "Suppress bidding 02:00-05:00 local — net negative ROAS contribution.",
+      confidence: Math.round((0.85 + r() * 0.10) * 100) / 100,
+    },
+  ];
+
+  const feedback = [
+    "→ bid_modifier['audience_match'] multiplier: 1.25 → 1.35",
+    "→ ssp_allowlist: drop ssp_openx, promote ssp_pubmatic to priority-1",
+    "→ dayparting hours 02-05: multiplier 0.6 → 0.0 (suppress)",
+  ];
+
+  return {
+    conversions,
+    conversion_value_usd: value,
+    realized_kpi: realized,
+    realized_kpi_unit: c.kpi_unit,
+    kpi_target: c.kpi_target,
+    kpi_status: status,
+    optimization_signals: signals,
+    feedback_into_strategy: feedback,
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,6 +60,7 @@ import {
   handleGovernancePreview,
   handleBrandRightsPreview,
 } from "./routes/registryRoutes";
+import { handleDspCampaigns } from "./routes/dspRoutes";
 import {
   handleAudienceCompose,
   handleAudienceSaturation,
@@ -251,6 +252,8 @@ export default {
             "/registry/governance-preview",
             // Refinement C: predictive brand-rights overlay.
             "/registry/brand-rights-preview",
+            // Campaign Canvas (DSP buy-side mock).
+            "/dsp/campaigns",
             "/taxonomy/reverse",
             // Sec-43: audience composer + activation-planning analytics.
             // Read-only — same posture as /portfolio/* and /analytics/*.
@@ -432,6 +435,10 @@ export default {
                 response = await handleGovernancePreview(request, env, logger);
             } else if ((method === "GET" || method === "POST") && path === "/registry/brand-rights-preview") {
                 response = await handleBrandRightsPreview(request, env, logger);
+
+                // ── Buy-side / DSP Canvas (mock) ────────────────────────────────────
+            } else if (method === "GET" && path.startsWith("/dsp/campaigns")) {
+                response = await handleDspCampaigns(request, env, logger);
 
                 // ── Sec-43: Audience Composer + activation analytics ────────────────
             } else if (method === "POST" && path === "/audience/compose") {

--- a/src/routes/demo.ts
+++ b/src/routes/demo.ts
@@ -153,6 +153,10 @@ ${STYLES}
         <svg class="ico"><use href="#icon-bolt"/></svg><span>Canvas</span>
         <span class="nav-tag">new</span>
       </button>
+      <button class="nav-item" data-tab="campaign">
+        <svg class="ico"><use href="#icon-network"/></svg><span>Campaign</span>
+        <span class="nav-tag">DSP</span>
+      </button>
       <button class="nav-item" data-tab="activations">
         <svg class="ico"><use href="#icon-activations"/></svg><span>Activations</span>
         <span class="nav-count" id="nav-activations-count">—</span>
@@ -1492,6 +1496,100 @@ ${STYLES}
           <button class="canvas-viewmode active" data-mode="canvas" title="Brand-anchored canvas (current)">brand canvas</button>
           <button class="canvas-viewmode disabled" data-mode="role" title="Pattern B from proposal #98 — coming soon" disabled>role-pivot</button>
           <button class="canvas-viewmode disabled" data-mode="graph" title="Pattern A from proposal #98 — coming soon" disabled>capability graph</button>
+        </div>
+      </section>
+
+      <!-- ── TAB: Campaign Canvas (DSP buy-side control loop) ─────────── -->
+      <section class="tab-pane" data-tab="campaign">
+        <div class="pane-header">
+          <div>
+            <h1 class="pane-title">Campaign Canvas <span class="pill pill-warning mono" style="font-size:9.5px;margin-left:8px;letter-spacing:0.04em">DSP buy-side · all primitives mocked</span></h1>
+            <p class="pane-subtitle">
+              Real-time control loop: bid strategy → bid stream → inventory match → brand-safety filter → delivery + attribution → optimization signals fed BACK into strategy.
+              <br/>
+              <span style="color:var(--text-mut)">All four buy-side AdCP primitives are unspec'd as of 3.0 GA: <code>submit_bid_strategy</code>, <code>get_bid_opportunities</code>, <code>get_pacing_status</code>, <code>optimize_strategy</code>. Every lane below mocks one of them.</span>
+            </p>
+          </div>
+        </div>
+
+        <!-- Campaign selector -->
+        <div class="campaign-selector" id="campaign-selector">
+          <span class="orch-small" style="color:var(--text-mut);margin-right:8px">campaign:</span>
+          <div class="campaign-selector-buttons" id="campaign-selector-buttons">
+            <span class="orch-small">loading…</span>
+          </div>
+        </div>
+
+        <!-- Top: Campaign card with KPI / flighting / budget rate -->
+        <div class="campaign-card-host" id="campaign-card-host">
+          <div class="empty-state"><div class="empty-title">Select a campaign above</div></div>
+        </div>
+
+        <!-- Control-loop grid: 5 lanes + feedback arrow back to top -->
+        <div class="campaign-loop" id="campaign-loop" style="display:none">
+
+          <!-- LANE 1: Bid strategy -->
+          <div class="campaign-lane campaign-lane-strategy" id="campaign-lane-strategy">
+            <div class="campaign-lane-head">
+              <span class="campaign-lane-label">1 · Bid strategy</span>
+              <span class="pill pill-muted mono" style="font-size:9px">submit_bid_strategy mock</span>
+            </div>
+            <div class="campaign-lane-body" id="campaign-strategy-body">
+              <span class="orch-small">…</span>
+            </div>
+          </div>
+
+          <!-- LANE 2: Bid stream -->
+          <div class="campaign-lane campaign-lane-stream" id="campaign-lane-stream">
+            <div class="campaign-lane-head">
+              <span class="campaign-lane-label">2 · Bid stream (last 60 min)</span>
+              <span class="pill pill-muted mono" style="font-size:9px">get_bid_opportunities mock</span>
+            </div>
+            <div class="campaign-lane-body" id="campaign-stream-body">
+              <span class="orch-small">…</span>
+            </div>
+          </div>
+
+          <!-- LANE 3: Inventory match (per-SSP) + Brand safety -->
+          <div class="campaign-lane campaign-lane-inventory" id="campaign-lane-inventory">
+            <div class="campaign-lane-head">
+              <span class="campaign-lane-label">3 · Inventory match · Brand safety</span>
+              <span class="pill pill-muted mono" style="font-size:9px">per-SSP performance · pre-bid filter</span>
+            </div>
+            <div class="campaign-lane-body campaign-lane-2col" id="campaign-inventory-body">
+              <div id="campaign-inventory-ssp"><span class="orch-small">…</span></div>
+              <div id="campaign-inventory-safety"><span class="orch-small">…</span></div>
+            </div>
+          </div>
+
+          <!-- LANE 4: Delivery (pacing curve) -->
+          <div class="campaign-lane campaign-lane-delivery" id="campaign-lane-delivery">
+            <div class="campaign-lane-head">
+              <span class="campaign-lane-label">4 · Delivery · Pacing</span>
+              <span class="pill pill-muted mono" style="font-size:9px">get_pacing_status mock</span>
+            </div>
+            <div class="campaign-lane-body" id="campaign-delivery-body">
+              <span class="orch-small">…</span>
+            </div>
+          </div>
+
+          <!-- LANE 5: Attribution + optimization (the feedback loop) -->
+          <div class="campaign-lane campaign-lane-attribution" id="campaign-lane-attribution">
+            <div class="campaign-lane-head">
+              <span class="campaign-lane-label">5 · Attribution · Optimization signals</span>
+              <span class="pill pill-muted mono" style="font-size:9px">optimize_strategy mock</span>
+            </div>
+            <div class="campaign-lane-body" id="campaign-attribution-body">
+              <span class="orch-small">…</span>
+            </div>
+          </div>
+
+          <!-- Closed-loop feedback arrow: signals feed BACK into strategy -->
+          <div class="campaign-feedback-arrow" id="campaign-feedback-arrow">
+            <svg class="ico" style="width:14px;height:14px"><use href="#icon-loop"/></svg>
+            <span>feedback loop — optimization signals re-tune the bid strategy each cycle</span>
+            <span class="campaign-feedback-arrow-tag mono">↻ continuous</span>
+          </div>
         </div>
       </section>
 
@@ -4824,6 +4922,303 @@ textarea.lab-input { resize: vertical; line-height: 1.5; }
   font-weight: 700; opacity: 0.75; margin-right: 1px;
 }
 
+/* ────────────────────────────────────────────────────────────────
+   Campaign Canvas (DSP buy-side control loop)
+   ──────────────────────────────────────────────────────────────── */
+
+.campaign-selector {
+  display: flex; align-items: center; gap: 6px; margin-bottom: 12px;
+  padding: 8px 12px; background: var(--bg-input);
+  border: 1px solid var(--border); border-radius: 5px;
+}
+.campaign-selector-buttons { display: flex; gap: 6px; flex-wrap: wrap; }
+.campaign-selector-btn {
+  display: inline-flex; flex-direction: column; align-items: flex-start; gap: 2px;
+  background: var(--bg-raised); color: var(--text-dim);
+  border: 1px solid var(--border); border-radius: 4px;
+  padding: 6px 12px; font-size: 11.5px; cursor: pointer;
+  font-family: inherit; transition: all 0.15s;
+}
+.campaign-selector-btn:hover { border-color: var(--accent); }
+.campaign-selector-btn.active { border-color: var(--accent); color: var(--accent); background: rgba(56,182,255,0.08); }
+.campaign-selector-name { font-weight: 600; }
+.campaign-selector-kpi { font-size: 9.5px; color: var(--text-mut); text-transform: uppercase; letter-spacing: 0.05em; }
+
+/* Campaign card */
+.campaign-card-host { margin-bottom: 14px; }
+.campaign-card {
+  background: var(--bg-surface); border: 1px solid var(--border);
+  border-radius: 6px; padding: 14px;
+}
+.campaign-card-head {
+  display: flex; align-items: baseline; gap: 12px;
+  padding-bottom: 8px; margin-bottom: 10px;
+  border-bottom: 1px solid var(--border);
+}
+.campaign-card-name { font-size: 16px; font-weight: 600; color: var(--text); }
+.campaign-card-brand { font-size: 12px; color: var(--text-mut); }
+.campaign-card-grid {
+  display: grid; grid-template-columns: repeat(5, 1fr); gap: 12px;
+  margin-bottom: 10px;
+}
+.campaign-card-cell-wide { grid-column: span 2; }
+.campaign-card-cell {
+  display: flex; flex-direction: column; gap: 2px;
+}
+.campaign-card-label {
+  font-size: 9.5px; text-transform: uppercase; letter-spacing: 0.06em;
+  color: var(--text-mut); font-weight: 500;
+}
+.campaign-card-value { font-size: 13px; color: var(--text); font-weight: 500; }
+.campaign-card-sub { color: var(--text-mut); font-size: 10.5px; }
+.campaign-kpi-roas        { color: var(--success); }
+.campaign-kpi-cpm         { color: var(--accent); }
+.campaign-kpi-cpa         { color: var(--warning, #d4a017); }
+.campaign-kpi-brand_lift  { color: #c084fc; }
+.campaign-card-progress { display: flex; flex-direction: column; gap: 4px; }
+.campaign-card-progress-label { display: flex; justify-content: space-between; }
+.campaign-card-progress-bar {
+  height: 4px; background: var(--bg-input); border-radius: 2px; overflow: hidden;
+}
+.campaign-card-progress-fill {
+  height: 100%; background: var(--accent); transition: width 0.3s;
+}
+
+/* Lane shell */
+.campaign-loop { display: flex; flex-direction: column; gap: 10px; }
+.campaign-lane {
+  background: var(--bg-surface); border: 1px solid var(--border);
+  border-left-width: 3px; border-radius: 5px; padding: 10px 12px;
+}
+.campaign-lane-strategy    { border-left-color: var(--accent); }
+.campaign-lane-stream      { border-left-color: var(--success); }
+.campaign-lane-inventory   { border-left-color: var(--warning, #d4a017); }
+.campaign-lane-delivery    { border-left-color: #c084fc; }
+.campaign-lane-attribution { border-left-color: #f97316; }
+.campaign-lane-head {
+  display: flex; align-items: center; gap: 10px;
+  padding-bottom: 6px; margin-bottom: 8px;
+  border-bottom: 1px dashed var(--border);
+}
+.campaign-lane-label {
+  font-size: 12px; font-weight: 600; color: var(--text);
+}
+.campaign-lane-body { display: flex; flex-direction: column; gap: 8px; }
+.campaign-lane-2col { display: grid; grid-template-columns: 1.5fr 1fr; gap: 16px; }
+
+/* Strategy lane */
+.campaign-strategy-row {
+  display: grid; grid-template-columns: repeat(6, 1fr); gap: 10px;
+}
+.campaign-strategy-cell { display: flex; flex-direction: column; gap: 2px; }
+.campaign-strategy-label {
+  font-size: 9.5px; text-transform: uppercase; letter-spacing: 0.05em;
+  color: var(--text-mut); font-weight: 500; margin-bottom: 4px;
+}
+.campaign-strategy-block { display: flex; flex-direction: column; gap: 4px; }
+.campaign-strategy-mods {
+  display: flex; flex-wrap: wrap; gap: 4px;
+}
+.campaign-strategy-mod {
+  display: inline-flex; gap: 6px; align-items: center;
+  padding: 3px 8px; background: var(--bg-raised);
+  border: 1px solid var(--border); border-radius: 3px;
+  font-size: 11px; cursor: help;
+}
+.campaign-strategy-mod.mod-up { border-color: var(--success); }
+.campaign-strategy-mod.mod-down { border-color: var(--error); }
+.campaign-strategy-mod-val { color: var(--text-dim); font-size: 10.5px; }
+.campaign-strategy-dayparting {
+  display: grid; grid-template-columns: repeat(24, 1fr);
+  gap: 1px; height: 32px; align-items: end;
+  padding: 4px 0;
+}
+.campaign-strategy-daypart {
+  display: flex; flex-direction: column; align-items: center;
+  height: 100%; justify-content: flex-end; cursor: help;
+}
+.campaign-strategy-daypart-bar {
+  width: 70%; background: var(--accent); opacity: 0.5;
+  border-radius: 1px;
+}
+.campaign-strategy-daypart.dp-peak .campaign-strategy-daypart-bar { opacity: 1; }
+.campaign-strategy-daypart.dp-low .campaign-strategy-daypart-bar { background: var(--text-mut); opacity: 0.3; }
+.campaign-strategy-daypart-h {
+  font-size: 7.5px; color: var(--text-mut); margin-top: 1px;
+}
+
+/* Bid stream lane */
+.campaign-stream-stats {
+  display: grid; grid-template-columns: repeat(5, 1fr); gap: 12px;
+  padding-bottom: 8px; border-bottom: 1px dashed var(--border);
+}
+.campaign-stream-stat { display: flex; flex-direction: column; gap: 2px; }
+.campaign-stream-stat-label {
+  font-size: 9.5px; text-transform: uppercase; letter-spacing: 0.05em;
+  color: var(--text-mut); font-weight: 500;
+}
+.campaign-stream-spark { display: flex; flex-direction: column; gap: 4px; padding-top: 4px; }
+.campaign-spark-label { color: var(--text-mut); }
+.campaign-spark-bars {
+  display: grid; grid-template-columns: repeat(60, 1fr); gap: 1px;
+  height: 36px; align-items: end; padding: 2px 0;
+  background: var(--bg-input); border-radius: 3px;
+}
+.campaign-spark-bar {
+  background: var(--success); opacity: 0.85; border-radius: 1px 1px 0 0;
+  cursor: help;
+}
+
+/* Inventory + brand-safety */
+.campaign-ssp-table {
+  width: 100%; border-collapse: collapse; font-size: 11.5px;
+}
+.campaign-ssp-table th {
+  text-align: left; padding: 4px 8px; color: var(--text-mut);
+  font-weight: 500; font-size: 10px; text-transform: uppercase;
+  letter-spacing: 0.05em; border-bottom: 1px solid var(--border);
+}
+.campaign-ssp-table td {
+  padding: 5px 8px; color: var(--text-dim); vertical-align: middle;
+  border-bottom: 1px dashed var(--border);
+}
+.campaign-ssp-table tr:last-child td { border-bottom: none; }
+.campaign-ssp-table tr.trend-up    .trend-up-icon    { color: var(--success); font-weight: 700; }
+.campaign-ssp-table tr.trend-down  .trend-down-icon  { color: var(--error); font-weight: 700; }
+.campaign-ssp-table tr.trend-flat  .trend-flat-icon  { color: var(--text-mut); }
+.campaign-share-bar {
+  position: relative; height: 14px; background: var(--bg-input);
+  border-radius: 2px; min-width: 60px; overflow: hidden;
+}
+.campaign-share-fill {
+  position: absolute; left: 0; top: 0; bottom: 0;
+  background: var(--accent); opacity: 0.55;
+}
+.campaign-share-num {
+  position: relative; padding: 0 5px; font-size: 10px;
+  line-height: 14px; color: var(--text);
+}
+.campaign-safety-totals {
+  display: grid; grid-template-columns: repeat(5, 1fr); gap: 8px;
+  padding-bottom: 8px; border-bottom: 1px dashed var(--border);
+}
+.campaign-safety-reasons {
+  display: flex; flex-direction: column; gap: 2px; padding-top: 4px;
+}
+.campaign-safety-reason {
+  display: flex; justify-content: space-between; gap: 8px;
+  font-size: 11px; color: var(--text-dim);
+  padding: 2px 0;
+}
+
+/* Delivery + pacing */
+.campaign-pacing-banner {
+  display: flex; align-items: center; gap: 10px;
+  padding: 6px 10px; border-radius: 4px;
+  border: 1px solid currentColor; font-size: 12px;
+}
+.campaign-pacing-banner-label {
+  font-family: var(--font-mono); font-weight: 700;
+  letter-spacing: 0.06em; font-size: 11px;
+}
+.campaign-pacing-banner-meta { margin-left: auto; }
+.campaign-pacing-on_track { color: var(--success); background: rgba(102,187,106,0.10); }
+.campaign-pacing-over     { color: var(--warning, #d4a017); background: rgba(212,160,23,0.10); }
+.campaign-pacing-under    { color: var(--error); background: rgba(239,68,68,0.10); }
+.campaign-pacing-stats {
+  display: grid; grid-template-columns: repeat(4, 1fr); gap: 12px;
+  padding: 6px 0;
+}
+.campaign-pacing-progress {
+  display: flex; align-items: center; gap: 8px;
+}
+.campaign-pacing-progress-bar {
+  flex: 1; height: 8px; background: var(--bg-input);
+  border-radius: 4px; overflow: hidden;
+}
+.campaign-pacing-progress-fill {
+  height: 100%; background: var(--accent);
+  transition: width 0.4s;
+}
+.campaign-pacing-bars {
+  display: flex; gap: 2px; align-items: end;
+  height: 64px; padding: 4px 2px;
+  background: var(--bg-input); border-radius: 3px;
+  overflow-x: auto;
+}
+.campaign-pacing-bar {
+  flex: 0 0 14px; height: 100%; display: flex;
+  flex-direction: column; justify-content: flex-end;
+  cursor: help;
+}
+.campaign-pacing-bar-fill { width: 100%; border-radius: 1px 1px 0 0; }
+.campaign-pacing-bar.var-on    .campaign-pacing-bar-fill { background: var(--success); opacity: 0.75; }
+.campaign-pacing-bar.var-over  .campaign-pacing-bar-fill { background: var(--warning, #d4a017); opacity: 0.85; }
+.campaign-pacing-bar.var-under .campaign-pacing-bar-fill { background: var(--error); opacity: 0.7; }
+
+/* Attribution + optimization */
+.campaign-attr-row {
+  display: grid; grid-template-columns: repeat(4, 1fr); gap: 12px;
+  padding-bottom: 8px; border-bottom: 1px dashed var(--border);
+}
+.kpi-status-above { color: var(--success); margin-left: 4px; font-size: 9.5px; padding: 1px 5px; border-radius: 2px; background: rgba(102,187,106,0.10); border: 1px solid var(--success); }
+.kpi-status-on    { color: var(--text); margin-left: 4px; font-size: 9.5px; padding: 1px 5px; border-radius: 2px; background: var(--bg-input); border: 1px solid var(--border); }
+.kpi-status-below { color: var(--error); margin-left: 4px; font-size: 9.5px; padding: 1px 5px; border-radius: 2px; background: rgba(239,68,68,0.10); border: 1px solid var(--error); }
+.campaign-opt-signals {
+  display: flex; flex-direction: column; gap: 6px;
+}
+.campaign-opt-signal {
+  background: var(--bg-raised); border: 1px solid var(--border);
+  border-left-width: 3px; border-radius: 4px;
+  padding: 6px 10px; font-size: 11px;
+}
+.campaign-opt-boost { border-left-color: var(--success); }
+.campaign-opt-decay { border-left-color: var(--error); }
+.campaign-opt-shift { border-left-color: var(--accent); }
+.campaign-opt-alert { border-left-color: var(--warning, #d4a017); }
+.campaign-opt-signal-head {
+  display: flex; align-items: center; gap: 8px; flex-wrap: wrap;
+  margin-bottom: 2px;
+}
+.campaign-opt-signal-kind {
+  font-family: var(--font-mono); font-size: 9.5px; font-weight: 700;
+  letter-spacing: 0.06em; padding: 1px 5px; border-radius: 2px;
+  background: var(--bg-input); color: var(--text);
+}
+.campaign-opt-signal-metric { color: var(--text); font-weight: 600; }
+.campaign-opt-signal-conf { margin-left: auto; }
+.campaign-opt-signal-rec { color: var(--text-dim); font-size: 11px; line-height: 1.4; }
+.campaign-feedback-list {
+  display: flex; flex-direction: column; gap: 2px;
+  padding: 6px 8px; background: var(--bg-raised);
+  border: 1px dashed var(--accent); border-radius: 4px;
+  font-size: 10.5px;
+}
+.campaign-feedback-item { color: var(--accent); }
+
+/* Closed-loop arrow */
+.campaign-feedback-arrow {
+  display: flex; align-items: center; gap: 8px;
+  padding: 8px 12px; margin-top: 4px;
+  background: linear-gradient(90deg, rgba(249,115,22,0.06), rgba(56,182,255,0.06));
+  border: 1px dashed var(--accent); border-radius: 5px;
+  font-size: 11px; color: var(--text-mut);
+}
+.campaign-feedback-arrow .ico { color: var(--accent); }
+.campaign-feedback-arrow-tag {
+  margin-left: auto; color: var(--accent); font-size: 10px;
+}
+
+@media (max-width: 1100px) {
+  .campaign-card-grid { grid-template-columns: repeat(3, 1fr); }
+  .campaign-card-cell-wide { grid-column: span 3; }
+  .campaign-strategy-row { grid-template-columns: repeat(3, 1fr); }
+  .campaign-stream-stats { grid-template-columns: repeat(2, 1fr); }
+  .campaign-safety-totals { grid-template-columns: repeat(3, 1fr); }
+  .campaign-attr-row { grid-template-columns: repeat(2, 1fr); }
+  .campaign-lane-2col { grid-template-columns: 1fr; }
+}
+
 /* MVP #6: portfolio-rebalance banner. Shows above the media-buy cells
    when N agents auth-gate and at least 1 succeeds. Communicates that
    the workflow is robust to partial failure and the deployable budget
@@ -5936,7 +6331,7 @@ function switchTab(name) {
     journey: "Journey", planner: "Scenario", snapshots: "Snapshots",
     freshness: "Freshness",
     seasonality: "Seasonality", federation: "Federation",
-    orchestrator: "Orchestrator", canvas: "Canvas",
+    orchestrator: "Orchestrator", canvas: "Canvas", campaign: "Campaign Canvas",
   };
   document.getElementById("crumb-current").textContent = crumbMap[name] || name;
 
@@ -5951,6 +6346,7 @@ function switchTab(name) {
   if (name === "devkit") ensureDevkit();
   if (name === "destinations") ensureDestinations();
   if (name === "canvas") _canvasReplayFromQuery();
+  if (name === "campaign") _campaignInit();
   if (name === "lab") ensureLab();
   if (name === "portfolio") ensurePortfolio();
   if (name === "composer") ensureComposer();
@@ -15180,5 +15576,320 @@ document.getElementById("toollog-export").addEventListener("click", () => {
     }
   } catch (e) { /* noop */ }
 })();
+
+// ─────────────────────────────────────────────────────────────────
+// Campaign Canvas (DSP buy-side control loop)
+// ─────────────────────────────────────────────────────────────────
+
+var _campaignCurrent = null;
+var _campaignList = [];
+var _campaignLoaded = false;
+
+async function _campaignInit() {
+  if (_campaignLoaded) return;
+  _campaignLoaded = true;
+  try {
+    var r = await fetch("/dsp/campaigns");
+    var d = await r.json();
+    _campaignList = d.campaigns || [];
+    _campaignRenderSelector();
+    if (_campaignList.length > 0) _campaignSelect(_campaignList[0].campaign_id);
+  } catch (e) {
+    var host = document.getElementById("campaign-card-host");
+    if (host) host.innerHTML = '<div class="empty-state" style="border-color:var(--error)"><div class="empty-title" style="color:var(--error)">Failed to load campaigns</div></div>';
+  }
+}
+
+function _campaignRenderSelector() {
+  var el = document.getElementById("campaign-selector-buttons");
+  if (!el) return;
+  el.innerHTML = _campaignList.map(function (c) {
+    var active = (_campaignCurrent && _campaignCurrent.campaign_id === c.campaign_id) ? "active" : "";
+    return '<button class="campaign-selector-btn ' + active + '" data-campaign-id="' + escapeHtml(c.campaign_id) + '">' +
+      '<span class="campaign-selector-name">' + escapeHtml(c.brand_name) + '</span>' +
+      '<span class="campaign-selector-kpi mono">' + escapeHtml(c.kpi) + ' ' + (c.kpi === "CPM" || c.kpi === "CPA" ? "$" : "") + escapeHtml(String(c.kpi_target)) + (c.kpi === "ROAS" ? "x" : c.kpi === "BRAND_LIFT" ? "%" : "") + '</span>' +
+    '</button>';
+  }).join("");
+  el.querySelectorAll(".campaign-selector-btn").forEach(function (btn) {
+    btn.addEventListener("click", function () {
+      var id = btn.getAttribute("data-campaign-id");
+      if (id) _campaignSelect(id);
+    });
+  });
+}
+
+async function _campaignSelect(campaignId) {
+  try {
+    var r = await fetch("/dsp/campaigns/" + encodeURIComponent(campaignId));
+    _campaignCurrent = await r.json();
+    _campaignRenderSelector();
+    _campaignRenderCard();
+    var loop = document.getElementById("campaign-loop");
+    if (loop) loop.style.display = "";
+    // Hydrate all 5 lanes in parallel.
+    _campaignFillStrategy();
+    _campaignFillStream();
+    _campaignFillInventory();
+    _campaignFillDelivery();
+    _campaignFillAttribution();
+  } catch (e) { /* noop */ }
+}
+
+function _campaignRenderCard() {
+  var c = _campaignCurrent;
+  var host = document.getElementById("campaign-card-host");
+  if (!host || !c) return;
+  var startMs = Date.parse(c.flight_start);
+  var endMs = Date.parse(c.flight_end);
+  var totalDays = Math.max(1, Math.round((endMs - startMs) / 86400000));
+  var daysElapsed = Math.min(totalDays, c.start_day_offset || 0);
+  var daysRemaining = totalDays - daysElapsed;
+  var pctElapsed = Math.round((daysElapsed / totalDays) * 100);
+  var kpiLabel = c.kpi + " target: " + (c.kpi === "CPM" || c.kpi === "CPA" ? "$" : "") + c.kpi_target + (c.kpi === "ROAS" ? "x" : c.kpi === "BRAND_LIFT" ? "%" : "");
+  var geoChips = (c.geo || []).map(function (g) {
+    return '<span class="pill pill-muted mono" style="font-size:10px">' + escapeHtml(g) + '</span>';
+  }).join(" ");
+  host.innerHTML =
+    '<div class="campaign-card">' +
+      '<div class="campaign-card-head">' +
+        '<div class="campaign-card-name">' + escapeHtml(c.name) + '</div>' +
+        '<div class="campaign-card-brand mono">' + escapeHtml(c.brand_domain || "") + '</div>' +
+      '</div>' +
+      '<div class="campaign-card-grid">' +
+        '<div class="campaign-card-cell">' +
+          '<div class="campaign-card-label">KPI target</div>' +
+          '<div class="campaign-card-value campaign-kpi-' + escapeHtml(String(c.kpi).toLowerCase()) + '">' + escapeHtml(kpiLabel) + '</div>' +
+        '</div>' +
+        '<div class="campaign-card-cell">' +
+          '<div class="campaign-card-label">Budget</div>' +
+          '<div class="campaign-card-value mono">$' + c.budget_total_usd.toLocaleString() + '</div>' +
+          '<div class="campaign-card-sub orch-small">cap $' + c.budget_daily_cap_usd.toLocaleString() + '/day</div>' +
+        '</div>' +
+        '<div class="campaign-card-cell">' +
+          '<div class="campaign-card-label">Flight</div>' +
+          '<div class="campaign-card-value mono">' + escapeHtml(c.flight_start) + ' → ' + escapeHtml(c.flight_end) + '</div>' +
+          '<div class="campaign-card-sub orch-small">day ' + daysElapsed + ' of ' + totalDays + ' · ' + daysRemaining + ' left</div>' +
+        '</div>' +
+        '<div class="campaign-card-cell">' +
+          '<div class="campaign-card-label">Frequency cap</div>' +
+          '<div class="campaign-card-value mono">' + c.freq_cap_per_user + '/user</div>' +
+        '</div>' +
+        '<div class="campaign-card-cell campaign-card-cell-wide">' +
+          '<div class="campaign-card-label">Geo + audience brief</div>' +
+          '<div class="campaign-card-value">' + geoChips + '</div>' +
+          '<div class="campaign-card-sub orch-small mono">' + escapeHtml(c.audience_brief || "") + '</div>' +
+        '</div>' +
+      '</div>' +
+      '<div class="campaign-card-progress">' +
+        '<div class="campaign-card-progress-label orch-small"><span style="color:var(--text-mut)">flight progress</span> <span class="mono">' + pctElapsed + '%</span></div>' +
+        '<div class="campaign-card-progress-bar"><div class="campaign-card-progress-fill" style="width:' + pctElapsed + '%"></div></div>' +
+      '</div>' +
+    '</div>';
+}
+
+// ── Lane 1: Bid strategy ─────────────────────────────────────────────
+async function _campaignFillStrategy() {
+  var body = document.getElementById("campaign-strategy-body");
+  if (!body || !_campaignCurrent) return;
+  try {
+    var r = await fetch("/dsp/campaigns/" + encodeURIComponent(_campaignCurrent.campaign_id) + "/strategy");
+    var d = await r.json();
+    var s = d.strategy;
+    var modifiers = s.bid_modifiers.map(function (m) {
+      var cls = m.multiplier > 1 ? "mod-up" : "mod-down";
+      return '<div class="campaign-strategy-mod ' + cls + '" title="' + escapeHtml(m.reason) + '">' +
+        '<span class="mono">' + escapeHtml(m.name) + '</span>' +
+        '<span class="campaign-strategy-mod-val mono">×' + m.multiplier + '</span>' +
+      '</div>';
+    }).join("");
+    var dayparting = s.dayparting.map(function (h) {
+      var hh = (h.hour < 10 ? "0" : "") + h.hour;
+      var height = Math.round((h.multiplier / 1.2) * 24);
+      var cls = h.multiplier > 1.05 ? "dp-peak" : h.multiplier < 0.7 ? "dp-low" : "";
+      return '<div class="campaign-strategy-daypart ' + cls + '" title="' + hh + ':00 ×' + h.multiplier + '"><div class="campaign-strategy-daypart-bar" style="height:' + height + 'px"></div><span class="campaign-strategy-daypart-h mono">' + hh + '</span></div>';
+    }).join("");
+    body.innerHTML =
+      '<div class="campaign-strategy-row">' +
+        '<div class="campaign-strategy-cell"><div class="campaign-strategy-label">Algorithm</div><div class="mono"><span class="pill pill-muted">' + escapeHtml(s.algorithm) + '</span></div></div>' +
+        '<div class="campaign-strategy-cell"><div class="campaign-strategy-label">Base bid</div><div class="mono">$' + s.base_bid_usd + ' CPM</div></div>' +
+        '<div class="campaign-strategy-cell"><div class="campaign-strategy-label">Pacing</div><div class="mono">' + escapeHtml(s.pacing_strategy) + '</div></div>' +
+        '<div class="campaign-strategy-cell"><div class="campaign-strategy-label">Floor</div><div class="mono">' + escapeHtml(s.floor_strategy) + '</div></div>' +
+        '<div class="campaign-strategy-cell"><div class="campaign-strategy-label">Brand safety floor</div><div class="mono">≥' + s.brand_safety_floor + '/100</div></div>' +
+        '<div class="campaign-strategy-cell"><div class="campaign-strategy-label">Viewability floor</div><div class="mono">≥' + Math.round(s.viewability_floor * 100) + '%</div></div>' +
+      '</div>' +
+      '<div class="campaign-strategy-block">' +
+        '<div class="campaign-strategy-label">Bid modifiers</div>' +
+        '<div class="campaign-strategy-mods">' + modifiers + '</div>' +
+      '</div>' +
+      '<div class="campaign-strategy-block">' +
+        '<div class="campaign-strategy-label">Dayparting (hour-of-day multipliers)</div>' +
+        '<div class="campaign-strategy-dayparting">' + dayparting + '</div>' +
+      '</div>';
+  } catch (e) { body.innerHTML = '<span class="orch-small" style="color:var(--error)">strategy load failed</span>'; }
+}
+
+// ── Lane 2: Bid stream ───────────────────────────────────────────────
+async function _campaignFillStream() {
+  var body = document.getElementById("campaign-stream-body");
+  if (!body || !_campaignCurrent) return;
+  try {
+    var r = await fetch("/dsp/campaigns/" + encodeURIComponent(_campaignCurrent.campaign_id) + "/bid-stream");
+    var d = await r.json();
+    var samples = d.samples || [];
+    if (samples.length === 0) { body.innerHTML = '<span class="orch-small">no samples</span>'; return; }
+    // Aggregate totals across the window
+    var totalReqs = samples.reduce(function (s, x) { return s + x.bid_requests_per_sec; }, 0) * 60;
+    var totalBids = samples.reduce(function (s, x) { return s + x.bids_per_sec; }, 0) * 60;
+    var totalWins = samples.reduce(function (s, x) { return s + x.wins_per_sec; }, 0) * 60;
+    var winRate = totalBids > 0 ? Math.round((totalWins / totalBids) * 1000) / 10 : 0;
+    var bidRate = totalReqs > 0 ? Math.round((totalBids / totalReqs) * 1000) / 10 : 0;
+    var avgCpm = samples.reduce(function (s, x) { return s + x.avg_winning_cpm_usd; }, 0) / samples.length;
+    var p95avg = Math.round(samples.reduce(function (s, x) { return s + x.latency_p95_ms; }, 0) / samples.length);
+    // Sparkline: 60 bars showing wins-per-sec over time
+    var maxW = Math.max.apply(null, samples.map(function (x) { return x.wins_per_sec; })) || 1;
+    var spark = samples.map(function (x) {
+      var h = Math.max(1, Math.round((x.wins_per_sec / maxW) * 32));
+      return '<div class="campaign-spark-bar" style="height:' + h + 'px" title="t-' + x.t_offset_sec + 's: ' + Math.round(x.wins_per_sec) + ' wins/s, CPM $' + x.avg_winning_cpm_usd + '"></div>';
+    }).join("");
+    body.innerHTML =
+      '<div class="campaign-stream-stats">' +
+        '<div class="campaign-stream-stat"><div class="campaign-stream-stat-label">bid requests</div><div class="mono">' + Math.round(totalReqs).toLocaleString() + '</div></div>' +
+        '<div class="campaign-stream-stat"><div class="campaign-stream-stat-label">bids submitted</div><div class="mono">' + Math.round(totalBids).toLocaleString() + ' <span class="orch-small">(' + bidRate + '%)</span></div></div>' +
+        '<div class="campaign-stream-stat"><div class="campaign-stream-stat-label">wins</div><div class="mono">' + Math.round(totalWins).toLocaleString() + ' <span class="orch-small">(' + winRate + '%)</span></div></div>' +
+        '<div class="campaign-stream-stat"><div class="campaign-stream-stat-label">avg winning CPM</div><div class="mono">$' + (Math.round(avgCpm * 100) / 100) + '</div></div>' +
+        '<div class="campaign-stream-stat"><div class="campaign-stream-stat-label">latency p95</div><div class="mono">' + p95avg + ' ms</div></div>' +
+      '</div>' +
+      '<div class="campaign-stream-spark"><div class="campaign-spark-label orch-small">wins/sec — last 60 minutes</div><div class="campaign-spark-bars">' + spark + '</div></div>';
+  } catch (e) { body.innerHTML = '<span class="orch-small" style="color:var(--error)">bid-stream load failed</span>'; }
+}
+
+// ── Lane 3: Inventory match (per-SSP) + Brand safety ──────────────────
+async function _campaignFillInventory() {
+  var sspEl = document.getElementById("campaign-inventory-ssp");
+  var safetyEl = document.getElementById("campaign-inventory-safety");
+  if (!sspEl || !safetyEl || !_campaignCurrent) return;
+  try {
+    var [invR, safR] = await Promise.all([
+      fetch("/dsp/campaigns/" + encodeURIComponent(_campaignCurrent.campaign_id) + "/inventory").then(function (r) { return r.json(); }),
+      fetch("/dsp/campaigns/" + encodeURIComponent(_campaignCurrent.campaign_id) + "/brand-safety").then(function (r) { return r.json(); }),
+    ]);
+    // SSP table
+    var ssps = invR.ssps || [];
+    var rows = ssps.map(function (s) {
+      var trendIcon = s.trend_24h === "up" ? "↑" : s.trend_24h === "down" ? "↓" : "→";
+      var trendCls = "trend-" + s.trend_24h;
+      return '<tr class="' + trendCls + '">' +
+        '<td class="mono"><span class="' + trendCls + '-icon">' + trendIcon + '</span> ' + escapeHtml(s.ssp_name) + '</td>' +
+        '<td class="mono">' + s.win_rate_pct + '%</td>' +
+        '<td class="mono">$' + s.avg_winning_cpm_usd + '</td>' +
+        '<td class="mono">' + s.audience_match_rate_pct + '%</td>' +
+        '<td class="mono">' + s.bid_qps + '</td>' +
+        '<td class="mono">' + s.latency_p95_ms + 'ms</td>' +
+        '<td class="mono"><div class="campaign-share-bar"><div class="campaign-share-fill" style="width:' + (s.share_of_spend_pct * 2.5) + '%"></div><span class="campaign-share-num">' + s.share_of_spend_pct + '%</span></div></td>' +
+      '</tr>';
+    }).join("");
+    sspEl.innerHTML =
+      '<div class="campaign-strategy-label">Per-SSP performance · sorted by composite (win × match)</div>' +
+      '<table class="campaign-ssp-table">' +
+        '<thead><tr><th>SSP</th><th>win</th><th>CPM</th><th>match</th><th>QPS</th><th>p95</th><th>share</th></tr></thead>' +
+        '<tbody>' + rows + '</tbody>' +
+      '</table>';
+    // Brand safety
+    var bs = safR.brand_safety || {};
+    var reasons = (bs.reasons || []).map(function (r) {
+      return '<div class="campaign-safety-reason"><span>' + escapeHtml(r.reason) + '</span><span class="mono">' + r.count.toLocaleString() + ' <span class="orch-small">(' + r.pct + '%)</span></span></div>';
+    }).join("");
+    safetyEl.innerHTML =
+      '<div class="campaign-strategy-label">Brand-safety pre-bid filter</div>' +
+      '<div class="campaign-safety-totals">' +
+        '<div class="campaign-safety-total"><div class="campaign-stream-stat-label">evaluated</div><div class="mono">' + (bs.total_impressions_evaluated || 0).toLocaleString() + '</div></div>' +
+        '<div class="campaign-safety-total"><div class="campaign-stream-stat-label">blocked</div><div class="mono">' + (bs.total_blocked || 0).toLocaleString() + ' <span class="orch-small">(' + bs.block_rate_pct + '%)</span></div></div>' +
+        '<div class="campaign-safety-total"><div class="campaign-stream-stat-label">avg DV/IAS</div><div class="mono">' + (bs.avg_brand_safety_score || 0) + '/100</div></div>' +
+        '<div class="campaign-safety-total"><div class="campaign-stream-stat-label">avg viewable</div><div class="mono">' + Math.round((bs.avg_predicted_viewability || 0) * 100) + '%</div></div>' +
+        '<div class="campaign-safety-total"><div class="campaign-stream-stat-label">filter latency</div><div class="mono">' + (bs.filter_latency_p50_ms || 0) + 'ms</div></div>' +
+      '</div>' +
+      '<div class="campaign-safety-reasons">' + reasons + '</div>';
+  } catch (e) { sspEl.innerHTML = '<span class="orch-small" style="color:var(--error)">inventory load failed</span>'; }
+}
+
+// ── Lane 4: Delivery + pacing ────────────────────────────────────────
+async function _campaignFillDelivery() {
+  var body = document.getElementById("campaign-delivery-body");
+  if (!body || !_campaignCurrent) return;
+  try {
+    var r = await fetch("/dsp/campaigns/" + encodeURIComponent(_campaignCurrent.campaign_id) + "/pacing");
+    var d = await r.json();
+    var p = d.pacing;
+    var spent = p.spent_to_date_usd;
+    var total = p.budget_total_usd;
+    var pctSpent = total > 0 ? Math.round((spent / total) * 100) : 0;
+    var healthCls = "campaign-pacing-" + p.pacing_health;
+    var healthLabel = p.pacing_health === "on_track" ? "ON TRACK" : p.pacing_health === "over" ? "OVER" : "UNDER";
+    var maxDayspend = Math.max.apply(null, (p.per_day || []).map(function (x) { return x.spend_usd; })) || 1;
+    var bars = (p.per_day || []).map(function (pt) {
+      var h = Math.max(2, Math.round((pt.spend_usd / maxDayspend) * 60));
+      var varCls = Math.abs(pt.variance_pct) < 5 ? "var-on" : pt.variance_pct > 0 ? "var-over" : "var-under";
+      return '<div class="campaign-pacing-bar ' + varCls + '" title="day ' + pt.day + ': $' + pt.spend_usd + ' (var ' + pt.variance_pct + '%)"><div class="campaign-pacing-bar-fill" style="height:' + h + 'px"></div></div>';
+    }).join("");
+    body.innerHTML =
+      '<div class="campaign-pacing-banner ' + healthCls + '">' +
+        '<span class="campaign-pacing-banner-label">' + healthLabel + '</span>' +
+        '<span class="campaign-pacing-banner-meta orch-small">variance ' + (p.pacing_variance_pct > 0 ? "+" : "") + p.pacing_variance_pct + '% vs target</span>' +
+      '</div>' +
+      '<div class="campaign-pacing-stats">' +
+        '<div class="campaign-stream-stat"><div class="campaign-stream-stat-label">spent / total</div><div class="mono">$' + spent.toLocaleString() + ' / $' + total.toLocaleString() + '</div></div>' +
+        '<div class="campaign-stream-stat"><div class="campaign-stream-stat-label">remaining</div><div class="mono">$' + p.remaining_usd.toLocaleString() + '</div></div>' +
+        '<div class="campaign-stream-stat"><div class="campaign-stream-stat-label">days elapsed</div><div class="mono">' + p.days_elapsed + ' / ' + p.days_total + '</div></div>' +
+        '<div class="campaign-stream-stat"><div class="campaign-stream-stat-label">total impressions</div><div class="mono">' + (p.total_impressions || 0).toLocaleString() + '</div></div>' +
+      '</div>' +
+      '<div class="campaign-pacing-progress">' +
+        '<div class="campaign-pacing-progress-bar"><div class="campaign-pacing-progress-fill" style="width:' + pctSpent + '%"></div></div>' +
+        '<span class="campaign-pacing-progress-label orch-small mono">' + pctSpent + '% of budget</span>' +
+      '</div>' +
+      '<div class="campaign-strategy-label">Daily spend (variance vs target)</div>' +
+      '<div class="campaign-pacing-bars">' + bars + '</div>';
+  } catch (e) { body.innerHTML = '<span class="orch-small" style="color:var(--error)">pacing load failed</span>'; }
+}
+
+// ── Lane 5: Attribution + optimization signals ───────────────────────
+async function _campaignFillAttribution() {
+  var body = document.getElementById("campaign-attribution-body");
+  if (!body || !_campaignCurrent) return;
+  try {
+    var r = await fetch("/dsp/campaigns/" + encodeURIComponent(_campaignCurrent.campaign_id) + "/attribution");
+    var d = await r.json();
+    var a = d.attribution;
+    var statusCls = "kpi-status-" + a.kpi_status;
+    var prefix = (_campaignCurrent.kpi === "CPM" || _campaignCurrent.kpi === "CPA") ? "$" : "";
+    var suffix = _campaignCurrent.kpi === "ROAS" ? "x" : _campaignCurrent.kpi === "BRAND_LIFT" ? "%" : "";
+    var statusLabel = a.kpi_status === "above" ? "ABOVE TARGET" : a.kpi_status === "below" ? "BELOW TARGET" : "ON TARGET";
+    var signals = a.optimization_signals.map(function (s) {
+      var kindCls = "campaign-opt-" + s.kind;
+      return '<div class="campaign-opt-signal ' + kindCls + '">' +
+        '<div class="campaign-opt-signal-head">' +
+          '<span class="campaign-opt-signal-kind">' + escapeHtml(s.kind.toUpperCase()) + '</span>' +
+          '<span class="mono">' + escapeHtml(s.target) + '</span>' +
+          '<span class="campaign-opt-signal-metric mono">' + escapeHtml(s.metric) + '</span>' +
+          '<span class="campaign-opt-signal-conf orch-small mono">conf ' + Math.round(s.confidence * 100) + '%</span>' +
+        '</div>' +
+        '<div class="campaign-opt-signal-rec">' + escapeHtml(s.recommendation) + '</div>' +
+      '</div>';
+    }).join("");
+    var feedback = (a.feedback_into_strategy || []).map(function (f) {
+      return '<div class="campaign-feedback-item mono">' + escapeHtml(f) + '</div>';
+    }).join("");
+    body.innerHTML =
+      '<div class="campaign-attr-row">' +
+        '<div class="campaign-stream-stat"><div class="campaign-stream-stat-label">conversions</div><div class="mono">' + a.conversions.toLocaleString() + '</div></div>' +
+        '<div class="campaign-stream-stat"><div class="campaign-stream-stat-label">conversion value</div><div class="mono">$' + a.conversion_value_usd.toLocaleString() + '</div></div>' +
+        '<div class="campaign-stream-stat campaign-kpi-realized"><div class="campaign-stream-stat-label">realized ' + escapeHtml(_campaignCurrent.kpi) + '</div><div class="mono">' + prefix + a.realized_kpi + suffix + ' <span class="' + statusCls + '">' + statusLabel + '</span></div></div>' +
+        '<div class="campaign-stream-stat"><div class="campaign-stream-stat-label">target</div><div class="mono">' + prefix + a.kpi_target + suffix + '</div></div>' +
+      '</div>' +
+      '<div class="campaign-strategy-label">Optimization signals · feedback into bid strategy</div>' +
+      '<div class="campaign-opt-signals">' + signals + '</div>' +
+      '<div class="campaign-strategy-label" style="margin-top:8px">Strategy diff (next cycle)</div>' +
+      '<div class="campaign-feedback-list">' + feedback + '</div>';
+  } catch (e) { body.innerHTML = '<span class="orch-small" style="color:var(--error)">attribution load failed</span>'; }
+}
 </script>`;
 }

--- a/src/routes/dspRoutes.ts
+++ b/src/routes/dspRoutes.ts
@@ -1,0 +1,103 @@
+// src/routes/dspRoutes.ts
+//
+// Buy-side / DSP Canvas endpoints. Six routes covering the missing
+// AdCP buy-side primitives (mocked locally via src/domain/dspMock.ts):
+//
+//   GET /dsp/campaigns                         — list demo campaigns
+//   GET /dsp/campaigns/:id                     — single campaign card
+//   GET /dsp/campaigns/:id/strategy            — bid strategy
+//   GET /dsp/campaigns/:id/bid-stream          — recent bid stream samples
+//   GET /dsp/campaigns/:id/inventory           — per-SSP performance
+//   GET /dsp/campaigns/:id/brand-safety        — pre-bid filter stats
+//   GET /dsp/campaigns/:id/pacing              — burn rate vs target
+//   GET /dsp/campaigns/:id/attribution         — conversions + optimization signals
+//
+// Workshop framing: "every endpoint here mocks an AdCP buy-side
+// primitive that doesn't exist yet — submit_bid_strategy,
+// get_bid_opportunities, get_pacing_status, optimize_strategy. Same
+// playbook as governanceMock + brandRightsMock — when upstream lands,
+// swap to passthrough."
+//
+// All endpoints are GET-only and unauth — same posture as the
+// governance/brand-rights preview routes.
+
+import type { Env } from "../types/env";
+import type { Logger } from "../utils/logger";
+import { jsonResponse, errorResponse } from "./shared";
+import {
+  listCampaigns,
+  getCampaign,
+  generateBidStrategy,
+  generateBidStream,
+  generateSspPerformance,
+  generateBrandSafety,
+  generatePacing,
+  generateAttribution,
+} from "../domain/dspMock";
+
+function parseCampaignIdFromPath(path: string): string | null {
+  // /dsp/campaigns/<id>[/...]
+  const m = path.match(/^\/dsp\/campaigns\/(cmp_[a-z0-9_]+)(?:\/[a-z-]+)?$/i);
+  return m ? m[1]! : null;
+}
+
+export async function handleDspCampaigns(
+  request: Request,
+  _env: Env,
+  _logger: Logger,
+): Promise<Response> {
+  const url = new URL(request.url);
+  const path = url.pathname;
+
+  // GET /dsp/campaigns
+  if (path === "/dsp/campaigns") {
+    const list = listCampaigns().map((c) => ({
+      campaign_id: c.campaign_id,
+      name: c.name,
+      brand_name: c.brand_name,
+      brand_domain: c.brand_domain,
+      kpi: c.kpi,
+      kpi_target: c.kpi_target,
+      kpi_unit: c.kpi_unit,
+      budget_total_usd: c.budget_total_usd,
+      flight_start: c.flight_start,
+      flight_end: c.flight_end,
+    }));
+    return jsonResponse({ count: list.length, campaigns: list });
+  }
+
+  const id = parseCampaignIdFromPath(path);
+  if (!id) {
+    return errorResponse("INVALID_INPUT", "expected /dsp/campaigns/<id>[/<sub>]", 400);
+  }
+  const c = getCampaign(id);
+  if (!c) return errorResponse("CAMPAIGN_NOT_FOUND", "no campaign with id " + id, 404);
+
+  // GET /dsp/campaigns/:id  (full card)
+  if (path === `/dsp/campaigns/${id}`) {
+    return jsonResponse(c);
+  }
+
+  if (path.endsWith("/strategy")) {
+    return jsonResponse({ mode: "stub", campaign_id: id, strategy: generateBidStrategy(c) });
+  }
+  if (path.endsWith("/bid-stream")) {
+    return jsonResponse({ mode: "stub", campaign_id: id, samples: generateBidStream(c, 60) });
+  }
+  if (path.endsWith("/inventory")) {
+    return jsonResponse({ mode: "stub", campaign_id: id, ssps: generateSspPerformance(c) });
+  }
+  if (path.endsWith("/brand-safety")) {
+    return jsonResponse({ mode: "stub", campaign_id: id, brand_safety: generateBrandSafety(c) });
+  }
+  if (path.endsWith("/pacing")) {
+    return jsonResponse({ mode: "stub", campaign_id: id, pacing: generatePacing(c) });
+  }
+  if (path.endsWith("/attribution")) {
+    const pacing = generatePacing(c);
+    const attribution = generateAttribution(c, pacing);
+    return jsonResponse({ mode: "stub", campaign_id: id, attribution });
+  }
+
+  return errorResponse("NOT_FOUND", "unknown DSP sub-resource at " + path, 404);
+}


### PR DESCRIPTION
## Summary

New \"Campaign\" tab parallel to the brand-anchored \"Canvas\" tab. Where Canvas visualizes a sell-side linear pipeline (signals → creative → products → buy), Campaign visualizes the buy-side **real-time control loop** (bid → win/loss → optimize → bid).

Same playbook as \`governanceMock\` + \`brandRightsMock\`: mock all four missing AdCP buy-side primitives locally, document the gap, swap to live when upstream catches up.

## The 4 missing AdCP primitives this mocks

| Primitive | What it should do | Lane mocking it |
|---|---|---|
| \`submit_bid_strategy\` | Declare how to bid | Lane 1 |
| \`get_bid_opportunities\` | Stream bid requests | Lane 2 |
| \`get_pacing_status\` | Burn rate vs target | Lane 4 |
| \`optimize_strategy\` | Feedback delivery → strategy | Lane 5 + closed-loop arrow |

## Three demo campaigns

| Campaign | KPI | Budget | Flight |
|---|---|---|---|
| Coca-Cola Summer Refresh | ROAS 3.5x | \$250K | 45-day |
| Nike Air Max Drop | CPM \$8.50 | \$120K | 7-day urban |
| Pfizer Brand Lift Study | BRAND_LIFT 12% | \$80K | contextual-only |

## Canvas layout

```
[ Campaign card: KPI · budget · flight · freq cap · audience brief + progress bar ]
[ 1 · Bid strategy ......: algo + base bid + 5 modifiers + 24-hour dayparting   ]
[ 2 · Bid stream ........: 5-stat row + 60-bar wins/sec sparkline               ]
[ 3 · Inventory · Safety : 7-SSP table (sorted by composite) + filter stats     ]
[ 4 · Delivery · Pacing .: health banner + per-day variance bars                ]
[ 5 · Attribution · Opt ..: realized KPI vs target + 4 opt signals + strategy diff]
[ ↻ closed-loop arrow: \"feedback loop — opt signals re-tune bid strategy\"     ]
```

## Stats

- **+1292 lines, 4 files changed** (2 new domain files: \`dspMock.ts\`, \`dspRoutes.ts\`)
- **428/428 tests pass**, type-check clean, SCRIPT_TAG audit clean
- **0 new dependencies** — sparklines are plain inline-flex divs, dayparting is grid

## Test plan
- [x] Type-check clean
- [x] 428/428 tests pass
- [x] SCRIPT_TAG audit clean
- [ ] Smoke after deploy:
  - [ ] \`/dsp/campaigns\` returns 3 campaigns
  - [ ] \`/dsp/campaigns/cmp_cocacola_summer/strategy\` returns base_bid + modifiers + 24-hour dayparting
  - [ ] \`/dsp/campaigns/cmp_cocacola_summer/bid-stream\` returns 60 samples
  - [ ] \`/dsp/campaigns/cmp_pfizer_lift/attribution\` returns BRAND_LIFT realized vs target
  - [ ] Canvas: Campaign tab → switch between 3 campaigns → all 5 lanes hydrate

🤖 Generated with [Claude Code](https://claude.com/claude-code)