### PR TITLE
Wave 4: spend orchestration + annotations on saved runs

### DIFF
--- a/src/domain/runAnnotations.ts
+++ b/src/domain/runAnnotations.ts
@@ -1,0 +1,76 @@
+// src/domain/runAnnotations.ts
+//
+// Wave 4 — annotations on saved workflow runs.
+//
+// Each saved workflow (KV-backed via /agents/workflow/save) can carry
+// a thread of plain-text annotations. Workshop attendees can leave
+// notes on permalinks ("fired this for Coca-Cola, auth-gated as
+// expected"); operators can append observations as a run goes live.
+//
+// Storage: KV at `wf_annotations:<workflow_id>` — JSON array of
+// Annotation objects. 30-day TTL (matches the underlying run TTL).
+// Cap of 50 annotations per run.
+//
+// We don't enforce author identity — this is a demo surface. In
+// production we'd require an authenticated operator id.
+
+import type { Env } from "../types/env";
+
+export interface Annotation {
+  annotation_id: string;
+  workflow_id: string;
+  ts: string;          // ISO
+  author: string;      // free-text; "anonymous" by default
+  text: string;        // ≤ 500 chars
+  /** Optional reference to a specific element of the run (e.g. "stage:media_buy" or "agent:adzymic_apx"). */
+  ref?: string;
+}
+
+const KEY_PREFIX = "wf_annotations:";
+const ANNOTATION_TTL = 60 * 60 * 24 * 30; // 30 days
+const MAX_PER_RUN = 50;
+const MAX_TEXT_LEN = 500;
+
+function key(workflowId: string): string { return KEY_PREFIX + workflowId; }
+
+export async function listAnnotations(env: Env, workflowId: string): Promise<Annotation[]> {
+  try {
+    const raw = await env.SIGNALS_CACHE.get(key(workflowId), "json");
+    if (Array.isArray(raw)) return raw as Annotation[];
+  } catch { /* empty */ }
+  return [];
+}
+
+export async function appendAnnotation(
+  env: Env,
+  workflowId: string,
+  input: { author?: string; text: string; ref?: string },
+): Promise<{ annotation: Annotation; total: number }> {
+  if (!input.text || input.text.trim().length === 0) {
+    throw new Error("annotation text required");
+  }
+  const text = input.text.trim().slice(0, MAX_TEXT_LEN);
+  const annotation: Annotation = {
+    annotation_id: "ann_" + Math.random().toString(36).slice(2, 10),
+    workflow_id: workflowId,
+    ts: new Date().toISOString(),
+    author: (input.author ?? "anonymous").slice(0, 80),
+    text,
+    ...(input.ref ? { ref: input.ref.slice(0, 80) } : {}),
+  };
+  const existing = await listAnnotations(env, workflowId);
+  // Newest first; cap to MAX_PER_RUN.
+  const updated = [annotation, ...existing].slice(0, MAX_PER_RUN);
+  await env.SIGNALS_CACHE.put(key(workflowId), JSON.stringify(updated), { expirationTtl: ANNOTATION_TTL });
+  return { annotation, total: updated.length };
+}
+
+export async function deleteAnnotation(env: Env, workflowId: string, annotationId: string): Promise<{ deleted: boolean; total: number }> {
+  const existing = await listAnnotations(env, workflowId);
+  const filtered = existing.filter((a) => a.annotation_id !== annotationId);
+  if (filtered.length === existing.length) {
+    return { deleted: false, total: existing.length };
+  }
+  await env.SIGNALS_CACHE.put(key(workflowId), JSON.stringify(filtered), { expirationTtl: ANNOTATION_TTL });
+  return { deleted: true, total: filtered.length };
+}

