### PR TITLE
Fix: /dsp/circuits to publicPaths (Wave 2 hotfix)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -280,6 +280,7 @@ export default {
             "/dsp/campaigns",
             "/dsp/agents",
             "/dsp/media-buys",
+            "/dsp/circuits",
             // Agentic Canvas (LLM-driven planner + executor).
             "/agentic/brief",
             "/agentic/plan",


### PR DESCRIPTION
One-line fix — Wave 2 added the diagnostic endpoint but missed publicPaths, returning 401 on smoke.