### PR TITLE
Agentic Canvas: chat-driven brief expander + tool planner + reasoning trace

### DIFF
--- a/src/domain/agenticBrief.ts
+++ b/src/domain/agenticBrief.ts
@@ -1,0 +1,247 @@
+// src/domain/agenticBrief.ts
+//
+// LLM-driven brief expander. Takes a natural-language sentence and
+// produces a structured CampaignBrief that downstream stages can
+// consume. Live mode uses Claude; template mode applies regex-based
+// extraction + sensible defaults.
+
+import { llmCall, type AgenticContext, type ReasoningStep, newReasoningStep } from "./agenticCore";
+import { enrichIndustries } from "./brandIndustryOverrides";
+
+export interface ExpandedBrief {
+  /** Original input. */
+  input: string;
+  /** Resolved brand name (may be best-guess). */
+  brand_name?: string;
+  /** Resolved brand domain (may be best-guess). */
+  brand_domain?: string;
+  /** Industries — registry-style + override-derived. */
+  industries: string[];
+  /** Audience descriptors extracted from the brief (e.g. "Gen Z urban"). */
+  audience_descriptors: string[];
+  /** Inferred KPI: ROAS · CPM · CPA · BRAND_LIFT. */
+  kpi: "ROAS" | "CPM" | "CPA" | "BRAND_LIFT";
+  /** Suggested target value. Numeric form. */
+  kpi_target?: number;
+  /** Inferred budget range in USD. */
+  budget_usd_estimate?: number;
+  /** Inferred geo. */
+  geo: string[];
+  /** Inferred flight duration in days. */
+  flight_days?: number;
+  /** Day-part hint: peak / always-on / business-hours / late-night. */
+  dayparting_hint?: "peak_evening" | "always_on" | "business_hours" | "late_night";
+  /** Confidence of the expansion 0–1. */
+  confidence: number;
+  /** Whether the brief was expanded by LLM (live) or template (rule). */
+  source: "live_llm" | "template";
+  /** Reasoning trace steps emitted while expanding. */
+  trace: ReasoningStep[];
+}
+
+const SYSTEM_PROMPT_BRIEF = `You are a senior media planner expanding a one-line campaign brief into a structured plan.
+Given a natural-language brief, extract:
+  - brand (name, domain if present)
+  - industries (registry-style: food_beverage, alcohol, pharma, gambling, financial, automotive, etc.)
+  - audience descriptors (verbatim phrases from the brief)
+  - KPI: ROAS / CPM / CPA / BRAND_LIFT (pick best fit; default ROAS for retail/CPG, BRAND_LIFT for awareness)
+  - kpi_target (numeric; e.g. 3.5 for ROAS, 8.50 for CPM, 12 for BRAND_LIFT %)
+  - budget_usd_estimate (parse from text; otherwise infer reasonable: $50K small, $250K mid, $1M+ enterprise)
+  - geo (ISO codes or DMAs)
+  - flight_days (parse from text; default 30)
+  - dayparting_hint (peak_evening for entertainment/retail; business_hours for B2B; always_on for awareness)
+  - confidence (0-1; how sure you are of the expansion)`;
+
+const BRIEF_SCHEMA_HINT = `{
+  "brand_name": string | null,
+  "brand_domain": string | null,
+  "industries": string[],
+  "audience_descriptors": string[],
+  "kpi": "ROAS" | "CPM" | "CPA" | "BRAND_LIFT",
+  "kpi_target": number,
+  "budget_usd_estimate": number,
+  "geo": string[],
+  "flight_days": number,
+  "dayparting_hint": "peak_evening" | "always_on" | "business_hours" | "late_night",
+  "confidence": number
+}`;
+
+// ── Template-mode extractor ──────────────────────────────────────────────────
+//
+// Rule-based fallback. Recognizes ~30 brand patterns + budget/KPI/geo
+// hints from the brief. Produces a structurally identical output to
+// the LLM path.
+
+interface BrandHint { name: string; domain: string; industries: string[] }
+
+const KNOWN_BRANDS: Array<{ pattern: RegExp; hint: BrandHint }> = [
+  { pattern: /\b(coca[- ]?cola|coke)\b/i, hint: { name: "Coca-Cola", domain: "coca-cola.com", industries: ["food_beverage", "beverages"] } },
+  { pattern: /\b(pepsi|pepsico)\b/i, hint: { name: "Pepsi", domain: "pepsi.com", industries: ["food_beverage", "beverages"] } },
+  { pattern: /\b(nike)\b/i, hint: { name: "Nike", domain: "nike.com", industries: ["apparel", "sportswear"] } },
+  { pattern: /\b(adidas)\b/i, hint: { name: "Adidas", domain: "adidas.com", industries: ["apparel", "sportswear"] } },
+  { pattern: /\b(heineken)\b/i, hint: { name: "Heineken", domain: "heinekenusa.com", industries: ["alcohol", "beer"] } },
+  { pattern: /\b(anheuser|bud(weiser)?)\b/i, hint: { name: "Anheuser-Busch", domain: "ab-inbev.com", industries: ["alcohol", "beer"] } },
+  { pattern: /\b(pfizer)\b/i, hint: { name: "Pfizer", domain: "pfizer.com", industries: ["pharma", "healthcare"] } },
+  { pattern: /\b(gsk|glaxo)\b/i, hint: { name: "GSK", domain: "gsk.com", industries: ["pharma", "healthcare"] } },
+  { pattern: /\b(draftkings)\b/i, hint: { name: "DraftKings", domain: "draftkings.com", industries: ["gambling", "sports_betting"] } },
+  { pattern: /\b(fanduel)\b/i, hint: { name: "FanDuel", domain: "fanduel.com", industries: ["gambling", "sports_betting"] } },
+  { pattern: /\b(lego)\b/i, hint: { name: "LEGO", domain: "lego.com", industries: ["children", "toys"] } },
+  { pattern: /\b(visa)\b/i, hint: { name: "Visa", domain: "visa.com", industries: ["financial", "fintech"] } },
+  { pattern: /\b(bank of america|bofa)\b/i, hint: { name: "Bank of America", domain: "bankofamerica.com", industries: ["financial", "banking"] } },
+  { pattern: /\b(toyota)\b/i, hint: { name: "Toyota", domain: "toyota.com", industries: ["automotive"] } },
+  { pattern: /\b(tesla)\b/i, hint: { name: "Tesla", domain: "tesla.com", industries: ["automotive", "electric_vehicles"] } },
+  { pattern: /\b(mcdonald|mcd)\b/i, hint: { name: "McDonald's", domain: "mcdonalds.com", industries: ["fast_food", "food_beverage"] } },
+];
+
+function extractBudget(input: string): number | undefined {
+  const m1 = input.match(/\$(\d+(?:[.,]\d+)?)\s*(k|m|b|million|billion|thousand)?\b/i);
+  if (m1) {
+    const n = parseFloat(m1[1]!.replace(/,/g, ""));
+    const unit = (m1[2] || "").toLowerCase();
+    if (unit === "k" || unit === "thousand") return n * 1_000;
+    if (unit === "m" || unit === "million") return n * 1_000_000;
+    if (unit === "b" || unit === "billion") return n * 1_000_000_000;
+    return n;
+  }
+  return undefined;
+}
+
+function extractGeo(input: string): string[] {
+  const out = new Set<string>();
+  if (/\b(US|united states|america)\b/i.test(input)) out.add("US");
+  if (/\b(EU|europe|european)\b/i.test(input)) out.add("EU");
+  if (/\b(UK|britain|british)\b/i.test(input)) out.add("GB");
+  if (/\b(canada|canadian)\b/i.test(input)) out.add("CA");
+  if (/\b(NYC|new york)\b/i.test(input)) out.add("US-NYC");
+  if (/\b(LA|los angeles)\b/i.test(input)) out.add("US-LA");
+  if (/\b(SF|san francisco)\b/i.test(input)) out.add("US-SF");
+  if (/\b(chicago)\b/i.test(input)) out.add("US-CHI");
+  if (out.size === 0) out.add("US");
+  return Array.from(out);
+}
+
+function inferKpi(input: string): { kpi: ExpandedBrief["kpi"]; target: number } {
+  const lo = input.toLowerCase();
+  if (/\b(awareness|brand lift|reach|impression)\b/.test(lo)) return { kpi: "BRAND_LIFT", target: 12 };
+  if (/\b(cpm|cost per mille|cost per thousand)\b/.test(lo)) return { kpi: "CPM", target: 8.5 };
+  if (/\b(cpa|cost per acquisition|sign[- ]?up|acquisition)\b/.test(lo)) return { kpi: "CPA", target: 25 };
+  if (/\b(roas|conversion|sale|purchase|ecommerce)\b/.test(lo)) return { kpi: "ROAS", target: 3.5 };
+  // Default: ROAS for known retail brands; BRAND_LIFT otherwise
+  return { kpi: "ROAS", target: 3.0 };
+}
+
+function inferDayparting(input: string): ExpandedBrief["dayparting_hint"] {
+  const lo = input.toLowerCase();
+  if (/\b(b2b|business hours|workday)\b/.test(lo)) return "business_hours";
+  if (/\b(late night|night owl|insomniac)\b/.test(lo)) return "late_night";
+  if (/\b(awareness|always[- ]?on|24[/ ]?7)\b/.test(lo)) return "always_on";
+  return "peak_evening";
+}
+
+function expandViaTemplate(input: string): Omit<ExpandedBrief, "trace" | "source"> {
+  const lower = input.toLowerCase();
+
+  // Brand match
+  let brand: BrandHint | null = null;
+  for (const { pattern, hint } of KNOWN_BRANDS) {
+    if (pattern.test(input)) { brand = hint; break; }
+  }
+
+  // Audience descriptors — just split out sequences of capitalized adjacent
+  // words + known hint words.
+  const audienceWords: string[] = [];
+  const audMatches = input.match(/\b(gen[ -]?z|millennial|boomer|gen[ -]?x|teen|adult|adults?|moms?|dads?|family|families|sneakerheads?|gamers?|sports fans?|foodies?)\b/gi) || [];
+  audienceWords.push(...audMatches.map((s) => s.trim()));
+  const urbanMatches = input.match(/\b(urban|suburban|rural|city|metro)\b/gi) || [];
+  audienceWords.push(...urbanMatches.map((s) => s.toLowerCase()));
+
+  const { kpi, target } = inferKpi(input);
+  const budget = extractBudget(input);
+  const geo = extractGeo(input);
+
+  // Flight days
+  let flightDays = 30;
+  const flightMatch = input.match(/\b(\d+)[- ]?(day|week|month|quarter)/i);
+  if (flightMatch) {
+    const n = parseInt(flightMatch[1]!, 10);
+    const unit = flightMatch[2]!.toLowerCase();
+    flightDays = unit.startsWith("week") ? n * 7 : unit.startsWith("month") ? n * 30 : unit.startsWith("quarter") ? n * 90 : n;
+  } else if (/\b(summer|winter|spring|fall)\b/.test(lower)) {
+    flightDays = 90;
+  }
+
+  // Industry enrichment overlay (alcohol/pharma/etc patterns)
+  const baseIndustries = brand?.industries ?? [];
+  const enr = enrichIndustries(brand?.name ?? input, baseIndustries);
+  const industries = enr.industries.length > 0 ? enr.industries : ["general"];
+
+  const dayparting = inferDayparting(input);
+  const out: Omit<ExpandedBrief, "trace" | "source"> = {
+    input,
+    industries,
+    audience_descriptors: Array.from(new Set(audienceWords)),
+    kpi,
+    kpi_target: target,
+    geo,
+    flight_days: flightDays,
+    confidence: brand ? 0.78 : 0.55,
+    ...(dayparting ? { dayparting_hint: dayparting } : {}),
+  };
+  if (brand) {
+    out.brand_name = brand.name;
+    out.brand_domain = brand.domain;
+  }
+  if (budget !== undefined) out.budget_usd_estimate = budget;
+  return out;
+}
+
+// ── Public expander ─────────────────────────────────────────────────────────
+
+export async function expandBrief(ctx: AgenticContext, input: string): Promise<ExpandedBrief> {
+  const trace: ReasoningStep[] = [];
+  trace.push(newReasoningStep("analyze", `Received brief: "${input}". Length ${input.length} chars; mode = ${ctx.mode}.`));
+
+  if (ctx.mode === "live") {
+    const start = Date.now();
+    const r = await llmCall(ctx, {
+      system: SYSTEM_PROMPT_BRIEF,
+      messages: [{ role: "user", content: `Expand this brief:\n\n"${input}"` }],
+      json_schema_hint: BRIEF_SCHEMA_HINT,
+      max_tokens: 1000,
+    });
+    if (r.ok && r.json) {
+      const j = r.json as Partial<ExpandedBrief>;
+      trace.push(newReasoningStep("decide", `Claude expanded the brief in ${r.latency_ms}ms with confidence ${j.confidence ?? "?"}.`, undefined, r.latency_ms));
+      const baseInds = Array.isArray(j.industries) ? j.industries : [];
+      const enr = enrichIndustries(j.brand_name ?? input, baseInds);
+      const expanded: ExpandedBrief = {
+        input,
+        ...(j.brand_name !== undefined && j.brand_name !== null ? { brand_name: j.brand_name } : {}),
+        ...(j.brand_domain !== undefined && j.brand_domain !== null ? { brand_domain: j.brand_domain } : {}),
+        industries: enr.industries.length > 0 ? enr.industries : ["general"],
+        audience_descriptors: Array.isArray(j.audience_descriptors) ? j.audience_descriptors : [],
+        kpi: (j.kpi as ExpandedBrief["kpi"]) ?? "ROAS",
+        ...(j.kpi_target !== undefined ? { kpi_target: j.kpi_target } : {}),
+        ...(j.budget_usd_estimate !== undefined ? { budget_usd_estimate: j.budget_usd_estimate } : {}),
+        geo: Array.isArray(j.geo) ? j.geo : ["US"],
+        ...(j.flight_days !== undefined ? { flight_days: j.flight_days } : {}),
+        ...(j.dayparting_hint ? { dayparting_hint: j.dayparting_hint } : {}),
+        confidence: typeof j.confidence === "number" ? j.confidence : 0.7,
+        source: "live_llm",
+        trace,
+      };
+      trace.push(newReasoningStep("complete", `Expansion done. KPI=${expanded.kpi}@${expanded.kpi_target}, geo=${expanded.geo.join("/")}, ${expanded.industries.length} industries.`, undefined, Date.now() - start));
+      return expanded;
+    }
+    trace.push(newReasoningStep("recover", `Live LLM call failed (${r.error || "unknown"}); falling back to template extraction.`));
+  } else {
+    trace.push(newReasoningStep("plan", "No live LLM key; using rule-based template extractor."));
+  }
+
+  // Template mode (or fallback from failed live)
+  const tStart = Date.now();
+  const tpl = expandViaTemplate(input);
+  trace.push(newReasoningStep("decide", `Template extraction: brand=${tpl.brand_name ?? "(unknown)"}, kpi=${tpl.kpi}@${tpl.kpi_target}, industries=[${tpl.industries.join(",")}], confidence=${tpl.confidence}.`, undefined, Date.now() - tStart));
+  trace.push(newReasoningStep("complete", `Brief ready for downstream tool planning.`));
+  return { ...tpl, source: "template", trace };
+}

