### PR TITLE
Wave 1: Sponsored-Intelligence mock + canonical demo button

### DIFF
--- a/src/domain/sponsoredIntelligenceMock.ts
+++ b/src/domain/sponsoredIntelligenceMock.ts
@@ -1,0 +1,236 @@
+// src/domain/sponsoredIntelligenceMock.ts
+//
+// Wave 1 — predictive Sponsored-Intelligence (SI) mock.
+//
+// Closes the 4th of 6 AdCP 3.0 GA protocol domains:
+//   1. media_buy             — live (sell-side + buy-side)
+//   2. creative              — live (Celtra, Advertible)
+//   3. signals               — live (us, Dstillery)
+//   4. governance            — predictive mock (no live vendor)
+//   5. brand                 — predictive mock (no live vendor)
+//   6. sponsored_intelligence — THIS — predictive mock (no live vendor)
+//
+// SI is the "competitive context" layer in the spec: knowing which
+// brands compete in your space, what their content/creative postures
+// look like, when they're up-bidding, etc. Spec-relevant tools:
+//   - submit_si_request   — declare intent for an SI session
+//   - si_session_lifecycle — open / close / extend a research session
+//   - si_availability     — what SI signals are available for this brand?
+//   - si_handoff          — pass SI context to a buyer agent for use
+//
+// All 4 are unspec'd in the directory. We mock the predictive
+// "what would SI look like for this brand" view; when upstream lands,
+// swap to passthrough.
+
+export type SiSessionState = "available" | "active" | "expired" | "rate_limited";
+export type SiInsightTier = "competitive" | "category" | "content_adjacency" | "share_of_voice";
+
+export interface SiCompetitor {
+  /** Best-effort competitor brand name. */
+  brand_name: string;
+  /** Domain (when known). */
+  brand_domain?: string;
+  /** Estimated share of voice 0-1 within the brand's primary industry. */
+  share_of_voice: number;
+  /** Active campaign overlap (0-1). */
+  campaign_overlap_pct: number;
+  /** Trend: bidding more / less / same vs last 30 days. */
+  trend_30d: "up" | "flat" | "down";
+}
+
+export interface SiInsight {
+  tier: SiInsightTier;
+  /** One-line headline of the insight. */
+  headline: string;
+  /** Plain-English narrative. */
+  detail: string;
+  /** Confidence of the insight (0-1). */
+  confidence: number;
+  /** Suggested action ("up-bid in DMA-X", "exclude page-category Y", etc). */
+  action?: string;
+}
+
+export interface SiAdvisory {
+  mode: "predictive_local";
+  /** Whether SI is available for this brand. Most brands will get
+   *  "available"; some return "rate_limited" to demo error states. */
+  state: SiSessionState;
+  /** Plain-language summary of the SI posture. */
+  summary: string;
+  /** Top competitors overlapping with the brand. */
+  competitors: SiCompetitor[];
+  /** Tier-grouped insights. */
+  insights: SiInsight[];
+  /** Refresh window in seconds. */
+  refresh_window_sec: number;
+}
+
+interface SiInputs {
+  brand_name: string;
+  brand_domain?: string;
+  industries: string[];
+  budget_usd?: number;
+}
+
+// Pattern: industry → typical competitor seed map. When the brand is
+// in one of these industries, we surface plausible competitors.
+const COMPETITOR_MAP: Record<string, Array<{ name: string; domain: string }>> = {
+  food_beverage: [
+    { name: "Pepsi", domain: "pepsi.com" },
+    { name: "Dr Pepper Snapple", domain: "drpeppersnapple.com" },
+    { name: "Monster Beverage", domain: "monsterbevcorp.com" },
+  ],
+  beverages: [
+    { name: "Pepsi", domain: "pepsi.com" },
+    { name: "Red Bull", domain: "redbull.com" },
+    { name: "Anheuser-Busch", domain: "ab-inbev.com" },
+  ],
+  alcohol: [
+    { name: "Anheuser-Busch", domain: "ab-inbev.com" },
+    { name: "Diageo", domain: "diageo.com" },
+    { name: "Constellation Brands", domain: "cbrands.com" },
+  ],
+  pharma: [
+    { name: "Merck", domain: "merck.com" },
+    { name: "Johnson & Johnson", domain: "jnj.com" },
+    { name: "AbbVie", domain: "abbvie.com" },
+  ],
+  gambling: [
+    { name: "FanDuel", domain: "fanduel.com" },
+    { name: "BetMGM", domain: "betmgm.com" },
+    { name: "Caesars Sportsbook", domain: "caesars.com" },
+  ],
+  apparel: [
+    { name: "Adidas", domain: "adidas.com" },
+    { name: "Under Armour", domain: "underarmour.com" },
+    { name: "Lululemon", domain: "lululemon.com" },
+  ],
+  automotive: [
+    { name: "Honda", domain: "honda.com" },
+    { name: "Ford", domain: "ford.com" },
+    { name: "Volkswagen", domain: "vw.com" },
+  ],
+  financial: [
+    { name: "Mastercard", domain: "mastercard.com" },
+    { name: "American Express", domain: "americanexpress.com" },
+    { name: "Capital One", domain: "capitalone.com" },
+  ],
+  fast_food: [
+    { name: "Burger King", domain: "bk.com" },
+    { name: "Wendy's", domain: "wendys.com" },
+    { name: "Chick-fil-A", domain: "chick-fil-a.com" },
+  ],
+  children: [
+    { name: "Mattel", domain: "mattel.com" },
+    { name: "Hasbro", domain: "hasbro.com" },
+    { name: "Spin Master", domain: "spinmaster.com" },
+  ],
+};
+
+// FNV-1a hash for deterministic per-brand pseudo-randomness.
+function fnv1a(s: string): number {
+  let h = 2166136261;
+  for (let i = 0; i < s.length; i++) {
+    h ^= s.charCodeAt(i);
+    h = Math.imul(h, 16777619);
+  }
+  return h >>> 0;
+}
+
+function rng(seed: string): () => number {
+  let s = fnv1a(seed);
+  return () => {
+    s = (Math.imul(s, 1664525) + 1013904223) >>> 0;
+    return s / 0xffffffff;
+  };
+}
+
+export function predictSi(input: SiInputs): SiAdvisory {
+  const brandName = input.brand_name || "(unknown)";
+  const r = rng(brandName + "|" + (input.industries || []).join(","));
+
+  // 5% rate-limited demo: helps the workshop show error states.
+  const state: SiSessionState = (fnv1a(brandName) % 20) === 0 ? "rate_limited" : "available";
+  if (state === "rate_limited") {
+    return {
+      mode: "predictive_local",
+      state,
+      summary: `SI session rate-limited for ${brandName}. Retry in 60s. (Demo: ~5% of brands hit this state on probe.)`,
+      competitors: [],
+      insights: [],
+      refresh_window_sec: 60,
+    };
+  }
+
+  // Pull competitors keyed on the FIRST matching industry.
+  const indLower = (input.industries || []).map((i) => i.toLowerCase());
+  let competitors: Array<{ name: string; domain: string }> = [];
+  for (const ind of indLower) {
+    const seed = COMPETITOR_MAP[ind];
+    if (seed) { competitors = seed; break; }
+  }
+  // Filter out self-matches (e.g. Coca-Cola seeded into food_beverage).
+  competitors = competitors.filter((c) => c.name.toLowerCase() !== brandName.toLowerCase());
+
+  const compEntries: SiCompetitor[] = competitors.map((c) => {
+    const sov = Math.round((0.10 + r() * 0.40) * 100) / 100;
+    const overlap = Math.round((0.20 + r() * 0.50) * 100) / 100;
+    const trend: SiCompetitor["trend_30d"] = r() < 0.4 ? "up" : r() < 0.75 ? "flat" : "down";
+    const entry: SiCompetitor = {
+      brand_name: c.name,
+      brand_domain: c.domain,
+      share_of_voice: sov,
+      campaign_overlap_pct: overlap,
+      trend_30d: trend,
+    };
+    return entry;
+  });
+
+  // Insights — 4 tiers, each producing 1-2 narrative items.
+  const insights: SiInsight[] = [];
+
+  if (compEntries.length > 0) {
+    const top = compEntries.sort((a, b) => b.share_of_voice - a.share_of_voice)[0]!;
+    insights.push({
+      tier: "competitive",
+      headline: `${top.brand_name} leads category share-of-voice at ${Math.round(top.share_of_voice * 100)}%`,
+      detail: `Top overlapping competitor in your industry. Trend: ${top.trend_30d} bid pressure last 30 days. Campaign-overlap with you: ${Math.round(top.campaign_overlap_pct * 100)}% — implies same audience pool.`,
+      confidence: Math.round((0.78 + r() * 0.15) * 100) / 100,
+      action: top.trend_30d === "up" ? `Up-bid by ~10% on overlapping inventory to defend SOV.` : `Hold bid floor; opportunity to expand reach without escalation.`,
+    });
+  }
+
+  insights.push({
+    tier: "category",
+    headline: `Category seasonality: ${(input.industries[0] || "your industry").replace(/_/g, " ")} sees ${(50 + Math.round(r() * 30))}% summer-uplift in CPM`,
+    detail: `Aggregate trend across the directory's category data. Driven by Q2/Q3 brand-budget cycles in this industry. Plan flight-windows accordingly.`,
+    confidence: Math.round((0.65 + r() * 0.20) * 100) / 100,
+  });
+
+  insights.push({
+    tier: "content_adjacency",
+    headline: `Brand-safe content adjacency rate at ${Math.round((0.70 + r() * 0.20) * 100)}%`,
+    detail: `Of impressions classified as "${(input.industries[0] || "general")}-adjacent" content, this share met your typical brand-safety floor (DV/IAS ≥ 70). Lift the floor to 80 to drop ~12% volume but push viewability ~5pp.`,
+    confidence: Math.round((0.72 + r() * 0.18) * 100) / 100,
+    action: `Consider raising brand_safety_floor to 80 on premium-CPC tactics; keep 70 on prospecting.`,
+  });
+
+  insights.push({
+    tier: "share_of_voice",
+    headline: `Your projected SOV: ${(8 + Math.round(r() * 14))}% if you fire the current plan`,
+    detail: `Modeled from your $${(input.budget_usd || 50000).toLocaleString()} budget × industry CPM × competitor pressure. Top quartile in this industry typically commits 22-30% SOV.`,
+    confidence: Math.round((0.60 + r() * 0.25) * 100) / 100,
+    action: input.budget_usd && input.budget_usd > 200_000
+      ? `Budget supports top-quartile SOV; allocate to high-overlap inventory.`
+      : `Budget limits competitive matchup; consider niche audience pockets to maximize lift-per-dollar.`,
+  });
+
+  return {
+    mode: "predictive_local",
+    state: "available",
+    summary: `SI session active for ${brandName}. ${compEntries.length} competitor(s) overlapping; ${insights.length} insight(s) across ${new Set(insights.map((i) => i.tier)).size} tier(s).`,
+    competitors: compEntries,
+    insights,
+    refresh_window_sec: 900,
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -59,6 +59,7 @@ import {
   handleRegistryPolicies,
   handleGovernancePreview,
   handleBrandRightsPreview,
+  handleSiPreview,
 } from "./routes/registryRoutes";
 import {
   handleDspCampaigns,
@@ -272,6 +273,8 @@ export default {
             "/registry/governance-preview",
             // Refinement C: predictive brand-rights overlay.
             "/registry/brand-rights-preview",
+            // Wave 1: predictive Sponsored-Intelligence overlay.
+            "/registry/si-preview",
             // Campaign Canvas (DSP buy-side mock + live hybrid).
             "/dsp/campaigns",
             "/dsp/agents",
@@ -466,6 +469,8 @@ export default {
                 response = await handleGovernancePreview(request, env, logger);
             } else if ((method === "GET" || method === "POST") && path === "/registry/brand-rights-preview") {
                 response = await handleBrandRightsPreview(request, env, logger);
+            } else if ((method === "GET" || method === "POST") && path === "/registry/si-preview") {
+                response = await handleSiPreview(request, env, logger);
 
                 // ── Buy-side / DSP Canvas (mock + live hybrid) ───────────────────────
                 // SPECIFIC routes BEFORE the campaigns catch-all — otherwise

--- a/src/routes/demo.ts
+++ b/src/routes/demo.ts
@@ -1334,6 +1334,11 @@ ${STYLES}
             <button class="canvas-quickpick" data-domain="scottbrand.com">scottbrand.com</button>
             <button class="canvas-quickpick" data-domain="rembrand.com">rembrand.com</button>
             <button class="canvas-quickpick" data-domain="brandvelocity.ai">brandvelocity.ai</button>
+            <span class="canvas-demo-spacer"></span>
+            <button class="canvas-demo-btn" id="canvas-demo-btn" title="One-click canonical demo: resolve Coca-Cola, run workflow, fire dry-run on default trio. Use on stage to skip typing.">
+              <svg class="ico" style="width:11px;height:11px"><use href="#icon-bolt"/></svg>
+              <span>Run canonical demo</span>
+            </button>
           </div>
         </div>
 
@@ -4776,6 +4781,17 @@ textarea.lab-input { resize: vertical; line-height: 1.5; }
   transition: color 0.12s, border-color 0.12s;
 }
 .canvas-quickpick:hover { color: var(--accent); border-color: var(--accent-border); }
+.canvas-demo-spacer { flex: 1; min-width: 8px; }
+.canvas-demo-btn {
+  display: inline-flex; align-items: center; gap: 5px;
+  background: var(--accent); color: #000;
+  border: 1px solid var(--accent); border-radius: 4px;
+  padding: 4px 10px; font-size: 11px; font-weight: 600;
+  cursor: pointer; font-family: inherit;
+  transition: filter 0.15s;
+}
+.canvas-demo-btn:hover:not(:disabled) { filter: brightness(1.1); }
+.canvas-demo-btn:disabled { opacity: 0.6; cursor: wait; }
 
 .canvas-search-list {
   margin-top: 10px;
@@ -6194,6 +6210,70 @@ textarea.lab-input { resize: vertical; line-height: 1.5; }
   color: var(--text-mut);
 }
 .canvas-rights-advisories li { margin-bottom: 2px; }
+
+/* Wave 1: Sponsored-Intelligence row — symmetric with brand-rights /
+   governance preview rows. Closes the AdCP 4th protocol domain
+   visually on Canvas. */
+.canvas-si-row {
+  margin-top: 8px; padding: 8px 0;
+  border-bottom: 1px solid var(--border);
+}
+.canvas-si-body { display: flex; flex-direction: column; gap: 6px; margin-top: 4px; }
+.canvas-si-banner {
+  display: flex; align-items: center; gap: 10px;
+  padding: 6px 10px; border-radius: 4px; font-size: 12px;
+  border: 1px solid currentColor;
+}
+.canvas-si-icon { font-size: 14px; }
+.canvas-si-rate-limited { color: var(--warning, #d4a017); background: rgba(212,160,23,0.10); }
+.canvas-si-summary { color: var(--text-dim); }
+.canvas-si-section-label {
+  font-size: 9.5px; text-transform: uppercase; letter-spacing: 0.05em;
+  color: var(--text-mut); font-weight: 600;
+  margin-top: 4px; margin-bottom: 2px;
+}
+.canvas-si-comps {
+  width: 100%; border-collapse: collapse; font-size: 11px;
+}
+.canvas-si-comps th {
+  text-align: left; padding: 3px 6px; color: var(--text-mut);
+  font-weight: 500; font-size: 9.5px; text-transform: uppercase;
+  letter-spacing: 0.05em; border-bottom: 1px solid var(--border);
+}
+.canvas-si-comps td {
+  padding: 4px 6px; color: var(--text-dim);
+  border-bottom: 1px dashed var(--border);
+}
+.canvas-si-comps tr:last-child td { border-bottom: none; }
+.canvas-si-comps tr.canvas-si-trend-up   .canvas-si-trend-icon { color: var(--success); font-weight: 700; }
+.canvas-si-comps tr.canvas-si-trend-down .canvas-si-trend-icon { color: var(--error); font-weight: 700; }
+.canvas-si-comps tr.canvas-si-trend-flat .canvas-si-trend-icon { color: var(--text-mut); }
+.canvas-si-insight {
+  padding: 6px 10px; border-radius: 4px; font-size: 11.5px;
+  background: var(--bg-raised); border: 1px solid var(--border);
+  border-left-width: 3px;
+}
+.canvas-si-insight-competitive       { border-left-color: var(--accent); }
+.canvas-si-insight-category          { border-left-color: var(--success); }
+.canvas-si-insight-content_adjacency { border-left-color: var(--warning, #d4a017); }
+.canvas-si-insight-share_of_voice    { border-left-color: #c084fc; }
+.canvas-si-insight-head {
+  display: flex; align-items: center; gap: 8px; flex-wrap: wrap;
+  margin-bottom: 3px;
+}
+.canvas-si-tier {
+  font-size: 8.5px; padding: 1px 5px; border-radius: 2px;
+  background: var(--bg-input); color: var(--text);
+  font-weight: 700; letter-spacing: 0.06em;
+}
+.canvas-si-headline { color: var(--text); font-weight: 500; }
+.canvas-si-conf { margin-left: auto; }
+.canvas-si-detail { color: var(--text-dim); font-size: 11px; line-height: 1.4; }
+.canvas-si-action {
+  margin-top: 4px; padding-top: 4px;
+  border-top: 1px dashed var(--border);
+  color: var(--accent); font-size: 10.5px;
+}
 
 /* Phase B: registry health bar. Strip across canvas-bottom showing
    how stale our local view of the registry is (agents + policies
@@ -14485,6 +14565,28 @@ async function ensureCanvas() {
       if (d) _canvasResolveBrand(d);
     });
   });
+  // Wave 1: Demo mode — single-click canonical run for stage demos.
+  var demoBtn = document.getElementById("canvas-demo-btn");
+  if (demoBtn) demoBtn.addEventListener("click", _canvasRunCanonicalDemo);
+}
+
+// Wave 1: Canonical demo run. Resolves Coca-Cola, then auto-clicks
+// "Run workflow" once the brand card finishes hydrating. Single-click
+// stage-day insurance — removes typing risk during the live demo.
+async function _canvasRunCanonicalDemo() {
+  var btn = document.getElementById("canvas-demo-btn");
+  if (btn) { btn.disabled = true; btn.querySelector("span").textContent = "running…"; }
+  try {
+    await _canvasResolveBrand("coca-cola.com");
+    // Wait for the brand card to render the run button (single tick).
+    await new Promise(function (r) { setTimeout(r, 250); });
+    var run = document.getElementById("canvas-run-btn");
+    if (run) run.click();
+    if (btn) { btn.querySelector("span").textContent = "Re-run canonical demo"; btn.disabled = false; }
+  } catch (e) {
+    if (btn) { btn.querySelector("span").textContent = "Retry"; btn.disabled = false; }
+    showToast("demo run failed: " + ((e && e.message) || e), true);
+  }
 }
 
 async function _canvasRunSearch() {
@@ -14736,6 +14838,18 @@ function _canvasRenderBrandCard(data) {
           '<span class="orch-small">awaiting creative-stage formats…</span>' +
         '</div>' +
       '</div>' +
+      // Wave 1: predictive Sponsored-Intelligence overlay. Closes the
+      // 4th of 6 AdCP protocol domains on Canvas. Populates from
+      // brand industries; no live vendor in the directory advertises
+      // any SI primitive yet.
+      '<div class="canvas-si-row" id="canvas-si-row">' +
+        '<div class="canvas-brand-label">Sponsored Intelligence ' +
+          '<span class="pill pill-muted mono" style="font-size:9px;margin-left:6px">predictive · si_session mock · 0 live agents</span>' +
+        '</div>' +
+        '<div class="canvas-si-body" id="canvas-si-body">' +
+          '<span class="orch-small">computing competitive overlap…</span>' +
+        '</div>' +
+      '</div>' +
       // Phase 2 + Multi-brand A/B: Run workflow + Compare buttons.
       '<div class="canvas-brand-actions">' +
         '<button class="btn-primary canvas-run-btn" id="canvas-run-btn">' +
@@ -14787,6 +14901,76 @@ function _canvasRenderBrandCard(data) {
   // shows "awaiting creative-stage formats"; the creative-stage
   // event handler calls it again with real format ids.
   _canvasFillBrandRights();
+  // Wave 1: hydrate Sponsored-Intelligence row.
+  _canvasFillSi(data, uniqInd);
+}
+
+// Wave 1: SI hydrator. Calls /registry/si-preview with the brand's
+// name + industries + (optional) budget; renders competitor table +
+// tier-grouped insights.
+async function _canvasFillSi(brand, industries) {
+  var body = document.getElementById("canvas-si-body");
+  if (!body) return;
+  try {
+    var qs = new URLSearchParams({
+      brand_name: brand.brand_name || "",
+      brand_domain: brand.canonical_domain || "",
+      industries: (industries || []).join(","),
+    });
+    var r = await fetch("/registry/si-preview?" + qs.toString());
+    var d = await r.json();
+    var adv = d.advisory;
+    if (!adv) {
+      body.innerHTML = '<span class="orch-small" style="color:var(--text-mut)">SI advisory unavailable</span>';
+      return;
+    }
+    if (adv.state === "rate_limited") {
+      body.innerHTML =
+        '<div class="canvas-si-banner canvas-si-rate-limited">' +
+          '<span class="canvas-si-icon">⏱</span>' +
+          '<span><strong>SI session rate-limited.</strong> Retry in ' + (adv.refresh_window_sec || 60) + 's. (Demo: ~5% of brands hit this on probe.)</span>' +
+        '</div>' +
+        '<div class="orch-small" style="color:var(--text-mut);margin-top:4px">' + escapeHtml(adv.summary || "") + '</div>';
+      return;
+    }
+    var compTbl = (adv.competitors || []).length === 0
+      ? '<div class="orch-small" style="color:var(--text-mut)">no overlapping competitors found for these industries</div>'
+      : '<table class="canvas-si-comps">' +
+          '<thead><tr><th>brand</th><th>SOV</th><th>overlap</th><th>30d</th></tr></thead>' +
+          '<tbody>' +
+            adv.competitors.map(function (c) {
+              var trendIcon = c.trend_30d === "up" ? "↑" : c.trend_30d === "down" ? "↓" : "→";
+              var trendCls = "canvas-si-trend-" + c.trend_30d;
+              return '<tr class="' + trendCls + '">' +
+                '<td><span class="mono">' + escapeHtml(c.brand_name) + '</span> ' + (c.brand_domain ? '<span class="orch-small mono" style="color:var(--text-mut)">' + escapeHtml(c.brand_domain) + '</span>' : '') + '</td>' +
+                '<td class="mono">' + Math.round((c.share_of_voice || 0) * 100) + '%</td>' +
+                '<td class="mono">' + Math.round((c.campaign_overlap_pct || 0) * 100) + '%</td>' +
+                '<td class="mono"><span class="canvas-si-trend-icon">' + trendIcon + '</span> ' + escapeHtml(c.trend_30d) + '</td>' +
+              '</tr>';
+            }).join("") +
+          '</tbody>' +
+        '</table>';
+    var insights = (adv.insights || []).map(function (i) {
+      var tierCls = "canvas-si-insight-" + i.tier;
+      return '<div class="canvas-si-insight ' + tierCls + '">' +
+        '<div class="canvas-si-insight-head">' +
+          '<span class="canvas-si-tier mono">' + escapeHtml(i.tier.replace(/_/g, " ").toUpperCase()) + '</span>' +
+          '<span class="canvas-si-headline">' + escapeHtml(i.headline) + '</span>' +
+          '<span class="canvas-si-conf orch-small mono">conf ' + Math.round((i.confidence || 0) * 100) + '%</span>' +
+        '</div>' +
+        '<div class="canvas-si-detail">' + escapeHtml(i.detail) + '</div>' +
+        (i.action ? '<div class="canvas-si-action mono">→ ' + escapeHtml(i.action) + '</div>' : '') +
+      '</div>';
+    }).join("");
+    body.innerHTML =
+      '<div class="canvas-si-summary orch-small">' + escapeHtml(adv.summary) + '</div>' +
+      '<div class="canvas-si-section-label">Top overlapping competitors</div>' +
+      compTbl +
+      '<div class="canvas-si-section-label" style="margin-top:8px">Insights</div>' +
+      insights;
+  } catch (e) {
+    body.innerHTML = '<span class="orch-small" style="color:var(--error)">SI preview failed</span>';
+  }
 }
 
 // Phase C: in-page policy cache + hits resolver.

--- a/src/routes/registryRoutes.ts
+++ b/src/routes/registryRoutes.ts
@@ -26,6 +26,7 @@ import { AGENT_REGISTRY } from "../domain/agentRegistry";
 import { getDemoProviderAttestations } from "../domain/workflowOrchestration";
 import { predictGovernance } from "../domain/governanceMock";
 import { predictBrandRights } from "../domain/brandRightsMock";
+import { predictSi } from "../domain/sponsoredIntelligenceMock";
 import { getLastDiffReport } from "../domain/registrySync";
 
 const REGISTRY_AGENTS_URL = "https://agenticadvertising.org/api/registry/agents";
@@ -252,6 +253,59 @@ export async function handleBrandRightsPreview(
       brand_classification: classification ?? null,
       chosen_format_count: formats.length,
     },
+    advisory,
+  });
+}
+
+// ── /registry/si-preview ───────────────────────────────────────────────────
+//
+// Wave 1: predictive Sponsored-Intelligence overlay. Closes the 4th
+// of 6 AdCP 3.0 GA protocol domains visually on Canvas. No vendor
+// in the directory currently advertises any SI primitive live;
+// when upstream lands, swap mock → passthrough.
+//
+// POST: { brand_name, brand_domain?, industries[], budget_usd? }
+// GET:  ?brand_name=&brand_domain=&industries=a,b,c&budget_usd=
+
+interface SiPreviewBody {
+  brand_name?: string;
+  brand_domain?: string;
+  industries?: string[];
+  budget_usd?: number;
+}
+
+export async function handleSiPreview(
+  request: Request,
+  _env: Env,
+  _logger: Logger,
+): Promise<Response> {
+  let inputs: SiPreviewBody = {};
+  if (request.method === "GET") {
+    const url = new URL(request.url);
+    const brandName = url.searchParams.get("brand_name") || "";
+    const brandDomain = url.searchParams.get("brand_domain") || undefined;
+    const inds = (url.searchParams.get("industries") || "").split(",").map((s) => s.trim()).filter(Boolean);
+    const budget = parseInt(url.searchParams.get("budget_usd") || "0", 10) || undefined;
+    inputs = { brand_name: brandName, ...(brandDomain ? { brand_domain: brandDomain } : {}), industries: inds, ...(budget ? { budget_usd: budget } : {}) };
+  } else {
+    try {
+      inputs = await request.json();
+    } catch {
+      return errorResponse("INVALID_INPUT", "body must be JSON", 400);
+    }
+  }
+  if (!inputs.brand_name) return errorResponse("INVALID_INPUT", "brand_name required", 400);
+
+  const advisory = predictSi({
+    brand_name: inputs.brand_name,
+    ...(inputs.brand_domain ? { brand_domain: inputs.brand_domain } : {}),
+    industries: Array.isArray(inputs.industries) ? inputs.industries : [],
+    ...(inputs.budget_usd ? { budget_usd: inputs.budget_usd } : {}),
+  });
+  return jsonResponse({
+    mode: "predictive_local",
+    note: "Mock Sponsored Intelligence — synthesized from competitor seed map × industry × budget. No vendor in the AdCP directory currently advertises submit_si_request / si_session_lifecycle / si_availability / si_handoff live.",
+    inputs,
     advisory,
   });
 }


### PR DESCRIPTION
## Summary

Closes the 4th of 6 AdCP 3.0 GA protocol domains visually + adds stage-day insurance for the May 7 demo.

## SI mock (closes domain 4 of 6)

| Domain | Status |
|---|---|
| ✅ media_buy | live (sell + buy) |
| ✅ creative | live (Celtra, Advertible) |
| ✅ signals | live (us + Dstillery) |
| ⚠️ governance | predictive mock |
| ⚠️ brand | predictive mock |
| **⚠️ sponsored_intelligence** | **predictive mock — NEW** |

**Decision matrix:** brand industry → competitor seed map (10 seed maps for food/beverage/alcohol/pharma/gambling/apparel/automotive/financial/fast_food/children) → per-competitor SOV + overlap + 30d trend. Plus 4 tier-grouped insights (competitive · category · content_adjacency · share_of_voice) each with headline + detail + action + confidence.

**5% rate-limited demo state** for showing error handling (deterministic via FNV-1a on brand name).

**Endpoint:** \`GET|POST /registry/si-preview\`. Same posture as governance + brand-rights mocks.

**Canvas surface:** new \"Sponsored Intelligence\" row on brand card with summary + competitor table (SOV / overlap / 30d trend) + tier-grouped insight cards.

## Canonical demo button

Single click on a new \"Run canonical demo\" pill next to the brand quickpicks → resolves Coca-Cola → auto-clicks \"Run workflow\". **Stage-day insurance:** zero typing risk during the live demo.

## Test plan
- [x] Type-check clean
- [x] 428/428 tests pass
- [x] SCRIPT_TAG audit clean
- [ ] Smoke after deploy:
  - [ ] \`/registry/si-preview?brand_name=Coca-Cola&industries=food_beverage,beverages\` returns 3 competitors + 4 insights
  - [ ] Canvas brand card has 4 prediction rows (Policy hits + Governance + Brand-rights + SI)
  - [ ] \"Run canonical demo\" fires Coca-Cola end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)