### PR TITLE
DSP: 5 more live MCP integrations (A-E) — full buy-side coverage

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -60,7 +60,12 @@ import {
   handleGovernancePreview,
   handleBrandRightsPreview,
 } from "./routes/registryRoutes";
-import { handleDspCampaigns } from "./routes/dspRoutes";
+import {
+  handleDspCampaigns,
+  handleDspCoverage,
+  handleDspMediaBuysLive,
+  handleDspDeliveryLive,
+} from "./routes/dspRoutes";
 import {
   handleAudienceCompose,
   handleAudienceSaturation,
@@ -252,8 +257,10 @@ export default {
             "/registry/governance-preview",
             // Refinement C: predictive brand-rights overlay.
             "/registry/brand-rights-preview",
-            // Campaign Canvas (DSP buy-side mock).
+            // Campaign Canvas (DSP buy-side mock + live hybrid).
             "/dsp/campaigns",
+            "/dsp/agents",
+            "/dsp/media-buys",
             "/taxonomy/reverse",
             // Sec-43: audience composer + activation-planning analytics.
             // Read-only — same posture as /portfolio/* and /analytics/*.
@@ -436,9 +443,15 @@ export default {
             } else if ((method === "GET" || method === "POST") && path === "/registry/brand-rights-preview") {
                 response = await handleBrandRightsPreview(request, env, logger);
 
-                // ── Buy-side / DSP Canvas (mock) ────────────────────────────────────
+                // ── Buy-side / DSP Canvas (mock + live hybrid) ───────────────────────
             } else if (method === "GET" && path.startsWith("/dsp/campaigns")) {
                 response = await handleDspCampaigns(request, env, logger);
+            } else if (method === "GET" && path === "/dsp/agents/coverage") {
+                response = await handleDspCoverage(request, env, logger);
+            } else if (method === "GET" && path === "/dsp/media-buys/live") {
+                response = await handleDspMediaBuysLive(request, env, logger);
+            } else if (method === "GET" && path.startsWith("/dsp/media-buys/") && path.endsWith("/delivery-live")) {
+                response = await handleDspDeliveryLive(request, env, logger);
 
                 // ── Sec-43: Audience Composer + activation analytics ────────────────
             } else if (method === "POST" && path === "/audience/compose") {

--- a/src/index.ts
+++ b/src/index.ts
@@ -65,6 +65,11 @@ import {
   handleDspCoverage,
   handleDspMediaBuysLive,
   handleDspDeliveryLive,
+  handleDspCampaignFireLive,
+  handleDspMediaBuyUpdateLive,
+  handleDspCampaignSignalsLive,
+  handleDspCampaignProductsLive,
+  handleDspAgentCapabilities,
 } from "./routes/dspRoutes";
 import {
   handleAudienceCompose,
@@ -452,6 +457,16 @@ export default {
                 response = await handleDspMediaBuysLive(request, env, logger);
             } else if (method === "GET" && path.startsWith("/dsp/media-buys/") && path.endsWith("/delivery-live")) {
                 response = await handleDspDeliveryLive(request, env, logger);
+            } else if (method === "POST" && path.startsWith("/dsp/media-buys/") && path.endsWith("/update-live")) {
+                response = await handleDspMediaBuyUpdateLive(request, env, logger);
+            } else if (method === "POST" && path.startsWith("/dsp/campaigns/") && path.endsWith("/fire-live")) {
+                response = await handleDspCampaignFireLive(request, env, logger);
+            } else if (method === "GET" && path.startsWith("/dsp/campaigns/") && path.endsWith("/signals-live")) {
+                response = await handleDspCampaignSignalsLive(request, env, logger);
+            } else if (method === "GET" && path.startsWith("/dsp/campaigns/") && path.endsWith("/products-live")) {
+                response = await handleDspCampaignProductsLive(request, env, logger);
+            } else if (method === "GET" && path.startsWith("/dsp/agents/") && path.endsWith("/capabilities-live")) {
+                response = await handleDspAgentCapabilities(request, env, logger);
 
                 // ── Sec-43: Audience Composer + activation analytics ────────────────
             } else if (method === "POST" && path === "/audience/compose") {

--- a/src/routes/demo.ts
+++ b/src/routes/demo.ts
@@ -1512,11 +1512,39 @@ ${STYLES}
           </div>
         </div>
 
-        <!-- Campaign selector -->
+        <!-- Live buy-side coverage strip: probes every live buying agent
+             and reports which advertise which buy-side primitives. The
+             upper-half lanes (strategy / bid-stream) flag 0/N coverage
+             prominently; lower-half lanes (delivery, attribution) show
+             the live count + opens-up live data path. -->
+        <div class="campaign-coverage" id="campaign-coverage">
+          <span class="orch-small" style="color:var(--text-mut);margin-right:8px">live MCP coverage:</span>
+          <div class="campaign-coverage-pills" id="campaign-coverage-pills">
+            <span class="orch-small">probing buying agents…</span>
+          </div>
+        </div>
+
+        <!-- Campaign selector + LIVE | DEMO toggle -->
         <div class="campaign-selector" id="campaign-selector">
           <span class="orch-small" style="color:var(--text-mut);margin-right:8px">campaign:</span>
           <div class="campaign-selector-buttons" id="campaign-selector-buttons">
             <span class="orch-small">loading…</span>
+          </div>
+          <span class="campaign-source-toggle" id="campaign-source-toggle">
+            <button class="campaign-source-btn active" data-source="demo">demo (mocked)</button>
+            <button class="campaign-source-btn" data-source="live">live (from agents)</button>
+          </span>
+        </div>
+
+        <!-- Live media-buys panel: appears in "live" mode. Aggregates
+             get_media_buys across every capable agent. -->
+        <div class="campaign-live-panel" id="campaign-live-panel" style="display:none">
+          <div class="campaign-live-head">
+            <span class="campaign-live-label">Real campaigns from live agents</span>
+            <span class="orch-small" id="campaign-live-meta">…</span>
+          </div>
+          <div id="campaign-live-list">
+            <span class="orch-small">querying get_media_buys across capable agents…</span>
           </div>
         </div>
 
@@ -5217,6 +5245,108 @@ textarea.lab-input { resize: vertical; line-height: 1.5; }
   .campaign-safety-totals { grid-template-columns: repeat(3, 1fr); }
   .campaign-attr-row { grid-template-columns: repeat(2, 1fr); }
   .campaign-lane-2col { grid-template-columns: 1fr; }
+}
+
+/* Live MCP coverage strip — top of Campaign Canvas */
+.campaign-coverage {
+  display: flex; align-items: center; gap: 6px; flex-wrap: wrap;
+  padding: 8px 12px; margin-bottom: 8px;
+  background: var(--bg-input); border: 1px solid var(--border);
+  border-radius: 5px; font-size: 11px;
+}
+.campaign-coverage-pills {
+  display: flex; gap: 4px; flex-wrap: wrap; align-items: center;
+}
+.campaign-coverage-group-label {
+  font-size: 9.5px; text-transform: uppercase; letter-spacing: 0.05em;
+  color: var(--text-mut); font-weight: 600; margin: 0 4px 0 2px;
+}
+.campaign-coverage-divider { color: var(--text-mut); margin: 0 4px; }
+.campaign-coverage-pill {
+  display: inline-flex; align-items: center; gap: 4px;
+  padding: 1px 5px; font-size: 9.5px; cursor: help;
+  border-radius: 3px; border: 1px solid;
+}
+.campaign-coverage-pill-tool { font-size: 9.5px; }
+.campaign-coverage-pill-frac { font-size: 9px; opacity: 0.8; }
+.campaign-coverage-pill.cov-full    { color: var(--success); border-color: var(--success); background: rgba(102,187,106,0.08); }
+.campaign-coverage-pill.cov-partial { color: var(--warning, #d4a017); border-color: var(--warning, #d4a017); background: rgba(212,160,23,0.08); }
+.campaign-coverage-pill.cov-zero    { color: var(--error); border-color: var(--error); background: rgba(239,68,68,0.08); }
+.campaign-coverage-pill.cov-unspec  { font-style: italic; opacity: 0.95; }
+
+/* Source toggle (demo / live) */
+.campaign-source-toggle {
+  margin-left: auto; display: inline-flex; gap: 1px;
+  padding: 2px; background: var(--bg-raised);
+  border: 1px solid var(--border); border-radius: 4px;
+}
+.campaign-source-btn {
+  background: transparent; color: var(--text-mut);
+  border: none; border-radius: 3px;
+  padding: 4px 10px; font-size: 11px; cursor: pointer;
+  font-family: inherit;
+}
+.campaign-source-btn.active {
+  background: var(--accent); color: #000; font-weight: 500;
+}
+
+/* Live media-buys panel */
+.campaign-live-panel {
+  background: var(--bg-surface); border: 1px solid var(--accent);
+  border-radius: 5px; padding: 10px 12px; margin-bottom: 12px;
+}
+.campaign-live-head {
+  display: flex; align-items: center; gap: 12px;
+  padding-bottom: 6px; margin-bottom: 8px;
+  border-bottom: 1px dashed var(--border);
+}
+.campaign-live-label { font-size: 12px; font-weight: 600; color: var(--accent); }
+.campaign-live-empty { display: flex; flex-direction: column; gap: 4px; }
+.campaign-live-agent-row {
+  display: flex; gap: 8px; align-items: center;
+  padding: 3px 6px; border-radius: 3px;
+  background: var(--bg-raised);
+}
+.campaign-live-agent-row.cov-full  { border-left: 3px solid var(--success); }
+.campaign-live-agent-row.cov-zero  { border-left: 3px solid var(--error); }
+.campaign-live-agent-row.cov-auth  { border-left: 3px solid var(--warning, #d4a017); }
+.campaign-live-buy-row {
+  display: flex; flex-direction: column; gap: 3px;
+  padding: 6px 8px; margin-bottom: 4px; border-radius: 4px;
+  background: var(--bg-raised); border: 1px solid var(--border);
+}
+.campaign-live-buy-head { display: flex; align-items: center; gap: 8px; }
+.campaign-live-buy-meta { color: var(--text-mut); }
+.campaign-live-buy-load {
+  align-self: flex-start; margin-top: 4px;
+  background: transparent; color: var(--accent);
+  border: 1px solid var(--accent); border-radius: 3px;
+  padding: 2px 8px; font-size: 10.5px; cursor: pointer;
+  font-family: inherit;
+}
+.campaign-live-buy-load:hover:not(:disabled) { background: var(--accent); color: #000; }
+.campaign-live-buy-load:disabled { opacity: 0.6; cursor: wait; }
+
+/* Per-lane provenance pill */
+.campaign-lane-prov {
+  display: flex; justify-content: flex-end; margin-bottom: 4px;
+}
+.campaign-provenance-pill {
+  font-family: var(--font-mono); font-size: 9px;
+  padding: 1px 6px; border-radius: 2px;
+  text-transform: uppercase; letter-spacing: 0.06em; font-weight: 600;
+  cursor: help; border: 1px solid;
+}
+.campaign-provenance-live     { color: var(--success); border-color: var(--success); background: rgba(102,187,106,0.10); }
+.campaign-provenance-fallback { color: var(--accent); border-color: var(--accent); background: rgba(56,182,255,0.08); }
+.campaign-provenance-zero     { color: var(--error); border-color: var(--error); background: rgba(239,68,68,0.08); }
+.campaign-provenance-mock     { color: var(--text-mut); border-color: var(--text-mut); background: var(--bg-input); }
+
+/* LIVE banner pill on the delivery panel */
+.campaign-data-source-pill {
+  font-family: var(--font-mono); font-size: 9px; font-weight: 700;
+  padding: 1px 6px; border-radius: 2px; letter-spacing: 0.08em;
+  background: var(--success); color: #000;
 }
 
 /* MVP #6: portfolio-rebalance banner. Shows above the media-buy cells
@@ -15584,10 +15714,15 @@ document.getElementById("toollog-export").addEventListener("click", () => {
 var _campaignCurrent = null;
 var _campaignList = [];
 var _campaignLoaded = false;
+var _campaignSource = "demo";   // "demo" | "live"
+var _campaignCoverage = null;   // probe matrix (cached after first load)
 
 async function _campaignInit() {
   if (_campaignLoaded) return;
   _campaignLoaded = true;
+  // Fire coverage probe + campaigns in parallel.
+  _campaignFillCoverage();
+  _campaignWireSourceToggle();
   try {
     var r = await fetch("/dsp/campaigns");
     var d = await r.json();
@@ -15597,6 +15732,148 @@ async function _campaignInit() {
   } catch (e) {
     var host = document.getElementById("campaign-card-host");
     if (host) host.innerHTML = '<div class="empty-state" style="border-color:var(--error)"><div class="empty-title" style="color:var(--error)">Failed to load campaigns</div></div>';
+  }
+}
+
+// ── Live MCP coverage strip ───────────────────────────────────────────
+async function _campaignFillCoverage() {
+  var pills = document.getElementById("campaign-coverage-pills");
+  if (!pills) return;
+  try {
+    var r = await fetch("/dsp/agents/coverage");
+    _campaignCoverage = await r.json();
+    var s = _campaignCoverage.coverage_summary || {};
+    var spec = (_campaignCoverage.spec_status && _campaignCoverage.spec_status.spec_lifecycle) || [];
+    var unspec = (_campaignCoverage.spec_status && _campaignCoverage.spec_status.unspec_primitives) || [];
+    function pill(tool, isUnspec) {
+      var sup = (s[tool] && s[tool].supported_count) || 0;
+      var total = (s[tool] && s[tool].total_buying_agents) || 0;
+      var clsState = sup === 0 ? "cov-zero" : sup === total ? "cov-full" : "cov-partial";
+      var cls = "campaign-coverage-pill " + clsState + (isUnspec ? " cov-unspec" : "");
+      var label = tool.replace(/^submit_|^get_|^optimize_/, "").replace(/_/g, " ");
+      return '<span class="' + cls + '" title="' + escapeHtml(tool) + ' — ' + sup + '/' + total + ' agents · ' + (isUnspec ? "unspec'd in 3.0 GA" : "lifecycle tool") + '">' +
+        '<span class="campaign-coverage-pill-tool mono">' + escapeHtml(label) + '</span>' +
+        '<span class="campaign-coverage-pill-frac mono">' + sup + '/' + total + '</span>' +
+      '</span>';
+    }
+    pills.innerHTML =
+      '<span class="campaign-coverage-group-label">spec lifecycle:</span>' +
+      spec.map(function (t) { return pill(t, false); }).join("") +
+      '<span class="campaign-coverage-divider">|</span>' +
+      '<span class="campaign-coverage-group-label">unspec&apos;d primitives:</span>' +
+      unspec.map(function (t) { return pill(t, true); }).join("");
+  } catch (e) {
+    pills.innerHTML = '<span class="orch-small" style="color:var(--text-mut)">coverage probe failed</span>';
+  }
+}
+
+// ── Source toggle (demo / live) ──────────────────────────────────────
+function _campaignWireSourceToggle() {
+  document.querySelectorAll(".campaign-source-btn").forEach(function (btn) {
+    btn.addEventListener("click", function () {
+      var src = btn.getAttribute("data-source");
+      if (!src || src === _campaignSource) return;
+      _campaignSource = src;
+      document.querySelectorAll(".campaign-source-btn").forEach(function (b) {
+        b.classList.toggle("active", b.getAttribute("data-source") === src);
+      });
+      var livePanel = document.getElementById("campaign-live-panel");
+      if (livePanel) livePanel.style.display = (src === "live") ? "" : "none";
+      if (src === "live") _campaignFillLiveBuys();
+    });
+  });
+}
+
+// ── Live media-buys aggregator ───────────────────────────────────────
+async function _campaignFillLiveBuys() {
+  var list = document.getElementById("campaign-live-list");
+  var meta = document.getElementById("campaign-live-meta");
+  if (!list) return;
+  list.innerHTML = '<span class="orch-small">querying get_media_buys across capable agents…</span>';
+  try {
+    var r = await fetch("/dsp/media-buys/live");
+    var d = await r.json();
+    if (meta) {
+      meta.textContent =
+        d.capable_agent_count + ' capable · ' +
+        d.ok_count + ' returned · ' +
+        d.auth_gated_count + ' auth-gated · ' +
+        d.total_media_buys + ' real campaigns found';
+    }
+    if (!d.media_buys || d.media_buys.length === 0) {
+      // Show per-agent status so the gap is visible.
+      var perAgent = (d.per_agent || []).map(function (a) {
+        var stateCls = a.ok ? "cov-full" : a.auth_gated ? "cov-auth" : "cov-zero";
+        var stateLabel = a.ok ? "ok (0 buys)" : a.auth_gated ? "auth-gated" : "error";
+        return '<div class="campaign-live-agent-row ' + stateCls + '">' +
+          '<span class="mono">' + escapeHtml(a.agent_id) + '</span>' +
+          '<span class="campaign-coverage-pill-frac">' + escapeHtml(stateLabel) + '</span>' +
+          (a.error ? '<span class="orch-small" style="color:var(--text-mut)">' + escapeHtml(String(a.error).slice(0, 100)) + '</span>' : '') +
+        '</div>';
+      }).join("");
+      list.innerHTML =
+        '<div class="campaign-live-empty">' +
+          '<div class="orch-small" style="color:var(--text-mut);margin-bottom:6px">no real campaigns returned — workshop story below:</div>' +
+          perAgent +
+          '<div class="orch-small" style="color:var(--text-mut);margin-top:6px">→ to populate this list, fire <code>create_media_buy</code> on a buying agent that returns ok (auth required for the default trio).</div>' +
+        '</div>';
+      return;
+    }
+    list.innerHTML = d.media_buys.map(function (b) {
+      var brand = (b.brand && (b.brand.name || b.brand.domain)) || (b.brand_manifest && b.brand_manifest.brand) || "(no brand)";
+      var budget = b.total_budget && (typeof b.total_budget === "object" ? b.total_budget.amount : b.total_budget);
+      return '<div class="campaign-live-buy-row" data-media-buy-id="' + escapeHtml(b.media_buy_id || b.buyer_ref || "") + '" data-source-agent-id="' + escapeHtml(b.source_agent_id) + '">' +
+        '<div class="campaign-live-buy-head">' +
+          '<span class="mono">' + escapeHtml(b.media_buy_id || b.buyer_ref || "?") + '</span>' +
+          '<span class="pill pill-muted mono" style="font-size:9.5px">' + escapeHtml(b.source_agent_id) + '</span>' +
+          (b.status ? '<span class="orch-small mono" style="color:var(--text-mut)">' + escapeHtml(String(b.status)) + '</span>' : '') +
+        '</div>' +
+        '<div class="campaign-live-buy-meta orch-small">' +
+          escapeHtml(brand) +
+          (budget ? ' · $' + budget.toLocaleString() : '') +
+          (b.start_time ? ' · ' + escapeHtml(String(b.start_time).slice(0, 10)) : '') +
+        '</div>' +
+        '<button class="campaign-live-buy-load mono" data-media-buy-id="' + escapeHtml(b.media_buy_id || "") + '" data-source-agent-id="' + escapeHtml(b.source_agent_id) + '">Load LIVE delivery</button>' +
+      '</div>';
+    }).join("");
+    list.querySelectorAll(".campaign-live-buy-load").forEach(function (btn) {
+      btn.addEventListener("click", function () {
+        var id = btn.getAttribute("data-media-buy-id");
+        var aid = btn.getAttribute("data-source-agent-id");
+        if (id && aid) _campaignLoadLiveDelivery(id, aid, btn);
+      });
+    });
+  } catch (e) {
+    list.innerHTML = '<span class="orch-small" style="color:var(--error)">live media-buys aggregator failed</span>';
+  }
+}
+
+async function _campaignLoadLiveDelivery(mediaBuyId, agentId, btn) {
+  if (btn) { btn.disabled = true; btn.textContent = "fetching…"; }
+  try {
+    var r = await fetch("/dsp/media-buys/" + encodeURIComponent(mediaBuyId) + "/delivery-live?agent_id=" + encodeURIComponent(agentId));
+    var d = await r.json();
+    var body = document.getElementById("campaign-delivery-body");
+    if (!body) return;
+    if (!d.ok) {
+      body.innerHTML =
+        '<div class="campaign-pacing-banner ' + (d.auth_gated ? "campaign-pacing-under" : "campaign-pacing-over") + '">' +
+          '<span class="campaign-pacing-banner-label">' + (d.auth_gated ? "AUTH-GATED" : "ERROR") + '</span>' +
+          '<span class="orch-small">live get_media_buy_delivery on ' + escapeHtml(d.agent_id) + ' returned ' + (d.error ? escapeHtml(d.error.slice(0, 200)) : "no body") + '</span>' +
+        '</div>' +
+        '<div class="orch-small" style="color:var(--text-mut)">falling back to mocked pacing for the demo.</div>';
+    } else {
+      body.innerHTML =
+        '<div class="campaign-pacing-banner campaign-pacing-on_track">' +
+          '<span class="campaign-pacing-banner-label">LIVE</span>' +
+          '<span class="orch-small">get_media_buy_delivery returned in ' + d.latency_ms + 'ms from ' + escapeHtml(d.agent_id) + '</span>' +
+          '<span class="campaign-data-source-pill" style="margin-left:auto">LIVE</span>' +
+        '</div>' +
+        '<pre class="wf-json mono" style="max-height:300px;overflow:auto">' + escapeHtml(JSON.stringify(d.delivery, null, 2).slice(0, 4000)) + '</pre>';
+    }
+    if (btn) { btn.textContent = "Reload LIVE delivery"; btn.disabled = false; }
+  } catch (e) {
+    if (btn) { btn.textContent = "Retry"; btn.disabled = false; }
   }
 }
 
@@ -15687,10 +15964,34 @@ function _campaignRenderCard() {
     '</div>';
 }
 
+// ── Provenance pill helper ───────────────────────────────────────────
+// Returns a small inline pill describing whether this lane's data is
+// LIVE (from a real agent), MOCK (synthetic), or LIVE-FALLBACK (we
+// tried live and got nothing usable). Workshop-relevant: every lane
+// states its provenance honestly.
+function _campaignProvenancePill(state, detail) {
+  var cls = "campaign-provenance-" + state;
+  var label = state === "live" ? "LIVE" : state === "fallback" ? "LIVE-FALLBACK" : state === "zero" ? "MOCK · 0 live agents" : "MOCK";
+  return '<span class="campaign-provenance-pill ' + cls + '" title="' + escapeHtml(detail || "") + '">' + label + '</span>';
+}
+
+function _campaignToolCoverage(tool) {
+  if (!_campaignCoverage || !_campaignCoverage.coverage_summary) return null;
+  var s = _campaignCoverage.coverage_summary[tool];
+  if (!s) return null;
+  return { sup: s.supported_count, total: s.total_buying_agents };
+}
+
 // ── Lane 1: Bid strategy ─────────────────────────────────────────────
 async function _campaignFillStrategy() {
   var body = document.getElementById("campaign-strategy-body");
   if (!body || !_campaignCurrent) return;
+  // Live coverage: 0 agents advertise submit_bid_strategy. Surface
+  // that explicitly so the mock framing stays honest.
+  var cov = _campaignToolCoverage("submit_bid_strategy");
+  var prov = cov && cov.sup === 0
+    ? _campaignProvenancePill("zero", "0/" + cov.total + " agents advertise submit_bid_strategy — primitive is unspec'd in 3.0 GA")
+    : _campaignProvenancePill("mock", "synthesized locally");
   try {
     var r = await fetch("/dsp/campaigns/" + encodeURIComponent(_campaignCurrent.campaign_id) + "/strategy");
     var d = await r.json();
@@ -15709,6 +16010,7 @@ async function _campaignFillStrategy() {
       return '<div class="campaign-strategy-daypart ' + cls + '" title="' + hh + ':00 ×' + h.multiplier + '"><div class="campaign-strategy-daypart-bar" style="height:' + height + 'px"></div><span class="campaign-strategy-daypart-h mono">' + hh + '</span></div>';
     }).join("");
     body.innerHTML =
+      '<div class="campaign-lane-prov">' + prov + '</div>' +
       '<div class="campaign-strategy-row">' +
         '<div class="campaign-strategy-cell"><div class="campaign-strategy-label">Algorithm</div><div class="mono"><span class="pill pill-muted">' + escapeHtml(s.algorithm) + '</span></div></div>' +
         '<div class="campaign-strategy-cell"><div class="campaign-strategy-label">Base bid</div><div class="mono">$' + s.base_bid_usd + ' CPM</div></div>' +
@@ -15732,6 +16034,10 @@ async function _campaignFillStrategy() {
 async function _campaignFillStream() {
   var body = document.getElementById("campaign-stream-body");
   if (!body || !_campaignCurrent) return;
+  var cov = _campaignToolCoverage("get_bid_opportunities");
+  var prov = cov && cov.sup === 0
+    ? _campaignProvenancePill("zero", "0/" + cov.total + " agents advertise get_bid_opportunities — primitive is unspec'd in 3.0 GA")
+    : _campaignProvenancePill("mock", "synthesized locally");
   try {
     var r = await fetch("/dsp/campaigns/" + encodeURIComponent(_campaignCurrent.campaign_id) + "/bid-stream");
     var d = await r.json();
@@ -15752,6 +16058,7 @@ async function _campaignFillStream() {
       return '<div class="campaign-spark-bar" style="height:' + h + 'px" title="t-' + x.t_offset_sec + 's: ' + Math.round(x.wins_per_sec) + ' wins/s, CPM $' + x.avg_winning_cpm_usd + '"></div>';
     }).join("");
     body.innerHTML =
+      '<div class="campaign-lane-prov">' + prov + '</div>' +
       '<div class="campaign-stream-stats">' +
         '<div class="campaign-stream-stat"><div class="campaign-stream-stat-label">bid requests</div><div class="mono">' + Math.round(totalReqs).toLocaleString() + '</div></div>' +
         '<div class="campaign-stream-stat"><div class="campaign-stream-stat-label">bids submitted</div><div class="mono">' + Math.round(totalBids).toLocaleString() + ' <span class="orch-small">(' + bidRate + '%)</span></div></div>' +
@@ -15788,7 +16095,13 @@ async function _campaignFillInventory() {
         '<td class="mono"><div class="campaign-share-bar"><div class="campaign-share-fill" style="width:' + (s.share_of_spend_pct * 2.5) + '%"></div><span class="campaign-share-num">' + s.share_of_spend_pct + '%</span></div></td>' +
       '</tr>';
     }).join("");
+    var covInv = _campaignToolCoverage("get_media_buys");
+    var provInv = covInv && covInv.sup > 0
+      ? _campaignProvenancePill("fallback", covInv.sup + "/" + covInv.total + " agents advertise get_media_buys; SSP-level rollup is unspec'd — synthesized")
+      : _campaignProvenancePill("mock", "synthesized locally");
+    var provSafety = _campaignProvenancePill("mock", "no agent in directory advertises pre-bid filter — entirely synthesized");
     sspEl.innerHTML =
+      '<div class="campaign-lane-prov">' + provInv + '</div>' +
       '<div class="campaign-strategy-label">Per-SSP performance · sorted by composite (win × match)</div>' +
       '<table class="campaign-ssp-table">' +
         '<thead><tr><th>SSP</th><th>win</th><th>CPM</th><th>match</th><th>QPS</th><th>p95</th><th>share</th></tr></thead>' +
@@ -15800,6 +16113,7 @@ async function _campaignFillInventory() {
       return '<div class="campaign-safety-reason"><span>' + escapeHtml(r.reason) + '</span><span class="mono">' + r.count.toLocaleString() + ' <span class="orch-small">(' + r.pct + '%)</span></span></div>';
     }).join("");
     safetyEl.innerHTML =
+      '<div class="campaign-lane-prov">' + provSafety + '</div>' +
       '<div class="campaign-strategy-label">Brand-safety pre-bid filter</div>' +
       '<div class="campaign-safety-totals">' +
         '<div class="campaign-safety-total"><div class="campaign-stream-stat-label">evaluated</div><div class="mono">' + (bs.total_impressions_evaluated || 0).toLocaleString() + '</div></div>' +
@@ -15816,6 +16130,18 @@ async function _campaignFillInventory() {
 async function _campaignFillDelivery() {
   var body = document.getElementById("campaign-delivery-body");
   if (!body || !_campaignCurrent) return;
+  // Pacing has TWO live primitives: get_pacing_status (unspec) and
+  // get_media_buy_delivery (lifecycle, broadly supported). The mock
+  // is the strategy-side; the delivery-side is replaced with LIVE
+  // when the user clicks "Load LIVE delivery" on a real campaign.
+  var covPacing = _campaignToolCoverage("get_pacing_status");
+  var covDelivery = _campaignToolCoverage("get_media_buy_delivery");
+  var prov;
+  if (covPacing && covPacing.sup === 0 && covDelivery && covDelivery.sup > 0) {
+    prov = _campaignProvenancePill("fallback", "0/" + covPacing.total + " agents advertise get_pacing_status (unspec'd); " + covDelivery.sup + "/" + covDelivery.total + " advertise get_media_buy_delivery — load a real campaign for live data");
+  } else {
+    prov = _campaignProvenancePill("mock", "synthesized locally");
+  }
   try {
     var r = await fetch("/dsp/campaigns/" + encodeURIComponent(_campaignCurrent.campaign_id) + "/pacing");
     var d = await r.json();
@@ -15832,6 +16158,7 @@ async function _campaignFillDelivery() {
       return '<div class="campaign-pacing-bar ' + varCls + '" title="day ' + pt.day + ': $' + pt.spend_usd + ' (var ' + pt.variance_pct + '%)"><div class="campaign-pacing-bar-fill" style="height:' + h + 'px"></div></div>';
     }).join("");
     body.innerHTML =
+      '<div class="campaign-lane-prov">' + prov + '</div>' +
       '<div class="campaign-pacing-banner ' + healthCls + '">' +
         '<span class="campaign-pacing-banner-label">' + healthLabel + '</span>' +
         '<span class="campaign-pacing-banner-meta orch-small">variance ' + (p.pacing_variance_pct > 0 ? "+" : "") + p.pacing_variance_pct + '% vs target</span>' +
@@ -15855,6 +16182,10 @@ async function _campaignFillDelivery() {
 async function _campaignFillAttribution() {
   var body = document.getElementById("campaign-attribution-body");
   if (!body || !_campaignCurrent) return;
+  var cov = _campaignToolCoverage("optimize_strategy");
+  var prov = cov && cov.sup === 0
+    ? _campaignProvenancePill("zero", "0/" + cov.total + " agents advertise optimize_strategy — primitive is unspec'd in 3.0 GA")
+    : _campaignProvenancePill("mock", "synthesized locally");
   try {
     var r = await fetch("/dsp/campaigns/" + encodeURIComponent(_campaignCurrent.campaign_id) + "/attribution");
     var d = await r.json();
@@ -15879,6 +16210,7 @@ async function _campaignFillAttribution() {
       return '<div class="campaign-feedback-item mono">' + escapeHtml(f) + '</div>';
     }).join("");
     body.innerHTML =
+      '<div class="campaign-lane-prov">' + prov + '</div>' +
       '<div class="campaign-attr-row">' +
         '<div class="campaign-stream-stat"><div class="campaign-stream-stat-label">conversions</div><div class="mono">' + a.conversions.toLocaleString() + '</div></div>' +
         '<div class="campaign-stream-stat"><div class="campaign-stream-stat-label">conversion value</div><div class="mono">$' + a.conversion_value_usd.toLocaleString() + '</div></div>' +

--- a/src/routes/demo.ts
+++ b/src/routes/demo.ts
@@ -5349,6 +5349,122 @@ textarea.lab-input { resize: vertical; line-height: 1.5; }
   background: var(--success); color: #000;
 }
 
+/* Feature B: campaign-card live fire button row */
+.campaign-card-actions {
+  display: flex; align-items: center; gap: 8px; flex-wrap: wrap;
+  margin-top: 10px; padding-top: 10px;
+  border-top: 1px dashed var(--border);
+}
+.campaign-fire-btn {
+  display: inline-flex; align-items: center; gap: 6px;
+  background: var(--accent); color: #000;
+  border: 1px solid var(--accent); border-radius: 4px;
+  padding: 6px 12px; font-size: 12px; font-weight: 500;
+  cursor: pointer; font-family: inherit; transition: filter 0.15s;
+}
+.campaign-fire-btn:hover:not(:disabled) { filter: brightness(1.1); }
+.campaign-fire-btn:disabled { opacity: 0.6; cursor: wait; }
+.campaign-fire-btn .ico { width: 12px; height: 12px; }
+.campaign-fire-agent {
+  background: var(--bg-input); color: var(--text-dim);
+  border: 1px solid var(--border); border-radius: 4px;
+  padding: 5px 8px; font-size: 11.5px;
+  font-family: var(--font-mono);
+}
+.campaign-fire-result { width: 100%; }
+.campaign-fire-row {
+  display: inline-flex; align-items: center; gap: 8px; flex-wrap: wrap;
+  padding: 4px 8px; border-radius: 3px; font-size: 11px;
+}
+.campaign-fire-row.campaign-fire-ok   { background: rgba(102,187,106,0.10); border: 1px solid var(--success); }
+.campaign-fire-row.campaign-fire-auth { background: rgba(212,160,23,0.10); border: 1px solid var(--warning, #d4a017); }
+.campaign-fire-row.campaign-fire-err  { background: rgba(239,68,68,0.10); border: 1px solid var(--error); }
+.campaign-fire-label {
+  font-family: var(--font-mono); font-size: 9.5px; font-weight: 700;
+  letter-spacing: 0.06em; padding: 1px 5px; border-radius: 2px;
+  background: var(--bg-raised); color: var(--text);
+}
+
+/* Feature A: apply-diff button row */
+.campaign-apply-diff-row {
+  display: flex; align-items: center; gap: 10px; flex-wrap: wrap;
+  margin-top: 8px; padding-top: 8px;
+  border-top: 1px dashed var(--border);
+}
+.campaign-apply-diff-btn {
+  background: transparent; color: var(--accent);
+  border: 1px solid var(--accent); border-radius: 4px;
+  padding: 4px 10px; font-size: 11px; cursor: pointer;
+  font-family: inherit; transition: background-color 0.15s;
+}
+.campaign-apply-diff-btn:hover:not(:disabled) { background: var(--accent); color: #000; }
+.campaign-apply-diff-btn:disabled { opacity: 0.6; cursor: wait; }
+.campaign-apply-diff-result { width: 100%; }
+
+/* Feature C: live audience signals on Lane 1 */
+.campaign-live-signals {
+  display: flex; flex-wrap: wrap; gap: 4px;
+}
+.campaign-live-signal-chip {
+  display: inline-flex; align-items: center; gap: 6px;
+  padding: 3px 8px; background: var(--bg-raised);
+  border: 1px solid var(--success); border-radius: 4px;
+  font-size: 10.5px; cursor: help;
+}
+.campaign-live-signal-name { color: var(--text); }
+.campaign-live-signal-meta { color: var(--text-mut); font-size: 9.5px; }
+.campaign-live-signal-source { font-size: 8.5px; color: var(--accent); }
+
+/* Feature D: live products on Lane 3 */
+.campaign-live-product-row {
+  display: flex; align-items: center; gap: 8px; flex-wrap: wrap;
+  padding: 3px 6px; border-bottom: 1px dashed var(--border);
+  font-size: 11px;
+}
+.campaign-live-product-row:last-child { border-bottom: none; }
+.campaign-live-product-name { color: var(--text-mut); font-size: 10.5px; }
+
+/* Feature E: capabilities modal */
+.campaign-cap-link {
+  background: transparent; color: var(--accent);
+  border: 1px solid transparent; border-radius: 3px;
+  padding: 1px 5px; font-size: 9.5px; cursor: pointer;
+  font-family: var(--font-mono);
+  text-decoration: underline; text-decoration-style: dotted;
+}
+.campaign-cap-link:hover { border-color: var(--accent); background: rgba(56,182,255,0.08); text-decoration: none; }
+.campaign-cap-modal {
+  position: fixed; inset: 0; z-index: 9000;
+  background: rgba(0,0,0,0.6); display: flex; align-items: center; justify-content: center;
+  padding: 20px;
+}
+.campaign-cap-modal-inner {
+  background: var(--bg-surface); border: 1px solid var(--accent);
+  border-radius: 6px; padding: 14px; min-width: 400px; max-width: 700px;
+  max-height: 80vh; overflow-y: auto;
+}
+.campaign-cap-modal-head {
+  display: flex; align-items: center; justify-content: space-between;
+  padding-bottom: 8px; margin-bottom: 10px;
+  border-bottom: 1px solid var(--border);
+  font-size: 12.5px; color: var(--text);
+}
+.campaign-cap-modal-close {
+  background: transparent; border: 1px solid var(--border);
+  border-radius: 3px; width: 24px; height: 24px;
+  cursor: pointer; color: var(--text-mut); font-size: 16px;
+}
+.campaign-cap-summary {
+  display: flex; flex-direction: column; gap: 4px;
+}
+.campaign-cap-row {
+  display: grid; grid-template-columns: 240px 1fr;
+  gap: 8px; padding: 4px 0;
+  border-bottom: 1px dashed var(--border); font-size: 11.5px;
+}
+.campaign-cap-row:last-child { border-bottom: none; }
+.campaign-cap-key { color: var(--text-mut); font-size: 11px; }
+
 /* MVP #6: portfolio-rebalance banner. Shows above the media-buy cells
    when N agents auth-gate and at least 1 succeeds. Communicates that
    the workflow is robust to partial failure and the deployable budget
@@ -15761,7 +15877,19 @@ async function _campaignFillCoverage() {
       spec.map(function (t) { return pill(t, false); }).join("") +
       '<span class="campaign-coverage-divider">|</span>' +
       '<span class="campaign-coverage-group-label">unspec&apos;d primitives:</span>' +
-      unspec.map(function (t) { return pill(t, true); }).join("");
+      unspec.map(function (t) { return pill(t, true); }).join("") +
+      // Feature E: per-agent capabilities deep-probe links.
+      '<span class="campaign-coverage-divider">|</span>' +
+      '<span class="campaign-coverage-group-label">caps:</span>' +
+      (_campaignCoverage.agents || []).map(function (a) {
+        return '<button class="campaign-cap-link" data-agent-id="' + escapeHtml(a.agent_id) + '" title="get_adcp_capabilities on ' + escapeHtml(a.agent_id) + '">' + escapeHtml(a.agent_id) + '</button>';
+      }).join(" ");
+    pills.querySelectorAll(".campaign-cap-link").forEach(function (btn) {
+      btn.addEventListener("click", function () {
+        var aid = btn.getAttribute("data-agent-id");
+        if (aid) _campaignShowAgentCaps(aid);
+      });
+    });
   } catch (e) {
     pills.innerHTML = '<span class="orch-small" style="color:var(--text-mut)">coverage probe failed</span>';
   }
@@ -15961,7 +16089,65 @@ function _campaignRenderCard() {
         '<div class="campaign-card-progress-label orch-small"><span style="color:var(--text-mut)">flight progress</span> <span class="mono">' + pctElapsed + '%</span></div>' +
         '<div class="campaign-card-progress-bar"><div class="campaign-card-progress-fill" style="width:' + pctElapsed + '%"></div></div>' +
       '</div>' +
+      // Feature B: live fire button. Calls /dsp/campaigns/:id/fire-live →
+      // create_media_buy on a real buying agent. Auth-gated response is
+      // expected for the default trio; surfaces inline with the boundary.
+      '<div class="campaign-card-actions">' +
+        '<button class="campaign-fire-btn" id="campaign-fire-btn" data-campaign-id="' + escapeHtml(c.campaign_id) + '">' +
+          '<svg class="ico"><use href="#icon-bolt"/></svg>' +
+          '<span>Simulate live fire</span>' +
+        '</button>' +
+        '<select class="campaign-fire-agent" id="campaign-fire-agent">' +
+          '<option value="adzymic_apx">adzymic_apx</option>' +
+          '<option value="claire_scope3">claire_scope3</option>' +
+          '<option value="swivel">swivel</option>' +
+          '<option value="content_ignite">content_ignite</option>' +
+        '</select>' +
+        '<span class="orch-small" style="color:var(--text-mut)">→ create_media_buy on the chosen agent with the campaign brief + brand + signals</span>' +
+        '<div class="campaign-fire-result orch-small" id="campaign-fire-result"></div>' +
+      '</div>' +
     '</div>';
+  // Wire fire button.
+  var fireBtn = document.getElementById("campaign-fire-btn");
+  if (fireBtn) fireBtn.addEventListener("click", _campaignFireLive);
+}
+
+// Feature B: live fire from Campaign card.
+async function _campaignFireLive() {
+  if (!_campaignCurrent) return;
+  var btn = document.getElementById("campaign-fire-btn");
+  var sel = document.getElementById("campaign-fire-agent");
+  var out = document.getElementById("campaign-fire-result");
+  if (!btn || !sel || !out) return;
+  var agentId = sel.value;
+  btn.disabled = true; btn.textContent = "firing…";
+  try {
+    var r = await fetch("/dsp/campaigns/" + encodeURIComponent(_campaignCurrent.campaign_id) + "/fire-live", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ agent_id: agentId, signal_ids: [] }),
+    });
+    var d = await r.json();
+    var statusCls = d.ok ? "campaign-fire-ok" : (d.auth_gated ? "campaign-fire-auth" : "campaign-fire-err");
+    var label = d.ok ? "OK" : (d.auth_gated ? "AUTH-GATED" : "ERROR");
+    var msg = d.ok ? "media-buy created · " + d.latency_ms + "ms" : (d.error || "no response body");
+    out.innerHTML =
+      '<div class="campaign-fire-row ' + statusCls + '">' +
+        '<span class="campaign-fire-label">' + label + '</span>' +
+        '<span class="mono">' + escapeHtml(d.agent_id) + '</span>' +
+        '<span>' + escapeHtml(String(msg).slice(0, 200)) + '</span>' +
+      '</div>';
+    if (d.ok) {
+      // Refresh the live media-buys panel since a new buy now exists.
+      _campaignSource = "live";
+      var liveToggle = document.querySelector('.campaign-source-btn[data-source="live"]');
+      if (liveToggle) liveToggle.click();
+    }
+    btn.textContent = "Re-fire"; btn.disabled = false;
+  } catch (e) {
+    out.innerHTML = '<span class="orch-small" style="color:var(--error)">' + escapeHtml(String((e && e.message) || e)) + '</span>';
+    btn.textContent = "Retry"; btn.disabled = false;
+  }
 }
 
 // ── Provenance pill helper ───────────────────────────────────────────
@@ -16026,8 +16212,93 @@ async function _campaignFillStrategy() {
       '<div class="campaign-strategy-block">' +
         '<div class="campaign-strategy-label">Dayparting (hour-of-day multipliers)</div>' +
         '<div class="campaign-strategy-dayparting">' + dayparting + '</div>' +
+      '</div>' +
+      // Feature C: live audience signals from get_signals against the brief.
+      '<div class="campaign-strategy-block" id="campaign-live-signals-block">' +
+        '<div class="campaign-strategy-label">' +
+          '<span>Live audience signals</span>' +
+          '<span class="campaign-provenance-pill campaign-provenance-live" style="margin-left:6px" title="real call to get_signals on every live signals agent">LIVE · get_signals</span>' +
+        '</div>' +
+        '<div id="campaign-live-signals-list"><span class="orch-small">querying signals agents…</span></div>' +
       '</div>';
+    _campaignFillLiveSignals();
   } catch (e) { body.innerHTML = '<span class="orch-small" style="color:var(--error)">strategy load failed</span>'; }
+}
+
+// Feature E: capabilities deep-probe modal.
+async function _campaignShowAgentCaps(agentId) {
+  var existing = document.getElementById("campaign-cap-modal");
+  if (existing) existing.remove();
+  var modal = document.createElement("div");
+  modal.id = "campaign-cap-modal";
+  modal.className = "campaign-cap-modal";
+  modal.innerHTML =
+    '<div class="campaign-cap-modal-inner">' +
+      '<div class="campaign-cap-modal-head">' +
+        '<span class="mono">' + escapeHtml(agentId) + ' · get_adcp_capabilities</span>' +
+        '<button class="campaign-cap-modal-close" id="campaign-cap-modal-close">×</button>' +
+      '</div>' +
+      '<div class="campaign-cap-modal-body" id="campaign-cap-modal-body"><span class="orch-small">probing…</span></div>' +
+    '</div>';
+  document.body.appendChild(modal);
+  document.getElementById("campaign-cap-modal-close").addEventListener("click", function () { modal.remove(); });
+  modal.addEventListener("click", function (e) { if (e.target === modal) modal.remove(); });
+  try {
+    var r = await fetch("/dsp/agents/" + encodeURIComponent(agentId) + "/capabilities-live");
+    var d = await r.json();
+    var body = document.getElementById("campaign-cap-modal-body");
+    if (!d.ok || !d.capabilities) {
+      body.innerHTML = '<span class="orch-small" style="color:var(--error)">no capabilities returned · ' + escapeHtml(d.error || "") + '</span>';
+      return;
+    }
+    var caps = d.capabilities;
+    var adcp = caps.adcp || {};
+    var idem = adcp.idempotency || {};
+    var summary =
+      '<div class="campaign-cap-summary">' +
+        '<div class="campaign-cap-row"><span class="campaign-cap-key">supported_protocols</span><span class="mono">' + escapeHtml(JSON.stringify(caps.supported_protocols || [])) + '</span></div>' +
+        '<div class="campaign-cap-row"><span class="campaign-cap-key">supports_governance</span><span class="mono">' + escapeHtml(String(caps.supports_governance ?? false)) + '</span></div>' +
+        '<div class="campaign-cap-row"><span class="campaign-cap-key">supports_si</span><span class="mono">' + escapeHtml(String(caps.supports_si ?? false)) + '</span></div>' +
+        '<div class="campaign-cap-row"><span class="campaign-cap-key">adcp.major_versions</span><span class="mono">' + escapeHtml(JSON.stringify(adcp.major_versions || [])) + '</span></div>' +
+        '<div class="campaign-cap-row"><span class="campaign-cap-key">adcp.idempotency.supported</span><span class="mono">' + escapeHtml(String(idem.supported ?? false)) + '</span></div>' +
+        '<div class="campaign-cap-row"><span class="campaign-cap-key">adcp.idempotency.replay_ttl_seconds</span><span class="mono">' + escapeHtml(String(idem.replay_ttl_seconds ?? "—")) + '</span></div>' +
+        '<div class="campaign-cap-row"><span class="campaign-cap-key">latency_ms</span><span class="mono">' + d.latency_ms + '</span></div>' +
+      '</div>';
+    body.innerHTML =
+      summary +
+      '<details style="margin-top:8px"><summary class="orch-small" style="cursor:pointer">raw capabilities JSON</summary><pre class="wf-json mono" style="max-height:240px;overflow:auto">' + escapeHtml(JSON.stringify(caps, null, 2).slice(0, 4000)) + '</pre></details>';
+  } catch (e) {
+    var b = document.getElementById("campaign-cap-modal-body");
+    if (b) b.innerHTML = '<span class="orch-small" style="color:var(--error)">' + escapeHtml(String((e && e.message) || e)) + '</span>';
+  }
+}
+
+// Feature C: live signals on Lane 1.
+async function _campaignFillLiveSignals() {
+  var el = document.getElementById("campaign-live-signals-list");
+  if (!el || !_campaignCurrent) return;
+  try {
+    var r = await fetch("/dsp/campaigns/" + encodeURIComponent(_campaignCurrent.campaign_id) + "/signals-live");
+    var d = await r.json();
+    var top = d.top_signals || [];
+    if (top.length === 0) {
+      el.innerHTML = '<span class="orch-small" style="color:var(--text-mut)">no signals returned for brief: ' + escapeHtml(d.audience_brief || "") + '</span>';
+      return;
+    }
+    el.innerHTML =
+      '<div class="campaign-live-signals-meta orch-small" style="margin-bottom:4px">brief: <code class="mono">' + escapeHtml(d.audience_brief || "") + '</code> · returned ' + top.length + ' top from ' + (d.per_agent || []).length + ' agents</div>' +
+      '<div class="campaign-live-signals">' + top.map(function (s) {
+        var cov = s.coverage_percentage != null ? s.coverage_percentage + "%" : "?";
+        var size = s.estimated_audience_size != null ? Math.round(s.estimated_audience_size / 1000000) + "M" : "?";
+        return '<div class="campaign-live-signal-chip" title="' + escapeHtml(s.signal_agent_segment_id) + ' · from ' + escapeHtml(s.source_agent_id) + '">' +
+          '<span class="campaign-live-signal-name">' + escapeHtml(s.name || s.signal_agent_segment_id) + '</span>' +
+          '<span class="campaign-live-signal-meta mono">cov ' + cov + ' · ~' + size + '</span>' +
+          '<span class="campaign-live-signal-source orch-small mono">' + escapeHtml(s.source_agent_id) + '</span>' +
+        '</div>';
+      }).join("") + '</div>';
+  } catch (e) {
+    el.innerHTML = '<span class="orch-small" style="color:var(--error)">signals fetch failed</span>';
+  }
 }
 
 // ── Lane 2: Bid stream ───────────────────────────────────────────────
@@ -16123,7 +16394,55 @@ async function _campaignFillInventory() {
         '<div class="campaign-safety-total"><div class="campaign-stream-stat-label">filter latency</div><div class="mono">' + (bs.filter_latency_p50_ms || 0) + 'ms</div></div>' +
       '</div>' +
       '<div class="campaign-safety-reasons">' + reasons + '</div>';
+    // Feature D: live products list under the SSP table.
+    sspEl.insertAdjacentHTML("beforeend",
+      '<div class="campaign-strategy-block" style="margin-top:10px" id="campaign-live-products-block">' +
+        '<div class="campaign-strategy-label">' +
+          '<span>Live targetable inventory (real get_products)</span>' +
+          '<span class="campaign-provenance-pill campaign-provenance-live" style="margin-left:6px" title="real call to get_products on every capable buying agent">LIVE · get_products</span>' +
+        '</div>' +
+        '<div id="campaign-live-products-list"><span class="orch-small">querying buying agents…</span></div>' +
+      '</div>');
+    _campaignFillLiveProducts();
   } catch (e) { sspEl.innerHTML = '<span class="orch-small" style="color:var(--error)">inventory load failed</span>'; }
+}
+
+// Feature D: live get_products on Lane 3.
+async function _campaignFillLiveProducts() {
+  var el = document.getElementById("campaign-live-products-list");
+  if (!el || !_campaignCurrent) return;
+  try {
+    var r = await fetch("/dsp/campaigns/" + encodeURIComponent(_campaignCurrent.campaign_id) + "/products-live");
+    var d = await r.json();
+    var meta =
+      d.capable_agent_count + ' capable · ' +
+      d.ok_count + ' returned · ' +
+      d.auth_gated_count + ' auth-gated · ' +
+      d.total_products + ' products';
+    var top = d.top_products || [];
+    if (top.length === 0) {
+      el.innerHTML =
+        '<div class="orch-small" style="color:var(--text-mut);margin-bottom:4px">' + escapeHtml(meta) + '</div>' +
+        '<div class="campaign-live-empty">' + (d.per_agent || []).map(function (a) {
+          var stateCls = a.ok ? "cov-full" : a.auth_gated ? "cov-auth" : "cov-zero";
+          var stateLabel = a.ok ? "ok (0 products)" : a.auth_gated ? "auth-gated" : "error";
+          return '<div class="campaign-live-agent-row ' + stateCls + '"><span class="mono">' + escapeHtml(a.agent_id) + '</span><span class="campaign-coverage-pill-frac">' + escapeHtml(stateLabel) + '</span></div>';
+        }).join("") + '</div>';
+      return;
+    }
+    el.innerHTML =
+      '<div class="orch-small" style="color:var(--text-mut);margin-bottom:4px">' + escapeHtml(meta) + '</div>' +
+      top.map(function (p) {
+        return '<div class="campaign-live-product-row">' +
+          '<span class="mono">' + escapeHtml(p.product_id) + '</span>' +
+          '<span class="pill pill-muted mono" style="font-size:9px">' + escapeHtml(p.source_agent_id) + '</span>' +
+          (p.cpm_floor != null ? '<span class="orch-small mono">CPM floor $' + p.cpm_floor + '</span>' : '') +
+          (p.name ? '<span class="campaign-live-product-name">' + escapeHtml(p.name) + '</span>' : '') +
+        '</div>';
+      }).join("");
+  } catch (e) {
+    el.innerHTML = '<span class="orch-small" style="color:var(--error)">products fetch failed</span>';
+  }
 }
 
 // ── Lane 4: Delivery + pacing ────────────────────────────────────────
@@ -16220,8 +16539,58 @@ async function _campaignFillAttribution() {
       '<div class="campaign-strategy-label">Optimization signals · feedback into bid strategy</div>' +
       '<div class="campaign-opt-signals">' + signals + '</div>' +
       '<div class="campaign-strategy-label" style="margin-top:8px">Strategy diff (next cycle)</div>' +
-      '<div class="campaign-feedback-list">' + feedback + '</div>';
+      '<div class="campaign-feedback-list">' + feedback + '</div>' +
+      // Feature A: apply diff via update_media_buy on a real media-buy.
+      // Picks the first live media-buy from the live panel; if none yet,
+      // shows hint about firing first.
+      '<div class="campaign-apply-diff-row">' +
+        '<button class="campaign-apply-diff-btn" id="campaign-apply-diff-btn">' +
+          '<span>Apply diff via update_media_buy</span>' +
+        '</button>' +
+        '<span class="orch-small" style="color:var(--text-mut)">→ calls update_media_buy on the first live media-buy from the live panel; tries each agent that fired one</span>' +
+        '<div class="campaign-apply-diff-result" id="campaign-apply-diff-result"></div>' +
+      '</div>';
+    var diffBtn = document.getElementById("campaign-apply-diff-btn");
+    if (diffBtn) diffBtn.addEventListener("click", _campaignApplyDiffLive);
   } catch (e) { body.innerHTML = '<span class="orch-small" style="color:var(--error)">attribution load failed</span>'; }
+}
+
+// Feature A: apply strategy diff via update_media_buy on a real buy.
+async function _campaignApplyDiffLive() {
+  var btn = document.getElementById("campaign-apply-diff-btn");
+  var out = document.getElementById("campaign-apply-diff-result");
+  if (!btn || !out) return;
+  btn.disabled = true; btn.textContent = "querying live media-buys…";
+  try {
+    var listResp = await fetch("/dsp/media-buys/live");
+    var listData = await listResp.json();
+    var buy = (listData.media_buys || [])[0];
+    if (!buy) {
+      out.innerHTML = '<span class="orch-small" style="color:var(--text-mut)">no live media-buys exist yet — fire one from the campaign card first.</span>';
+      btn.textContent = "Apply diff via update_media_buy"; btn.disabled = false;
+      return;
+    }
+    btn.textContent = "calling update_media_buy…";
+    var r = await fetch("/dsp/media-buys/" + encodeURIComponent(buy.media_buy_id || buy.buyer_ref) + "/update-live", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ agent_id: buy.source_agent_id }),
+    });
+    var d = await r.json();
+    var statusCls = d.ok ? "campaign-fire-ok" : (d.auth_gated ? "campaign-fire-auth" : "campaign-fire-err");
+    var label = d.ok ? "OK" : (d.auth_gated ? "AUTH-GATED" : "ERROR");
+    out.innerHTML =
+      '<div class="campaign-fire-row ' + statusCls + '">' +
+        '<span class="campaign-fire-label">' + label + '</span>' +
+        '<span class="mono">' + escapeHtml(d.agent_id) + '</span>' +
+        '<span>update_media_buy → ' + d.latency_ms + 'ms</span>' +
+        (d.error ? '<span class="orch-small">' + escapeHtml(String(d.error).slice(0, 200)) + '</span>' : '') +
+      '</div>';
+    btn.textContent = "Re-apply"; btn.disabled = false;
+  } catch (e) {
+    out.innerHTML = '<span class="orch-small" style="color:var(--error)">' + escapeHtml(String((e && e.message) || e)) + '</span>';
+    btn.textContent = "Retry"; btn.disabled = false;
+  }
 }
 </script>`;
 }

--- a/src/routes/dspRoutes.ts
+++ b/src/routes/dspRoutes.ts
@@ -36,6 +36,7 @@ import {
 } from "../domain/dspMock";
 import { AGENT_REGISTRY } from "../domain/agentRegistry";
 import { callAgentTool, probeAgent } from "../federation/genericMcpClient";
+import { buildCreateMediaBuyPayload, applyVendorAdapter, getDemoProviderAttestations } from "../domain/workflowOrchestration";
 
 // The 11 buy-side primitives we care about. The first 7 are AdCP-spec'd
 // lifecycle tools (get_media_buy_delivery is in 3.0 GA; the rest are
@@ -375,4 +376,326 @@ export async function handleDspCampaigns(
   }
 
   return errorResponse("NOT_FOUND", "unknown DSP sub-resource at " + path, 404);
+}
+
+// ── B: /dsp/campaigns/:id/fire-live ────────────────────────────────────────
+//
+// Picks a buying agent (default: adzymic_apx) and fires create_media_buy
+// with a synthesized payload from the campaign brief + live get_signals
+// against the campaign's audience_brief. Reuses sell-side
+// buildCreateMediaBuyPayload + applyVendorAdapter so vendor-adapter
+// rules (Sec-48r6) are applied identically.
+
+interface FireLiveBody {
+  agent_id?: string;
+  signal_ids?: string[];
+}
+
+export async function handleDspCampaignFireLive(
+  request: Request,
+  _env: Env,
+  logger: Logger,
+): Promise<Response> {
+  const url = new URL(request.url);
+  const m = url.pathname.match(/^\/dsp\/campaigns\/(cmp_[a-z0-9_]+)\/fire-live$/);
+  if (!m) return errorResponse("INVALID_INPUT", "expected /dsp/campaigns/<id>/fire-live", 400);
+  const c = getCampaign(m[1]!);
+  if (!c) return errorResponse("CAMPAIGN_NOT_FOUND", "no campaign with id " + m[1], 404);
+
+  let body: FireLiveBody = {};
+  try { body = await request.json(); } catch { /* default agent below */ }
+
+  const agentId = body.agent_id || "adzymic_apx";
+  const agent = AGENT_REGISTRY.find((a) => a.id === agentId);
+  if (!agent || !agent.mcp_url) return errorResponse("UNKNOWN_AGENT", "no agent " + agentId, 404);
+
+  const workflowId = "wf_dsp_" + Math.random().toString(36).slice(2, 10);
+  const chosenSignals = (Array.isArray(body.signal_ids) ? body.signal_ids : []).filter((s) => typeof s === "string");
+
+  const payload = buildCreateMediaBuyPayload({
+    workflowId,
+    agentId: agent.id,
+    brief: c.audience_brief,
+    chosenProductId: null,
+    chosenSignalIds: chosenSignals,
+    chosenFormatIds: [],
+    brandContext: { domain: c.brand_domain, name: c.brand_name },
+    totalBudgetUsd: c.budget_total_usd,
+    attestations: chosenSignals.length > 0 ? getDemoProviderAttestations() : [],
+  });
+  const wirePayload = applyVendorAdapter(agent.id, payload, { brandDomain: c.brand_domain });
+
+  const start = Date.now();
+  const r = await callAgentTool(agent.mcp_url, "create_media_buy", wirePayload as unknown as Record<string, unknown>, { timeoutMs: 15_000 });
+  const latency = Date.now() - start;
+
+  let authGated = false;
+  let errorText: string | undefined;
+  if (!r.ok) {
+    const blocks = (r.content as Array<{ type?: string; text?: string }> | undefined) || [];
+    for (const blk of blocks) {
+      if (blk?.type === "text" && typeof blk.text === "string") {
+        if (AUTH_GATE_RE.test(blk.text)) authGated = true;
+        if (!errorText) errorText = blk.text.slice(0, 280);
+        break;
+      }
+    }
+    if (!errorText && r.error) errorText = r.error;
+  }
+
+  logger.info("dsp_fire_live", {
+    campaign_id: c.campaign_id, agent_id: agent.id, ok: r.ok, latency_ms: latency, auth_gated: authGated,
+  });
+
+  return jsonResponse({
+    campaign_id: c.campaign_id,
+    workflow_id: workflowId,
+    agent_id: agent.id,
+    agent_name: agent.name,
+    vendor: agent.vendor,
+    ok: r.ok,
+    auth_gated: authGated,
+    error: errorText ?? null,
+    latency_ms: latency,
+    payload_preview: payload,
+    result: r.structured_content ?? null,
+    content: r.content ?? null,
+  });
+}
+
+// ── A: /dsp/media-buys/:id/update-live ─────────────────────────────────────
+//
+// Calls update_media_buy on the owning agent with a synthesized strategy
+// diff (e.g. budget reallocation, signal swap). Mirrors the optimization-
+// signals output from Lane 5 — turns the visualized feedback into a real
+// vendor call. Even when auth-gated, the response surfaces the boundary.
+
+interface UpdateLiveBody {
+  agent_id?: string;
+  // The diff body is opaque to us; vendors define their own update shape.
+  // We ship a minimal one that's broadly accepted.
+  patch?: Record<string, unknown>;
+}
+
+export async function handleDspMediaBuyUpdateLive(
+  request: Request,
+  _env: Env,
+  logger: Logger,
+): Promise<Response> {
+  const url = new URL(request.url);
+  const m = url.pathname.match(/^\/dsp\/media-buys\/([^/]+)\/update-live$/);
+  if (!m) return errorResponse("INVALID_INPUT", "expected /dsp/media-buys/<id>/update-live", 400);
+  const mediaBuyId = decodeURIComponent(m[1]!);
+
+  let body: UpdateLiveBody = {};
+  try { body = await request.json(); } catch { /* default below */ }
+
+  const agentId = body.agent_id;
+  if (!agentId) return errorResponse("INVALID_INPUT", "agent_id required in body", 400);
+  const agent = AGENT_REGISTRY.find((a) => a.id === agentId);
+  if (!agent || !agent.mcp_url) return errorResponse("UNKNOWN_AGENT", "no agent " + agentId, 404);
+
+  // Default patch — workshop-realistic strategy-diff: pause + bump budget +
+  // swap signals. Vendors that don't accept all keys ignore extras.
+  const patch = body.patch ?? {
+    status: "paused",
+    targeting_overlay: { required_axe_signals: ["sig_int_market_beverages", "sig_aff_qsr_visitors"] },
+    notes: "Applied optimization signals: boost PubMatic; decay OpenX; suppress dayparting 02-05.",
+  };
+
+  const args: Record<string, unknown> = { media_buy_id: mediaBuyId, ...patch };
+  const start = Date.now();
+  const r = await callAgentTool(agent.mcp_url, "update_media_buy", args, { timeoutMs: 12_000 });
+  const latency = Date.now() - start;
+
+  let authGated = false;
+  let errorText: string | undefined;
+  if (!r.ok) {
+    const blocks = (r.content as Array<{ type?: string; text?: string }> | undefined) || [];
+    for (const blk of blocks) {
+      if (blk?.type === "text" && typeof blk.text === "string") {
+        if (AUTH_GATE_RE.test(blk.text)) authGated = true;
+        if (!errorText) errorText = blk.text.slice(0, 280);
+        break;
+      }
+    }
+    if (!errorText && r.error) errorText = r.error;
+  }
+
+  logger.info("dsp_update_live", {
+    media_buy_id: mediaBuyId, agent_id: agent.id, ok: r.ok, latency_ms: latency, auth_gated: authGated,
+  });
+
+  return jsonResponse({
+    media_buy_id: mediaBuyId,
+    agent_id: agent.id,
+    agent_name: agent.name,
+    vendor: agent.vendor,
+    ok: r.ok,
+    auth_gated: authGated,
+    error: errorText ?? null,
+    latency_ms: latency,
+    patch_sent: args,
+    result: r.structured_content ?? null,
+    content: r.content ?? null,
+  });
+}
+
+// ── C: /dsp/campaigns/:id/signals-live ─────────────────────────────────────
+//
+// Calls get_signals on every live signals agent with the campaign's
+// audience_brief. Returns merged + ranked top results so Lane 1 can
+// show real signals being targeted, not synthetic.
+
+export async function handleDspCampaignSignalsLive(
+  _request: Request,
+  _env: Env,
+  _logger: Logger,
+): Promise<Response> {
+  const url = new URL(_request.url);
+  const m = url.pathname.match(/^\/dsp\/campaigns\/(cmp_[a-z0-9_]+)\/signals-live$/);
+  if (!m) return errorResponse("INVALID_INPUT", "expected /dsp/campaigns/<id>/signals-live", 400);
+  const c = getCampaign(m[1]!);
+  if (!c) return errorResponse("CAMPAIGN_NOT_FOUND", "no campaign with id " + m[1], 404);
+
+  const signalsAgents = AGENT_REGISTRY.filter((a) => a.role === "signals" && a.stage === "live" && a.mcp_url);
+
+  interface SignalLite { source_agent_id: string; source_agent_name: string; signal_agent_segment_id: string; name?: string; coverage_percentage?: number; estimated_audience_size?: number }
+
+  const results = await Promise.all(signalsAgents.map(async (a) => {
+    const start = Date.now();
+    const r = await callAgentTool(a.mcp_url!, "get_signals", {
+      signal_spec: c.audience_brief,
+      max_results: 10,
+      pagination: { max_results: 10 },
+      deliver_to: { deployments: [{ type: "platform", platform: "mock_dsp" }], countries: ["US"] },
+    }, { timeoutMs: 10_000 });
+    const latency = Date.now() - start;
+    interface SignalShape { signal_agent_segment_id?: string; id?: string; name?: string; coverage_percentage?: number; estimated_audience_size?: number }
+    const sc = (r.structured_content as { signals?: SignalShape[] } | undefined) ?? {};
+    const signals: SignalLite[] = (sc.signals ?? []).slice(0, 10).map((s) => {
+      const item: SignalLite = {
+        source_agent_id: a.id,
+        source_agent_name: a.name,
+        signal_agent_segment_id: s.signal_agent_segment_id ?? s.id ?? "",
+      };
+      if (s.name !== undefined) item.name = s.name;
+      if (s.coverage_percentage !== undefined) item.coverage_percentage = s.coverage_percentage;
+      if (s.estimated_audience_size !== undefined) item.estimated_audience_size = s.estimated_audience_size;
+      return item;
+    });
+    return { agent_id: a.id, agent_name: a.name, ok: r.ok, latency_ms: latency, signal_count: signals.length, signals, error: r.error };
+  }));
+
+  // Merge + rank top-5 by coverage.
+  const merged: SignalLite[] = results.flatMap((r) => r.signals);
+  merged.sort((a, b) => (b.coverage_percentage ?? 0) - (a.coverage_percentage ?? 0));
+
+  return jsonResponse({
+    campaign_id: c.campaign_id,
+    audience_brief: c.audience_brief,
+    per_agent: results,
+    top_signals: merged.slice(0, 5),
+  });
+}
+
+// ── D: /dsp/campaigns/:id/products-live ────────────────────────────────────
+//
+// Calls get_products on every capable buying agent with the campaign's
+// audience_brief + brand context. Aggregates real product candidates
+// the campaign could target — workshop story: "the inventory side IS
+// live and discoverable; only the bid-time primitives are unspec'd".
+
+export async function handleDspCampaignProductsLive(
+  _request: Request,
+  env: Env,
+  logger: Logger,
+): Promise<Response> {
+  const url = new URL(_request.url);
+  const m = url.pathname.match(/^\/dsp\/campaigns\/(cmp_[a-z0-9_]+)\/products-live$/);
+  if (!m) return errorResponse("INVALID_INPUT", "expected /dsp/campaigns/<id>/products-live", 400);
+  const c = getCampaign(m[1]!);
+  if (!c) return errorResponse("CAMPAIGN_NOT_FOUND", "no campaign with id " + m[1], 404);
+
+  const coverage = await getCoverageInternal(env, logger);
+  const capable = coverage.agents.filter((e) => e.tools_supported.includes("create_media_buy"));
+
+  const results = await Promise.all(capable.map(async (a) => {
+    const start = Date.now();
+    const r = await callAgentTool(a.mcp_url, "get_products", {
+      brief: c.audience_brief,
+      brand: { domain: c.brand_domain, name: c.brand_name },
+    }, { timeoutMs: 12_000 });
+    const latency = Date.now() - start;
+    interface ProductShape { product_id?: string; id?: string; name?: string; description?: string; cpm_floor?: number; pricing_options?: Array<{ id?: string; cpm?: number }> }
+    const sc = (r.structured_content as { products?: ProductShape[] } | undefined) ?? {};
+    const products = (sc.products ?? []).slice(0, 5).map((p) => ({
+      source_agent_id: a.agent_id,
+      source_agent_name: a.agent_name,
+      product_id: p.product_id ?? p.id ?? "",
+      name: p.name,
+      description: p.description,
+      cpm_floor: p.cpm_floor ?? (p.pricing_options?.[0]?.cpm),
+    }));
+    let authGated = false;
+    let errorText: string | undefined;
+    if (!r.ok) {
+      const blocks = (r.content as Array<{ type?: string; text?: string }> | undefined) || [];
+      for (const blk of blocks) {
+        if (blk?.type === "text" && typeof blk.text === "string") {
+          if (AUTH_GATE_RE.test(blk.text)) authGated = true;
+          if (!errorText) errorText = blk.text.slice(0, 200);
+          break;
+        }
+      }
+    }
+    return { agent_id: a.agent_id, agent_name: a.agent_name, vendor: a.vendor, ok: r.ok, auth_gated: authGated, error: errorText ?? null, latency_ms: latency, products };
+  }));
+
+  const merged = results.flatMap((r) => r.products);
+
+  return jsonResponse({
+    campaign_id: c.campaign_id,
+    audience_brief: c.audience_brief,
+    capable_agent_count: capable.length,
+    ok_count: results.filter((r) => r.ok).length,
+    auth_gated_count: results.filter((r) => r.auth_gated).length,
+    total_products: merged.length,
+    per_agent: results,
+    top_products: merged.slice(0, 8),
+  });
+}
+
+// ── E: /dsp/agents/:id/capabilities-live ───────────────────────────────────
+//
+// Calls get_adcp_capabilities on the agent. Returns the full declared
+// capabilities object so the UI can show idempotency support, supported
+// protocols, governance flags, etc. Closes the "what does this agent
+// actually claim to support" question.
+
+export async function handleDspAgentCapabilities(
+  _request: Request,
+  _env: Env,
+  _logger: Logger,
+): Promise<Response> {
+  const url = new URL(_request.url);
+  const m = url.pathname.match(/^\/dsp\/agents\/([a-z0-9_]+)\/capabilities-live$/i);
+  if (!m) return errorResponse("INVALID_INPUT", "expected /dsp/agents/<id>/capabilities-live", 400);
+  const agentId = m[1]!;
+  const agent = AGENT_REGISTRY.find((a) => a.id === agentId);
+  if (!agent || !agent.mcp_url) return errorResponse("UNKNOWN_AGENT", "no agent " + agentId, 404);
+
+  const start = Date.now();
+  const r = await callAgentTool(agent.mcp_url, "get_adcp_capabilities", {}, { timeoutMs: 10_000 });
+  const latency = Date.now() - start;
+
+  return jsonResponse({
+    agent_id: agent.id,
+    agent_name: agent.name,
+    vendor: agent.vendor,
+    ok: r.ok,
+    latency_ms: latency,
+    error: r.error ?? null,
+    capabilities: r.structured_content ?? null,
+  });
 }

--- a/src/routes/dspRoutes.ts
+++ b/src/routes/dspRoutes.ts
@@ -34,11 +34,286 @@ import {
   generatePacing,
   generateAttribution,
 } from "../domain/dspMock";
+import { AGENT_REGISTRY } from "../domain/agentRegistry";
+import { callAgentTool, probeAgent } from "../federation/genericMcpClient";
+
+// The 11 buy-side primitives we care about. The first 7 are AdCP-spec'd
+// lifecycle tools (get_media_buy_delivery is in 3.0 GA; the rest are
+// implied by media-buy mutability). The last 4 are completely unspec'd
+// in 3.0 GA — none of the live directory agents advertise them.
+const BUY_SIDE_TOOLS = [
+  "create_media_buy",
+  "update_media_buy",
+  "cancel_media_buy",
+  "pause_media_buy",
+  "resume_media_buy",
+  "get_media_buy_delivery",
+  "get_media_buys",
+  // Unspec'd primitives — 0 agents advertise these. Workshop-cite-able.
+  "submit_bid_strategy",
+  "get_bid_opportunities",
+  "get_pacing_status",
+  "optimize_strategy",
+] as const;
+const BUY_SIDE_LIFECYCLE_TOOLS = BUY_SIDE_TOOLS.slice(0, 7);
+const BUY_SIDE_UNSPEC_TOOLS = BUY_SIDE_TOOLS.slice(7);
 
 function parseCampaignIdFromPath(path: string): string | null {
   // /dsp/campaigns/<id>[/...]
   const m = path.match(/^\/dsp\/campaigns\/(cmp_[a-z0-9_]+)(?:\/[a-z-]+)?$/i);
   return m ? m[1]! : null;
+}
+
+// ── Phase 1: live coverage probe ────────────────────────────────────────────
+//
+// Probes every live buying agent for the 11 buy-side primitives. Returns
+// a matrix that the Canvas surfaces as a live coverage strip.
+// Cached 5 min — probe is non-trivial.
+
+const COVERAGE_TTL_SEC = 300;
+const COVERAGE_KEY = "dsp_coverage:v1";
+
+interface CoverageEntry {
+  agent_id: string;
+  agent_name: string;
+  vendor: string;
+  mcp_url: string;
+  alive: boolean;
+  latency_ms?: number | null;
+  tools_supported: string[];
+  tools_missing: string[];
+  error?: string;
+}
+
+interface CoverageReport {
+  probed_at: string;
+  cache: "hit" | "miss";
+  buy_side_tools: typeof BUY_SIDE_TOOLS;
+  spec_status: {
+    spec_lifecycle: typeof BUY_SIDE_LIFECYCLE_TOOLS;
+    unspec_primitives: typeof BUY_SIDE_UNSPEC_TOOLS;
+  };
+  coverage_summary: Record<string, { supported_count: number; total_buying_agents: number }>;
+  agents: CoverageEntry[];
+}
+
+export async function handleDspCoverage(
+  _request: Request,
+  env: Env,
+  logger: Logger,
+): Promise<Response> {
+  // KV cache first.
+  try {
+    const cached = await env.SIGNALS_CACHE.get(COVERAGE_KEY, "json");
+    if (cached) return jsonResponse({ ...(cached as object), cache: "hit" });
+  } catch { /* fall through */ }
+
+  const buyingAgents = AGENT_REGISTRY.filter((a) => a.role === "buying" && a.stage === "live" && a.mcp_url);
+
+  const entries: CoverageEntry[] = await Promise.all(buyingAgents.map(async (a): Promise<CoverageEntry> => {
+    const probe = await probeAgent(a.mcp_url!, { timeoutMs: 8000 });
+    const toolNames = (probe.tools || []).map((t) => t.name);
+    const supported = BUY_SIDE_TOOLS.filter((t) => toolNames.includes(t));
+    const missing = BUY_SIDE_TOOLS.filter((t) => !toolNames.includes(t));
+    const out: CoverageEntry = {
+      agent_id: a.id,
+      agent_name: a.name,
+      vendor: a.vendor,
+      mcp_url: a.mcp_url!,
+      alive: probe.alive,
+      latency_ms: probe.latency_ms ?? null,
+      tools_supported: supported,
+      tools_missing: missing,
+    };
+    if (probe.error) out.error = probe.error;
+    return out;
+  }));
+
+  // Per-tool support counts across all live buying agents.
+  const summary: CoverageReport["coverage_summary"] = {};
+  for (const t of BUY_SIDE_TOOLS) {
+    summary[t] = {
+      supported_count: entries.filter((e) => e.tools_supported.includes(t)).length,
+      total_buying_agents: entries.length,
+    };
+  }
+
+  const report: CoverageReport = {
+    probed_at: new Date().toISOString(),
+    cache: "miss",
+    buy_side_tools: BUY_SIDE_TOOLS,
+    spec_status: {
+      spec_lifecycle: BUY_SIDE_LIFECYCLE_TOOLS,
+      unspec_primitives: BUY_SIDE_UNSPEC_TOOLS,
+    },
+    coverage_summary: summary,
+    agents: entries,
+  };
+
+  try {
+    const { cache: _c, ...store } = report;
+    void _c;
+    await env.SIGNALS_CACHE.put(COVERAGE_KEY, JSON.stringify(store), { expirationTtl: COVERAGE_TTL_SEC });
+  } catch (e) {
+    logger.warn("dsp_coverage_kv_write_failed", { error: String((e as Error).message || e) });
+  }
+
+  return jsonResponse(report);
+}
+
+// ── Phase 2: live media-buys aggregator ─────────────────────────────────────
+//
+// Fans out get_media_buys across every agent that advertises it. Returns
+// a flat aggregated list with per-buy provenance (which agent owns it).
+// Auth-gated agents surface as `ok: false` with the same regex detection
+// the Brand Canvas uses.
+
+const AUTH_GATE_RE = /principal id not found|authentication required|auth_token_invalid|unauthorized|\b401\b|tenant policy/i;
+
+interface MediaBuyLite {
+  media_buy_id?: string;
+  buyer_ref?: string;
+  brand?: { domain?: string; name?: string };
+  brand_manifest?: { brand?: string; advertiser?: string };
+  status?: string;
+  total_budget?: { amount?: number } | number;
+  start_time?: string;
+  end_time?: string;
+  // Vendors return arbitrary additional fields — we pass through.
+}
+
+interface MediaBuyOwned extends MediaBuyLite {
+  source_agent_id: string;
+  source_agent_name: string;
+  source_vendor: string;
+}
+
+export async function handleDspMediaBuysLive(
+  _request: Request,
+  env: Env,
+  logger: Logger,
+): Promise<Response> {
+  const coverage = await getCoverageInternal(env, logger);
+  const capable = coverage.agents.filter((e) => e.tools_supported.includes("get_media_buys"));
+
+  const results = await Promise.all(capable.map(async (a) => {
+    const start = Date.now();
+    const r = await callAgentTool(a.mcp_url, "get_media_buys", {}, { timeoutMs: 12_000 });
+    const latency = Date.now() - start;
+    let buys: MediaBuyOwned[] = [];
+    let authGated = false;
+    let errorText: string | undefined;
+    if (r.ok && r.structured_content) {
+      const sc = r.structured_content as { media_buys?: MediaBuyLite[]; results?: MediaBuyLite[] };
+      const list = sc.media_buys ?? sc.results ?? [];
+      buys = list.map((b) => ({
+        ...b,
+        source_agent_id: a.agent_id,
+        source_agent_name: a.agent_name,
+        source_vendor: a.vendor,
+      }));
+    } else {
+      // Look at content[].text for auth-gate detection.
+      const blocks = (r.content as Array<{ type?: string; text?: string }> | undefined) || [];
+      for (const blk of blocks) {
+        if (blk?.type === "text" && typeof blk.text === "string") {
+          if (AUTH_GATE_RE.test(blk.text)) authGated = true;
+          if (!errorText) errorText = blk.text.slice(0, 200);
+          break;
+        }
+      }
+      if (!errorText && r.error) errorText = r.error;
+    }
+    return {
+      agent_id: a.agent_id,
+      agent_name: a.agent_name,
+      vendor: a.vendor,
+      ok: r.ok,
+      auth_gated: authGated,
+      error: errorText ?? null,
+      latency_ms: latency,
+      buys,
+    };
+  }));
+
+  const allBuys = results.flatMap((r) => r.buys);
+  const okCount = results.filter((r) => r.ok).length;
+  const authCount = results.filter((r) => r.auth_gated).length;
+
+  return jsonResponse({
+    fetched_at: new Date().toISOString(),
+    capable_agent_count: capable.length,
+    ok_count: okCount,
+    auth_gated_count: authCount,
+    total_media_buys: allBuys.length,
+    media_buys: allBuys,
+    per_agent: results,
+  });
+}
+
+// ── Phase 3: live delivery for a specific media_buy ─────────────────────────
+//
+// Calls get_media_buy_delivery on the owning agent. The Canvas pacing
+// lane uses this when a real campaign is selected; falls back to mock
+// when no agent owns a buy for the campaign's brand.
+
+export async function handleDspDeliveryLive(
+  request: Request,
+  env: Env,
+  logger: Logger,
+): Promise<Response> {
+  const url = new URL(request.url);
+  const m = url.pathname.match(/^\/dsp\/media-buys\/([^/]+)\/delivery-live$/);
+  if (!m) return errorResponse("INVALID_INPUT", "expected /dsp/media-buys/<id>/delivery-live", 400);
+  const mediaBuyId = decodeURIComponent(m[1]!);
+  const agentId = url.searchParams.get("agent_id");
+  if (!agentId) return errorResponse("INVALID_INPUT", "agent_id query param required", 400);
+
+  const agent = AGENT_REGISTRY.find((a) => a.id === agentId);
+  if (!agent || !agent.mcp_url) return errorResponse("UNKNOWN_AGENT", "no agent " + agentId, 404);
+
+  const start = Date.now();
+  const r = await callAgentTool(
+    agent.mcp_url,
+    "get_media_buy_delivery",
+    { media_buy_id: mediaBuyId },
+    { timeoutMs: 12_000 },
+  );
+  const latency = Date.now() - start;
+
+  let authGated = false;
+  let errorText: string | undefined;
+  if (!r.ok) {
+    const blocks = (r.content as Array<{ type?: string; text?: string }> | undefined) || [];
+    for (const blk of blocks) {
+      if (blk?.type === "text" && typeof blk.text === "string") {
+        if (AUTH_GATE_RE.test(blk.text)) authGated = true;
+        if (!errorText) errorText = blk.text.slice(0, 280);
+        break;
+      }
+    }
+    if (!errorText && r.error) errorText = r.error;
+  }
+
+  return jsonResponse({
+    media_buy_id: mediaBuyId,
+    agent_id: agentId,
+    agent_name: agent.name,
+    vendor: agent.vendor,
+    ok: r.ok,
+    auth_gated: authGated,
+    error: errorText ?? null,
+    latency_ms: latency,
+    delivery: r.structured_content ?? null,
+    content: r.content ?? null,
+  });
+}
+
+async function getCoverageInternal(env: Env, logger: Logger): Promise<CoverageReport> {
+  // Reuse the coverage handler's body via a synthetic fake request.
+  const req = new Request("http://internal/dsp/agents/coverage", { method: "GET" });
+  const res = await handleDspCoverage(req, env, logger);
+  return await res.json<CoverageReport>();
 }
 
 export async function handleDspCampaigns(


### PR DESCRIPTION
## Summary

Closes the last 5 untapped buy-side primitives identified after PR #120. Every primitive any agent advertises is now wired LIVE on Campaign Canvas.

| Feature | Endpoint | Surface |
|---|---|---|
| **A** \`update_media_buy\` | POST /dsp/media-buys/:id/update-live | \"Apply diff via update_media_buy\" button on Lane 5 |
| **B** \`create_media_buy\` fire-live | POST /dsp/campaigns/:id/fire-live | \"Simulate live fire\" button + agent dropdown on Campaign card |
| **C** \`get_signals\` live | GET /dsp/campaigns/:id/signals-live | Top-5 audience signal chips on Lane 1 with cov% + size + source |
| **D** \`get_products\` live | GET /dsp/campaigns/:id/products-live | Top-8 inventory rows on Lane 3 with CPM floor + source |
| **E** \`get_adcp_capabilities\` deep-probe | GET /dsp/agents/:id/capabilities-live | Per-agent \"view caps\" link in coverage strip → modal with idempotency / governance / protocols |

## Workshop framing — now complete

| Layer | State |
|---|---|
| Read primitives | LIVE everywhere they're advertised |
| Mutations | LIVE wherever advertised; auth-gated boundary surfaces honestly |
| Unspec'd primitives (4) | mocked + flagged 0/N agents in coverage strip |
| Capabilities | on-demand probe per agent |

Every \"can you actually call X live?\" attendee question now has a precise yes/no/here-is-the-gap answer.

## Test plan
- [x] Type-check clean (one exactOptionalPropertyTypes fix)
- [x] 428/428 tests pass
- [x] SCRIPT_TAG audit clean
- [ ] Smoke after deploy:
  - [ ] /dsp/campaigns/cmp_cocacola_summer/signals-live → returns ≥3 ranked signals from live agents
  - [ ] /dsp/campaigns/cmp_cocacola_summer/products-live → returns per-agent state (likely auth-gated mostly)
  - [ ] /dsp/agents/adzymic_apx/capabilities-live → returns adcp.idempotency block
  - [ ] Canvas: fire button on Coca-Cola Summer → calls create_media_buy live; auto-refreshes live panel
  - [ ] Canvas: caps link on coverage strip → modal renders capabilities

🤖 Generated with [Claude Code](https://claude.com/claude-code)