--- a/src/domain/agenticCore.ts
+++ b/src/domain/agenticCore.ts
@@ -1,0 +1,184 @@
+// src/domain/agenticCore.ts
+//
+// Shared LLM-inference primitive for the Agentic Canvas. Two modes:
+//
+//   1. LIVE — uses Anthropic Messages API when ANTHROPIC_API_KEY is set
+//      in env. Same pattern as src/domain/queryParser.ts (model
+//      claude-sonnet-4-20250514).
+//
+//   2. TEMPLATE — rule-based fallback when no API key. Generates
+//      structurally-identical reasoning traces from deterministic
+//      templates filled with the actual data. Fast, free, suitable
+//      for the workshop demo. v2 swaps to live by setting the key.
+//
+// Why both: the Canvas surface is identical regardless of mode. The
+// "agentic" feel comes from streaming the trace, showing decisions
+// with rationale, and chaining tool calls — all of which work without
+// a live LLM. Live mode adds open-ended brief understanding + novel
+// tool-sequence reasoning the templates can't anticipate.
+
+import type { Env } from "../types/env";
+
+export type AgenticMode = "live" | "template";
+
+export interface AgenticContext {
+  env: Env;
+  mode: AgenticMode;
+  /** True when ANTHROPIC_API_KEY is configured. Used to feature-gate
+   *  live LLM calls; templates handle everything else. */
+  hasLiveLlm: boolean;
+  /** Caller-supplied request id for tracing. */
+  request_id?: string;
+}
+
+export function makeAgenticContext(env: Env, request_id?: string): AgenticContext {
+  const hasLiveLlm = typeof env.ANTHROPIC_API_KEY === "string" && env.ANTHROPIC_API_KEY.length > 10;
+  return {
+    env,
+    mode: hasLiveLlm ? "live" : "template",
+    hasLiveLlm,
+    ...(request_id ? { request_id } : {}),
+  };
+}
+
+// ── Live Anthropic call ─────────────────────────────────────────────────────
+
+export interface LlmCallOptions {
+  system?: string;
+  messages: Array<{ role: "user" | "assistant"; content: string }>;
+  model?: string;
+  max_tokens?: number;
+  /** When set, ask the model to return ONLY JSON matching this schema
+   *  description (free-form text). We strip ``` fences post-response. */
+  json_schema_hint?: string;
+  /** Timeout in ms. Default 30s. */
+  timeout_ms?: number;
+}
+
+export interface LlmCallResult {
+  ok: boolean;
+  text: string;
+  /** Best-effort JSON parse when json_schema_hint set. */
+  json?: unknown;
+  model: string;
+  latency_ms: number;
+  error?: string;
+}
+
+export async function llmCall(ctx: AgenticContext, opts: LlmCallOptions): Promise<LlmCallResult> {
+  if (!ctx.hasLiveLlm) {
+    return {
+      ok: false,
+      text: "",
+      model: "template",
+      latency_ms: 0,
+      error: "ANTHROPIC_API_KEY not configured — agentic templates only",
+    };
+  }
+  const start = Date.now();
+  const model = opts.model ?? "claude-sonnet-4-20250514";
+  const maxTokens = opts.max_tokens ?? 1500;
+  const timeoutMs = opts.timeout_ms ?? 30_000;
+  const system = opts.system
+    ? (opts.json_schema_hint
+        ? opts.system + "\n\nReturn ONLY a JSON object matching this shape — no prose, no markdown:\n" + opts.json_schema_hint
+        : opts.system)
+    : opts.json_schema_hint
+      ? "Return ONLY a JSON object matching this shape — no prose, no markdown:\n" + opts.json_schema_hint
+      : "";
+
+  const body: Record<string, unknown> = {
+    model,
+    max_tokens: maxTokens,
+    messages: opts.messages,
+  };
+  if (system) body.system = system;
+
+  try {
+    const resp = await fetch("https://api.anthropic.com/v1/messages", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "anthropic-version": "2023-06-01",
+        "x-api-key": ctx.env.ANTHROPIC_API_KEY!,
+      },
+      body: JSON.stringify(body),
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+    const latency = Date.now() - start;
+    if (!resp.ok) {
+      const errText = await resp.text();
+      return { ok: false, text: "", model, latency_ms: latency, error: "Claude API " + resp.status + ": " + errText.slice(0, 200) };
+    }
+    const data = (await resp.json()) as { content?: Array<{ type: string; text?: string }> };
+    const raw = (data.content ?? []).find((b) => b.type === "text")?.text ?? "";
+    const cleaned = raw.replace(/^```(?:json)?\s*/m, "").replace(/\s*```\s*$/m, "").trim();
+    let json: unknown;
+    if (opts.json_schema_hint) {
+      try { json = JSON.parse(cleaned); } catch { /* return raw text only */ }
+    }
+    const result: LlmCallResult = {
+      ok: true,
+      text: cleaned,
+      model,
+      latency_ms: latency,
+    };
+    if (json !== undefined) result.json = json;
+    return result;
+  } catch (e) {
+    return {
+      ok: false,
+      text: "",
+      model,
+      latency_ms: Date.now() - start,
+      error: String((e as Error).message || e),
+    };
+  }
+}
+
+// ── Reasoning trace primitive ────────────────────────────────────────────────
+//
+// Every agentic decision emits a ReasoningStep. The Canvas streams
+// these progressively (via SSE) so the user sees the agent thinking
+// in real time. Template mode populates these from rule-based
+// templates; live mode fills them from LLM responses.
+
+export type ReasoningStepKind =
+  | "analyze"      // observing the input
+  | "plan"         // deciding the next step
+  | "call"         // invoking a tool
+  | "observe"      // recording a tool result
+  | "decide"       // a non-tool decision (e.g. picking top-3)
+  | "reflect"      // self-evaluation of partial results
+  | "recover"      // retry/fallback after an error
+  | "remediate"    // suggesting a fix (e.g. swap signal to unblock governance)
+  | "complete";    // final summary
+
+export interface ReasoningStep {
+  step_id: string;
+  ts: string;       // ISO
+  kind: ReasoningStepKind;
+  /** Plain-language sentence shown to the user. */
+  message: string;
+  /** Structured payload — varies by kind. */
+  data?: unknown;
+  /** Latency for this step (e.g. tool call duration). */
+  latency_ms?: number;
+}
+
+export function newReasoningStep(
+  kind: ReasoningStepKind,
+  message: string,
+  data?: unknown,
+  latency_ms?: number,
+): ReasoningStep {
+  const step: ReasoningStep = {
+    step_id: "rs_" + Math.random().toString(36).slice(2, 10),
+    ts: new Date().toISOString(),
+    kind,
+    message,
+  };
+  if (data !== undefined) step.data = data;
+  if (latency_ms !== undefined) step.latency_ms = latency_ms;
+  return step;
+}

--- a/src/domain/agenticHelpers.ts
+++ b/src/domain/agenticHelpers.ts
@@ -1,0 +1,190 @@
+// src/domain/agenticHelpers.ts
+//
+// Three small agentic helpers, grouped because each is light:
+//
+//   1. agenticMemory  — KV-backed recall of past similar workflows
+//   2. agenticRecovery — auto-retry strategy on tool failures
+//   3. agenticRemediation — compliance suggestions (signal swaps to unblock)
+
+import type { Env } from "../types/env";
+import { type AgenticContext, type ReasoningStep, newReasoningStep } from "./agenticCore";
+import type { ExpandedBrief } from "./agenticBrief";
+import { POLICIES } from "./policyRegistry";
+import { predictGovernance, type GovernanceAdvisory } from "./governanceMock";
+import { getDemoProviderAttestations } from "./workflowOrchestration";
+
+// ── 1. Memory ──────────────────────────────────────────────────────────────
+
+const MEMORY_INDEX_KEY = "agentic_memory_index:v1";
+const MEMORY_PREFIX = "agentic_memory:";
+const MEMORY_TTL = 60 * 60 * 24 * 30;  // 30 days
+const MEMORY_MAX = 50;
+
+export interface MemoryEntry {
+  memory_id: string;
+  ran_at: string;
+  brief_input: string;
+  brief_industries: string[];
+  brief_kpi: string;
+  outcome: "success" | "partial" | "failed";
+  chosen_signals: string[];
+  chosen_formats: string[];
+  notable_findings: string[];
+}
+
+export async function recallSimilar(env: Env, brief: ExpandedBrief): Promise<{ matches: MemoryEntry[]; hint: string }> {
+  let idx: MemoryEntry[] = [];
+  try {
+    const raw = await env.SIGNALS_CACHE.get(MEMORY_INDEX_KEY, "json");
+    if (Array.isArray(raw)) idx = raw as MemoryEntry[];
+  } catch { /* empty */ }
+
+  const briefIndsLower = brief.industries.map((s) => s.toLowerCase());
+  const scored = idx.map((m) => {
+    const overlap = m.brief_industries.filter((i) => briefIndsLower.includes(i.toLowerCase())).length;
+    const kpiMatch = m.brief_kpi === brief.kpi ? 1 : 0;
+    return { m, score: overlap * 2 + kpiMatch };
+  }).filter((x) => x.score > 0)
+    .sort((a, b) => b.score - a.score)
+    .slice(0, 3);
+
+  const matches = scored.map((x) => x.m);
+  const hint = matches.length === 0
+    ? "No prior similar workflows in memory."
+    : `Found ${matches.length} similar prior run(s). Top match: ${matches[0]!.brief_input.slice(0, 80)}…`;
+  return { matches, hint };
+}
+
+export async function rememberWorkflow(env: Env, entry: MemoryEntry): Promise<void> {
+  try {
+    await env.SIGNALS_CACHE.put(MEMORY_PREFIX + entry.memory_id, JSON.stringify(entry), { expirationTtl: MEMORY_TTL });
+    let idx: MemoryEntry[] = [];
+    try {
+      const raw = await env.SIGNALS_CACHE.get(MEMORY_INDEX_KEY, "json");
+      if (Array.isArray(raw)) idx = raw as MemoryEntry[];
+    } catch { /* fresh */ }
+    idx = [entry, ...idx.filter((e) => e.memory_id !== entry.memory_id)].slice(0, MEMORY_MAX);
+    await env.SIGNALS_CACHE.put(MEMORY_INDEX_KEY, JSON.stringify(idx), { expirationTtl: MEMORY_TTL });
+  } catch { /* non-fatal */ }
+}
+
+// ── 2. Recovery ────────────────────────────────────────────────────────────
+
+export interface RecoveryStrategy {
+  /** Plain-language description of what we'll try. */
+  approach: string;
+  /** Concrete next-step suggestions. */
+  retry_actions: Array<{ kind: "alternate_agent" | "simplified_payload" | "drop_field" | "fallback_dry_run"; detail: string }>;
+}
+
+const AUTH_GATE_RE = /principal id not found|authentication required|auth_token_invalid|unauthorized|\b401\b|tenant policy/i;
+const SHAPE_ERR_RE = /validation error|input should be|extra field not allowed|required field is missing|schema/i;
+
+export function suggestRecovery(failedTool: string, errorText: string, alternateAgents: string[]): RecoveryStrategy {
+  const isAuth = AUTH_GATE_RE.test(errorText);
+  const isShape = SHAPE_ERR_RE.test(errorText);
+
+  const actions: RecoveryStrategy["retry_actions"] = [];
+  if (isAuth && alternateAgents.length > 0) {
+    actions.push({ kind: "alternate_agent", detail: `Retry on ${alternateAgents.slice(0, 2).join(", ")} — different vendors may not auth-gate.` });
+  }
+  if (isAuth) {
+    actions.push({ kind: "fallback_dry_run", detail: `Auth-gated — switch to dry-run mode and present payload-preview only.` });
+  }
+  if (isShape) {
+    actions.push({ kind: "simplified_payload", detail: `Drop optional fields and retry — Sec-48r6 vendor adapter rules suggest scalar budget, drop signal_attestations, etc.` });
+    actions.push({ kind: "drop_field", detail: `Inspect the validation error: missing-field name = required to add; extra-field name = required to drop.` });
+  }
+  if (actions.length === 0) {
+    actions.push({ kind: "fallback_dry_run", detail: `Unrecognized error — falling back to dry-run preview to keep the workflow visible.` });
+  }
+
+  return {
+    approach: isAuth
+      ? `Auth boundary detected. Either rotate to an unauthenticated alternate or fall back to dry-run.`
+      : isShape
+        ? `Shape mismatch detected. Apply per-vendor adapter rules and retry.`
+        : `Generic error — fall back to dry-run preview and surface the error trace.`,
+    retry_actions: actions,
+  };
+}
+
+// ── 3. Compliance auto-remediation ─────────────────────────────────────────
+//
+// Given a governance BLOCK, suggest signal swaps that would unblock.
+// Strategy: for each `block`-outcome policy, look for a substitute
+// signal in our attestation set that claims compliant/exempt for that
+// policy. If found, suggest swapping. If no substitute, document why
+// override is required.
+
+export interface RemediationSuggestion {
+  blocking_policy: string;
+  policy_name: string;
+  why_blocked: string;
+  suggestion: "swap_signal" | "add_attestation" | "manual_override_only";
+  detail: string;
+}
+
+export function suggestRemediations(advisory: GovernanceAdvisory): RemediationSuggestion[] {
+  const out: RemediationSuggestion[] = [];
+  const attest = getDemoProviderAttestations();
+  const attestedClaims = new Map(attest.map((a) => [a.policy_id, a.claim]));
+
+  for (const a of advisory.advisories.filter((x) => x.outcome === "block")) {
+    const policy = POLICIES.find((p) => p.policy_id === a.policy_id);
+    const policyName = policy?.name ?? a.policy_id;
+
+    const knownClaim = attestedClaims.get(a.policy_id);
+    if (knownClaim && (knownClaim === "compliant" || knownClaim === "exempt" || knownClaim === "out_of_scope" || knownClaim === "not_applicable")) {
+      out.push({
+        blocking_policy: a.policy_id,
+        policy_name: policyName,
+        why_blocked: a.reason,
+        suggestion: "add_attestation",
+        detail: `Provider already attests "${knownClaim}" to this policy — wire the existing attestation into the signal_attestations[] array on create_media_buy.`,
+      });
+      continue;
+    }
+
+    if (policy?.industries_inferred.includes("ai_generated_content")) {
+      out.push({
+        blocking_policy: a.policy_id,
+        policy_name: policyName,
+        why_blocked: a.reason,
+        suggestion: "add_attestation",
+        detail: `EU AI Act Article 50: file an attestor process documenting that no AI-generated content is included in signal payloads, then sign + add to attestations.`,
+      });
+      continue;
+    }
+
+    out.push({
+      blocking_policy: a.policy_id,
+      policy_name: policyName,
+      why_blocked: a.reason,
+      suggestion: "manual_override_only",
+      detail: `No automated remediation. Operator must override (with documented justification) or remove the offending audience scope.`,
+    });
+  }
+
+  return out;
+}
+
+// ── Convenience: full compliance check + remediation in one ────────────────
+
+export function checkAndRemediate(brief: ExpandedBrief): { advisory: GovernanceAdvisory; remediations: RemediationSuggestion[]; trace: ReasoningStep[] } {
+  const trace: ReasoningStep[] = [];
+  trace.push(newReasoningStep("analyze", `Running predictive governance check on industries [${brief.industries.join(",")}].`));
+  // Pull policies for the brief's industries.
+  const indLower = brief.industries.map((i) => i.toLowerCase());
+  const applicable = POLICIES.filter((p) => p.industries_inferred.includes("all") || p.industries_inferred.some((i) => indLower.includes(i.toLowerCase())));
+  const advisory = predictGovernance(applicable, getDemoProviderAttestations());
+  trace.push(newReasoningStep("decide", `Outcome: ${advisory.outcome.toUpperCase()}. ${advisory.restricted_attributes.length} block(s), ${advisory.advisories.filter((a) => a.outcome === "warn").length} warn(s), ${advisory.advisories.filter((a) => a.outcome === "allow").length} allow(s).`, { restricted_attributes: advisory.restricted_attributes }));
+  const remediations = suggestRemediations(advisory);
+  if (remediations.length > 0) {
+    trace.push(newReasoningStep("remediate", `Generated ${remediations.length} remediation suggestion(s) for unblocking.`, undefined));
+  }
+  return { advisory, remediations, trace };
+}
+
+// Helpers exposed for endpoints
+export { newReasoningStep };