--- a/src/domain/spendAllocator.ts
+++ b/src/domain/spendAllocator.ts
@@ -1,0 +1,191 @@
+// src/domain/spendAllocator.ts
+//
+// Wave 4 — per-vendor spend allocation policies.
+//
+// AdCP today doesn't speak about budget allocation across multiple
+// buying agents. The orchestrator's default behavior gives every
+// fired agent the same scalar budget — fine for a demo, terrible
+// for production. This module formalizes 4 allocation strategies:
+//
+//   - equal_split        — total / N (the default; what we have today)
+//   - score_weighted     — weight each agent by a score (e.g. coverage
+//                          rank, win rate, latency p95)
+//   - priority_first     — give the first agent X% of the budget,
+//                          split the rest equally across the others
+//   - cap_then_split     — apply per-agent caps first, then split the
+//                          residual equally across uncapped agents
+//
+// Returns per-agent allocation in cents (avoids floating-point
+// rounding drift). Sum of allocations always equals total_budget_cents
+// (within ±1 cent for rounding).
+
+export type AllocationStrategy =
+  | "equal_split"
+  | "score_weighted"
+  | "priority_first"
+  | "cap_then_split";
+
+export interface AllocationInput {
+  total_budget_usd: number;
+  agents: Array<{
+    agent_id: string;
+    /** Score 0..1; only used by score_weighted. Defaults to 1.0. */
+    score?: number;
+    /** Per-agent maximum allocation in USD; only used by cap_then_split. */
+    max_usd?: number;
+    /** Whether this agent is the priority agent; only used by priority_first.
+     *  At most one agent should have this set. */
+    priority?: boolean;
+  }>;
+  strategy: AllocationStrategy;
+  /** Strategy-specific config. */
+  config?: {
+    /** priority_first: % of total to give to the priority agent (0-100). Default 40. */
+    priority_share_pct?: number;
+    /** Floor: minimum allocation per agent in USD. Default 0. */
+    min_per_agent_usd?: number;
+  };
+}
+
+export interface AllocationResult {
+  strategy: AllocationStrategy;
+  total_budget_usd: number;
+  total_budget_cents: number;
+  allocations: Array<{
+    agent_id: string;
+    allocation_usd: number;
+    allocation_cents: number;
+    /** Share of total budget 0..1. */
+    share: number;
+    /** Plain-language reason this agent got this allocation. */
+    rationale: string;
+  }>;
+  /** Sum of all allocations in cents (sanity check). */
+  total_allocated_cents: number;
+  /** Any rounding drift (target - sum), distributed to the largest allocation. */
+  rounding_drift_cents: number;
+  /** Plain-English summary. */
+  summary: string;
+}
+
+const USD_TO_CENTS = 100;
+const round = (n: number): number => Math.round(n);
+
+export function allocateSpend(input: AllocationInput): AllocationResult {
+  const totalCents = round(input.total_budget_usd * USD_TO_CENTS);
+  const minPerAgentCents = round((input.config?.min_per_agent_usd ?? 0) * USD_TO_CENTS);
+  const n = input.agents.length;
+  if (n === 0) {
+    return {
+      strategy: input.strategy, total_budget_usd: input.total_budget_usd, total_budget_cents: totalCents,
+      allocations: [], total_allocated_cents: 0, rounding_drift_cents: 0,
+      summary: "No agents to allocate to.",
+    };
+  }
+
+  let allocCents: number[] = new Array(n).fill(0);
+  let summary = "";
+
+  if (input.strategy === "equal_split") {
+    const per = Math.floor(totalCents / n);
+    allocCents = allocCents.map(() => per);
+    summary = `Equal split — $${(per / 100).toFixed(2)} per agent across ${n} agents.`;
+  } else if (input.strategy === "score_weighted") {
+    const scores = input.agents.map((a) => Math.max(0, Math.min(1, a.score ?? 1)));
+    const totalScore = scores.reduce((s, x) => s + x, 0);
+    if (totalScore === 0) {
+      // Fallback to equal
+      const per = Math.floor(totalCents / n);
+      allocCents = allocCents.map(() => per);
+      summary = `Score-weighted (all scores zero — fell back to equal-split): $${(per / 100).toFixed(2)} per agent.`;
+    } else {
+      allocCents = scores.map((s) => Math.floor(totalCents * (s / totalScore)));
+      const topScoreIdx = scores.indexOf(Math.max(...scores));
+      summary = `Score-weighted — agent ${input.agents[topScoreIdx]!.agent_id} (score ${scores[topScoreIdx]!.toFixed(2)}) gets the largest share.`;
+    }
+  } else if (input.strategy === "priority_first") {
+    const priorityIdx = input.agents.findIndex((a) => a.priority === true);
+    const priorityShare = (input.config?.priority_share_pct ?? 40) / 100;
+    if (priorityIdx === -1 || n === 1) {
+      // No priority specified or only one agent — fallback to equal
+      const per = Math.floor(totalCents / n);
+      allocCents = allocCents.map(() => per);
+      summary = `Priority-first (no priority agent specified — fell back to equal-split): $${(per / 100).toFixed(2)} per agent.`;
+    } else {
+      const priorityCents = Math.floor(totalCents * priorityShare);
+      const remaining = totalCents - priorityCents;
+      const perOther = Math.floor(remaining / (n - 1));
+      allocCents = input.agents.map((_a, i) => i === priorityIdx ? priorityCents : perOther);
+      summary = `Priority-first — ${input.agents[priorityIdx]!.agent_id} gets ${(priorityShare * 100).toFixed(0)}% ($${(priorityCents / 100).toFixed(0)}); remaining ${n - 1} agents split the rest equally.`;
+    }
+  } else if (input.strategy === "cap_then_split") {
+    // First, apply per-agent caps; remaining budget splits across uncapped.
+    const cappedCents = input.agents.map((a) => a.max_usd !== undefined ? round(a.max_usd * USD_TO_CENTS) : null);
+    let consumed = 0;
+    const cappedIdx: number[] = [];
+    cappedCents.forEach((c, i) => {
+      if (c !== null) {
+        allocCents[i] = c;
+        consumed += c;
+        cappedIdx.push(i);
+      }
+    });
+    const uncappedIdx = input.agents.map((_, i) => i).filter((i) => !cappedIdx.includes(i));
+    const remaining = totalCents - consumed;
+    if (uncappedIdx.length === 0) {
+      // All capped — capped allocation IS the result, even if doesn't sum to total
+      summary = `Cap-then-split — all ${n} agents have caps; total capped allocation $${(consumed / 100).toFixed(0)} (vs total $${input.total_budget_usd}).`;
+    } else if (remaining <= 0) {
+      // Caps exceed total — uncapped get zero
+      uncappedIdx.forEach((i) => allocCents[i] = 0);
+      summary = `Cap-then-split — caps consumed all of $${input.total_budget_usd}; ${uncappedIdx.length} uncapped agent(s) get $0.`;
+    } else {
+      const perUncapped = Math.floor(remaining / uncappedIdx.length);
+      uncappedIdx.forEach((i) => allocCents[i] = perUncapped);
+      summary = `Cap-then-split — ${cappedIdx.length} capped agent(s) consume $${(consumed / 100).toFixed(0)}; remaining $${(remaining / 100).toFixed(0)} split across ${uncappedIdx.length} uncapped at $${(perUncapped / 100).toFixed(0)} each.`;
+    }
+  }
+
+  // Apply minimum-per-agent floor (if any).
+  if (minPerAgentCents > 0) {
+    allocCents = allocCents.map((c) => Math.max(c, minPerAgentCents));
+  }
+
+  // Distribute rounding drift to the largest allocation so the sum
+  // exactly matches the input total.
+  const sum = allocCents.reduce((s, x) => s + x, 0);
+  const drift = totalCents - sum;
+  if (drift !== 0 && allocCents.length > 0) {
+    const maxIdx = allocCents.indexOf(Math.max(...allocCents));
+    allocCents[maxIdx] = (allocCents[maxIdx] ?? 0) + drift;
+  }
+
+  // Build final allocation rows with rationales.
+  const allocations = input.agents.map((a, i) => {
+    const cents = allocCents[i] ?? 0;
+    const usd = cents / USD_TO_CENTS;
+    const share = totalCents > 0 ? cents / totalCents : 0;
+    let rationale = "";
+    if (input.strategy === "equal_split") {
+      rationale = "Equal split across all agents.";
+    } else if (input.strategy === "score_weighted") {
+      rationale = `Score ${(a.score ?? 1).toFixed(2)} → ${(share * 100).toFixed(1)}% share.`;
+    } else if (input.strategy === "priority_first") {
+      rationale = a.priority ? `Priority agent → ${(share * 100).toFixed(0)}% share.` : `Non-priority agent → split of remaining.`;
+    } else if (input.strategy === "cap_then_split") {
+      if (a.max_usd !== undefined) rationale = `Capped at $${a.max_usd}.`;
+      else rationale = `Uncapped — split of residual after caps.`;
+    }
+    return { agent_id: a.agent_id, allocation_usd: usd, allocation_cents: cents, share, rationale };
+  });
+
+  return {
+    strategy: input.strategy,
+    total_budget_usd: input.total_budget_usd,
+    total_budget_cents: totalCents,
+    allocations,
+    total_allocated_cents: allocCents.reduce((s, x) => s + x, 0),
+    rounding_drift_cents: drift,
+    summary,
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,6 +48,8 @@ import {
   handleWorkflowSave,
   handleWorkflowRuns,
   handleWorkflowMeasurementStub,
+  handleWorkflowAllocate,
+  handleWorkflowAnnotation,
 } from "./routes/agentsEndpoints";
 import {
   handleBrandSearch,
@@ -448,10 +450,16 @@ export default {
                 response = await handleWorkflowFireBuy(request, env, logger);
             } else if (method === "POST" && path === "/agents/workflow/save") {
                 response = await handleWorkflowSave(request, env, logger);
+                // Wave 4: annotations — must be BEFORE the runs catch-all
+                // since /runs/<id>/annotation would otherwise collide.
+            } else if (path.match(/\/agents\/workflow\/runs\/wf_[a-z0-9]+\/annotation/i) && (method === "GET" || method === "POST" || method === "DELETE")) {
+                response = await handleWorkflowAnnotation(request, env, logger);
             } else if (method === "GET" && path.startsWith("/agents/workflow/runs")) {
                 response = await handleWorkflowRuns(request, env, logger);
             } else if (method === "GET" && path === "/agents/workflow/measurement-stub") {
                 response = await handleWorkflowMeasurementStub(request, env, logger);
+            } else if (method === "POST" && path === "/agents/workflow/allocate") {
+                response = await handleWorkflowAllocate(request, env, logger);
 
                 // ── Canvas v2 Phase 1: brand registry passthrough ───────────────────
             } else if (method === "GET" && path === "/brands/search") {

--- a/src/routes/agentsEndpoints.ts
+++ b/src/routes/agentsEndpoints.ts
@@ -55,6 +55,9 @@ import {
   type ProductFilter,
 } from "../domain/workflowOrchestration";
 import { ADCP_TOOLS } from "../mcp/tools";
+// Wave 4: spend allocation + run annotations
+import { allocateSpend, type AllocationStrategy } from "../domain/spendAllocator";
+import { listAnnotations, appendAnnotation, deleteAnnotation } from "../domain/runAnnotations";
 
 // Sec-48b: hook the generic MCP client with a self-detector. When the orchestrator
 // probes or fans-out to our own URL, Cloudflare Workers refuse self-fetch; we
@@ -1363,14 +1366,16 @@ export async function handleWorkflowSave(request: Request, env: Env, logger: Log
 
 export async function handleWorkflowRuns(request: Request, env: Env, _logger: Logger): Promise<Response> {
   const url = new URL(request.url);
-  // GET /agents/workflow/runs/:id  → load specific
+  // GET /agents/workflow/runs/:id  → load specific (now also includes annotations[])
   const m = url.pathname.match(/\/agents\/workflow\/runs\/(wf_[a-z0-9]+)$/i);
   if (m) {
     const id = m[1]!;
     try {
       const snap = await env.SIGNALS_CACHE.get(WF_HISTORY_PREFIX + id, "json");
       if (!snap) return errorResponse("NOT_FOUND", "no run with id " + id, 404);
-      return jsonResponse(snap as object);
+      // Wave 4: hydrate annotations alongside the snapshot.
+      const annotations = await listAnnotations(env, id);
+      return jsonResponse({ ...(snap as object), annotations });
     } catch {
       return errorResponse("STORAGE_ERROR", "read failed", 500);
     }
@@ -1382,4 +1387,75 @@ export async function handleWorkflowRuns(request: Request, env: Env, _logger: Lo
   } catch {
     return jsonResponse({ count: 0, runs: [] });
   }
+}
+
+// ── Wave 4: workflow allocation + annotations ─────────────────────────────
+
+interface AllocateBody {
+  total_budget_usd?: number;
+  agents?: Array<{ agent_id: string; score?: number; max_usd?: number; priority?: boolean }>;
+  strategy?: AllocationStrategy;
+  config?: { priority_share_pct?: number; min_per_agent_usd?: number };
+}
+
+export async function handleWorkflowAllocate(request: Request, _env: Env, _logger: Logger): Promise<Response> {
+  let body: AllocateBody = {};
+  try { body = await request.json(); } catch { /* empty */ }
+  if (typeof body.total_budget_usd !== "number" || body.total_budget_usd <= 0) {
+    return errorResponse("INVALID_INPUT", "total_budget_usd > 0 required", 400);
+  }
+  if (!Array.isArray(body.agents) || body.agents.length === 0) {
+    return errorResponse("INVALID_INPUT", "agents (non-empty array) required", 400);
+  }
+  const strategy = body.strategy ?? "equal_split";
+  const validStrategies: AllocationStrategy[] = ["equal_split", "score_weighted", "priority_first", "cap_then_split"];
+  if (!validStrategies.includes(strategy)) {
+    return errorResponse("INVALID_INPUT", "strategy must be one of: " + validStrategies.join(", "), 400);
+  }
+  const result = allocateSpend({
+    total_budget_usd: body.total_budget_usd,
+    agents: body.agents,
+    strategy,
+    ...(body.config ? { config: body.config } : {}),
+  });
+  return jsonResponse(result);
+}
+
+interface AnnotationBody { author?: string; text?: string; ref?: string }
+
+export async function handleWorkflowAnnotation(request: Request, env: Env, _logger: Logger): Promise<Response> {
+  const url = new URL(request.url);
+  const m = url.pathname.match(/\/agents\/workflow\/runs\/(wf_[a-z0-9]+)\/annotation/i);
+  if (!m) return errorResponse("INVALID_INPUT", "expected /agents/workflow/runs/<id>/annotation", 400);
+  const workflowId = m[1]!;
+
+  if (request.method === "GET") {
+    // List
+    const list = await listAnnotations(env, workflowId);
+    return jsonResponse({ workflow_id: workflowId, count: list.length, annotations: list });
+  }
+  if (request.method === "POST") {
+    let body: AnnotationBody = {};
+    try { body = await request.json(); } catch { /* empty */ }
+    if (!body.text || body.text.trim().length === 0) {
+      return errorResponse("INVALID_INPUT", "text required", 400);
+    }
+    try {
+      const out = await appendAnnotation(env, workflowId, {
+        ...(body.author !== undefined ? { author: body.author } : {}),
+        text: body.text,
+        ...(body.ref !== undefined ? { ref: body.ref } : {}),
+      });
+      return jsonResponse(out);
+    } catch (e) {
+      return errorResponse("INVALID_INPUT", String((e as Error).message || e), 400);
+    }
+  }
+  if (request.method === "DELETE") {
+    const annId = url.searchParams.get("annotation_id");
+    if (!annId) return errorResponse("INVALID_INPUT", "annotation_id query param required", 400);
+    const out = await deleteAnnotation(env, workflowId, annId);
+    return jsonResponse(out);
+  }
+  return errorResponse("METHOD_NOT_ALLOWED", "GET / POST / DELETE only", 405);
 }

--- a/src/routes/demo.ts
+++ b/src/routes/demo.ts
@@ -5957,6 +5957,72 @@ textarea.lab-input { resize: vertical; line-height: 1.5; }
 }
 .canvas-permalink-copy:hover { color: var(--accent); border-color: var(--accent); }
 
+/* Wave 4: annotations modal — comments thread on a saved run */
+.canvas-annotation-toggle {
+  background: transparent; color: var(--text-mut);
+  border: 1px solid var(--border); border-radius: 3px;
+  padding: 0 8px; font-size: 10px; cursor: pointer;
+  font-family: inherit;
+}
+.canvas-annotation-toggle:hover { color: var(--accent); border-color: var(--accent); }
+.canvas-annotation-modal {
+  position: fixed; inset: 0; z-index: 9200;
+  background: rgba(0,0,0,0.6);
+  display: flex; align-items: center; justify-content: center;
+  padding: 20px;
+}
+.canvas-annotation-inner {
+  background: var(--bg-surface); border: 1px solid var(--accent);
+  border-radius: 6px; padding: 14px;
+  min-width: 480px; max-width: 700px;
+  display: flex; flex-direction: column; gap: 10px;
+  max-height: 80vh;
+}
+.canvas-annotation-head {
+  display: flex; justify-content: space-between; align-items: center;
+  padding-bottom: 8px; border-bottom: 1px solid var(--border);
+}
+.canvas-annotation-close {
+  background: transparent; border: 1px solid var(--border);
+  border-radius: 3px; width: 22px; height: 22px;
+  cursor: pointer; color: var(--text-mut); font-size: 14px;
+}
+.canvas-annotation-body {
+  flex: 1; overflow-y: auto; max-height: 50vh;
+  display: flex; flex-direction: column; gap: 6px;
+}
+.canvas-annotation-row {
+  padding: 6px 10px; border-radius: 4px;
+  background: var(--bg-raised); border: 1px solid var(--border);
+}
+.canvas-annotation-meta {
+  display: flex; align-items: center; gap: 4px;
+  color: var(--text-mut); margin-bottom: 3px;
+}
+.canvas-annotation-del {
+  margin-left: auto; background: transparent; color: var(--text-mut);
+  border: 1px solid transparent; border-radius: 2px;
+  width: 18px; height: 18px; cursor: pointer; font-size: 10px;
+}
+.canvas-annotation-del:hover { color: var(--error); border-color: var(--error); }
+.canvas-annotation-text { color: var(--text); font-size: 12px; line-height: 1.4; }
+.canvas-annotation-form {
+  display: grid; grid-template-columns: 130px 1fr 60px; gap: 6px;
+  padding-top: 8px; border-top: 1px solid var(--border);
+}
+.canvas-annotation-form input {
+  padding: 5px 8px; font-size: 11.5px;
+  background: var(--bg-input); color: var(--text);
+  border: 1px solid var(--border); border-radius: 3px;
+  font-family: inherit;
+}
+.canvas-annotation-form input:focus { outline: none; border-color: var(--accent); }
+.canvas-annotation-form button {
+  background: var(--accent); color: #000;
+  border: 1px solid var(--accent); border-radius: 3px;
+  font-size: 11.5px; cursor: pointer; font-family: inherit;
+}
+
 /* Multi-brand A/B (light) — comparison panel + side-by-side cards. */
 .canvas-compare-btn {
   background: transparent; color: var(--text-dim);
@@ -15593,7 +15659,8 @@ async function _canvasSaveRun() {
     chip.innerHTML =
       '<svg class="ico" style="width:10px;height:10px"><use href="#icon-link"/></svg> ' +
       'permalink: <a href="' + escapeHtml(permalink) + '" class="mono">' + escapeHtml(d.permalink) + '</a> ' +
-      '<button class="canvas-permalink-copy" title="copy">copy</button>';
+      '<button class="canvas-permalink-copy" title="copy">copy</button>' +
+      '<button class="canvas-annotation-toggle" data-wf-id="' + escapeHtml(_canvasState.workflow_id || "") + '" title="Add or view annotations on this run">💬 annotations</button>';
     actions.appendChild(chip);
     var copyBtn = chip.querySelector(".canvas-permalink-copy");
     if (copyBtn) {
@@ -15604,7 +15671,105 @@ async function _canvasSaveRun() {
         });
       });
     }
+    var annBtn = chip.querySelector(".canvas-annotation-toggle");
+    if (annBtn) {
+      annBtn.addEventListener("click", function () {
+        var wfId = annBtn.getAttribute("data-wf-id");
+        if (wfId) _canvasOpenAnnotations(wfId);
+      });
+    }
   } catch (e) { /* non-fatal */ }
+}
+
+// Wave 4: annotations modal — list + add + delete on a saved workflow.
+async function _canvasOpenAnnotations(workflowId) {
+  var existing = document.getElementById("canvas-annotation-modal");
+  if (existing) existing.remove();
+  var modal = document.createElement("div");
+  modal.id = "canvas-annotation-modal";
+  modal.className = "canvas-annotation-modal";
+  modal.innerHTML =
+    '<div class="canvas-annotation-inner">' +
+      '<div class="canvas-annotation-head">' +
+        '<span class="mono">annotations · ' + escapeHtml(workflowId) + '</span>' +
+        '<button class="canvas-annotation-close" id="canvas-annotation-close">×</button>' +
+      '</div>' +
+      '<div class="canvas-annotation-body" id="canvas-annotation-body"><span class="orch-small">loading…</span></div>' +
+      '<div class="canvas-annotation-form">' +
+        '<input type="text" id="canvas-annotation-author" placeholder="your name (optional)" maxlength="80" />' +
+        '<input type="text" id="canvas-annotation-text" placeholder="add a note (max 500 chars)…" maxlength="500" />' +
+        '<button id="canvas-annotation-add">Add</button>' +
+      '</div>' +
+    '</div>';
+  document.body.appendChild(modal);
+  document.getElementById("canvas-annotation-close").addEventListener("click", function () { modal.remove(); });
+  modal.addEventListener("click", function (e) { if (e.target === modal) modal.remove(); });
+  document.getElementById("canvas-annotation-add").addEventListener("click", function () { _canvasAddAnnotation(workflowId); });
+  document.getElementById("canvas-annotation-text").addEventListener("keydown", function (e) {
+    if (e.key === "Enter") _canvasAddAnnotation(workflowId);
+  });
+  await _canvasReloadAnnotations(workflowId);
+}
+
+async function _canvasReloadAnnotations(workflowId) {
+  var body = document.getElementById("canvas-annotation-body");
+  if (!body) return;
+  try {
+    var r = await fetch("/agents/workflow/runs/" + encodeURIComponent(workflowId) + "/annotation");
+    var d = await r.json();
+    if (!d.annotations || d.annotations.length === 0) {
+      body.innerHTML = '<span class="orch-small" style="color:var(--text-mut)">No annotations yet. Be the first.</span>';
+      return;
+    }
+    body.innerHTML = d.annotations.map(function (a) {
+      return '<div class="canvas-annotation-row">' +
+        '<div class="canvas-annotation-meta orch-small">' +
+          '<span class="mono">' + escapeHtml(a.author || "anonymous") + '</span> · ' +
+          '<span>' + escapeHtml(String(a.ts).slice(0, 19).replace("T", " ")) + '</span>' +
+          (a.ref ? ' · <span class="mono">' + escapeHtml(a.ref) + '</span>' : '') +
+          '<button class="canvas-annotation-del" data-ann-id="' + escapeHtml(a.annotation_id) + '" title="delete">✕</button>' +
+        '</div>' +
+        '<div class="canvas-annotation-text">' + escapeHtml(a.text) + '</div>' +
+      '</div>';
+    }).join("");
+    body.querySelectorAll(".canvas-annotation-del").forEach(function (b) {
+      b.addEventListener("click", function () {
+        var id = b.getAttribute("data-ann-id");
+        if (id) _canvasDeleteAnnotation(workflowId, id);
+      });
+    });
+  } catch (e) {
+    body.innerHTML = '<span class="orch-small" style="color:var(--error)">load failed</span>';
+  }
+}
+
+async function _canvasAddAnnotation(workflowId) {
+  var author = document.getElementById("canvas-annotation-author");
+  var text = document.getElementById("canvas-annotation-text");
+  if (!text) return;
+  var t = (text.value || "").trim();
+  if (!t) return;
+  try {
+    var r = await fetch("/agents/workflow/runs/" + encodeURIComponent(workflowId) + "/annotation", {
+      method: "POST", headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        author: (author && author.value) || "anonymous",
+        text: t,
+      }),
+    });
+    if (!r.ok) { showToast("annotation failed", true); return; }
+    text.value = "";
+    await _canvasReloadAnnotations(workflowId);
+  } catch (e) {
+    showToast("annotation error: " + ((e && e.message) || e), true);
+  }
+}
+
+async function _canvasDeleteAnnotation(workflowId, annId) {
+  try {
+    await fetch("/agents/workflow/runs/" + encodeURIComponent(workflowId) + "/annotation?annotation_id=" + encodeURIComponent(annId), { method: "DELETE" });
+    await _canvasReloadAnnotations(workflowId);
+  } catch (e) { /* noop */ }
 }
 
 // MVP #1: replay support — if the page loads with ?wf=<id>, fetch the


