### PR TITLE
Fix: DSP route ordering — specific live routes before campaigns catch-all

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -449,8 +449,8 @@ export default {
                 response = await handleBrandRightsPreview(request, env, logger);
 
                 // ── Buy-side / DSP Canvas (mock + live hybrid) ───────────────────────
-            } else if (method === "GET" && path.startsWith("/dsp/campaigns")) {
-                response = await handleDspCampaigns(request, env, logger);
+                // SPECIFIC routes BEFORE the campaigns catch-all — otherwise
+                // the catch-all eats /dsp/campaigns/<id>/signals-live etc.
             } else if (method === "GET" && path === "/dsp/agents/coverage") {
                 response = await handleDspCoverage(request, env, logger);
             } else if (method === "GET" && path === "/dsp/media-buys/live") {
@@ -467,6 +467,9 @@ export default {
                 response = await handleDspCampaignProductsLive(request, env, logger);
             } else if (method === "GET" && path.startsWith("/dsp/agents/") && path.endsWith("/capabilities-live")) {
                 response = await handleDspAgentCapabilities(request, env, logger);
+                // Catch-all comes LAST.
+            } else if (method === "GET" && path.startsWith("/dsp/campaigns")) {
+                response = await handleDspCampaigns(request, env, logger);
 
                 // ── Sec-43: Audience Composer + activation analytics ────────────────
             } else if (method === "POST" && path === "/audience/compose") {


### PR DESCRIPTION
Hotfix to PR #121.

Bug surfaced post-deploy: \`GET /dsp/campaigns/:id/signals-live\` and \`/products-live\` returned 404 because \`path.startsWith(\"/dsp/campaigns\")\` matched first and routed to \`handleDspCampaigns\` (which doesn't know about the live sub-resources).

Fix: reorder so all specific routes are checked BEFORE the broad \`startsWith\` catch-all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)