--- a/src/domain/agenticPlanner.ts
+++ b/src/domain/agenticPlanner.ts
@@ -1,0 +1,238 @@
+// src/domain/agenticPlanner.ts
+//
+// Tool-selection planner. Given an ExpandedBrief and a coverage matrix
+// (which agents advertise which tools), produce an ordered Plan of
+// step-by-step tool invocations + per-step rationale.
+//
+// Live mode: LLM picks the sequence given the catalog of available
+// tools + the brief.
+// Template mode: deterministic 5-stage plan that mirrors the existing
+// Brand Canvas pipeline (signals → creative → products → governance →
+// dry-run media-buy), filtered by what's actually live in coverage.
+
+import type { ExpandedBrief } from "./agenticBrief";
+import { type AgenticContext, type ReasoningStep, newReasoningStep, llmCall } from "./agenticCore";
+
+export interface PlanStep {
+  step_id: string;
+  index: number;
+  /** Tool name (matches the AdCP tool surface). */
+  tool: string;
+  /** Which agent(s) to call this tool on. */
+  agents: string[];
+  /** Plain-language rationale for picking this step. */
+  rationale: string;
+  /** Args the planner expects to pass (at execution time, the executor
+   *  may refine these from prior-step results). */
+  args_template: Record<string, unknown>;
+  /** What downstream steps depend on this step's output. */
+  downstream_uses: string[];
+  /** Whether this step can be skipped if zero capable agents. */
+  optional: boolean;
+}
+
+export interface ExecutionPlan {
+  plan_id: string;
+  brief: ExpandedBrief;
+  steps: PlanStep[];
+  /** Estimated total wall-clock for the plan. */
+  estimated_duration_ms: number;
+  /** Confidence of the plan 0–1. */
+  confidence: number;
+  source: "live_llm" | "template";
+  trace: ReasoningStep[];
+}
+
+export interface AgentCoverage {
+  agent_id: string;
+  agent_name: string;
+  vendor: string;
+  role: "signals" | "creative" | "buying" | "unclassified";
+  tools_supported: string[];
+}
+
+const SYSTEM_PROMPT_PLANNER = `You are an agentic media-planning orchestrator.
+Given an ExpandedBrief and a list of available agents (with their tools), produce a step-by-step execution plan.
+
+Allowed tools (call only what's available):
+  - get_signals          — discover audience signals (signals agents)
+  - list_creative_formats — list creative formats (creative agents)
+  - get_products         — discover targetable inventory (buying agents)
+  - check_governance     — predictive policy check (mocked locally)
+  - check_brand_rights   — predictive rights check (mocked locally)
+  - create_media_buy     — fire a buy (buying agents; auth-gated mostly)
+  - update_media_buy     — mutate an existing buy
+  - get_media_buy_delivery — pull pacing/delivery for a fired buy
+
+Plan the SHORTEST useful sequence. Each step states WHY it's there.
+Skip steps that would call tools no available agent advertises.`;
+
+const PLAN_SCHEMA_HINT = `{
+  "steps": [
+    {
+      "tool": string,
+      "agents": string[],
+      "rationale": string,
+      "args_template": object,
+      "downstream_uses": string[],
+      "optional": boolean
+    }
+  ],
+  "confidence": number,
+  "estimated_duration_ms": number
+}`;
+
+// ── Template planner ────────────────────────────────────────────────────────
+
+function pickAgentsForTool(coverage: AgentCoverage[], tool: string): string[] {
+  return coverage.filter((a) => a.tools_supported.includes(tool)).map((a) => a.agent_id);
+}
+
+function defaultPlanForBrief(brief: ExpandedBrief, coverage: AgentCoverage[]): PlanStep[] {
+  const signalsAgents = coverage.filter((c) => c.role === "signals" && c.tools_supported.includes("get_signals")).map((c) => c.agent_id);
+  const creativeAgents = coverage.filter((c) => c.role === "creative" && c.tools_supported.includes("list_creative_formats")).map((c) => c.agent_id);
+  const productsAgents = pickAgentsForTool(coverage, "get_products");
+  const buyingAgents = pickAgentsForTool(coverage, "create_media_buy");
+
+  const briefStr = brief.input;
+  const baseArgs = {
+    brief: briefStr,
+    industries: brief.industries,
+    geo: brief.geo,
+    audience_descriptors: brief.audience_descriptors,
+  };
+
+  const steps: PlanStep[] = [];
+  let idx = 1;
+  const mk = (tool: string, agents: string[], rationale: string, args: Record<string, unknown>, downstream: string[], optional: boolean): PlanStep => ({
+    step_id: "ps_" + Math.random().toString(36).slice(2, 8),
+    index: idx++,
+    tool,
+    agents,
+    rationale,
+    args_template: args,
+    downstream_uses: downstream,
+    optional,
+  });
+
+  if (signalsAgents.length > 0) {
+    steps.push(mk(
+      "get_signals",
+      signalsAgents,
+      `Discover audience signals matching the brief's audience descriptors (${brief.audience_descriptors.join(", ") || "none extracted"}). Fan out to ${signalsAgents.length} signals agent(s) in parallel; rank by coverage_percentage; pick top-3.`,
+      { signal_spec: briefStr, max_results: 10, deliver_to: { deployments: [{ type: "platform", platform: "mock_dsp" }], countries: brief.geo } },
+      ["create_media_buy.targeting_overlay", "check_governance.signal_attestations"],
+      false,
+    ));
+  }
+  if (creativeAgents.length > 0) {
+    steps.push(mk(
+      "list_creative_formats",
+      creativeAgents,
+      `Enumerate available creative formats. Filter by brand industries (${brief.industries.slice(0, 2).join("/")}) — DOOH for retail/CPG, native for editorial brands.`,
+      { brand_categories: brief.industries },
+      ["create_media_buy.creatives", "check_brand_rights.formats"],
+      false,
+    ));
+  }
+  steps.push(mk(
+    "check_brand_rights",
+    ["self"],
+    `Predictive rights check on chosen creative formats × brand classification. Master brands → owned; sub-brands → delegated; DOOH → needs_clearance.`,
+    { brand_industries: brief.industries },
+    ["create_media_buy.rights_attestation"],
+    true,
+  ));
+  if (productsAgents.length > 0) {
+    steps.push(mk(
+      "get_products",
+      productsAgents,
+      `Query targetable inventory from ${productsAgents.length} buying agent(s). Filter by chosen signals + chosen formats. Pick highest-CPM-floor product per agent.`,
+      { ...baseArgs, filters: { signals: "${chosen_signal_ids}", format_ids: "${chosen_format_ids}" } },
+      ["create_media_buy.product_id"],
+      false,
+    ));
+  }
+  steps.push(mk(
+    "check_governance",
+    ["self"],
+    `Predictive governance check: ${brief.industries.length} brand industries × signal attestations. KPI ${brief.kpi}@${brief.kpi_target} carries default catch-alls (GDPR, CSBS).`,
+    { brand_industries: brief.industries },
+    ["create_media_buy.governance_decision"],
+    false,
+  ));
+  if (buyingAgents.length > 0) {
+    const targetBuy = buyingAgents.slice(0, 3);  // cap fan-out for the demo
+    steps.push(mk(
+      "create_media_buy",
+      targetBuy,
+      `Synthesize a create_media_buy payload (idempotency_key = FNV-1a hash; signal_attestations propagated). Apply per-vendor adapter rules (Adzymic/Claire/Swivel schema split). Emit dry-run by default — fire only with explicit user opt-in. ${brief.budget_usd_estimate ? `Budget: $${brief.budget_usd_estimate.toLocaleString()}.` : ""}`,
+      { brief: briefStr, brand: { domain: brief.brand_domain, name: brief.brand_name }, total_budget: { amount: brief.budget_usd_estimate ?? 1000, currency: "USD" } },
+      [],
+      false,
+    ));
+  }
+  return steps;
+}
+
+// ── Public planner ──────────────────────────────────────────────────────────
+
+export async function planExecution(ctx: AgenticContext, brief: ExpandedBrief, coverage: AgentCoverage[]): Promise<ExecutionPlan> {
+  const trace: ReasoningStep[] = [];
+  trace.push(newReasoningStep("analyze", `Planning execution for brief: industries=[${brief.industries.join(",")}], kpi=${brief.kpi}@${brief.kpi_target}, ${coverage.length} agents in coverage.`));
+
+  if (ctx.mode === "live") {
+    const start = Date.now();
+    const r = await llmCall(ctx, {
+      system: SYSTEM_PROMPT_PLANNER,
+      messages: [{
+        role: "user",
+        content: `Brief:\n${JSON.stringify(brief, null, 2)}\n\nAvailable agents (only these tools are callable):\n${JSON.stringify(coverage, null, 2)}\n\nProduce a plan.`,
+      }],
+      json_schema_hint: PLAN_SCHEMA_HINT,
+      max_tokens: 2000,
+    });
+    if (r.ok && r.json) {
+      const j = r.json as { steps?: Array<Partial<PlanStep>>; confidence?: number; estimated_duration_ms?: number };
+      const steps: PlanStep[] = (j.steps ?? []).map((s, i) => ({
+        step_id: "ps_" + Math.random().toString(36).slice(2, 8),
+        index: i + 1,
+        tool: s.tool ?? "unknown",
+        agents: Array.isArray(s.agents) ? s.agents : [],
+        rationale: s.rationale ?? "",
+        args_template: typeof s.args_template === "object" && s.args_template !== null ? s.args_template : {},
+        downstream_uses: Array.isArray(s.downstream_uses) ? s.downstream_uses : [],
+        optional: s.optional === true,
+      }));
+      trace.push(newReasoningStep("decide", `Claude planned ${steps.length} step(s) in ${r.latency_ms}ms with confidence ${j.confidence ?? "?"}.`, { tools: steps.map((s) => s.tool) }, r.latency_ms));
+      trace.push(newReasoningStep("complete", `Plan ready: ${steps.map((s) => s.tool).join(" → ")}.`, undefined, Date.now() - start));
+      return {
+        plan_id: "pl_" + Math.random().toString(36).slice(2, 10),
+        brief,
+        steps,
+        estimated_duration_ms: typeof j.estimated_duration_ms === "number" ? j.estimated_duration_ms : steps.length * 1500,
+        confidence: typeof j.confidence === "number" ? j.confidence : 0.75,
+        source: "live_llm",
+        trace,
+      };
+    }
+    trace.push(newReasoningStep("recover", `Live planner failed (${r.error || "unknown"}); falling back to template plan.`));
+  } else {
+    trace.push(newReasoningStep("plan", "No live LLM; using deterministic 5-stage template plan filtered by coverage."));
+  }
+
+  // Template plan
+  const steps = defaultPlanForBrief(brief, coverage);
+  trace.push(newReasoningStep("decide", `Template plan: ${steps.length} steps. Skipped tools with 0 capable agents.`, { sequence: steps.map((s) => s.tool) }));
+  trace.push(newReasoningStep("complete", `Plan ready: ${steps.map((s) => s.tool).join(" → ")}.`));
+
+  return {
+    plan_id: "pl_" + Math.random().toString(36).slice(2, 10),
+    brief,
+    steps,
+    estimated_duration_ms: steps.length * 1500,
+    confidence: 0.85,
+    source: "template",
+    trace,
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -72,6 +72,16 @@ import {
   handleDspAgentCapabilities,
 } from "./routes/dspRoutes";
 import {
+  handleAgenticExpand,
+  handleAgenticPlan,
+  handleAgenticExecute,
+  handleAgenticExplain,
+  handleAgenticRecover,
+  handleAgenticRemediate,
+  handleAgenticMemoryRecall,
+  handleAgenticChat,
+} from "./routes/agenticRoutes";
+import {
   handleAudienceCompose,
   handleAudienceSaturation,
   handleAffinityAudit,
@@ -266,6 +276,15 @@ export default {
             "/dsp/campaigns",
             "/dsp/agents",
             "/dsp/media-buys",
+            // Agentic Canvas (LLM-driven planner + executor).
+            "/agentic/brief",
+            "/agentic/plan",
+            "/agentic/execute",
+            "/agentic/explain",
+            "/agentic/chat",
+            "/agentic/recover",
+            "/agentic/remediate",
+            "/agentic/memory",
             "/taxonomy/reverse",
             // Sec-43: audience composer + activation-planning analytics.
             // Read-only — same posture as /portfolio/* and /analytics/*.
@@ -470,6 +489,24 @@ export default {
                 // Catch-all comes LAST.
             } else if (method === "GET" && path.startsWith("/dsp/campaigns")) {
                 response = await handleDspCampaigns(request, env, logger);
+
+                // ── Agentic Canvas ───────────────────────────────────────────────────
+            } else if (method === "POST" && path === "/agentic/brief/expand") {
+                response = await handleAgenticExpand(request, env, logger);
+            } else if (method === "POST" && path === "/agentic/plan") {
+                response = await handleAgenticPlan(request, env, logger);
+            } else if (method === "POST" && path === "/agentic/execute") {
+                response = await handleAgenticExecute(request, env, logger);
+            } else if (method === "POST" && path === "/agentic/explain") {
+                response = await handleAgenticExplain(request, env, logger);
+            } else if (method === "POST" && path === "/agentic/recover") {
+                response = await handleAgenticRecover(request, env, logger);
+            } else if (method === "POST" && path === "/agentic/remediate") {
+                response = await handleAgenticRemediate(request, env, logger);
+            } else if (method === "POST" && path === "/agentic/chat") {
+                response = await handleAgenticChat(request, env, logger);
+            } else if (method === "GET" && path === "/agentic/memory/recall") {
+                response = await handleAgenticMemoryRecall(request, env, logger);
 
                 // ── Sec-43: Audience Composer + activation analytics ────────────────
             } else if (method === "POST" && path === "/audience/compose") {

--- a/src/routes/agenticRoutes.ts
+++ b/src/routes/agenticRoutes.ts
@@ -1,0 +1,406 @@
+// src/routes/agenticRoutes.ts
+//
+// Agentic Canvas endpoints:
+//
+//   POST /agentic/brief/expand          — natural-language → structured brief
+//   POST /agentic/plan                  — given brief + coverage → tool plan
+//   POST /agentic/execute               — execute a plan with reasoning trace
+//                                         (returns NDJSON stream)
+//   POST /agentic/explain               — explain a past decision in prose
+//   POST /agentic/chat                  — unified chat: expand + plan + execute
+//   POST /agentic/recover               — suggest retry strategy for a failed call
+//   POST /agentic/remediate             — suggest signal-swap / attestation fixes
+//                                         given a governance BLOCK
+//   GET  /agentic/memory/recall?brief=... — recall similar past workflows
+//
+// All endpoints are unauth (same posture as the other Canvas routes).
+// Live LLM mode requires ANTHROPIC_API_KEY in env; otherwise template
+// mode kicks in automatically.
+
+import type { Env } from "../types/env";
+import type { Logger } from "../utils/logger";
+import { jsonResponse, errorResponse } from "./shared";
+import { makeAgenticContext, type ReasoningStep, llmCall, newReasoningStep } from "../domain/agenticCore";
+import { expandBrief, type ExpandedBrief } from "../domain/agenticBrief";
+import { planExecution, type AgentCoverage, type ExecutionPlan } from "../domain/agenticPlanner";
+import { recallSimilar, suggestRecovery, suggestRemediations, checkAndRemediate, rememberWorkflow } from "../domain/agenticHelpers";
+import { AGENT_REGISTRY } from "../domain/agentRegistry";
+import { probeAgent, callAgentTool } from "../federation/genericMcpClient";
+import { ensureSelfHooksInstalled } from "./agentsEndpoints";
+import { predictGovernance, type GovernanceAdvisory } from "../domain/governanceMock";
+import { POLICIES } from "../domain/policyRegistry";
+import { getDemoProviderAttestations } from "../domain/workflowOrchestration";
+
+// ── Coverage helper ─────────────────────────────────────────────────────────
+//
+// The planner needs a list of agents + their tools. We build it from
+// a fresh probe (cached against the same KV key as /dsp/agents/coverage).
+
+const COVERAGE_KEY = "dsp_coverage:v1";
+
+async function buildCoverage(env: Env): Promise<AgentCoverage[]> {
+  // Check KV first.
+  try {
+    const cached = await env.SIGNALS_CACHE.get(COVERAGE_KEY, "json") as { agents?: Array<{ agent_id: string; agent_name: string; vendor: string; tools_supported: string[] }> } | null;
+    if (cached && Array.isArray(cached.agents)) {
+      return cached.agents.map((c) => {
+        const meta = AGENT_REGISTRY.find((a) => a.id === c.agent_id);
+        return {
+          agent_id: c.agent_id,
+          agent_name: c.agent_name,
+          vendor: c.vendor,
+          role: (meta?.role ?? "unclassified") as AgentCoverage["role"],
+          tools_supported: c.tools_supported,
+        };
+      });
+    }
+  } catch { /* fall through */ }
+  // Fresh probe (signals + creative + buying).
+  const live = AGENT_REGISTRY.filter((a) => a.stage === "live" && a.mcp_url);
+  const probes = await Promise.all(live.map(async (a) => {
+    const p = await probeAgent(a.mcp_url!, { timeoutMs: 6000 });
+    return { agent: a, tools: (p.tools || []).map((t) => t.name) };
+  }));
+  return probes.map(({ agent, tools }) => ({
+    agent_id: agent.id,
+    agent_name: agent.name,
+    vendor: agent.vendor,
+    role: agent.role as AgentCoverage["role"],
+    tools_supported: tools,
+  }));
+}
+
+// ── POST /agentic/brief/expand ─────────────────────────────────────────────
+
+interface ExpandBody { input?: string }
+
+export async function handleAgenticExpand(request: Request, env: Env, logger: Logger): Promise<Response> {
+  void logger;
+  let body: ExpandBody = {};
+  try { body = await request.json(); } catch { /* empty */ }
+  if (!body.input || body.input.trim().length === 0) {
+    return errorResponse("INVALID_INPUT", "input (string) required", 400);
+  }
+  if (body.input.length > 1000) return errorResponse("INVALID_INPUT", "input max 1000 chars", 400);
+
+  const ctx = makeAgenticContext(env);
+  const expanded = await expandBrief(ctx, body.input.trim());
+  return jsonResponse({ mode: ctx.mode, expanded });
+}
+
+// ── POST /agentic/plan ─────────────────────────────────────────────────────
+
+interface PlanBody { brief?: ExpandedBrief; coverage_override?: AgentCoverage[] }
+
+export async function handleAgenticPlan(request: Request, env: Env, logger: Logger): Promise<Response> {
+  void logger;
+  let body: PlanBody = {};
+  try { body = await request.json(); } catch { /* empty */ }
+  if (!body.brief || !Array.isArray(body.brief.industries)) {
+    return errorResponse("INVALID_INPUT", "brief (ExpandedBrief) required", 400);
+  }
+  const ctx = makeAgenticContext(env);
+  const coverage = body.coverage_override ?? (await buildCoverage(env));
+  const plan = await planExecution(ctx, body.brief, coverage);
+  return jsonResponse({ mode: ctx.mode, plan, coverage_size: coverage.length });
+}
+
+// ── POST /agentic/execute ──────────────────────────────────────────────────
+//
+// Streams reasoning steps as NDJSON. Each line is a JSON object with
+// `kind` field describing the event type. The Canvas client reads
+// these one at a time and renders them in the trace pane.
+
+export async function handleAgenticExecute(request: Request, env: Env, logger: Logger): Promise<Response> {
+  ensureSelfHooksInstalled(env, logger);
+  let body: { plan?: ExecutionPlan } = {};
+  try { body = await request.json(); } catch { /* empty */ }
+  if (!body.plan || !Array.isArray(body.plan.steps)) {
+    return errorResponse("INVALID_INPUT", "plan (ExecutionPlan) required", 400);
+  }
+  const plan = body.plan;
+  const stream = new ReadableStream({
+    async start(controller) {
+      const enc = new TextEncoder();
+      const emit = (obj: unknown) => controller.enqueue(enc.encode(JSON.stringify(obj) + "\n"));
+      try {
+        emit({ event: "execution_start", plan_id: plan.plan_id, step_count: plan.steps.length, ts: new Date().toISOString() });
+
+        // Emit prior trace from planning stage.
+        for (const t of plan.trace || []) emit({ event: "reasoning", step: t });
+
+        const stepResults: Array<{ index: number; tool: string; ok: boolean; agent_results: unknown[] }> = [];
+        const choices: { signals: string[]; formats: string[]; products: Record<string, string> } = { signals: [], formats: [], products: {} };
+
+        for (const step of plan.steps) {
+          emit({ event: "reasoning", step: newReasoningStep("plan", `Step ${step.index}/${plan.steps.length}: ${step.tool} → ${step.agents.join(", ")}. ${step.rationale}`) });
+
+          if (step.tool === "check_governance" || step.tool === "check_brand_rights") {
+            // Local-only mock — no agent call.
+            const indLower = (plan.brief.industries || []).map((s) => s.toLowerCase());
+            const applicable = POLICIES.filter((p) => p.industries_inferred.includes("all") || p.industries_inferred.some((i) => indLower.includes(i.toLowerCase())));
+            const advisory = predictGovernance(applicable, getDemoProviderAttestations());
+            emit({ event: "tool_complete", step_id: step.step_id, tool: step.tool, ok: true, latency_ms: 5, result: advisory, agent_results: [] });
+            emit({ event: "reasoning", step: newReasoningStep("observe", `${step.tool}: outcome=${advisory.outcome}, ${advisory.restricted_attributes.length} block, ${advisory.advisories.filter((a) => a.outcome === "warn").length} warn`) });
+            stepResults.push({ index: step.index, tool: step.tool, ok: true, agent_results: [advisory] });
+            continue;
+          }
+
+          // Real fan-out
+          const targets = step.agents.map((id) => AGENT_REGISTRY.find((a) => a.id === id)).filter((a): a is typeof AGENT_REGISTRY[number] => !!a && !!a.mcp_url);
+          if (targets.length === 0) {
+            emit({ event: "reasoning", step: newReasoningStep("recover", `Step ${step.index} has no callable targets — skipping (optional=${step.optional}).`) });
+            continue;
+          }
+          const results = await Promise.all(targets.map(async (a) => {
+            // Build args from template; resolve "${chosen_*}" interpolations.
+            const args = JSON.parse(JSON.stringify(step.args_template)) as Record<string, unknown>;
+            // Resolve filter signal/format placeholders.
+            if (args.filters && typeof args.filters === "object") {
+              const f = args.filters as Record<string, unknown>;
+              if (f.signals === "${chosen_signal_ids}") f.signals = choices.signals;
+              if (f.format_ids === "${chosen_format_ids}") f.format_ids = choices.formats;
+            }
+            const start = Date.now();
+            const r = await callAgentTool(a.mcp_url!, step.tool, args, { timeoutMs: 12_000 });
+            return { agent_id: a.id, agent_name: a.name, vendor: a.vendor, ok: r.ok, latency_ms: Date.now() - start, error: r.error, structured_content: r.structured_content, content: r.content };
+          }));
+
+          // Update choices from step results
+          if (step.tool === "get_signals") {
+            interface SigShape { signal_agent_segment_id?: string; id?: string; coverage_percentage?: number }
+            const merged: Array<{ id: string; cov: number }> = [];
+            for (const r of results) {
+              if (!r.ok || !r.structured_content) continue;
+              const sc = r.structured_content as { signals?: SigShape[] };
+              for (const s of sc.signals || []) {
+                const id = s.signal_agent_segment_id ?? s.id ?? "";
+                if (id) merged.push({ id, cov: s.coverage_percentage ?? 0 });
+              }
+            }
+            merged.sort((a, b) => b.cov - a.cov);
+            const seen = new Set<string>();
+            for (const m of merged) {
+              if (seen.has(m.id)) continue;
+              seen.add(m.id);
+              choices.signals.push(m.id);
+              if (choices.signals.length >= 3) break;
+            }
+            emit({ event: "reasoning", step: newReasoningStep("decide", `Picked top-${choices.signals.length} signals by coverage: [${choices.signals.join(", ")}].`) });
+          } else if (step.tool === "list_creative_formats") {
+            interface FormatShape { format_id?: string; id?: string }
+            for (const r of results) {
+              if (!r.ok || !r.structured_content) continue;
+              const sc = r.structured_content as { formats?: FormatShape[] };
+              for (const f of (sc.formats || []).slice(0, 2)) {
+                const id = f.format_id ?? f.id;
+                if (id && !choices.formats.includes(id)) choices.formats.push(id);
+              }
+            }
+            emit({ event: "reasoning", step: newReasoningStep("decide", `Picked ${choices.formats.length} creative formats: [${choices.formats.slice(0, 3).join(", ")}].`) });
+          } else if (step.tool === "get_products") {
+            interface ProdShape { product_id?: string; id?: string }
+            for (const r of results) {
+              if (!r.ok || !r.structured_content) continue;
+              const sc = r.structured_content as { products?: ProdShape[] };
+              const top = (sc.products || [])[0];
+              if (top) {
+                const id = top.product_id ?? top.id;
+                if (id) choices.products[r.agent_id] = id;
+              }
+            }
+            emit({ event: "reasoning", step: newReasoningStep("decide", `Picked one product per agent: ${Object.keys(choices.products).length} agent(s) returned products.`) });
+          } else if (step.tool === "create_media_buy") {
+            const okCount = results.filter((r) => r.ok).length;
+            const authCount = results.filter((r) => !r.ok && /principal id not found|authentication required|auth_token_invalid|unauthorized|\b401\b|tenant policy/i.test(JSON.stringify(r.content || "") + (r.error || ""))).length;
+            emit({ event: "reasoning", step: newReasoningStep("observe", `create_media_buy: ${okCount}/${results.length} OK, ${authCount} auth-gated. Workshop punchline visible inline.`) });
+          }
+
+          for (const r of results) {
+            const status = r.ok ? "ok" : "error";
+            emit({ event: "agent_result", step_id: step.step_id, tool: step.tool, agent_id: r.agent_id, status, latency_ms: r.latency_ms, error: r.error });
+          }
+          emit({ event: "tool_complete", step_id: step.step_id, tool: step.tool, ok: results.some((r) => r.ok), latency_ms: Math.max(...results.map((r) => r.latency_ms), 0), agent_results: results });
+          stepResults.push({ index: step.index, tool: step.tool, ok: results.some((r) => r.ok), agent_results: results });
+        }
+
+        emit({ event: "reasoning", step: newReasoningStep("complete", `Plan executed: ${stepResults.filter((s) => s.ok).length}/${stepResults.length} steps successful. Final picks: ${choices.signals.length} signals, ${choices.formats.length} formats, ${Object.keys(choices.products).length} product(s).`) });
+        emit({ event: "execution_complete", plan_id: plan.plan_id, choices, step_results: stepResults, ts: new Date().toISOString() });
+
+        // Persist memory.
+        const memId = "mem_" + Math.random().toString(36).slice(2, 10);
+        await rememberWorkflow(env, {
+          memory_id: memId,
+          ran_at: new Date().toISOString(),
+          brief_input: plan.brief.input,
+          brief_industries: plan.brief.industries,
+          brief_kpi: plan.brief.kpi,
+          outcome: stepResults.every((s) => s.ok) ? "success" : stepResults.some((s) => s.ok) ? "partial" : "failed",
+          chosen_signals: choices.signals,
+          chosen_formats: choices.formats,
+          notable_findings: stepResults.flatMap((s) => s.tool === "create_media_buy" && !s.ok ? ["create_media_buy auth-gated"] : []),
+        });
+      } catch (e) {
+        controller.enqueue(new TextEncoder().encode(JSON.stringify({ event: "error", error: String((e as Error).message || e) }) + "\n"));
+      } finally {
+        controller.close();
+      }
+    },
+  });
+  return new Response(stream, {
+    status: 200,
+    headers: { "Content-Type": "application/x-ndjson", "Cache-Control": "no-cache", "Connection": "keep-alive" },
+  });
+}
+
+// ── POST /agentic/explain ──────────────────────────────────────────────────
+//
+// Explain a decision in prose. Live mode = LLM call. Template mode =
+// pretty-format the supplied data into a sentence.
+
+interface ExplainBody {
+  /** What to explain — e.g. "signal_pick", "governance_outcome", "fire_buy_result". */
+  topic: string;
+  /** Structured payload describing what was decided. */
+  decision: unknown;
+  /** Optional brief for context. */
+  brief?: ExpandedBrief;
+}
+
+export async function handleAgenticExplain(request: Request, env: Env, logger: Logger): Promise<Response> {
+  void logger;
+  let body: ExplainBody = { topic: "", decision: null };
+  try { body = await request.json(); } catch { /* empty */ }
+  if (!body.topic) return errorResponse("INVALID_INPUT", "topic required", 400);
+  const ctx = makeAgenticContext(env);
+
+  if (ctx.mode === "live") {
+    const r = await llmCall(ctx, {
+      system: "You are an AdCP orchestrator explaining a decision in plain language. Be concise (2-4 sentences). Cite the data. Focus on WHY, not just WHAT.",
+      messages: [{ role: "user", content: `Explain this ${body.topic} decision:\n\n${JSON.stringify(body.decision, null, 2)}\n\n${body.brief ? "Context brief:\n" + JSON.stringify(body.brief, null, 2) : ""}` }],
+      max_tokens: 400,
+    });
+    if (r.ok) return jsonResponse({ mode: "live", explanation: r.text, model: r.model, latency_ms: r.latency_ms });
+  }
+
+  // Template explainers
+  let explanation = "Decision details:";
+  switch (body.topic) {
+    case "signal_pick": {
+      const d = body.decision as { signal_id?: string; coverage_percentage?: number; source_agent_id?: string; rank?: number };
+      explanation = `Picked signal **${d.signal_id ?? "?"}** at rank ${d.rank ?? "?"} because its coverage_percentage of ${d.coverage_percentage ?? "?"}% topped the merged ranking from ${d.source_agent_id ?? "?"}. Tie-break is appearance order across agents.`;
+      break;
+    }
+    case "governance_outcome": {
+      const d = body.decision as GovernanceAdvisory;
+      explanation = `Governance preview: **${d.outcome.toUpperCase()}**. ${d.restricted_attributes.length === 0 ? "No must-policies are unmet." : `Unmet must-policies: ${d.restricted_attributes.join(", ")}.`} ${d.advisories.length} applicable polic${d.advisories.length === 1 ? "y" : "ies"} evaluated against the signal's attestation set.`;
+      break;
+    }
+    case "fire_buy_result": {
+      const d = body.decision as { ok?: boolean; auth_gated?: boolean; agent_id?: string; error?: string };
+      if (d.ok) explanation = `Fire succeeded on **${d.agent_id ?? "?"}**. Real media-buy created.`;
+      else if (d.auth_gated) explanation = `**Auth-gated** on ${d.agent_id ?? "?"} — payload shape passed validation, vendor requires credentials we don't carry. This is the canonical Sec-48 finding: the buy-side has the surface but no shared auth posture in 3.0 GA.`;
+      else explanation = `Fire failed on ${d.agent_id ?? "?"}: ${(d.error || "no error body").slice(0, 200)}.`;
+      break;
+    }
+    default:
+      explanation = `Topic "${body.topic}" not in template library. Decision payload: ${JSON.stringify(body.decision).slice(0, 300)}.`;
+  }
+
+  return jsonResponse({ mode: "template", explanation, topic: body.topic });
+}
+
+// ── POST /agentic/recover ──────────────────────────────────────────────────
+
+interface RecoverBody { failed_tool?: string; error_text?: string; alternate_agents?: string[] }
+
+export async function handleAgenticRecover(request: Request, env: Env, _logger: Logger): Promise<Response> {
+  void env;
+  let body: RecoverBody = {};
+  try { body = await request.json(); } catch { /* empty */ }
+  if (!body.failed_tool || !body.error_text) {
+    return errorResponse("INVALID_INPUT", "failed_tool and error_text required", 400);
+  }
+  const strategy = suggestRecovery(body.failed_tool, body.error_text, Array.isArray(body.alternate_agents) ? body.alternate_agents : []);
+  return jsonResponse({ failed_tool: body.failed_tool, strategy });
+}
+
+// ── POST /agentic/remediate ────────────────────────────────────────────────
+
+interface RemediateBody { brief?: ExpandedBrief }
+
+export async function handleAgenticRemediate(request: Request, env: Env, _logger: Logger): Promise<Response> {
+  void env;
+  let body: RemediateBody = {};
+  try { body = await request.json(); } catch { /* empty */ }
+  if (!body.brief) return errorResponse("INVALID_INPUT", "brief required", 400);
+  const out = checkAndRemediate(body.brief);
+  return jsonResponse({ advisory: out.advisory, remediations: out.remediations, trace: out.trace });
+}
+
+// ── GET /agentic/memory/recall ─────────────────────────────────────────────
+
+export async function handleAgenticMemoryRecall(request: Request, env: Env, _logger: Logger): Promise<Response> {
+  const url = new URL(request.url);
+  const briefStr = url.searchParams.get("brief") || "";
+  const industriesStr = url.searchParams.get("industries") || "";
+  const kpi = url.searchParams.get("kpi") || "ROAS";
+  if (!briefStr) return errorResponse("INVALID_INPUT", "brief query param required", 400);
+  const brief: ExpandedBrief = {
+    input: briefStr,
+    industries: industriesStr.split(",").map((s) => s.trim()).filter(Boolean),
+    audience_descriptors: [],
+    kpi: kpi as ExpandedBrief["kpi"],
+    geo: ["US"],
+    confidence: 1.0,
+    source: "template",
+    trace: [],
+  };
+  const r = await recallSimilar(env, brief);
+  return jsonResponse(r);
+}
+
+// ── POST /agentic/chat ─────────────────────────────────────────────────────
+//
+// Unified chat endpoint: input → expand → plan → return both. The
+// caller can then POST the plan to /agentic/execute for streaming
+// execution. We split expand and execute so the user can review the
+// plan before it runs.
+
+interface ChatBody { input?: string }
+
+export async function handleAgenticChat(request: Request, env: Env, _logger: Logger): Promise<Response> {
+  let body: ChatBody = {};
+  try { body = await request.json(); } catch { /* empty */ }
+  if (!body.input || body.input.trim().length === 0) {
+    return errorResponse("INVALID_INPUT", "input required", 400);
+  }
+  const ctx = makeAgenticContext(env);
+  const expanded = await expandBrief(ctx, body.input.trim());
+  const coverage = await buildCoverage(env);
+  const plan = await planExecution(ctx, expanded, coverage);
+  const memory = await recallSimilar(env, expanded);
+  const compliance = checkAndRemediate(expanded);
+
+  // Compose a short prose summary for the chat surface.
+  const summaryParts: string[] = [];
+  summaryParts.push(`Brief expanded: brand="${expanded.brand_name ?? "(unknown)"}", industries=[${expanded.industries.slice(0, 3).join(", ")}], KPI=${expanded.kpi}@${expanded.kpi_target ?? "?"}.`);
+  summaryParts.push(`Plan: ${plan.steps.length} step(s) — ${plan.steps.map((s) => s.tool).join(" → ")}.`);
+  summaryParts.push(`Governance preview: ${compliance.advisory.outcome.toUpperCase()}${compliance.advisory.restricted_attributes.length > 0 ? ` (block on ${compliance.advisory.restricted_attributes.join(", ")})` : ""}.`);
+  if (memory.matches.length > 0) summaryParts.push(`Memory: ${memory.hint}`);
+  summaryParts.push(`Mode: ${ctx.mode}.`);
+  const summary = summaryParts.join(" ");
+
+  // Combine traces for client.
+  const trace: ReasoningStep[] = [...expanded.trace, ...plan.trace, ...compliance.trace];
+
+  return jsonResponse({
+    mode: ctx.mode,
+    summary,
+    expanded,
+    plan,
+    memory,
+    compliance,
+    trace,
+  });
+}

--- a/src/routes/agentsEndpoints.ts
+++ b/src/routes/agentsEndpoints.ts
@@ -60,7 +60,7 @@ import { ADCP_TOOLS } from "../mcp/tools";
 // probes or fans-out to our own URL, Cloudflare Workers refuse self-fetch; we
 // short-circuit and return our real tool list / dispatch the call in-process.
 let _envHookInstalled = false;
-function ensureSelfHooksInstalled(env: Env, logger: Logger): void {
+export function ensureSelfHooksInstalled(env: Env, logger: Logger): void {
   if (_envHookInstalled) return;
   _envHookInstalled = true;
   installSelfProbeHook((url) => {

--- a/src/routes/demo.ts
+++ b/src/routes/demo.ts
@@ -157,6 +157,10 @@ ${STYLES}
         <svg class="ico"><use href="#icon-network"/></svg><span>Campaign</span>
         <span class="nav-tag">DSP</span>
       </button>
+      <button class="nav-item" data-tab="agentic">
+        <svg class="ico"><use href="#icon-bolt"/></svg><span>Agentic</span>
+        <span class="nav-tag">AI</span>
+      </button>
       <button class="nav-item" data-tab="activations">
         <svg class="ico"><use href="#icon-activations"/></svg><span>Activations</span>
         <span class="nav-count" id="nav-activations-count">—</span>
@@ -1617,6 +1621,99 @@ ${STYLES}
             <svg class="ico" style="width:14px;height:14px"><use href="#icon-loop"/></svg>
             <span>feedback loop — optimization signals re-tune the bid strategy each cycle</span>
             <span class="campaign-feedback-arrow-tag mono">↻ continuous</span>
+          </div>
+        </div>
+      </section>
+
+      <!-- ── TAB: Agentic Canvas ─────────────────────────────────────── -->
+      <section class="tab-pane" data-tab="agentic">
+        <div class="pane-header">
+          <div>
+            <h1 class="pane-title">Agentic Canvas <span class="pill pill-warning mono" style="font-size:9.5px;margin-left:8px;letter-spacing:0.04em" id="agentic-mode-pill">probing mode…</span></h1>
+            <p class="pane-subtitle">
+              Type a brief in plain English. The agent expands it, plans the call sequence dynamically, executes against live MCP agents, and narrates every decision.
+              <br/>
+              <span style="color:var(--text-mut)">Live mode requires <code>ANTHROPIC_API_KEY</code>; otherwise rule-based templates produce the same surface deterministically.</span>
+            </p>
+          </div>
+        </div>
+
+        <div class="agentic-shell">
+          <div class="agentic-chat-col">
+            <div class="agentic-chat-input-row">
+              <textarea class="agentic-input" id="agentic-input" rows="2" placeholder='e.g. "Plan a $50K Coca-Cola summer campaign for Gen Z urban — ROAS 3.5x"'></textarea>
+              <button class="agentic-submit-btn" id="agentic-submit-btn">
+                <svg class="ico"><use href="#icon-bolt"/></svg>
+                <span>Plan</span>
+              </button>
+            </div>
+            <div class="agentic-suggestions" id="agentic-suggestions">
+              <span class="orch-small" style="color:var(--text-mut);margin-right:6px">try:</span>
+              <button class="agentic-sugg" data-prompt='Plan a $50K Coca-Cola summer campaign for Gen Z urban — ROAS 3.5x'>Coca-Cola summer · Gen Z</button>
+              <button class="agentic-sugg" data-prompt='Pfizer healthcare brand-lift study, US adults 35+, $80K budget, 30 days'>Pfizer · brand-lift</button>
+              <button class="agentic-sugg" data-prompt='Heineken USA — alcohol, urban DMAs, evening peak, ROAS focus, $200K'>Heineken · alcohol</button>
+              <button class="agentic-sugg" data-prompt='LEGO holiday awareness — children, parents, US + EU, $1M, awareness'>LEGO · children</button>
+            </div>
+
+            <!-- Brief expansion panel -->
+            <div class="agentic-section" id="agentic-brief-section" style="display:none">
+              <div class="agentic-section-head">
+                <span class="agentic-section-label">1 · Brief expanded</span>
+                <span class="agentic-section-source mono" id="agentic-brief-source">…</span>
+              </div>
+              <div class="agentic-section-body" id="agentic-brief-body"></div>
+            </div>
+
+            <!-- Plan panel -->
+            <div class="agentic-section" id="agentic-plan-section" style="display:none">
+              <div class="agentic-section-head">
+                <span class="agentic-section-label">2 · Execution plan</span>
+                <span class="agentic-section-source mono" id="agentic-plan-source">…</span>
+              </div>
+              <div class="agentic-section-body" id="agentic-plan-body"></div>
+              <div class="agentic-plan-actions">
+                <button class="agentic-execute-btn" id="agentic-execute-btn">
+                  <svg class="ico"><use href="#icon-bolt"/></svg>
+                  <span>Execute plan</span>
+                </button>
+                <span class="orch-small" style="color:var(--text-mut)">streams reasoning + tool results live</span>
+              </div>
+            </div>
+
+            <!-- Execution panel -->
+            <div class="agentic-section" id="agentic-exec-section" style="display:none">
+              <div class="agentic-section-head">
+                <span class="agentic-section-label">3 · Execution</span>
+                <span class="agentic-section-source mono" id="agentic-exec-status">idle</span>
+              </div>
+              <div class="agentic-section-body" id="agentic-exec-body"></div>
+            </div>
+
+            <!-- Compliance + memory + recovery sidebar -->
+            <div class="agentic-section" id="agentic-compliance-section" style="display:none">
+              <div class="agentic-section-head">
+                <span class="agentic-section-label">Governance + remediation</span>
+              </div>
+              <div class="agentic-section-body" id="agentic-compliance-body"></div>
+            </div>
+
+            <div class="agentic-section" id="agentic-memory-section" style="display:none">
+              <div class="agentic-section-head">
+                <span class="agentic-section-label">Memory</span>
+              </div>
+              <div class="agentic-section-body" id="agentic-memory-body"></div>
+            </div>
+          </div>
+
+          <!-- Right: reasoning trace pane -->
+          <div class="agentic-trace-col">
+            <div class="agentic-section-head">
+              <span class="agentic-section-label">Reasoning trace</span>
+              <span class="agentic-section-source mono" id="agentic-trace-count">0 steps</span>
+            </div>
+            <div class="agentic-trace" id="agentic-trace">
+              <span class="orch-small" style="color:var(--text-mut)">decisions will narrate here as the agent works…</span>
+            </div>
           </div>
         </div>
       </section>
@@ -5247,6 +5344,264 @@ textarea.lab-input { resize: vertical; line-height: 1.5; }
   .campaign-lane-2col { grid-template-columns: 1fr; }
 }
 
+/* ────────────────────────────────────────────────────────────────
+   Agentic Canvas
+   ──────────────────────────────────────────────────────────────── */
+
+.agentic-shell {
+  display: grid; grid-template-columns: minmax(0, 1.5fr) minmax(280px, 1fr);
+  gap: 16px; min-height: 500px;
+}
+.agentic-chat-col { display: flex; flex-direction: column; gap: 12px; }
+.agentic-chat-input-row {
+  display: flex; gap: 8px; align-items: stretch;
+}
+.agentic-input {
+  flex: 1; padding: 10px 12px; font-size: 13px; line-height: 1.4;
+  background: var(--bg-input); color: var(--text);
+  border: 1px solid var(--border); border-radius: 5px;
+  font-family: inherit; resize: vertical; min-height: 50px;
+}
+.agentic-input:focus { outline: none; border-color: var(--accent); }
+.agentic-submit-btn {
+  display: inline-flex; align-items: center; gap: 6px;
+  padding: 0 18px; background: var(--accent); color: #000;
+  border: 1px solid var(--accent); border-radius: 5px;
+  font-size: 13px; font-weight: 600; cursor: pointer;
+  font-family: inherit; transition: filter 0.15s;
+}
+.agentic-submit-btn:hover:not(:disabled) { filter: brightness(1.1); }
+.agentic-submit-btn:disabled { opacity: 0.6; cursor: wait; }
+.agentic-submit-btn .ico { width: 14px; height: 14px; }
+.agentic-suggestions {
+  display: flex; flex-wrap: wrap; gap: 4px; align-items: center;
+}
+.agentic-sugg {
+  background: var(--bg-raised); color: var(--text-dim);
+  border: 1px solid var(--border); border-radius: 4px;
+  padding: 4px 10px; font-size: 10.5px; cursor: pointer;
+  font-family: inherit;
+}
+.agentic-sugg:hover { border-color: var(--accent); color: var(--accent); }
+
+/* Sections */
+.agentic-section {
+  background: var(--bg-surface); border: 1px solid var(--border);
+  border-left-width: 3px; border-left-color: var(--accent);
+  border-radius: 5px; padding: 10px 12px;
+}
+.agentic-section-head {
+  display: flex; align-items: center; gap: 10px;
+  padding-bottom: 6px; margin-bottom: 8px;
+  border-bottom: 1px dashed var(--border);
+}
+.agentic-section-label {
+  font-size: 11.5px; font-weight: 600; color: var(--text);
+}
+.agentic-section-source {
+  margin-left: auto; font-size: 9.5px; color: var(--text-mut);
+  text-transform: uppercase; letter-spacing: 0.05em;
+}
+.agentic-section-body { display: flex; flex-direction: column; gap: 6px; }
+
+/* Brief panel */
+.agentic-brief-grid {
+  display: grid; grid-template-columns: repeat(3, 1fr); gap: 10px;
+}
+.agentic-brief-cell-wide { grid-column: span 3; }
+.agentic-brief-cell { display: flex; flex-direction: column; gap: 2px; }
+.agentic-brief-label {
+  font-size: 9.5px; text-transform: uppercase; letter-spacing: 0.05em;
+  color: var(--text-mut); font-weight: 500;
+}
+
+/* Plan panel */
+.agentic-plan-steps { display: flex; flex-direction: column; gap: 6px; }
+.agentic-plan-step {
+  background: var(--bg-raised); border: 1px solid var(--border);
+  border-radius: 4px; padding: 6px 10px;
+}
+.agentic-plan-step-head {
+  display: flex; align-items: center; gap: 8px; flex-wrap: wrap;
+  margin-bottom: 3px;
+}
+.agentic-plan-step-num {
+  background: var(--accent); color: #000;
+  width: 18px; height: 18px; border-radius: 50%;
+  display: inline-flex; align-items: center; justify-content: center;
+  font-size: 10px; font-weight: 700;
+}
+.agentic-plan-step-tool { color: var(--text); font-weight: 600; font-size: 12px; }
+.agentic-plan-step-agents { color: var(--text-mut); }
+.agentic-plan-step-rationale {
+  color: var(--text-dim); font-size: 11px; line-height: 1.4;
+  padding-left: 26px;
+}
+.agentic-plan-actions {
+  display: flex; align-items: center; gap: 10px;
+  padding-top: 8px; margin-top: 8px;
+  border-top: 1px dashed var(--border);
+}
+.agentic-execute-btn {
+  display: inline-flex; align-items: center; gap: 6px;
+  padding: 4px 12px; background: var(--success); color: #000;
+  border: 1px solid var(--success); border-radius: 4px;
+  font-size: 12px; font-weight: 500; cursor: pointer;
+  font-family: inherit;
+}
+.agentic-execute-btn:disabled { opacity: 0.6; cursor: wait; }
+.agentic-execute-btn .ico { width: 12px; height: 12px; }
+
+/* Execution panel */
+.agentic-exec-step {
+  border-left: 3px solid var(--text-mut);
+  padding: 4px 10px; margin-bottom: 4px;
+  background: var(--bg-raised); border-radius: 0 4px 4px 0;
+}
+.agentic-exec-step.agentic-exec-ok  { border-left-color: var(--success); }
+.agentic-exec-step.agentic-exec-err { border-left-color: var(--error); }
+.agentic-exec-step-head {
+  display: flex; align-items: center; gap: 8px; font-size: 11px;
+}
+.agentic-exec-status {
+  font-size: 9px; padding: 1px 5px; border-radius: 2px;
+  background: var(--bg-input); color: var(--text);
+  text-transform: uppercase; letter-spacing: 0.06em;
+}
+.agentic-exec-lat { margin-left: auto; color: var(--text-mut); }
+.agentic-agent-row {
+  display: flex; gap: 8px; align-items: center;
+  padding: 2px 8px 2px 26px; font-size: 10.5px;
+  color: var(--text-mut);
+}
+.agentic-agent-row.agentic-agent-ok  { border-left: 2px solid var(--success); }
+.agentic-agent-row.agentic-agent-err { border-left: 2px solid var(--error); }
+
+/* Compliance panel */
+.agentic-comp-banner {
+  display: flex; align-items: center; gap: 10px;
+  padding: 5px 10px; border-radius: 3px;
+  border: 1px solid currentColor; font-size: 11px;
+}
+.agentic-comp-icon { font-size: 14px; }
+.agentic-comp-allow { color: var(--success); background: rgba(102,187,106,0.10); }
+.agentic-comp-warn  { color: var(--warning, #d4a017); background: rgba(212,160,23,0.10); }
+.agentic-comp-block { color: var(--error); background: rgba(239,68,68,0.10); }
+.agentic-comp-row {
+  display: grid; grid-template-columns: 200px 80px 1fr;
+  gap: 8px; padding: 3px 0; font-size: 10.5px;
+  border-bottom: 1px dashed var(--border);
+}
+.agentic-comp-row-block .mono:nth-child(2) { color: var(--error); font-weight: 600; }
+.agentic-comp-row-warn  .mono:nth-child(2) { color: var(--warning, #d4a017); font-weight: 600; }
+.agentic-comp-row-allow .mono:nth-child(2) { color: var(--success); }
+.agentic-rem-block { padding-top: 4px; }
+.agentic-rem-row {
+  font-size: 10.5px; color: var(--text-dim);
+  padding: 3px 0; border-bottom: 1px dashed var(--border);
+}
+.agentic-rem-suggestion {
+  font-size: 9px; padding: 1px 5px; border-radius: 2px;
+  background: var(--accent); color: #000; font-weight: 600;
+  text-transform: uppercase; letter-spacing: 0.06em;
+  margin-right: 4px;
+}
+
+/* Memory panel */
+.agentic-mem-row {
+  display: grid; grid-template-columns: 90px 1fr 80px;
+  gap: 8px; padding: 3px 0; font-size: 10.5px;
+  color: var(--text-dim);
+  border-bottom: 1px dashed var(--border);
+}
+.agentic-mem-when { color: var(--text-mut); }
+.agentic-mem-outcome { color: var(--accent); text-align: right; }
+
+/* Trace pane */
+.agentic-trace-col {
+  background: var(--bg-input); border: 1px solid var(--border);
+  border-radius: 5px; padding: 10px 12px;
+  display: flex; flex-direction: column; gap: 8px;
+  min-height: 400px; max-height: 80vh;
+}
+.agentic-trace {
+  flex: 1; overflow-y: auto;
+  display: flex; flex-direction: column; gap: 4px;
+  padding-right: 4px;
+}
+.agentic-trace-step {
+  display: grid; grid-template-columns: 70px 1fr 50px;
+  gap: 6px; padding: 3px 6px; align-items: baseline;
+  font-size: 10.5px; line-height: 1.35;
+  border-left: 2px solid transparent;
+  background: var(--bg-raised); border-radius: 3px;
+}
+.agentic-trace-kind {
+  font-size: 8.5px; font-weight: 700; letter-spacing: 0.06em;
+  color: var(--text-mut);
+}
+.agentic-trace-msg { color: var(--text-dim); }
+.agentic-trace-lat { color: var(--text-mut); text-align: right; }
+.agentic-trace-step.agentic-trace-analyze   { border-left-color: var(--text-mut); }
+.agentic-trace-step.agentic-trace-plan      { border-left-color: var(--accent); }
+.agentic-trace-step.agentic-trace-call      { border-left-color: var(--accent); }
+.agentic-trace-step.agentic-trace-observe   { border-left-color: var(--success); }
+.agentic-trace-step.agentic-trace-decide    { border-left-color: var(--accent); }
+.agentic-trace-step.agentic-trace-reflect   { border-left-color: var(--warning, #d4a017); }
+.agentic-trace-step.agentic-trace-recover   { border-left-color: var(--warning, #d4a017); }
+.agentic-trace-step.agentic-trace-remediate { border-left-color: var(--warning, #d4a017); }
+.agentic-trace-step.agentic-trace-complete  { border-left-color: var(--success); background: rgba(102,187,106,0.06); }
+
+@media (max-width: 1100px) {
+  .agentic-shell { grid-template-columns: 1fr; }
+  .agentic-brief-grid { grid-template-columns: repeat(2, 1fr); }
+  .agentic-brief-cell-wide { grid-column: span 2; }
+}
+
+/* "Explain this" badge + modal — works across all surfaces */
+.explain-badge {
+  display: inline-flex; align-items: center; justify-content: center;
+  width: 16px; height: 16px; margin-left: 6px;
+  border-radius: 50%; border: 1px solid var(--text-mut);
+  background: transparent; color: var(--text-mut);
+  font-size: 9px; font-weight: 700; cursor: pointer;
+  font-family: inherit;
+  transition: border-color 0.15s, color 0.15s;
+}
+.explain-badge:hover { border-color: var(--accent); color: var(--accent); }
+.explain-modal {
+  position: fixed; inset: 0; z-index: 9100;
+  background: rgba(0,0,0,0.6);
+  display: flex; align-items: center; justify-content: center;
+  padding: 20px;
+}
+.explain-modal-inner {
+  background: var(--bg-surface); border: 1px solid var(--accent);
+  border-radius: 6px; padding: 14px;
+  min-width: 380px; max-width: 600px; max-height: 80vh; overflow-y: auto;
+}
+.explain-modal-head {
+  display: flex; justify-content: space-between; align-items: center;
+  padding-bottom: 8px; margin-bottom: 10px;
+  border-bottom: 1px solid var(--border);
+}
+.explain-modal-close {
+  background: transparent; border: 1px solid var(--border);
+  border-radius: 3px; width: 22px; height: 22px;
+  cursor: pointer; color: var(--text-mut); font-size: 14px;
+}
+.explain-modal-close:hover { color: var(--error); border-color: var(--error); }
+.explain-mode-pill {
+  display: inline-block; padding: 2px 6px;
+  background: var(--bg-input); color: var(--text-mut);
+  border-radius: 3px; font-size: 9.5px;
+  text-transform: uppercase; letter-spacing: 0.04em;
+  margin-bottom: 6px;
+}
+.explain-text {
+  color: var(--text-dim); font-size: 12.5px; line-height: 1.55;
+}
+
 /* Live MCP coverage strip — top of Campaign Canvas */
 .campaign-coverage {
   display: flex; align-items: center; gap: 6px; flex-wrap: wrap;
@@ -6577,7 +6932,7 @@ function switchTab(name) {
     journey: "Journey", planner: "Scenario", snapshots: "Snapshots",
     freshness: "Freshness",
     seasonality: "Seasonality", federation: "Federation",
-    orchestrator: "Orchestrator", canvas: "Canvas", campaign: "Campaign Canvas",
+    orchestrator: "Orchestrator", canvas: "Canvas", campaign: "Campaign Canvas", agentic: "Agentic Canvas",
   };
   document.getElementById("crumb-current").textContent = crumbMap[name] || name;
 
@@ -6593,6 +6948,7 @@ function switchTab(name) {
   if (name === "destinations") ensureDestinations();
   if (name === "canvas") _canvasReplayFromQuery();
   if (name === "campaign") _campaignInit();
+  if (name === "agentic") _agenticInit();
   if (name === "lab") ensureLab();
   if (name === "portfolio") ensurePortfolio();
   if (name === "composer") ensureComposer();
@@ -14578,6 +14934,7 @@ async function _canvasFillGovernancePreview(industries) {
         adv.advisories.filter(function (a) { return a.outcome === "warn"; }).length + ' warn · ' +
         adv.advisories.filter(function (a) { return a.outcome === "allow"; }).length + ' allow' +
       '</span>' +
+      _explainBadge("governance_outcome", adv) +
     '</div>';
     var chips = adv.advisories.map(function (a) {
       var enfTag = a.enforcement === "must" ? "M" : a.enforcement === "should" ? "S" : "?";
@@ -16591,6 +16948,330 @@ async function _campaignApplyDiffLive() {
     out.innerHTML = '<span class="orch-small" style="color:var(--error)">' + escapeHtml(String((e && e.message) || e)) + '</span>';
     btn.textContent = "Retry"; btn.disabled = false;
   }
+}
+
+// ─────────────────────────────────────────────────────────────────
+// Agentic helper: "Explain this decision" reusable button + modal.
+// Clickable "?" badge on any surface. POSTs to /agentic/explain.
+// ─────────────────────────────────────────────────────────────────
+
+function _explainBadge(topic, decision) {
+  // Returns the HTML for an inline "?" badge. Caller is responsible
+  // for wiring the click handler post-innerHTML via the data attrs.
+  var key = "ex_" + Math.random().toString(36).slice(2, 8);
+  if (!window._explainPayloads) window._explainPayloads = {};
+  window._explainPayloads[key] = { topic: topic, decision: decision };
+  return '<button class="explain-badge mono" data-explain-key="' + escapeHtml(key) + '" title="Explain this decision">?</button>';
+}
+
+document.addEventListener("click", function (e) {
+  var t = e.target;
+  if (!t || !t.closest) return;
+  var btn = t.closest(".explain-badge");
+  if (!btn) return;
+  var key = btn.getAttribute("data-explain-key");
+  if (!key || !window._explainPayloads || !window._explainPayloads[key]) return;
+  var payload = window._explainPayloads[key];
+  _showExplainModal(payload.topic, payload.decision);
+});
+
+async function _showExplainModal(topic, decision) {
+  var existing = document.getElementById("explain-modal");
+  if (existing) existing.remove();
+  var modal = document.createElement("div");
+  modal.id = "explain-modal";
+  modal.className = "explain-modal";
+  modal.innerHTML =
+    '<div class="explain-modal-inner">' +
+      '<div class="explain-modal-head">' +
+        '<span class="mono">explain · ' + escapeHtml(topic) + '</span>' +
+        '<button class="explain-modal-close" id="explain-modal-close">×</button>' +
+      '</div>' +
+      '<div class="explain-modal-body" id="explain-modal-body">' +
+        '<span class="orch-small">asking the orchestrator…</span>' +
+      '</div>' +
+    '</div>';
+  document.body.appendChild(modal);
+  document.getElementById("explain-modal-close").addEventListener("click", function () { modal.remove(); });
+  modal.addEventListener("click", function (e) { if (e.target === modal) modal.remove(); });
+  try {
+    var r = await fetch("/agentic/explain", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ topic: topic, decision: decision }) });
+    var d = await r.json();
+    var body = document.getElementById("explain-modal-body");
+    if (!body) return;
+    body.innerHTML =
+      '<div class="explain-mode-pill mono">' + escapeHtml(d.mode || "?") + (d.model ? " · " + escapeHtml(d.model) : "") + (d.latency_ms ? " · " + d.latency_ms + "ms" : "") + '</div>' +
+      '<div class="explain-text">' + escapeHtml(d.explanation || "no explanation returned") + '</div>' +
+      '<details style="margin-top:8px"><summary class="orch-small" style="cursor:pointer">decision payload</summary><pre class="wf-json mono" style="max-height:200px;overflow:auto;font-size:10.5px">' + escapeHtml(JSON.stringify(decision, null, 2).slice(0, 1500)) + '</pre></details>';
+  } catch (e) {
+    var b = document.getElementById("explain-modal-body");
+    if (b) b.innerHTML = '<span class="orch-small" style="color:var(--error)">' + escapeHtml(String((e && e.message) || e)) + '</span>';
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────
+// Agentic Canvas — chat-first orchestrator
+// ─────────────────────────────────────────────────────────────────
+
+var _agenticCurrent = null;
+var _agenticTrace = [];
+var _agenticInitialized = false;
+
+async function _agenticInit() {
+  if (_agenticInitialized) return;
+  _agenticInitialized = true;
+  // Wire input + suggestions
+  var input = document.getElementById("agentic-input");
+  var submit = document.getElementById("agentic-submit-btn");
+  if (submit) submit.addEventListener("click", _agenticSubmit);
+  if (input) {
+    input.addEventListener("keydown", function (e) {
+      if (e.key === "Enter" && (e.ctrlKey || e.metaKey)) { e.preventDefault(); _agenticSubmit(); }
+    });
+  }
+  document.querySelectorAll(".agentic-sugg").forEach(function (b) {
+    b.addEventListener("click", function () {
+      var p = b.getAttribute("data-prompt");
+      if (p && input) { input.value = p; _agenticSubmit(); }
+    });
+  });
+  // Probe mode
+  try {
+    // Cheap mode probe: hit the expand endpoint with a minimal input.
+    var r = await fetch("/agentic/brief/expand", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ input: "test" }) });
+    var d = await r.json();
+    var pill = document.getElementById("agentic-mode-pill");
+    if (pill) {
+      pill.textContent = d.mode === "live" ? "live · Claude" : "template mode · no API key";
+      pill.className = "pill mono " + (d.mode === "live" ? "pill-success" : "pill-muted") + " agentic-mode-pill";
+      pill.style.fontSize = "9.5px"; pill.style.marginLeft = "8px"; pill.style.letterSpacing = "0.04em";
+    }
+  } catch (e) { /* noop */ }
+}
+
+async function _agenticSubmit() {
+  var input = document.getElementById("agentic-input");
+  if (!input || !input.value.trim()) return;
+  var brief = input.value.trim();
+  _agenticTrace = [];
+  _agenticUpdateTrace();
+  document.getElementById("agentic-brief-section").style.display = "none";
+  document.getElementById("agentic-plan-section").style.display = "none";
+  document.getElementById("agentic-exec-section").style.display = "none";
+  document.getElementById("agentic-compliance-section").style.display = "none";
+  document.getElementById("agentic-memory-section").style.display = "none";
+  var btn = document.getElementById("agentic-submit-btn");
+  if (btn) { btn.disabled = true; btn.querySelector("span").textContent = "thinking…"; }
+  try {
+    var r = await fetch("/agentic/chat", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ input: brief }) });
+    var d = await r.json();
+    _agenticCurrent = d;
+    // Append all initial trace steps
+    for (var i = 0; i < (d.trace || []).length; i++) _agenticTrace.push(d.trace[i]);
+    _agenticUpdateTrace();
+    _agenticRenderBrief(d.expanded);
+    _agenticRenderPlan(d.plan);
+    _agenticRenderCompliance(d.compliance);
+    _agenticRenderMemory(d.memory);
+  } catch (e) {
+    showToast("agentic chat failed: " + ((e && e.message) || e), true);
+  } finally {
+    if (btn) { btn.disabled = false; btn.querySelector("span").textContent = "Plan"; }
+  }
+}
+
+function _agenticUpdateTrace() {
+  var pane = document.getElementById("agentic-trace");
+  var counter = document.getElementById("agentic-trace-count");
+  if (counter) counter.textContent = _agenticTrace.length + " step" + (_agenticTrace.length === 1 ? "" : "s");
+  if (!pane) return;
+  if (_agenticTrace.length === 0) {
+    pane.innerHTML = '<span class="orch-small" style="color:var(--text-mut)">decisions will narrate here as the agent works…</span>';
+    return;
+  }
+  pane.innerHTML = _agenticTrace.map(function (s, idx) {
+    return '<div class="agentic-trace-step agentic-trace-' + escapeHtml(s.kind || "info") + '">' +
+      '<span class="agentic-trace-kind mono">' + escapeHtml((s.kind || "info").toUpperCase()) + '</span>' +
+      '<span class="agentic-trace-msg">' + escapeHtml(s.message || "") + '</span>' +
+      (s.latency_ms != null ? '<span class="agentic-trace-lat mono orch-small">' + s.latency_ms + 'ms</span>' : '') +
+    '</div>';
+  }).join("");
+  pane.scrollTop = pane.scrollHeight;
+}
+
+function _agenticRenderBrief(b) {
+  var sec = document.getElementById("agentic-brief-section");
+  var src = document.getElementById("agentic-brief-source");
+  var body = document.getElementById("agentic-brief-body");
+  if (!sec || !body) return;
+  sec.style.display = "";
+  if (src) src.textContent = "source: " + (b.source === "live_llm" ? "Claude" : "template") + " · confidence " + Math.round((b.confidence || 0) * 100) + "%";
+  var industries = (b.industries || []).map(function (i) { return '<span class="pill pill-muted mono" style="font-size:9.5px">' + escapeHtml(i) + '</span>'; }).join(" ");
+  var aud = (b.audience_descriptors || []).map(function (a) { return '<span class="pill pill-muted mono" style="font-size:9.5px">' + escapeHtml(a) + '</span>'; }).join(" ");
+  body.innerHTML =
+    '<div class="agentic-brief-grid">' +
+      '<div class="agentic-brief-cell"><div class="agentic-brief-label">Brand</div><div class="mono">' + escapeHtml(b.brand_name || "(unknown)") + (b.brand_domain ? ' <span class="orch-small" style="color:var(--text-mut)">' + escapeHtml(b.brand_domain) + '</span>' : '') + '</div></div>' +
+      '<div class="agentic-brief-cell"><div class="agentic-brief-label">KPI</div><div class="mono">' + escapeHtml(b.kpi || "?") + ' @ ' + escapeHtml(String(b.kpi_target || "?")) + '</div></div>' +
+      '<div class="agentic-brief-cell"><div class="agentic-brief-label">Budget</div><div class="mono">' + (b.budget_usd_estimate ? '$' + b.budget_usd_estimate.toLocaleString() : '—') + '</div></div>' +
+      '<div class="agentic-brief-cell"><div class="agentic-brief-label">Geo</div><div class="mono">' + escapeHtml((b.geo || []).join(", ")) + '</div></div>' +
+      '<div class="agentic-brief-cell"><div class="agentic-brief-label">Flight</div><div class="mono">' + (b.flight_days ? b.flight_days + " days" : "—") + '</div></div>' +
+      '<div class="agentic-brief-cell"><div class="agentic-brief-label">Dayparting</div><div class="mono">' + escapeHtml(b.dayparting_hint || "—") + '</div></div>' +
+      '<div class="agentic-brief-cell agentic-brief-cell-wide"><div class="agentic-brief-label">Industries</div><div>' + (industries || '<span class="orch-small">unclassified</span>') + '</div></div>' +
+      '<div class="agentic-brief-cell agentic-brief-cell-wide"><div class="agentic-brief-label">Audience</div><div>' + (aud || '<span class="orch-small">none extracted</span>') + '</div></div>' +
+    '</div>';
+}
+
+function _agenticRenderPlan(plan) {
+  var sec = document.getElementById("agentic-plan-section");
+  var src = document.getElementById("agentic-plan-source");
+  var body = document.getElementById("agentic-plan-body");
+  if (!sec || !body) return;
+  sec.style.display = "";
+  if (src) src.textContent = "source: " + (plan.source === "live_llm" ? "Claude" : "template") + " · " + plan.steps.length + " steps · est " + Math.round((plan.estimated_duration_ms || 0) / 1000) + "s";
+  body.innerHTML = '<div class="agentic-plan-steps">' + plan.steps.map(function (s) {
+    return '<div class="agentic-plan-step">' +
+      '<div class="agentic-plan-step-head">' +
+        '<span class="agentic-plan-step-num mono">' + s.index + '</span>' +
+        '<span class="agentic-plan-step-tool mono">' + escapeHtml(s.tool) + '</span>' +
+        '<span class="agentic-plan-step-agents orch-small mono">→ ' + escapeHtml(s.agents.join(", ")) + '</span>' +
+        (s.optional ? '<span class="pill pill-muted mono" style="font-size:8.5px">optional</span>' : '') +
+      '</div>' +
+      '<div class="agentic-plan-step-rationale">' + escapeHtml(s.rationale) + '</div>' +
+    '</div>';
+  }).join("") + '</div>';
+  var execBtn = document.getElementById("agentic-execute-btn");
+  if (execBtn) {
+    execBtn.onclick = null;
+    execBtn.addEventListener("click", _agenticExecute);
+  }
+}
+
+function _agenticRenderCompliance(comp) {
+  var sec = document.getElementById("agentic-compliance-section");
+  var body = document.getElementById("agentic-compliance-body");
+  if (!sec || !body || !comp || !comp.advisory) return;
+  sec.style.display = "";
+  var adv = comp.advisory;
+  var outClass = "agentic-comp-" + adv.outcome;
+  var ico = adv.outcome === "block" ? "⛔" : adv.outcome === "warn" ? "⚠" : "✓";
+  var pols = adv.advisories.slice(0, 5).map(function (a) {
+    return '<div class="agentic-comp-row agentic-comp-row-' + escapeHtml(a.outcome) + '">' +
+      '<span class="mono">' + escapeHtml(a.policy_id) + '</span>' +
+      '<span class="mono">' + escapeHtml(a.outcome) + '</span>' +
+      '<span class="orch-small">' + escapeHtml((a.signal_claim || "silent") + " · " + (a.reason || "").slice(0, 80)) + '</span>' +
+    '</div>';
+  }).join("");
+  var rems = (comp.remediations || []).map(function (r) {
+    return '<div class="agentic-rem-row"><span class="agentic-rem-suggestion mono">' + escapeHtml(r.suggestion) + '</span> <span class="mono">' + escapeHtml(r.blocking_policy) + '</span> — <span>' + escapeHtml(r.detail) + '</span></div>';
+  }).join("");
+  body.innerHTML =
+    '<div class="agentic-comp-banner ' + outClass + '">' +
+      '<span class="agentic-comp-icon">' + ico + '</span>' +
+      '<span>governance preview <strong>' + escapeHtml(adv.outcome.toUpperCase()) + '</strong></span>' +
+      '<span class="orch-small">' + adv.restricted_attributes.length + ' block · ' + adv.advisories.filter(function (a) { return a.outcome === "warn"; }).length + ' warn · ' + adv.advisories.filter(function (a) { return a.outcome === "allow"; }).length + ' allow</span>' +
+    '</div>' +
+    pols +
+    (rems ? '<div class="agentic-rem-block"><div class="agentic-section-label" style="margin:8px 0 4px;font-size:10.5px">remediation</div>' + rems + '</div>' : '');
+}
+
+function _agenticRenderMemory(mem) {
+  var sec = document.getElementById("agentic-memory-section");
+  var body = document.getElementById("agentic-memory-body");
+  if (!sec || !body || !mem) return;
+  sec.style.display = "";
+  body.innerHTML =
+    '<div class="orch-small" style="margin-bottom:6px">' + escapeHtml(mem.hint || "") + '</div>' +
+    (mem.matches || []).map(function (m) {
+      return '<div class="agentic-mem-row">' +
+        '<span class="agentic-mem-when mono">' + escapeHtml(String(m.ran_at).slice(0, 10)) + '</span>' +
+        '<span class="agentic-mem-input">' + escapeHtml(m.brief_input.slice(0, 80)) + '</span>' +
+        '<span class="agentic-mem-outcome mono">' + escapeHtml(m.outcome) + '</span>' +
+      '</div>';
+    }).join("");
+}
+
+async function _agenticExecute() {
+  if (!_agenticCurrent || !_agenticCurrent.plan) return;
+  var btn = document.getElementById("agentic-execute-btn");
+  var sec = document.getElementById("agentic-exec-section");
+  var status = document.getElementById("agentic-exec-status");
+  var body = document.getElementById("agentic-exec-body");
+  if (!sec || !body) return;
+  sec.style.display = "";
+  body.innerHTML = "";
+  if (btn) { btn.disabled = true; btn.querySelector("span").textContent = "executing…"; }
+  if (status) status.textContent = "streaming…";
+  try {
+    var resp = await fetch("/agentic/execute", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ plan: _agenticCurrent.plan }) });
+    if (!resp.body) throw new Error("no stream body");
+    var reader = resp.body.getReader();
+    var dec = new TextDecoder();
+    var buffer = "";
+    var stepResults = {};
+    while (true) {
+      var read = await reader.read();
+      if (read.done) break;
+      buffer += dec.decode(read.value, { stream: true });
+      var lines = buffer.split("\n");
+      buffer = lines.pop() || "";
+      for (var li = 0; li < lines.length; li++) {
+        var line = lines[li].trim();
+        if (!line) continue;
+        var ev = null;
+        try { ev = JSON.parse(line); } catch (e) { continue; }
+        if (ev.event === "reasoning" && ev.step) {
+          _agenticTrace.push(ev.step);
+          _agenticUpdateTrace();
+        } else if (ev.event === "tool_complete") {
+          stepResults[ev.step_id] = ev;
+          _agenticAppendExec(ev);
+        } else if (ev.event === "agent_result") {
+          _agenticAppendAgentResult(ev);
+        } else if (ev.event === "execution_complete") {
+          if (status) status.textContent = "done · " + (ev.step_results ? ev.step_results.length + " steps" : "");
+        } else if (ev.event === "error") {
+          showToast("execution error: " + ev.error, true);
+        }
+      }
+    }
+  } catch (e) {
+    showToast("agentic execute failed: " + ((e && e.message) || e), true);
+    if (status) status.textContent = "error";
+  } finally {
+    if (btn) { btn.disabled = false; btn.querySelector("span").textContent = "Re-execute"; }
+  }
+}
+
+function _agenticAppendExec(ev) {
+  var body = document.getElementById("agentic-exec-body");
+  if (!body) return;
+  var statusCls = ev.ok ? "agentic-exec-ok" : "agentic-exec-err";
+  var resultPreview = "";
+  try { resultPreview = JSON.stringify(ev.result || ev.agent_results, null, 2).slice(0, 400); } catch (e) { /* noop */ }
+  body.insertAdjacentHTML("beforeend",
+    '<div class="agentic-exec-step ' + statusCls + '">' +
+      '<div class="agentic-exec-step-head">' +
+        '<span class="mono">' + escapeHtml(ev.tool || "?") + '</span>' +
+        '<span class="agentic-exec-status mono">' + (ev.ok ? "ok" : "err") + '</span>' +
+        '<span class="agentic-exec-lat orch-small mono">' + (ev.latency_ms || 0) + 'ms</span>' +
+      '</div>' +
+      (resultPreview ? '<details><summary class="orch-small" style="cursor:pointer">payload preview</summary><pre class="wf-json mono" style="max-height:160px;overflow:auto;font-size:10.5px">' + escapeHtml(resultPreview) + '</pre></details>' : '') +
+    '</div>'
+  );
+}
+
+function _agenticAppendAgentResult(ev) {
+  var body = document.getElementById("agentic-exec-body");
+  if (!body) return;
+  var statusCls = ev.status === "ok" ? "agentic-agent-ok" : "agentic-agent-err";
+  body.insertAdjacentHTML("beforeend",
+    '<div class="agentic-agent-row ' + statusCls + '">' +
+      '<span class="mono">' + escapeHtml(ev.agent_id) + '</span>' +
+      '<span class="orch-small mono">' + escapeHtml(ev.tool) + '</span>' +
+      '<span class="orch-small mono">' + (ev.latency_ms || 0) + 'ms</span>' +
+      (ev.status !== "ok" && ev.error ? '<span class="orch-small">' + escapeHtml(String(ev.error).slice(0, 100)) + '</span>' : '') +
+    '</div>'
+  );
 }
 </script>`;
 }


### PR DESCRIPTION
## Summary

Foundational agentic surface across all 7 patterns identified in the gap synthesis. Single new tab \"Agentic\" alongside Canvas + Campaign. Two-mode: **live LLM** (Claude Sonnet 4 via Anthropic API) when \`ANTHROPIC_API_KEY\` is set, or **rule-based templates** that produce structurally-identical output deterministically.

## What ships

| # | Pattern | Implementation |
|---|---|---|
| **1** | LLM brief expander | \`agenticBrief.ts\` — 16 brand patterns + budget/KPI/geo/flight regex; LLM-augmented in live mode |
| **2** | Tool-selection planner | \`agenticPlanner.ts\` — coverage-aware 5-stage template; LLM picks dynamic sequence in live mode |
| **3** | Conversational chat surface | New tab with chat input + 4 prompt suggestions + 5 progressive sections |
| **4** | Reasoning-trace pane | Right-side stream of every decision (kind-coded colors) |
| **5** | Auto-recovery strategy | \`/agentic/recover\` — suggests alternate agent / simplified payload / fallback dry-run |
| **6** | Memory layer | \`/agentic/memory/recall\` — KV-backed top-K similar past workflows |
| **7** | Compliance auto-remediation | \`/agentic/remediate\` — signal swaps + attestation hints to unblock governance BLOCK |

## Plus quick-win

- **\"Explain this\" overlay** — reusable \`_explainBadge(topic, decision)\` helper drops a \"?\" on any surface; modal calls \`/agentic/explain\`. First wired on the Canvas governance banner; pattern works on every existing decision surface.

## 8 new endpoints
\`POST /agentic/brief/expand\` · \`POST /agentic/plan\` · \`POST /agentic/execute\` (NDJSON stream) · \`POST /agentic/explain\` · \`POST /agentic/chat\` · \`POST /agentic/recover\` · \`POST /agentic/remediate\` · \`GET /agentic/memory/recall\`

## Test plan
- [x] Type-check clean
- [x] 428/428 tests pass
- [x] SCRIPT_TAG audit clean
- [ ] Smoke after deploy:
  - [ ] Visit /, click **Agentic** tab → mode pill renders
  - [ ] Click \"Coca-Cola summer · Gen Z\" suggestion → brief expands → plan renders → governance pulls in
  - [ ] Click \"Execute plan\" → stream populates reasoning trace + execution panel live
  - [ ] Click \"?\" badge on Canvas governance banner → explain modal renders

## Workshop framing flip
Before: \"federated tool router with provenance\"
After: \"chat-driven planner that decomposes a brief, selects tools dynamically, narrates every decision, recovers from failures, remembers past runs, and auto-suggests remediation when governance blocks. Templates today; swap to Claude with one env-var.\"

🤖 Generated with [Claude Code](https://claude.com/claude-code)