### PR DESCRIPTION
## Summary

Two production-readiness primitives:

1. **Spend orchestration** — 4 allocation strategies for fanning a budget across multiple buying agents (\`equal_split\` / \`score_weighted\` / \`priority_first\` / \`cap_then_split\`). Cents-precision; rounding-drift redistribution; floor support.

2. **Annotations on saved runs** — KV-backed comment thread per workflow_id. Workshop attendees can leave notes on permalinks; per-run audit trail.

## What ships

| Endpoint | Purpose |
|---|---|
| \`POST /agents/workflow/allocate\` | Compute per-agent allocations given budget + strategy |
| \`GET /agents/workflow/runs/:id\` | (existing) now hydrates \`annotations[]\` alongside snapshot |
| \`GET\|POST\|DELETE /agents/workflow/runs/:id/annotation\` | List / add / delete annotations |

## UI

- **\"💬 annotations\" button** in the permalink chip after a run is saved
- Click → modal with annotation list (newest first) + author/text inputs + Add button + per-row × delete
- Enter-key submits; click-outside closes

## Test plan
- [x] Type-check clean
- [x] 428/428 tests pass
- [x] SCRIPT_TAG audit clean
- [ ] Smoke after deploy:
  - [ ] \`POST /agents/workflow/allocate\` with \`equal_split\` returns N agents × $total/N
  - [ ] \`POST /agents/workflow/allocate\` with \`score_weighted\` weights correctly
  - [ ] Run a workflow → click annotations → add → reload page from permalink → annotation persists

🤖 Generated with [Claude Code](https://claude.com/claude-code)