### PR TITLE
Wave 3: agentic depth — multi-turn refine + self-critique + corrections

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -82,6 +82,10 @@ import {
   handleAgenticRemediate,
   handleAgenticMemoryRecall,
   handleAgenticChat,
+  handleAgenticRefine,
+  handleAgenticCritique,
+  handleAgenticCorrection,
+  handleAgenticCorrectionsRecall,
 } from "./routes/agenticRoutes";
 import {
   handleAudienceCompose,
@@ -513,6 +517,14 @@ export default {
                 response = await handleAgenticRemediate(request, env, logger);
             } else if (method === "POST" && path === "/agentic/chat") {
                 response = await handleAgenticChat(request, env, logger);
+            } else if (method === "POST" && path === "/agentic/refine") {
+                response = await handleAgenticRefine(request, env, logger);
+            } else if (method === "POST" && path === "/agentic/critique") {
+                response = await handleAgenticCritique(request, env, logger);
+            } else if (method === "POST" && path === "/agentic/memory/correction") {
+                response = await handleAgenticCorrection(request, env, logger);
+            } else if (method === "GET" && path === "/agentic/memory/corrections") {
+                response = await handleAgenticCorrectionsRecall(request, env, logger);
             } else if (method === "GET" && path === "/agentic/memory/recall") {
                 response = await handleAgenticMemoryRecall(request, env, logger);
 

--- a/src/routes/agenticRoutes.ts
+++ b/src/routes/agenticRoutes.ts
@@ -338,6 +338,311 @@ export async function handleAgenticRemediate(request: Request, env: Env, _logger
   return jsonResponse({ advisory: out.advisory, remediations: out.remediations, trace: out.trace });
 }
 
+// ── POST /agentic/refine ───────────────────────────────────────────────────
+//
+// Wave 3 — multi-turn conversational refinement.
+//
+// Caller provides the previous ExpandedBrief + ExecutionPlan + a free-text
+// instruction ("actually exclude alcohol", "shorten flight to 14 days",
+// "increase budget to $200K", "skip Adzymic"). We re-expand the brief
+// taking the instruction into account, then re-plan against the current
+// coverage. Returns the diff so the client can highlight what changed.
+
+interface RefineBody {
+  previous_brief?: ExpandedBrief;
+  previous_plan?: ExecutionPlan;
+  instruction?: string;
+}
+
+export async function handleAgenticRefine(request: Request, env: Env, logger: Logger): Promise<Response> {
+  void logger;
+  let body: RefineBody = {};
+  try { body = await request.json(); } catch { /* empty */ }
+  if (!body.previous_brief || !body.instruction || body.instruction.trim().length === 0) {
+    return errorResponse("INVALID_INPUT", "previous_brief and instruction required", 400);
+  }
+  if (body.instruction.length > 500) {
+    return errorResponse("INVALID_INPUT", "instruction max 500 chars", 400);
+  }
+  const ctx = makeAgenticContext(env);
+
+  // Synthesize a new input by combining the old brief input with the
+  // refinement instruction. The expander's LLM path treats this as a
+  // fresh expansion; the template path falls back to its rules.
+  const composed = `${body.previous_brief.input} — refinement: ${body.instruction}`;
+  const refined = await expandBrief(ctx, composed);
+
+  // Diff: industries / kpi / budget / geo / flight that changed.
+  const changes: Array<{ field: string; before: unknown; after: unknown }> = [];
+  const fields = ["brand_name", "kpi", "kpi_target", "budget_usd_estimate", "flight_days", "dayparting_hint"] as const;
+  for (const f of fields) {
+    const a = body.previous_brief[f];
+    const b = refined[f];
+    if (a !== b) changes.push({ field: f, before: a, after: b });
+  }
+  // Industries: detect added/removed
+  const prevInd = new Set((body.previous_brief.industries || []).map((s) => s.toLowerCase()));
+  const newInd = new Set((refined.industries || []).map((s) => s.toLowerCase()));
+  const addedInd = [...newInd].filter((i) => !prevInd.has(i));
+  const removedInd = [...prevInd].filter((i) => !newInd.has(i));
+  if (addedInd.length > 0) changes.push({ field: "industries.added", before: null, after: addedInd });
+  if (removedInd.length > 0) changes.push({ field: "industries.removed", before: removedInd, after: null });
+
+  // Re-plan against the (refined) brief.
+  const coverage = await buildCoverage(env);
+  const plan = await planExecution(ctx, refined, coverage);
+
+  // Plan-step diff: what tools changed, what agents changed.
+  const prevTools = new Set((body.previous_plan?.steps ?? []).map((s) => s.tool));
+  const newTools = new Set(plan.steps.map((s) => s.tool));
+  const planChanges: Array<{ kind: string; detail: string }> = [];
+  for (const t of newTools) if (!prevTools.has(t)) planChanges.push({ kind: "tool_added", detail: t });
+  for (const t of prevTools) if (!newTools.has(t)) planChanges.push({ kind: "tool_removed", detail: t });
+
+  return jsonResponse({
+    mode: ctx.mode,
+    instruction: body.instruction.trim(),
+    refined,
+    plan,
+    changes,
+    plan_changes: planChanges,
+    summary: changes.length === 0 && planChanges.length === 0
+      ? "No structural changes — the refinement nudged language only."
+      : `${changes.length} brief field(s) changed${planChanges.length ? `; ${planChanges.length} plan step(s) changed.` : "."}`,
+  });
+}
+
+// ── POST /agentic/critique ─────────────────────────────────────────────────
+//
+// Wave 3 — self-critique. Before execution, ask the agent to review its
+// own plan. Live mode = LLM critique (Claude inspects the plan + brief
+// for inconsistencies, missing steps, or risky assumptions). Template
+// mode = rule-based heuristics (e.g. "plan has create_media_buy but
+// no governance gate; flag", "BRAND_LIFT KPI without viewability_floor;
+// flag").
+
+interface CritiqueBody {
+  brief?: ExpandedBrief;
+  plan?: ExecutionPlan;
+}
+
+export interface CritiqueIssue {
+  severity: "info" | "warn" | "block";
+  category: "missing_step" | "risky_assumption" | "kpi_mismatch" | "compliance_gap" | "vendor_concern" | "other";
+  message: string;
+  suggested_fix?: string;
+}
+
+export interface CritiqueResult {
+  mode: "live" | "template";
+  issues: CritiqueIssue[];
+  overall: "looks_good" | "minor_issues" | "needs_revision" | "block";
+  summary: string;
+  /** Confidence of the critique 0-1. */
+  confidence: number;
+}
+
+const CRITIQUE_SYSTEM = `You are a senior media-buying strategist reviewing a colleague's execution plan before they fire it. Your job is to flag issues — missing steps, risky assumptions, KPI mismatches, compliance gaps, vendor concerns — in a constructive, terse way. Each issue: severity (info/warn/block), category, message (1 sentence), suggested_fix (optional, 1 sentence). Don't pad; only flag real concerns. Bias toward action — every issue should have a fix the operator can apply.`;
+
+const CRITIQUE_SCHEMA_HINT = `{
+  "issues": [
+    {
+      "severity": "info" | "warn" | "block",
+      "category": "missing_step" | "risky_assumption" | "kpi_mismatch" | "compliance_gap" | "vendor_concern" | "other",
+      "message": string,
+      "suggested_fix": string | null
+    }
+  ],
+  "overall": "looks_good" | "minor_issues" | "needs_revision" | "block",
+  "confidence": number
+}`;
+
+function templateCritique(brief: ExpandedBrief, plan: ExecutionPlan): CritiqueResult {
+  const issues: CritiqueIssue[] = [];
+  const tools = new Set(plan.steps.map((s) => s.tool));
+
+  // Heuristic 1: BRAND_LIFT campaign with no viewability hint
+  if (brief.kpi === "BRAND_LIFT" && !brief.dayparting_hint) {
+    issues.push({
+      severity: "info",
+      category: "kpi_mismatch",
+      message: "BRAND_LIFT KPI without dayparting hint — typical brand-lift campaigns over-index on peak hours for memorability.",
+      suggested_fix: "Add dayparting_hint='peak_evening' to the brief for awareness goals.",
+    });
+  }
+  // Heuristic 2: media_buy without governance gate
+  if (tools.has("create_media_buy") && !tools.has("check_governance")) {
+    issues.push({
+      severity: "warn",
+      category: "missing_step",
+      message: "Plan fires create_media_buy without an explicit governance gate — predictive check is silent.",
+      suggested_fix: "Add a check_governance step before media-buy. (Self-mock available; no live vendor needed.)",
+    });
+  }
+  // Heuristic 3: industries-imply-policy but no gate (alcohol/pharma/gambling/tobacco/cannabis/political)
+  const REGULATED = ["alcohol", "tobacco", "cannabis", "gambling", "pharma", "political", "ai_generated_content"];
+  const hasRegulated = (brief.industries || []).some((i) => REGULATED.some((r) => i.toLowerCase().includes(r)));
+  if (hasRegulated && !tools.has("check_governance")) {
+    issues.push({
+      severity: "block",
+      category: "compliance_gap",
+      message: `Brand industries include regulated category (${brief.industries.find((i) => REGULATED.some((r) => i.toLowerCase().includes(r)))}); plan does NOT include check_governance.`,
+      suggested_fix: "Add check_governance and check_brand_rights before create_media_buy. Don't fire on regulated brands without.",
+    });
+  }
+  // Heuristic 4: plan length sanity
+  if (plan.steps.length === 0) {
+    issues.push({
+      severity: "block",
+      category: "other",
+      message: "Plan is empty — no steps to execute.",
+      suggested_fix: "Re-run brief expansion + planning.",
+    });
+  }
+  // Heuristic 5: budget sanity
+  if (brief.budget_usd_estimate !== undefined && brief.budget_usd_estimate < 1000) {
+    issues.push({
+      severity: "warn",
+      category: "risky_assumption",
+      message: `Budget estimate is very low ($${brief.budget_usd_estimate}). Most buying agents impose a minimum.`,
+      suggested_fix: "Confirm budget with the operator; add a minimum-budget guard before fire.",
+    });
+  }
+
+  let overall: CritiqueResult["overall"];
+  if (issues.some((i) => i.severity === "block")) overall = "block";
+  else if (issues.filter((i) => i.severity === "warn").length >= 2) overall = "needs_revision";
+  else if (issues.length > 0) overall = "minor_issues";
+  else overall = "looks_good";
+
+  const summary = issues.length === 0
+    ? "Template critique: no concerns flagged. Plan looks ready to execute."
+    : `Template critique flagged ${issues.length} issue(s): ${issues.filter((i) => i.severity === "block").length} block · ${issues.filter((i) => i.severity === "warn").length} warn · ${issues.filter((i) => i.severity === "info").length} info.`;
+
+  return { mode: "template", issues, overall, summary, confidence: 0.85 };
+}
+
+export async function handleAgenticCritique(request: Request, env: Env, _logger: Logger): Promise<Response> {
+  let body: CritiqueBody = {};
+  try { body = await request.json(); } catch { /* empty */ }
+  if (!body.brief || !body.plan) return errorResponse("INVALID_INPUT", "brief and plan required", 400);
+  const ctx = makeAgenticContext(env);
+
+  if (ctx.mode === "live") {
+    const r = await llmCall(ctx, {
+      system: CRITIQUE_SYSTEM,
+      messages: [{
+        role: "user",
+        content: `Brief:\n${JSON.stringify(body.brief, null, 2)}\n\nPlan:\n${JSON.stringify(body.plan, null, 2)}\n\nProvide a critique. Be terse and actionable — only flag real concerns.`,
+      }],
+      json_schema_hint: CRITIQUE_SCHEMA_HINT,
+      max_tokens: 1500,
+    });
+    if (r.ok && r.json) {
+      const j = r.json as Partial<CritiqueResult>;
+      const issues = Array.isArray(j.issues) ? j.issues : [];
+      const out: CritiqueResult = {
+        mode: "live",
+        issues: issues as CritiqueIssue[],
+        overall: (j.overall as CritiqueResult["overall"]) || "looks_good",
+        summary: `Claude critique: ${issues.length} issue(s) flagged. Latency ${r.latency_ms}ms.`,
+        confidence: typeof j.confidence === "number" ? j.confidence : 0.8,
+      };
+      return jsonResponse(out);
+    }
+  }
+
+  // Template fallback (also runs if live mode fails).
+  return jsonResponse(templateCritique(body.brief, body.plan));
+}
+
+// ── POST /agentic/memory/correction ────────────────────────────────────────
+//
+// Wave 3 — few-shot learning from corrections.
+//
+// When the operator overrides governance / rejects a signal pick / swaps
+// a product, log the correction to the agentic memory ring buffer so
+// future similar briefs surface the prior decision. The correction is
+// keyed on the brief that triggered it; recall semantics use the same
+// industry-overlap match as the existing memory recall.
+
+interface CorrectionBody {
+  brief?: ExpandedBrief;
+  correction?: {
+    kind: "override_governance" | "reject_signal" | "swap_product" | "add_attestation" | "other";
+    before: unknown;
+    after: unknown;
+    note?: string;
+  };
+}
+
+export async function handleAgenticCorrection(request: Request, env: Env, _logger: Logger): Promise<Response> {
+  let body: CorrectionBody = {};
+  try { body = await request.json(); } catch { /* empty */ }
+  if (!body.brief || !body.correction || !body.correction.kind) {
+    return errorResponse("INVALID_INPUT", "brief and correction.kind required", 400);
+  }
+
+  // Memory entry mirrors the workflow-history pattern; corrections live
+  // in a parallel ring buffer keyed by industries × kpi.
+  const id = "corr_" + Math.random().toString(36).slice(2, 10);
+  const entry = {
+    correction_id: id,
+    ts: new Date().toISOString(),
+    brief_input: body.brief.input,
+    brief_industries: body.brief.industries,
+    brief_kpi: body.brief.kpi,
+    kind: body.correction.kind,
+    before: body.correction.before,
+    after: body.correction.after,
+    ...(body.correction.note ? { note: body.correction.note } : {}),
+  };
+
+  const indexKey = "agentic_corrections_index:v1";
+  try {
+    const existing = await env.SIGNALS_CACHE.get(indexKey, "json");
+    const list: Array<typeof entry> = Array.isArray(existing) ? (existing as Array<typeof entry>) : [];
+    const updated = [entry, ...list].slice(0, 50);
+    await env.SIGNALS_CACHE.put(indexKey, JSON.stringify(updated), { expirationTtl: 60 * 60 * 24 * 30 });
+  } catch (e) {
+    return errorResponse("KV_ERROR", "failed to persist correction: " + String((e as Error).message || e), 500);
+  }
+
+  return jsonResponse({ correction_id: id, stored: true });
+}
+
+// ── GET /agentic/memory/corrections ────────────────────────────────────────
+//
+// Wave 3 — recall corrections relevant to a brief. Same scoring as
+// recallSimilar (industry-overlap × kpi-match). The Agentic Canvas
+// surfaces matching corrections in the memory panel as "you previously
+// did X for similar brands" hints.
+
+export async function handleAgenticCorrectionsRecall(request: Request, env: Env, _logger: Logger): Promise<Response> {
+  const url = new URL(request.url);
+  const industriesStr = url.searchParams.get("industries") || "";
+  const kpi = url.searchParams.get("kpi") || "ROAS";
+  const indLower = industriesStr.split(",").map((s) => s.trim().toLowerCase()).filter(Boolean);
+
+  let list: Array<{ correction_id: string; ts: string; brief_industries: string[]; brief_kpi: string; brief_input: string; kind: string; before: unknown; after: unknown; note?: string }> = [];
+  try {
+    const raw = await env.SIGNALS_CACHE.get("agentic_corrections_index:v1", "json");
+    if (Array.isArray(raw)) list = raw as typeof list;
+  } catch { /* empty */ }
+
+  const scored = list.map((c) => {
+    const overlap = c.brief_industries.filter((i) => indLower.includes(i.toLowerCase())).length;
+    const kpiMatch = c.brief_kpi === kpi ? 1 : 0;
+    return { c, score: overlap * 2 + kpiMatch };
+  }).filter((x) => x.score > 0).sort((a, b) => b.score - a.score).slice(0, 5);
+
+  return jsonResponse({
+    matches: scored.map((s) => s.c),
+    count: scored.length,
+    hint: scored.length === 0 ? "No matching corrections in memory." : `Found ${scored.length} matching correction(s) from prior runs.`,
+  });
+}
+
 // ── GET /agentic/memory/recall ─────────────────────────────────────────────
 
 export async function handleAgenticMemoryRecall(request: Request, env: Env, _logger: Logger): Promise<Response> {

--- a/src/routes/demo.ts
+++ b/src/routes/demo.ts
@@ -1681,8 +1681,23 @@ ${STYLES}
                   <svg class="ico"><use href="#icon-bolt"/></svg>
                   <span>Execute plan</span>
                 </button>
+                <button class="agentic-critique-btn" id="agentic-critique-btn" title="Self-critique: agent reviews its own plan for missing steps, risky assumptions, compliance gaps before fire">
+                  <span>🔍 Self-critique</span>
+                </button>
                 <span class="orch-small" style="color:var(--text-mut)">streams reasoning + tool results live</span>
               </div>
+              <!-- Wave 3: critique result panel -->
+              <div class="agentic-critique-result" id="agentic-critique-result"></div>
+              <!-- Wave 3: multi-turn refinement input -->
+              <div class="agentic-refine-row">
+                <input type="text" class="agentic-refine-input" id="agentic-refine-input"
+                  placeholder='Refine: "exclude alcohol", "shorten flight to 14 days", "skip Adzymic"…'
+                  maxlength="500" />
+                <button class="agentic-refine-btn" id="agentic-refine-btn">
+                  <span>↻ Refine</span>
+                </button>
+              </div>
+              <div class="agentic-refine-result" id="agentic-refine-result"></div>
             </div>
 
             <!-- Execution panel -->
@@ -5466,6 +5481,89 @@ textarea.lab-input { resize: vertical; line-height: 1.5; }
   font-family: inherit;
 }
 .agentic-execute-btn:disabled { opacity: 0.6; cursor: wait; }
+
+/* Wave 3: self-critique button + result panel */
+.agentic-critique-btn {
+  background: transparent; color: var(--accent);
+  border: 1px solid var(--accent); border-radius: 4px;
+  padding: 4px 12px; font-size: 12px; cursor: pointer;
+  font-family: inherit;
+}
+.agentic-critique-btn:hover:not(:disabled) { background: var(--accent); color: #000; }
+.agentic-critique-btn:disabled { opacity: 0.6; cursor: wait; }
+.agentic-critique-result { display: flex; flex-direction: column; gap: 4px; margin-top: 6px; }
+.agentic-crit-banner {
+  display: flex; align-items: center; gap: 10px;
+  padding: 5px 10px; border-radius: 3px;
+  border: 1px solid currentColor; font-size: 11px;
+}
+.agentic-crit-icon { font-size: 14px; }
+.agentic-crit-looks_good     { color: var(--success); background: rgba(102,187,106,0.10); }
+.agentic-crit-minor_issues   { color: var(--text-mut); background: var(--bg-input); }
+.agentic-crit-needs_revision { color: var(--warning, #d4a017); background: rgba(212,160,23,0.10); }
+.agentic-crit-block          { color: var(--error); background: rgba(239,68,68,0.10); }
+.agentic-crit-issue {
+  padding: 5px 10px; border-radius: 3px;
+  background: var(--bg-raised); border: 1px solid var(--border);
+  border-left-width: 3px;
+  display: grid; grid-template-columns: 50px 100px 1fr; gap: 6px;
+  align-items: baseline; font-size: 11px;
+}
+.agentic-crit-issue .agentic-crit-msg { grid-column: 3; color: var(--text-dim); }
+.agentic-crit-issue .agentic-crit-fix {
+  grid-column: 1 / -1; color: var(--accent); font-size: 10.5px;
+  margin-top: 2px; padding-top: 2px;
+  border-top: 1px dashed var(--border);
+}
+.agentic-crit-sev {
+  font-size: 8.5px; padding: 1px 4px; border-radius: 2px;
+  font-weight: 700; letter-spacing: 0.05em;
+}
+.agentic-crit-issue.agentic-crit-sev-info  { border-left-color: var(--text-mut); }
+.agentic-crit-issue.agentic-crit-sev-warn  { border-left-color: var(--warning, #d4a017); }
+.agentic-crit-issue.agentic-crit-sev-block { border-left-color: var(--error); }
+.agentic-crit-issue.agentic-crit-sev-info  .agentic-crit-sev { background: var(--bg-input); color: var(--text-mut); }
+.agentic-crit-issue.agentic-crit-sev-warn  .agentic-crit-sev { background: var(--warning, #d4a017); color: #000; }
+.agentic-crit-issue.agentic-crit-sev-block .agentic-crit-sev { background: var(--error); color: #000; }
+.agentic-crit-cat {
+  font-size: 9px; color: var(--text-mut);
+  text-transform: uppercase; letter-spacing: 0.04em;
+}
+
+/* Wave 3: refinement input + diff panel */
+.agentic-refine-row {
+  display: flex; gap: 6px; margin-top: 8px;
+  padding-top: 8px; border-top: 1px dashed var(--border);
+}
+.agentic-refine-input {
+  flex: 1; padding: 5px 10px; font-size: 12px;
+  background: var(--bg-raised); color: var(--text);
+  border: 1px solid var(--border); border-radius: 4px;
+  font-family: inherit;
+}
+.agentic-refine-input:focus { outline: none; border-color: var(--accent); }
+.agentic-refine-btn {
+  background: var(--bg-input); color: var(--text-dim);
+  border: 1px solid var(--border); border-radius: 4px;
+  padding: 4px 12px; font-size: 11px; cursor: pointer;
+  font-family: inherit;
+}
+.agentic-refine-btn:hover:not(:disabled) { color: var(--accent); border-color: var(--accent); }
+.agentic-refine-btn:disabled { opacity: 0.6; cursor: wait; }
+.agentic-refine-result { margin-top: 6px; display: flex; flex-direction: column; gap: 3px; }
+.agentic-refine-summary {
+  font-size: 11.5px; color: var(--accent); font-style: italic;
+  padding: 4px 8px; background: rgba(56,182,255,0.06);
+  border-radius: 3px;
+}
+.agentic-refine-change {
+  display: flex; align-items: center; gap: 8px;
+  padding: 3px 8px; font-size: 11px;
+  background: var(--bg-raised); border-radius: 3px;
+}
+.agentic-refine-field { color: var(--text); font-weight: 600; min-width: 140px; }
+.agentic-refine-arrow { color: var(--accent); }
+.agentic-refine-change-plan { background: rgba(102,187,106,0.06); }
 .agentic-execute-btn .ico { width: 12px; height: 12px; }
 
 /* Execution panel */
@@ -17563,6 +17661,107 @@ function _agenticRenderPlan(plan) {
   if (execBtn) {
     execBtn.onclick = null;
     execBtn.addEventListener("click", _agenticExecute);
+  }
+  // Wave 3: wire self-critique + refine controls.
+  var critBtn = document.getElementById("agentic-critique-btn");
+  if (critBtn) { critBtn.onclick = null; critBtn.addEventListener("click", _agenticCritique); }
+  var refineBtn = document.getElementById("agentic-refine-btn");
+  if (refineBtn) { refineBtn.onclick = null; refineBtn.addEventListener("click", _agenticRefine); }
+  var refineInp = document.getElementById("agentic-refine-input");
+  if (refineInp) {
+    refineInp.onkeydown = null;
+    refineInp.addEventListener("keydown", function (e) { if (e.key === "Enter") _agenticRefine(); });
+  }
+}
+
+// Wave 3: self-critique. Calls /agentic/critique with brief + plan;
+// renders issue cards color-coded by severity.
+async function _agenticCritique() {
+  if (!_agenticCurrent || !_agenticCurrent.plan) return;
+  var btn = document.getElementById("agentic-critique-btn");
+  var out = document.getElementById("agentic-critique-result");
+  if (!out) return;
+  if (btn) { btn.disabled = true; btn.querySelector("span").textContent = "🔍 reviewing…"; }
+  out.innerHTML = '<span class="orch-small">agent reviewing the plan…</span>';
+  try {
+    var r = await fetch("/agentic/critique", {
+      method: "POST", headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ brief: _agenticCurrent.expanded, plan: _agenticCurrent.plan }),
+    });
+    var d = await r.json();
+    var overallCls = "agentic-crit-" + (d.overall || "looks_good");
+    var ico = d.overall === "block" ? "⛔" : d.overall === "needs_revision" ? "⚠" : d.overall === "minor_issues" ? "ℹ" : "✓";
+    out.innerHTML =
+      '<div class="agentic-crit-banner ' + overallCls + '">' +
+        '<span class="agentic-crit-icon">' + ico + '</span>' +
+        '<span><strong>' + escapeHtml((d.overall || "looks_good").toUpperCase().replace(/_/g, " ")) + '</strong></span>' +
+        '<span class="orch-small">' + escapeHtml(d.summary || "") + '</span>' +
+        '<span class="orch-small mono" style="margin-left:auto">' + (d.mode === "live" ? "Claude" : "template") + '</span>' +
+      '</div>' +
+      (d.issues && d.issues.length ? d.issues.map(function (i) {
+        return '<div class="agentic-crit-issue agentic-crit-sev-' + escapeHtml(i.severity) + '">' +
+          '<span class="agentic-crit-sev mono">' + escapeHtml((i.severity || "info").toUpperCase()) + '</span>' +
+          '<span class="agentic-crit-cat mono">' + escapeHtml(i.category || "other") + '</span>' +
+          '<div class="agentic-crit-msg">' + escapeHtml(i.message || "") + '</div>' +
+          (i.suggested_fix ? '<div class="agentic-crit-fix">→ ' + escapeHtml(i.suggested_fix) + '</div>' : '') +
+        '</div>';
+      }).join("") : '<div class="orch-small" style="color:var(--text-mut);margin-top:6px">No issues flagged. Plan ready to execute.</div>');
+  } catch (e) {
+    out.innerHTML = '<span class="orch-small" style="color:var(--error)">' + escapeHtml(String((e && e.message) || e)) + '</span>';
+  } finally {
+    if (btn) { btn.disabled = false; btn.querySelector("span").textContent = "🔍 Self-critique"; }
+  }
+}
+
+// Wave 3: multi-turn refinement.
+async function _agenticRefine() {
+  if (!_agenticCurrent || !_agenticCurrent.expanded || !_agenticCurrent.plan) return;
+  var inp = document.getElementById("agentic-refine-input");
+  var btn = document.getElementById("agentic-refine-btn");
+  var out = document.getElementById("agentic-refine-result");
+  if (!inp || !out) return;
+  var instruction = (inp.value || "").trim();
+  if (!instruction) return;
+  if (btn) { btn.disabled = true; btn.querySelector("span").textContent = "thinking…"; }
+  out.innerHTML = '<span class="orch-small">refining brief + replanning against current coverage…</span>';
+  try {
+    var r = await fetch("/agentic/refine", {
+      method: "POST", headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        previous_brief: _agenticCurrent.expanded,
+        previous_plan: _agenticCurrent.plan,
+        instruction: instruction,
+      }),
+    });
+    var d = await r.json();
+    if (d.error) { out.innerHTML = '<span class="orch-small" style="color:var(--error)">' + escapeHtml(d.error) + '</span>'; return; }
+
+    // Replace state + re-render the brief + plan sections.
+    _agenticCurrent.expanded = d.refined;
+    _agenticCurrent.plan = d.plan;
+    _agenticRenderBrief(d.refined);
+    _agenticRenderPlan(d.plan);
+
+    // Show diff inline
+    var changeRows = (d.changes || []).map(function (c) {
+      return '<div class="agentic-refine-change">' +
+        '<span class="agentic-refine-field mono">' + escapeHtml(c.field) + '</span>' +
+        '<span class="agentic-refine-arrow">→</span>' +
+        '<span class="orch-small">' + escapeHtml(JSON.stringify(c.before)) + ' ⇒ ' + escapeHtml(JSON.stringify(c.after)) + '</span>' +
+      '</div>';
+    }).join("");
+    var planChangeRows = (d.plan_changes || []).map(function (c) {
+      return '<div class="agentic-refine-change agentic-refine-change-plan"><span class="mono">' + escapeHtml(c.kind) + '</span> <span class="mono">' + escapeHtml(c.detail) + '</span></div>';
+    }).join("");
+    out.innerHTML =
+      '<div class="agentic-refine-summary">' + escapeHtml(d.summary || "Refined.") + '</div>' +
+      changeRows +
+      planChangeRows;
+    inp.value = "";
+  } catch (e) {
+    out.innerHTML = '<span class="orch-small" style="color:var(--error)">' + escapeHtml(String((e && e.message) || e)) + '</span>';
+  } finally {
+    if (btn) { btn.disabled = false; btn.querySelector("span").textContent = "↻ Refine"; }
   }
 }
 


### PR DESCRIPTION
## Summary

Three agentic primitives turning the Agentic Canvas from single-shot planner into a conversational, self-aware orchestrator that learns from operator overrides.

## What ships

| Endpoint | What it does |
|---|---|
| \`POST /agentic/refine\` | Multi-turn: previous brief + plan + free-text instruction → re-expanded brief + re-planned + structural diff |
| \`POST /agentic/critique\` | Self-critique: live Claude (or 5-heuristic template fallback) reviews plan for missing steps / risky assumptions / compliance gaps / vendor concerns |
| \`POST /agentic/memory/correction\` | Logs operator overrides (override_governance / reject_signal / swap_product) for few-shot learning |
| \`GET /agentic/memory/corrections\` | Recall matching corrections by industries × KPI |

## UI

- **\"🔍 Self-critique\" button** in plan-actions row — banner (looks_good/minor/needs_revision/block) + issue cards color-coded by severity with suggested-fix lines
- **Refine input** below plan with placeholder examples (\"exclude alcohol\", \"shorten flight to 14 days\", \"skip Adzymic\") — submits → re-renders brief + plan + shows structural diff inline

## Workshop demo upgrade

> Click prompt → plan renders → click \"🔍 Self-critique\" → Claude flags issues with fixes
> Type \"exclude alcohol\" in refine box → brief re-expands → plan re-runs → see what changed
> Both work in template mode if no API key (5 deterministic heuristics)

## Test plan
- [x] Type-check clean
- [x] 428/428 tests pass
- [x] SCRIPT_TAG audit clean
- [ ] Smoke after deploy:
  - [ ] \`/agentic/critique\` flags BLOCK on a plan with regulated industry but no governance gate
  - [ ] \`/agentic/refine\` correctly re-plans with \"exclude alcohol\" instruction
  - [ ] \`/agentic/memory/correction\` persists; recall surfaces matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)