### PR TITLE
Fix: SCRIPT_TAG newline trap in agentic execute streamer

### DIFF
--- a/src/routes/demo.ts
+++ b/src/routes/demo.ts
@@ -17212,7 +17212,7 @@ async function _agenticExecute() {
       var read = await reader.read();
       if (read.done) break;
       buffer += dec.decode(read.value, { stream: true });
-      var lines = buffer.split("\n");
+      var lines = buffer.split("\\n");
       buffer = lines.pop() || "";
       for (var li = 0; li < lines.length; li++) {
         var line = lines[li].trim();

--- a/tmp-mining/trap_audit.py
+++ b/tmp-mining/trap_audit.py
@@ -1,0 +1,86 @@
+"""SCRIPT_TAG escape-trap audit for demo.ts.
+
+The whole demo.ts client JS lives inside a TypeScript template literal
+(backticks). A backslash escape sequence in the source is collapsed
+ONCE by the TS template, so `\\n` in source becomes `\n` in the served
+JS. To get a literal `\n` (two-char escape) in the served JS, the
+source needs `\\n` (two backslashes).
+
+Two trap patterns this audit catches in the script-body region:
+
+  Trap 1 — single-backslash-apostrophe inside a JS string:
+    source: '...don\\'t...' → served: '...don't...' (string ends early)
+    safe:   '...don\\\\'t...' → served: '...don\\'t...' (escaped properly)
+
+  Trap 2 — single-backslash-newline (or other escape) inside a JS string:
+    source: split("\\n")  → served: split("(literal newline)") — broken
+    safe:   split("\\\\n") → served: split("\\n") — works
+"""
+import sys
+
+BS = chr(92)        # backslash
+APO = chr(39)       # apostrophe
+SCRIPT_BODY_START_LINE = 4322   # approximate; tune if demo.ts shifts
+
+with open('src/routes/demo.ts', 'r', encoding='utf-8') as f:
+    lines = f.read().split('\n')
+
+traps_apo = []
+traps_esc = []
+
+for i, line in enumerate(lines, 1):
+    if i < SCRIPT_BODY_START_LINE:
+        continue
+    stripped = line.lstrip()
+    if stripped.startswith('//') or stripped.startswith('*'):
+        continue
+
+    # Trap 1: single \' inside a non-comment line.
+    j = 0
+    while j < len(line):
+        if line[j] == APO:
+            bs = 0
+            k = j - 1
+            while k >= 0 and line[k] == BS:
+                bs += 1
+                k -= 1
+            if bs == 1:
+                traps_apo.append((i, line.rstrip()[:200]))
+                break
+        j += 1
+
+    # Trap 2: single-backslash escape inside a JS string.
+    # Match patterns like split("\n"), join("\n"), "\n", etc. where
+    # the surrounding quotes are " and the escape is single-backslash.
+    # We look for `"\X"` where X is n/t/r and there's no preceding \.
+    import re
+    for m in re.finditer(r'"([^"]*?)"', line):
+        s = m.group(1)
+        # Look for unsafe \n / \t / \r in the string body.
+        bs_count = 0
+        idx = 0
+        while idx < len(s):
+            if s[idx] == BS:
+                bs_count += 1
+                idx += 1
+                continue
+            # Reset and check what follows BS run.
+            if bs_count == 1 and s[idx] in 'ntr':
+                # Single \n / \t / \r — the trap.
+                traps_esc.append((i, line.rstrip()[:200]))
+                break
+            bs_count = 0
+            idx += 1
+
+print(f'Trap 1 — single \\\' inside non-comment line: {len(traps_apo)} match(es)')
+for i, l in traps_apo[:10]:
+    print(f'  L{i}: {l}')
+print()
+print(f'Trap 2 — single-backslash escape in JS string: {len(traps_esc)} match(es)')
+for i, l in traps_esc[:10]:
+    print(f'  L{i}: {l}')
+
+if traps_apo or traps_esc:
+    print()
+    print('REMEDIATION: double the backslash in source so the served JS sees the intended escape.')
+    sys.exit(1)


### PR DESCRIPTION
Hotfix to PR #125.

Browser error reported: \`Uncaught SyntaxError: Invalid or unexpected token (at (index):17167:32)\`.

**Cause:** \`/agentic/execute\` NDJSON streamer used \`buffer.split(\"\n\")\` in source. The TS template literal collapses \`\n\` to a literal newline before serving, breaking the JS string literal in the rendered page.

**Class:** SCRIPT_TAG escape trap variant — same family as Sec-48h. Single backslash + escape letter inside a JS string at template-literal scope = unrecoverable.

**Fix:** double the backslash in source so the served JS sees \`\n\` correctly.

**Plus:** strengthened \`tmp-mining/trap_audit.py\` to catch both trap variants (single-\' apostrophe AND single-backslash escapes \n/\t/\r). Pre-flighted clean against current source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)