### PR TITLE
adcp-watch: track @adcp/sdk 6.x line as secondary (migration target)

### DIFF
--- a/.github/adcp-watch-config.json
+++ b/.github/adcp-watch-config.json
@@ -3,6 +3,12 @@
     "package_name": "@adcp/client",
     "package_json_path": "package.json"
   },
+  "secondary_sdks": [
+    {
+      "package_name": "@adcp/sdk",
+      "context": "Renamed from @adcp/client at 5.23.0 (parallel-shipped through 5.25.1). 6.x onward is sdk-only — @adcp/client EOL at 5.25.1. Migration target: switch import in scripts/run-compliance.mjs + repin package.json. Watcher pings on every new release so we can audit before bumping."
+    }
+  ],
   "spec_repo": "adcontextprotocol/adcp",
   "tracking_issue_label": "adcp-watcher-tracker",
   "tracked_issues": [

--- a/scripts/adcp-watch.mjs
+++ b/scripts/adcp-watch.mjs
@@ -167,6 +167,23 @@ async function buildNewState() {
   }
   newState.client_sdk = { current_pin: pin, latest_published: latest };
 
+  // 3a-bis. Secondary SDKs — packages we don't pin yet but want to watch
+  // (e.g. @adcp/sdk while migrating off @adcp/client). Watcher pings on
+  // every new release so we can audit before bumping. State diff fires
+  // any time `latest_published` for a secondary changes.
+  if (Array.isArray(config.secondary_sdks) && config.secondary_sdks.length > 0) {
+    newState.secondary_sdks = {};
+    for (const s of config.secondary_sdks) {
+      let secondaryLatest = null;
+      try {
+        secondaryLatest = JSON.parse(execSync(`npm view ${s.package_name} version --json`, { encoding: "utf8" }));
+      } catch (e) {
+        secondaryLatest = { error: String(e.message ?? e) };
+      }
+      newState.secondary_sdks[s.package_name] = { latest_published: secondaryLatest };
+    }
+  }
+
   // 3b. AdCP spec latest release
   try {
     const release = ghJson(`api repos/${config.spec_repo}/releases/latest`);


### PR DESCRIPTION
Adds secondary_sdks tracking to the daily watcher. State diff fires when @adcp/sdk publishes a new release (currently 6.4.0). Workshop posture stays on @adcp/client@5.25.1; migration deferred.