### PR TITLE
SDK bump: @adcp/client 5.23.0 → 5.25.1 (compliance 4 → 7 scenarios)

### DIFF
--- a/.github/adcp-watch-config.json
+++ b/.github/adcp-watch-config.json
@@ -14,15 +14,9 @@
     },
     {
       "repo": "adcontextprotocol/adcp-client",
-      "number": 1060,
-      "kind": "issue",
-      "context": "Filed 2026-04-29: SCENARIO_REQUIREMENTS gates error_handling / validation / schema_compliance behind get_products, so signals-only agents skip all three even though they should run universally. Companion to #2916 systemic class. Workshop cite-able."
-    },
-    {
-      "repo": "adcontextprotocol/adcp-client",
       "number": 1062,
       "kind": "issue",
-      "context": "Filed 2026-04-29: past_start_enforcement runs unconditionally on signals-only agents instead of SKIP. Same systemic class as #2916; SCENARIO_REQUIREMENTS row needs media_buy_lifecycle dependency. Workshop cite-able."
+      "context": "Filed 2026-04-29, closed 2026-04-30. Fix shipped in @adcp/sdk 5.25.0; we're on 5.25.1. Tracking kept transiently because the adjacent spec-side normative note ('Storyboards MUST report SKIP, not FAIL, when supported_protocols excludes the scenario's required protocol') was filed as a small follow-up — closure event will fire when that lands. Drop after spec follow-up resolves."
     }
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "zod": "^3.23.8"
       },
       "devDependencies": {
-        "@adcp/client": "^5.23.0",
+        "@adcp/client": "^5.25.1",
         "@cloudflare/workers-types": "^4.20241022.0",
         "@vitest/coverage-v8": "^2.0.0",
         "typescript": "^5.5.0",
@@ -50,23 +50,22 @@
       }
     },
     "node_modules/@adcp/client": {
-      "version": "5.23.0",
-      "resolved": "https://registry.npmjs.org/@adcp/client/-/client-5.23.0.tgz",
-      "integrity": "sha512-tn/sV51bHuKjQjKbT7kcJRPhdNxRrLOqllmm8wU6UQyVcdn0Da6WScnrF83EHO2GzbSghprOrj2ratL1PdiRNA==",
-      "deprecated": "version",
+      "version": "5.25.1",
+      "resolved": "https://registry.npmjs.org/@adcp/client/-/client-5.25.1.tgz",
+      "integrity": "sha512-G/HBHTly6NXIAFb097CY10UfNfLN5HIsQU636xFNtyxuhPGBW2YTGE6udPWLCt/9g8R1Vsw71iFa+ZsVbWt6/A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@adcp/sdk": "^5.23.0"
+        "@adcp/sdk": "^5.25.1"
       },
       "bin": {
         "adcp": "bin/adcp.js"
       }
     },
     "node_modules/@adcp/sdk": {
-      "version": "5.23.0",
-      "resolved": "https://registry.npmjs.org/@adcp/sdk/-/sdk-5.23.0.tgz",
-      "integrity": "sha512-xy80zuP/navsMZuNs4OJQC717eO40ai3rJbOBG4EPR3+9885udhhxPfiaZ8acd67Cpf9cQHuNug0GS6JIkVSig==",
+      "version": "5.25.1",
+      "resolved": "https://registry.npmjs.org/@adcp/sdk/-/sdk-5.25.1.tgz",
+      "integrity": "sha512-53WiJqlYcxcsrFs7GkeV7ibTCc5yNTMqud5+3bo+9/8nM0ha1KiZ24lCqcQUiYlG9RYX+9ekPV2YVS9B2tV+KA==",
       "dev": true,
       "license": "Apache-2.0",
       "workspaces": [
@@ -2944,9 +2943,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.15",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.15.tgz",
-      "integrity": "sha512-qM0jDhFEaCBb4TxoW7f53Qrpv9RBiayUHo0S52JudprkhvpjIrGoU1mnnr29Fvd1U335ZFPZQY1wlkqgfGXyLg==",
+      "version": "4.12.16",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.16.tgz",
+      "integrity": "sha512-jN0ZewiNAWSe5khM3EyCmBb250+b40wWbwNILNfEvq84VREWwOIkuUsFONk/3i3nqkz7Oe1PcpM2mwQEK2L9Kg==",
       "dev": true,
       "license": "MIT",
       "peer": true,

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "lint": "eslint src --ext .ts"
   },
   "devDependencies": {
-    "@adcp/client": "^5.23.0",
+    "@adcp/client": "^5.25.1",
     "@cloudflare/workers-types": "^4.20241022.0",
     "@vitest/coverage-v8": "^2.0.0",
     "typescript": "^5.5.0",


### PR DESCRIPTION
## Summary

Picks up the fixes for both issues we filed yesterday + the 5.25 version-negotiation hardening.

## Fixes shipping in this bump

| Source | What |
|---|---|
| **#1060 → PR #1061** | get_products gate dropped on protocol-wide scenarios |
| **#1062 → PR #1063** | storyboard required_tools pre-flight gate in runner |
| **#1073** | caller-supplied \`adcp_major_version\` no longer SDK-overridden |
| **#1075** | single-field \`VERSION_UNSUPPORTED\` check on createAdcpServer |

## Compliance impact (against deployed agent)

| | Before (5.23.0) | After (5.25.1) |
|---|---|---|
| Scenarios passed | 4 | **7** |
| Scenarios skipped | 35 | 32 |
| **New runs** | — | error_handling (1) · validation (1) · schema_compliance (4) |

All three previously-skipped protocol-level scenarios now run on signals-only agents. Direct confirmation that the runner gate fix is live.

## Watcher cleanup

- Drop \`adcp-client#1060\` (closed 2026-04-30, fix in 5.25.0, live in our 5.25.1)
- Keep \`adcp-client#1062\` transiently — adjacent spec-side normative-note follow-up pending; drop after that resolves
- \`adcp#2916\` still tracked (3.1.0 milestone)

## Test plan
- [x] \`npm install\` — 5.25.1 resolved cleanly
- [x] Type-check clean
- [x] 428/428 tests pass
- [x] Compliance run: 7 passed, 0 failed (was 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)