### PR TITLE
Wave 6: Race Canvas — vendor waterfall + disagreement halo + audit receipts

### DIFF
--- a/src/domain/auditReceipts.ts
+++ b/src/domain/auditReceipts.ts
@@ -1,0 +1,120 @@
+// src/domain/auditReceipts.ts
+//
+// Wave 6 (Race Canvas) — audit receipts for vendor calls.
+//
+// Each agent call in the race emits a receipt: a small, deterministic,
+// inspectable record of what we asked, what came back, how long it took,
+// and a content digest for replay verification.
+//
+// Why this matters for the workshop:
+//   - The governance-flavored audience pushes back on multi-agent
+//     orchestration with "isn't this a black box?" The receipt stack is
+//     the answer — every agent call has a paper trail with hashes.
+//   - Connects AdCP's `idempotency_key` story (HEAD-spec) to a visible
+//     artifact. The same idempotency key would replay safely; the digest
+//     proves the response payload is the one we got.
+//   - The receipt is shown in real-time in the right sidebar of the
+//     Race Canvas. Clicking a receipt opens a modal with full input/output.
+//
+// Hash algorithm: FNV-1a (32-bit). Same as our HEAD-spec idempotency
+// implementation. NOT cryptographically secure — fine for replay
+// verification, NOT for tamper resistance. Real audit trails would use
+// SHA-256 + a signature; the workshop demo uses the cheaper hash for
+// determinism and zero-dep portability.
+
+export interface AuditReceipt {
+  receipt_id: string;
+  ts: string;
+  vendor_id: string;
+  vendor_name: string;
+  /** Tool/action invoked, e.g. "get_signals" / "synthesize_audience_size". */
+  action: string;
+  /** Hex of FNV-1a over the canonicalized input args. */
+  input_hash: string;
+  /** Hex of FNV-1a over the canonicalized output content. */
+  output_digest: string;
+  /** Stable replay key. Same input + same vendor → same key. */
+  idempotency_key: string;
+  latency_ms: number;
+  /** True if the input/output round-trip is consistent. Always true for
+   * synthesized vendors; for live calls this is a future hook. */
+  verified: boolean;
+  /** Optional — the raw input + output for the modal click-through. */
+  inspect?: { input: unknown; output: unknown };
+}
+
+function fnv1a(s: string): number {
+  let h = 0x811c9dc5;
+  for (let i = 0; i < s.length; i++) {
+    h ^= s.charCodeAt(i);
+    h = (h + ((h << 1) + (h << 4) + (h << 7) + (h << 8) + (h << 24))) >>> 0;
+  }
+  return h >>> 0;
+}
+
+function fnv1aHex(s: string): string {
+  return fnv1a(s).toString(16).padStart(8, "0");
+}
+
+/**
+ * Canonicalize an object for hashing. Sorts keys recursively so equivalent
+ * objects always produce the same JSON string regardless of insertion order.
+ */
+function canonicalize(value: unknown): string {
+  if (value === null || value === undefined) return "null";
+  if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
+    return JSON.stringify(value);
+  }
+  if (Array.isArray(value)) {
+    return "[" + value.map(canonicalize).join(",") + "]";
+  }
+  if (typeof value === "object") {
+    const keys = Object.keys(value as Record<string, unknown>).sort();
+    const parts = keys.map((k) => JSON.stringify(k) + ":" + canonicalize((value as Record<string, unknown>)[k]));
+    return "{" + parts.join(",") + "}";
+  }
+  return JSON.stringify(value);
+}
+
+export interface BuildReceiptInput {
+  vendor_id: string;
+  vendor_name: string;
+  action: string;
+  input: unknown;
+  output: unknown;
+  latency_ms: number;
+  /** Optional — if omitted, derived from input+vendor for replay determinism. */
+  idempotency_key?: string;
+  /** If false, omits the inspect blob (smaller payload). Default true. */
+  include_inspect?: boolean;
+}
+
+let _receiptCounter = 0;
+
+export function buildReceipt(args: BuildReceiptInput): AuditReceipt {
+  _receiptCounter++;
+  const ts = new Date().toISOString();
+  const inputCanon = canonicalize(args.input);
+  const outputCanon = canonicalize(args.output);
+  const input_hash = fnv1aHex(inputCanon);
+  const output_digest = fnv1aHex(outputCanon);
+  const idempotency_key = args.idempotency_key
+    ?? fnv1aHex(args.vendor_id + "::" + args.action + "::" + input_hash);
+
+  const receipt: AuditReceipt = {
+    receipt_id: "rcpt_" + ts.replace(/[^0-9]/g, "").slice(0, 14) + "_" + _receiptCounter.toString(36),
+    ts,
+    vendor_id: args.vendor_id,
+    vendor_name: args.vendor_name,
+    action: args.action,
+    input_hash,
+    output_digest,
+    idempotency_key,
+    latency_ms: args.latency_ms,
+    verified: true,
+  };
+  if (args.include_inspect !== false) {
+    receipt.inspect = { input: args.input, output: args.output };
+  }
+  return receipt;
+}

--- a/src/domain/disagreementDetector.ts
+++ b/src/domain/disagreementDetector.ts
@@ -1,0 +1,189 @@
+// src/domain/disagreementDetector.ts
+//
+// Wave 6 (Race Canvas) — detects substantive disagreement between vendor
+// responses on the same brief.
+//
+// Demo purpose:
+//   - When two vendors disagree on a key field, the canvas draws a halo
+//     between them and the agentic layer reconciles. This module is the
+//     decision function for "do we draw the halo?"
+//
+// Disagreement criteria (governance audience appropriate):
+//
+//   audience_size                     numeric, ±15% threshold
+//   recommended_bid_floor_cents       numeric, ±20% threshold
+//   sensitive_category_verdict        categorical, any difference
+//   governance_outcome                categorical, any difference
+//
+// Numeric threshold is intentionally generous — vendors legitimately
+// disagree on sizing within ±10%, that's noise. ±15% means "they're
+// reading the audience differently," which is the wow-factor moment.
+
+import type { VendorRaceResponse } from "./vendorRaceMock";
+
+export type DisagreementField =
+  | "audience_size"
+  | "recommended_bid_floor_cents"
+  | "sensitive_category_verdict"
+  | "governance_outcome";
+
+export type DisagreementSeverity = "minor" | "material" | "blocking";
+
+export interface Disagreement {
+  field: DisagreementField;
+  field_label: string;
+  severity: DisagreementSeverity;
+  /** Two vendors that diverge most on this field. UI highlights these. */
+  conflict_pair: Array<{ vendor_id: string; vendor_name: string; value: string | number }>;
+  /** All distinct values across all vendors (for the callout text). */
+  all_values: Array<{ vendor_id: string; value: string | number }>;
+  /** Human-readable rationale the canvas can render under the halo. */
+  rationale: string;
+  /** Suggested reconciled value the agentic layer would pick. */
+  reconciled_value: string | number;
+  /** One-line explanation of why the reconciled value was chosen. */
+  reconcile_rationale: string;
+}
+
+const NUMERIC_THRESHOLDS: Partial<Record<DisagreementField, number>> = {
+  audience_size: 0.15,
+  recommended_bid_floor_cents: 0.20,
+};
+
+const FIELD_LABELS: Record<DisagreementField, string> = {
+  audience_size: "Audience size",
+  recommended_bid_floor_cents: "Recommended bid floor",
+  sensitive_category_verdict: "Sensitive-category verdict",
+  governance_outcome: "Governance outcome",
+};
+
+function formatValue(field: DisagreementField, value: string | number): string {
+  if (field === "audience_size" && typeof value === "number") {
+    if (value >= 1_000_000) return (value / 1_000_000).toFixed(1) + "M";
+    if (value >= 1_000) return (value / 1_000).toFixed(0) + "K";
+    return String(value);
+  }
+  if (field === "recommended_bid_floor_cents" && typeof value === "number") {
+    return "$" + (value / 100).toFixed(2) + " CPM";
+  }
+  return String(value);
+}
+
+function severityFor(field: DisagreementField, divergence: number): DisagreementSeverity {
+  // governance_outcome=block is always blocking — caller passes a synthetic
+  // divergence of 1.0 for that case.
+  if (field === "governance_outcome") {
+    return divergence >= 0.99 ? "blocking" : "material";
+  }
+  if (field === "sensitive_category_verdict") return "material";
+  // Numeric: ±15% min for audience, ±25% means material, ±50% means blocking.
+  if (divergence >= 0.50) return "blocking";
+  if (divergence >= 0.25) return "material";
+  return "minor";
+}
+
+function detectNumericDisagreement(
+  responses: VendorRaceResponse[],
+  field: "audience_size" | "recommended_bid_floor_cents",
+): Disagreement | null {
+  const values = responses.map((r) => ({ vendor_id: r.vendor_id, vendor_name: r.vendor_name, value: r[field] as number }));
+  if (values.length < 2) return null;
+
+  // Find min and max — the two vendors most in conflict.
+  let min = values[0]!;
+  let max = values[0]!;
+  for (const v of values) {
+    if (v.value < min.value) min = v;
+    if (v.value > max.value) max = v;
+  }
+  if (max.value === 0) return null;
+  const divergence = (max.value - min.value) / max.value;
+  const threshold = NUMERIC_THRESHOLDS[field] ?? 0.15;
+  if (divergence < threshold) return null;
+
+  // Reconciled value: median across vendors (robust to outliers).
+  const sorted = values.map((v) => v.value).slice().sort((a, b) => a - b);
+  const median = sorted[Math.floor(sorted.length / 2)]!;
+
+  const severity = severityFor(field, divergence);
+  const pctDiff = Math.round(divergence * 100);
+
+  return {
+    field,
+    field_label: FIELD_LABELS[field],
+    severity,
+    conflict_pair: [min, max].map((v) => ({ ...v, value: v.value })),
+    all_values: values,
+    rationale: `${max.vendor_name} reports ${formatValue(field, max.value)}; ${min.vendor_name} reports ${formatValue(field, min.value)}. ${pctDiff}% gap exceeds the ${Math.round(threshold * 100)}% threshold.`,
+    reconciled_value: median,
+    reconcile_rationale: `Reconciled to median across ${values.length} vendors: ${formatValue(field, median)}. Robust to single-vendor outliers; aligns with the consensus cluster.`,
+  };
+}
+
+function detectCategoricalDisagreement(
+  responses: VendorRaceResponse[],
+  field: "sensitive_category_verdict" | "governance_outcome",
+): Disagreement | null {
+  const values = responses.map((r) => ({ vendor_id: r.vendor_id, vendor_name: r.vendor_name, value: r[field] as string }));
+  if (values.length < 2) return null;
+  const distinct = new Set(values.map((v) => v.value));
+  if (distinct.size < 2) return null;
+
+  // Find the majority value and the minority — minority is the "outlier."
+  const counts = new Map<string, number>();
+  for (const v of values) counts.set(v.value, (counts.get(v.value) ?? 0) + 1);
+  const sortedCounts = [...counts.entries()].sort((a, b) => b[1] - a[1]);
+  const majority = sortedCounts[0]![0];
+  const minority = sortedCounts[sortedCounts.length - 1]![0];
+  const majorityVendor = values.find((v) => v.value === majority)!;
+  const minorityVendor = values.find((v) => v.value === minority)!;
+
+  // For governance: any "block" is blocking severity; otherwise material.
+  const divergence = field === "governance_outcome" && [...distinct].includes("block") ? 1.0 : 0.5;
+  const severity = severityFor(field, divergence);
+
+  // Reconcile: take the more conservative value (warn > allow; elevated > none).
+  const orderGov: Record<string, number> = { allow: 0, warn: 1, block: 2 };
+  const orderSens: Record<string, number> = { none: 0, elevated: 1, restricted: 2 };
+  const order = field === "governance_outcome" ? orderGov : orderSens;
+  let reconciled = majority;
+  for (const [val] of sortedCounts) {
+    if ((order[val] ?? 0) > (order[reconciled] ?? 0)) reconciled = val;
+  }
+
+  return {
+    field,
+    field_label: FIELD_LABELS[field],
+    severity,
+    conflict_pair: [minorityVendor, majorityVendor],
+    all_values: values,
+    rationale: `${minorityVendor.vendor_name} returns "${minority}"; ${sortedCounts[0]![1]} other vendor(s) return "${majority}". A single dissent on a categorical field is treated as material.`,
+    reconciled_value: reconciled,
+    reconcile_rationale: `Reconciled to "${reconciled}" — the more conservative read. When vendors disagree on a categorical safety field, defer to the stricter posture.`,
+  };
+}
+
+/**
+ * Detect all disagreements across a set of vendor responses. Returns
+ * them in render-priority order: blocking > material > minor.
+ */
+export function detectDisagreements(responses: VendorRaceResponse[]): Disagreement[] {
+  const out: Disagreement[] = [];
+
+  const numAudience = detectNumericDisagreement(responses, "audience_size");
+  if (numAudience) out.push(numAudience);
+
+  const numFloor = detectNumericDisagreement(responses, "recommended_bid_floor_cents");
+  if (numFloor) out.push(numFloor);
+
+  const catSens = detectCategoricalDisagreement(responses, "sensitive_category_verdict");
+  if (catSens) out.push(catSens);
+
+  const catGov = detectCategoricalDisagreement(responses, "governance_outcome");
+  if (catGov) out.push(catGov);
+
+  // Sort: blocking first, then material, then minor.
+  const order: Record<DisagreementSeverity, number> = { blocking: 0, material: 1, minor: 2 };
+  out.sort((a, b) => order[a.severity] - order[b.severity]);
+  return out;
+}

--- a/src/domain/vendorRaceMock.ts
+++ b/src/domain/vendorRaceMock.ts
@@ -1,0 +1,186 @@
+// src/domain/vendorRaceMock.ts
+//
+// Wave 6 (Race Canvas) — deterministic per-vendor mock responses for the
+// vendor race waterfall demo.
+//
+// Why mocked:
+//   - Most live vendors auth-gate the calls we'd want to demo (cohort
+//     sizing, bid-floor recommendation, governance verdict). Demo-time
+//     reliability matters more than live authenticity here.
+//   - We need ENGINEERED DISAGREEMENT — two vendors must return materially
+//     different audience sizes so the disagreement halo fires. Live data
+//     wouldn't reliably produce this without staging.
+//
+// What's deterministic:
+//   - Per (vendor_id, brief_hash) the four key fields are stable across
+//     reruns. Same brief → same numbers, every time.
+//   - Latency varies per-vendor by a fixed personality (some are fast,
+//     some slow). Adds visual texture to the waterfall without randomness.
+//
+// What's NOT mocked:
+//   - The four key fields are intentionally simple. Real vendor responses
+//     carry richer payloads (cohort definitions, taxonomy mappings, etc.).
+//     The race demo is about ORCHESTRATION + DISAGREEMENT, not depth of
+//     each vendor response.
+
+import type { RegisteredAgent } from "./agentRegistry";
+
+export type GovernanceVerdict = "allow" | "warn" | "block";
+export type SensitiveVerdict = "none" | "elevated" | "restricted";
+
+export interface VendorRaceResponse {
+  vendor_id: string;
+  vendor_name: string;
+  /** Estimated reach in unique users. Numeric field that drives disagreement. */
+  audience_size: number;
+  /** Vendor's read on whether the audience touches sensitive categories. */
+  sensitive_category_verdict: SensitiveVerdict;
+  /** Recommended bid floor in cents (CPM context). */
+  recommended_bid_floor_cents: number;
+  /** Predicted governance outcome at activation time. */
+  governance_outcome: GovernanceVerdict;
+  /** Per-vendor latency for the simulated call. */
+  latency_ms: number;
+  /** Free-text rationale the vendor would emit alongside structured fields. */
+  rationale: string;
+  /** True if this vendor's response was synthesized vs live-fetched. */
+  mocked: boolean;
+}
+
+// ── FNV-1a (32-bit) — same hash used in dspMock + sponsoredIntelligenceMock.
+// Local copy keeps the module self-contained; switch to a shared util later.
+function fnv1a(s: string): number {
+  let h = 0x811c9dc5;
+  for (let i = 0; i < s.length; i++) {
+    h ^= s.charCodeAt(i);
+    h = (h + ((h << 1) + (h << 4) + (h << 7) + (h << 8) + (h << 24))) >>> 0;
+  }
+  return h >>> 0;
+}
+
+// Per-vendor "personality" — keeps each vendor's responses feeling distinct
+// without random variation. Latency budget + the disagreement assignment.
+//
+// Disagreement choreography (designed for visual punch in a 6-vendor race):
+//
+//   Default cluster (4 vendors): audience_size in 9-12M range, governance=allow
+//   Outlier A (1 vendor):        audience_size in 4-6M range — undercount
+//   Outlier B (1 vendor):        sensitive_verdict=elevated, gov=warn
+//
+// The disagreement detector picks these up on the first eligible field and
+// fires the halo. With 6 vendors selected from the typical demo set, two
+// disagreements fire — one numeric, one categorical.
+
+interface VendorPersonality {
+  /** Cluster bucket — drives both audience-size and governance defaults. */
+  bucket: "consensus" | "undercount" | "elevated_risk";
+  /** Latency in ms; deterministic per vendor. */
+  latency_ms: number;
+  /** Bid floor variance from baseline (cents). */
+  bid_floor_offset_cents: number;
+}
+
+const PERSONALITIES: Record<string, VendorPersonality> = {
+  // ── Consensus cluster (return values aligned with the dominant view) ──
+  evgeny_signals:    { bucket: "consensus",      latency_ms: 420, bid_floor_offset_cents: 0 },
+  dstillery:         { bucket: "consensus",      latency_ms: 680, bid_floor_offset_cents: 50 },
+  swivel:            { bucket: "consensus",      latency_ms: 540, bid_floor_offset_cents: -25 },
+  claire_pub:        { bucket: "consensus",      latency_ms: 720, bid_floor_offset_cents: 75 },
+  // ── Undercounts the audience by ~50% (numeric disagreement) ──────────
+  adzymic_apx:       { bucket: "undercount",     latency_ms: 380, bid_floor_offset_cents: -50 },
+  // ── Flags elevated sensitivity (categorical disagreement) ────────────
+  celtra:            { bucket: "elevated_risk",  latency_ms: 510, bid_floor_offset_cents: 100 },
+  // ── Fallbacks for any other vendor not enumerated ────────────────────
+  // Anything not in the table goes to consensus with a base latency.
+};
+
+function personalityFor(vendor_id: string): VendorPersonality {
+  return PERSONALITIES[vendor_id] ?? { bucket: "consensus", latency_ms: 600, bid_floor_offset_cents: 25 };
+}
+
+/**
+ * Synthesize a VendorRaceResponse for a (vendor, brief) pair. Deterministic.
+ *
+ * The brief drives a baseline audience size (interpreted as one user per
+ * 100 dollars of budget for demo purposes) and an FNV-1a hash mixes
+ * vendor+brief into a stable per-cell jitter.
+ */
+export function synthesizeVendorResponse(
+  vendor: Pick<RegisteredAgent, "id" | "name" | "vendor">,
+  briefInput: string,
+  baselineAudience: number,
+): VendorRaceResponse {
+  const personality = personalityFor(vendor.id);
+  const seed = fnv1a(vendor.id + "::" + briefInput);
+  // Jitter in [-12%, +12%] within the bucket — keeps cluster visually
+  // tight but not artificially identical.
+  const jitterPct = ((seed % 240) - 120) / 1000; // -0.12 .. +0.12
+
+  let audience_size: number;
+  let sensitive_category_verdict: SensitiveVerdict;
+  let governance_outcome: GovernanceVerdict;
+
+  switch (personality.bucket) {
+    case "undercount":
+      // Roughly half of the consensus reach.
+      audience_size = Math.round(baselineAudience * (0.45 + jitterPct));
+      sensitive_category_verdict = "none";
+      governance_outcome = "allow";
+      break;
+    case "elevated_risk":
+      // Same reach as consensus, but flags the audience as sensitive.
+      audience_size = Math.round(baselineAudience * (1.0 + jitterPct));
+      sensitive_category_verdict = "elevated";
+      governance_outcome = "warn";
+      break;
+    case "consensus":
+    default:
+      audience_size = Math.round(baselineAudience * (1.0 + jitterPct));
+      sensitive_category_verdict = "none";
+      governance_outcome = "allow";
+      break;
+  }
+
+  // Bid floor: $4.50 baseline + per-vendor offset + small jitter.
+  const recommended_bid_floor_cents = 450 + personality.bid_floor_offset_cents + ((seed >>> 8) % 30);
+
+  const rationale = (() => {
+    if (personality.bucket === "undercount") {
+      return vendor.vendor + " applies stricter dedup across cookieless cohorts; reach numbers come in below consensus on most briefs.";
+    }
+    if (personality.bucket === "elevated_risk") {
+      return vendor.vendor + " flags this audience as elevated based on inferred contextual adjacencies; recommends review before activation.";
+    }
+    return vendor.vendor + " returns standard cohort sizing aligned with peer estimates; no governance flags raised.";
+  })();
+
+  return {
+    vendor_id: vendor.id,
+    vendor_name: vendor.name,
+    audience_size,
+    sensitive_category_verdict,
+    recommended_bid_floor_cents,
+    governance_outcome,
+    latency_ms: personality.latency_ms,
+    rationale,
+    mocked: true,
+  };
+}
+
+/**
+ * Compute a baseline audience size from the brief. Crude — uses budget
+ * if extractable, otherwise a fixed 10M default. Real implementations
+ * would call out to the catalog.
+ */
+export function inferBaselineAudience(briefInput: string): number {
+  const m = briefInput.match(/\$(\d+(?:\.\d+)?)\s*([KMB])?/i);
+  if (m) {
+    const num = parseFloat(m[1]!);
+    const suffix = (m[2] ?? "").toUpperCase();
+    const dollars = suffix === "K" ? num * 1_000 : suffix === "M" ? num * 1_000_000 : suffix === "B" ? num * 1_000_000_000 : num;
+    // ~1 user per $0.025 of budget — gets us 10M for $250K, which lines
+    // up with the Coca-Cola Summer Refresh demo brief.
+    return Math.round(dollars / 0.025);
+  }
+  return 10_000_000;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -131,6 +131,12 @@ import { handleAdminPurge } from "./routes/adminPurge";
 import { runScheduledPurge } from "./storage/scheduledPurge";
 import { runRegistrySyncDiff, getLastDiffReport } from "./domain/registrySync";
 import { handleDemo } from "./routes/demo";
+import { handleRaceCanvas } from "./routes/raceCanvas";
+import {
+  handleRaceStart,
+  handleRaceAddVendor,
+  handleRaceAvailableVendors,
+} from "./routes/raceRoutes";
 import { handleEstimate } from "./routes/estimate";
 import { handleListOperations } from "./routes/listOperations";
 import { handleGenerateSegment } from "./routes/generateSegment";
@@ -299,6 +305,13 @@ export default {
             "/agentic/memory",
             "/agentic/refine",
             "/agentic/critique",
+            // Wave 6: Race Canvas — vendor race waterfall + disagreement halo
+            // + audit receipt stack + add-vendor mid-flight. All read-only
+            // (no paid actions); same posture as the other Canvas routes.
+            "/race-canvas",
+            "/race/start",
+            "/race/add-vendor",
+            "/race/available-vendors",
             "/taxonomy/reverse",
             // Sec-43: audience composer + activation-planning analytics.
             // Read-only — same posture as /portfolio/* and /analytics/*.
@@ -357,6 +370,20 @@ export default {
                 // root surfaces a product-quality UI for exec/buyer demos;
                 // programmatic clients already know to go to /mcp or /capabilities.
                 response = handleDemo(env);
+
+            } else if (method === "GET" && path === "/race-canvas") {
+                // Wave 6: standalone Race Canvas page. Self-contained; doesn't
+                // touch the main demo's SCRIPT_TAG-laden template.
+                response = handleRaceCanvas(env);
+
+            } else if (method === "POST" && path === "/race/start") {
+                response = await handleRaceStart(request, env, logger);
+
+            } else if (method === "POST" && path === "/race/add-vendor") {
+                response = await handleRaceAddVendor(request, env, logger);
+
+            } else if (method === "POST" && path === "/race/available-vendors") {
+                response = await handleRaceAvailableVendors(request, env, logger);
 
             } else if (method === "GET" && path === "/health") {
                 response = jsonResponse({ status: "ok", version: "3.0" });

--- a/src/routes/demo.ts
+++ b/src/routes/demo.ts
@@ -161,6 +161,10 @@ ${STYLES}
         <svg class="ico"><use href="#icon-bolt"/></svg><span>Agentic</span>
         <span class="nav-tag">AI</span>
       </button>
+      <a class="nav-item" href="/race-canvas">
+        <svg class="ico"><use href="#icon-network"/></svg><span>Race Canvas</span>
+        <span class="nav-tag">new</span>
+      </a>
       <button class="nav-item" data-tab="activations">
         <svg class="ico"><use href="#icon-activations"/></svg><span>Activations</span>
         <span class="nav-count" id="nav-activations-count">—</span>

--- a/src/routes/raceCanvas.ts
+++ b/src/routes/raceCanvas.ts
@@ -1,0 +1,1084 @@
+// src/routes/raceCanvas.ts
+//
+// Wave 6 — Race Canvas HTML page (served at /race-canvas).
+//
+// Self-contained single-page UI for the vendor race waterfall demo.
+// Lives in its own route (not embedded in demo.ts) to keep the SCRIPT_TAG
+// escape blast radius small — none of demo.ts's existing JS is touched.
+//
+// Three features stack on this one page:
+//   1. Vendor race waterfall (live progress bars per vendor)
+//   2. Disagreement halo (SVG arc connecting conflicting rows)
+//   3. Add-vendor mid-flight (chat-style input that appends a new row)
+// Plus an Audit Receipt sidebar that fills in real-time.
+//
+// Escape-trap discipline (see feedback_script_tag_template_trap.md):
+//   - All JS strings inside this file's template literal use DOUBLE QUOTES
+//   - No regex literals — string.indexOf / split instead
+//   - No backticks inside the embedded JS (string concat with +)
+//   - For escape sequences in served JS: write \\n / \\t / \\' (doubled)
+//   - Every change here must pass tmp-mining/trap_audit.py before commit
+//
+// Auth: public (path is in publicPaths). DEMO_API_KEY is injected so the
+// fetch calls can include it as a Bearer token if any endpoint becomes
+// auth-gated later.
+
+export function handleRaceCanvas(env: { DEMO_API_KEY: string }): Response {
+  return new Response(renderRaceCanvas(env.DEMO_API_KEY), {
+    status: 200,
+    headers: {
+      "Content-Type": "text/html; charset=utf-8",
+      "Cache-Control": "public, max-age=300",
+      "Content-Security-Policy":
+        "default-src 'self'; style-src 'self' 'unsafe-inline'; " +
+        "script-src 'self' 'unsafe-inline'; " +
+        "img-src 'self' data:; connect-src 'self';",
+    },
+  });
+}
+
+function renderRaceCanvas(demoKey: string): string {
+  const safeKey = JSON.stringify(demoKey);
+  return `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>Race Canvas — Vendor Orchestration</title>
+<link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Ccircle cx='8' cy='8' r='2' fill='%2338b6ff'/%3E%3Ccircle cx='8' cy='8' r='5' fill='none' stroke='%2338b6ff' stroke-width='0.8' opacity='0.6'/%3E%3C/svg%3E"/>
+<style>
+  :root {
+    --bg: #0a0d12;
+    --bg-elevated: #11161e;
+    --bg-panel: #161c26;
+    --border: #232b38;
+    --border-strong: #2e3947;
+    --text: #e6ebf2;
+    --text-dim: #8a95a8;
+    --text-faint: #5b6679;
+    --accent: #38b6ff;
+    --accent-glow: rgba(56, 182, 255, 0.35);
+    --warn: #f0b400;
+    --warn-glow: rgba(240, 180, 0, 0.4);
+    --block: #ff4d5e;
+    --block-glow: rgba(255, 77, 94, 0.45);
+    --ok: #2ed573;
+    --font-mono: "JetBrains Mono", "SF Mono", Consolas, Menlo, monospace;
+    --font-ui: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  }
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  html, body { height: 100%; }
+  body {
+    background: var(--bg);
+    color: var(--text);
+    font: 14px/1.5 var(--font-ui);
+    overflow-x: hidden;
+  }
+  .app {
+    display: grid;
+    grid-template-columns: 1fr 380px;
+    grid-template-rows: auto 1fr;
+    height: 100vh;
+    gap: 0;
+  }
+  .header {
+    grid-column: 1 / -1;
+    padding: 16px 24px;
+    border-bottom: 1px solid var(--border);
+    background: var(--bg-elevated);
+    display: flex;
+    align-items: center;
+    gap: 16px;
+  }
+  .header-title {
+    font-size: 18px;
+    font-weight: 600;
+    color: var(--text);
+    letter-spacing: -0.01em;
+  }
+  .header-title .accent { color: var(--accent); }
+  .header-sub {
+    font: 12px/1.4 var(--font-mono);
+    color: var(--text-faint);
+  }
+  .header-back {
+    color: var(--text-dim);
+    text-decoration: none;
+    font-size: 13px;
+    border: 1px solid var(--border);
+    padding: 6px 12px;
+    border-radius: 6px;
+    transition: all 0.15s;
+  }
+  .header-back:hover {
+    border-color: var(--accent);
+    color: var(--accent);
+  }
+  .header-spacer { flex: 1; }
+  .main {
+    overflow-y: auto;
+    padding: 24px;
+    position: relative;
+  }
+  .sidebar {
+    border-left: 1px solid var(--border);
+    background: var(--bg-elevated);
+    overflow-y: auto;
+    padding: 20px;
+  }
+
+  /* ── Brief input + control bar ─────────────────────────────────────── */
+  .controls {
+    background: var(--bg-panel);
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    padding: 16px;
+    margin-bottom: 20px;
+  }
+  .controls-row {
+    display: flex;
+    gap: 12px;
+    align-items: stretch;
+  }
+  .controls-label {
+    font: 11px/1.4 var(--font-mono);
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--text-faint);
+    margin-bottom: 6px;
+  }
+  .brief-input {
+    flex: 1;
+    background: var(--bg);
+    border: 1px solid var(--border);
+    color: var(--text);
+    padding: 10px 14px;
+    border-radius: 6px;
+    font: 13px/1.4 var(--font-ui);
+    transition: border-color 0.15s;
+  }
+  .brief-input:focus {
+    outline: none;
+    border-color: var(--accent);
+  }
+  .btn {
+    background: var(--accent);
+    color: #0a0d12;
+    border: none;
+    padding: 10px 18px;
+    border-radius: 6px;
+    font: 600 13px var(--font-ui);
+    cursor: pointer;
+    transition: all 0.15s;
+  }
+  .btn:hover { filter: brightness(1.1); }
+  .btn:disabled { opacity: 0.4; cursor: not-allowed; }
+  .btn-ghost {
+    background: transparent;
+    border: 1px solid var(--border-strong);
+    color: var(--text);
+  }
+  .btn-ghost:hover {
+    border-color: var(--accent);
+    color: var(--accent);
+  }
+
+  /* ── Vendor waterfall ──────────────────────────────────────────────── */
+  .race-board {
+    background: var(--bg-panel);
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    padding: 18px;
+    position: relative;
+  }
+  .race-board-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 14px;
+  }
+  .race-board-title {
+    font-size: 14px;
+    font-weight: 600;
+    color: var(--text);
+  }
+  .race-board-meta {
+    font: 11px/1.4 var(--font-mono);
+    color: var(--text-faint);
+  }
+  .vendor-rows {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    position: relative;
+    min-height: 100px;
+  }
+  .vendor-row {
+    display: grid;
+    grid-template-columns: 200px 1fr 280px;
+    gap: 16px;
+    align-items: center;
+    padding: 12px 14px;
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    position: relative;
+    transition: all 0.3s;
+    opacity: 0;
+    animation: fadeInRow 0.35s ease-out forwards;
+  }
+  @keyframes fadeInRow {
+    from { opacity: 0; transform: translateY(6px); }
+    to { opacity: 1; transform: translateY(0); }
+  }
+  .vendor-row.is-conflict {
+    border-color: var(--block);
+    box-shadow: 0 0 0 1px var(--block-glow), 0 0 20px var(--block-glow);
+  }
+  .vendor-row.is-warn {
+    border-color: var(--warn);
+    box-shadow: 0 0 0 1px var(--warn-glow), 0 0 16px var(--warn-glow);
+  }
+  .vendor-name {
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+  }
+  .vendor-name-primary {
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--text);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .vendor-name-secondary {
+    font: 11px/1 var(--font-mono);
+    color: var(--text-faint);
+  }
+  .vendor-progress {
+    height: 8px;
+    background: var(--bg-elevated);
+    border-radius: 4px;
+    position: relative;
+    overflow: hidden;
+  }
+  .vendor-progress-fill {
+    position: absolute;
+    top: 0;
+    left: 0;
+    bottom: 0;
+    background: linear-gradient(90deg, var(--accent), #6dd5ff);
+    border-radius: 4px;
+    width: 0;
+    transition: width 0.4s ease-out;
+  }
+  .vendor-progress-fill.is-done {
+    background: linear-gradient(90deg, var(--ok), #5eea96);
+  }
+  .vendor-progress-fill.is-failed {
+    background: linear-gradient(90deg, var(--block), #ff7a87);
+  }
+  .vendor-stage-label {
+    position: absolute;
+    right: 8px;
+    top: 50%;
+    transform: translateY(-50%);
+    font: 10px/1 var(--font-mono);
+    color: var(--text-faint);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+  }
+  .vendor-response {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 4px 12px;
+    font: 11px/1.4 var(--font-mono);
+  }
+  .vendor-response-k { color: var(--text-faint); }
+  .vendor-response-v { color: var(--text); text-align: right; }
+  .vendor-response-v.warn { color: var(--warn); }
+  .vendor-response-v.block { color: var(--block); }
+  .vendor-response-empty {
+    color: var(--text-faint);
+    font-style: italic;
+    text-align: right;
+  }
+
+  /* ── Disagreement halo overlay ─────────────────────────────────────── */
+  .halo-overlay {
+    position: absolute;
+    top: 0; left: 0;
+    width: 100%;
+    height: 100%;
+    pointer-events: none;
+    z-index: 10;
+  }
+  .halo-callout {
+    position: absolute;
+    background: rgba(255, 77, 94, 0.95);
+    color: #0a0d12;
+    padding: 10px 14px;
+    border-radius: 8px;
+    font: 600 12px var(--font-ui);
+    box-shadow: 0 0 0 1px rgba(255,255,255,0.15), 0 12px 32px rgba(255, 77, 94, 0.4);
+    max-width: 320px;
+    z-index: 11;
+    pointer-events: auto;
+    animation: pulseCallout 2.5s ease-in-out infinite;
+  }
+  .halo-callout.warn {
+    background: rgba(240, 180, 0, 0.95);
+    box-shadow: 0 0 0 1px rgba(255,255,255,0.15), 0 12px 32px rgba(240, 180, 0, 0.4);
+  }
+  .halo-callout.minor {
+    background: rgba(56, 182, 255, 0.95);
+    box-shadow: 0 0 0 1px rgba(255,255,255,0.15), 0 12px 32px rgba(56, 182, 255, 0.4);
+  }
+  .halo-callout-title {
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    opacity: 0.7;
+    margin-bottom: 4px;
+  }
+  .halo-callout-body {
+    font-size: 13px;
+    line-height: 1.4;
+  }
+  .halo-callout-reconcile {
+    margin-top: 8px;
+    padding-top: 8px;
+    border-top: 1px solid rgba(0,0,0,0.2);
+    font-size: 11px;
+    line-height: 1.4;
+  }
+  @keyframes pulseCallout {
+    0%, 100% { transform: scale(1); }
+    50% { transform: scale(1.02); }
+  }
+
+  /* ── Receipt sidebar ───────────────────────────────────────────────── */
+  .sidebar-title {
+    font: 11px/1 var(--font-mono);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--text-faint);
+    margin-bottom: 4px;
+  }
+  .sidebar-sub {
+    font-size: 13px;
+    color: var(--text);
+    margin-bottom: 18px;
+  }
+  .receipt-list {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+  .receipt-card {
+    background: var(--bg-panel);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    padding: 10px 12px;
+    cursor: pointer;
+    transition: all 0.15s;
+    opacity: 0;
+    animation: fadeInRow 0.3s ease-out forwards;
+  }
+  .receipt-card:hover {
+    border-color: var(--accent);
+    transform: translateX(-2px);
+  }
+  .receipt-card-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+  }
+  .receipt-card-row + .receipt-card-row { margin-top: 4px; }
+  .receipt-card-vendor {
+    font-size: 12px;
+    font-weight: 600;
+    color: var(--text);
+  }
+  .receipt-card-meta {
+    font: 10px/1 var(--font-mono);
+    color: var(--text-faint);
+  }
+  .receipt-card-action {
+    font: 10px/1 var(--font-mono);
+    color: var(--accent);
+  }
+  .receipt-card-pill {
+    display: inline-block;
+    padding: 2px 6px;
+    border-radius: 3px;
+    background: var(--ok);
+    color: #0a0d12;
+    font: 600 9px var(--font-mono);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+  }
+  .receipt-card-empty {
+    color: var(--text-faint);
+    font-size: 13px;
+    font-style: italic;
+    padding: 16px 0;
+    text-align: center;
+  }
+
+  /* ── Receipt modal ─────────────────────────────────────────────────── */
+  .modal-backdrop {
+    position: fixed;
+    inset: 0;
+    background: rgba(0,0,0,0.6);
+    display: none;
+    align-items: center;
+    justify-content: center;
+    z-index: 100;
+  }
+  .modal-backdrop.is-open { display: flex; }
+  .modal {
+    background: var(--bg-elevated);
+    border: 1px solid var(--border-strong);
+    border-radius: 10px;
+    padding: 24px;
+    width: 90%;
+    max-width: 720px;
+    max-height: 80vh;
+    overflow-y: auto;
+  }
+  .modal-title {
+    font-size: 16px;
+    font-weight: 600;
+    margin-bottom: 4px;
+  }
+  .modal-sub {
+    font: 11px/1.4 var(--font-mono);
+    color: var(--text-faint);
+    margin-bottom: 16px;
+  }
+  .modal-section {
+    margin-top: 14px;
+  }
+  .modal-section-title {
+    font: 11px/1 var(--font-mono);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--text-faint);
+    margin-bottom: 6px;
+  }
+  .modal pre {
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    padding: 10px;
+    font: 11px/1.5 var(--font-mono);
+    color: var(--text);
+    overflow-x: auto;
+    white-space: pre-wrap;
+    word-break: break-all;
+  }
+  .modal-close {
+    position: absolute;
+    top: 16px;
+    right: 16px;
+    background: transparent;
+    border: 1px solid var(--border);
+    color: var(--text);
+    padding: 6px 10px;
+    border-radius: 4px;
+    cursor: pointer;
+    font: 11px var(--font-mono);
+  }
+
+  /* ── Add-vendor bar ────────────────────────────────────────────────── */
+  .add-vendor-bar {
+    margin-top: 24px;
+    background: var(--bg-panel);
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    padding: 14px 16px;
+    display: flex;
+    gap: 10px;
+    align-items: center;
+  }
+  .add-vendor-bar.is-disabled { opacity: 0.4; pointer-events: none; }
+  .add-vendor-label {
+    font: 11px/1 var(--font-mono);
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--text-faint);
+  }
+  .add-vendor-select {
+    flex: 1;
+    background: var(--bg);
+    border: 1px solid var(--border);
+    color: var(--text);
+    padding: 8px 12px;
+    border-radius: 6px;
+    font: 13px var(--font-ui);
+  }
+
+  /* ── Reconcile chat ────────────────────────────────────────────────── */
+  .reconcile-chat {
+    margin-top: 16px;
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 12px 14px;
+    display: none;
+  }
+  .reconcile-chat.is-active { display: block; }
+  .reconcile-chat-title {
+    font: 11px/1 var(--font-mono);
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--accent);
+    margin-bottom: 6px;
+  }
+  .reconcile-chat-body {
+    font-size: 13px;
+    line-height: 1.5;
+    color: var(--text);
+  }
+  .reconcile-chat-body em {
+    color: var(--text-dim);
+    font-style: italic;
+  }
+
+  /* ── Empty state ───────────────────────────────────────────────────── */
+  .empty-state {
+    color: var(--text-faint);
+    font-size: 13px;
+    text-align: center;
+    padding: 40px 20px;
+  }
+</style>
+</head>
+<body>
+
+<div class="app">
+  <header class="header">
+    <a class="header-back" href="/">&larr; Back to Signals</a>
+    <div>
+      <div class="header-title">Race <span class="accent">Canvas</span></div>
+      <div class="header-sub">multi-agent orchestration / disagreement halo / audit receipts</div>
+    </div>
+    <div class="header-spacer"></div>
+    <div class="header-sub">May 7 workshop / iHeartMedia</div>
+  </header>
+
+  <main class="main">
+    <div class="controls">
+      <div class="controls-label">Brief</div>
+      <div class="controls-row">
+        <input id="brief-input" class="brief-input" placeholder="e.g., Coca-Cola Summer Refresh, $250K, 30 days, ROAS 3.5x" value="Coca-Cola Summer Refresh, $250K, 30 days, ROAS 3.5x"/>
+        <button id="btn-start" class="btn">Start race</button>
+        <button id="btn-clear" class="btn btn-ghost">Clear</button>
+      </div>
+    </div>
+
+    <div class="race-board" id="race-board">
+      <div class="race-board-header">
+        <div class="race-board-title">Vendor Race Waterfall</div>
+        <div class="race-board-meta" id="race-meta">awaiting brief...</div>
+      </div>
+      <div class="vendor-rows" id="vendor-rows">
+        <div class="empty-state">Click "Start race" to fan out across 6 vendors.</div>
+      </div>
+      <svg class="halo-overlay" id="halo-overlay"></svg>
+    </div>
+
+    <div class="reconcile-chat" id="reconcile-chat">
+      <div class="reconcile-chat-title">Claude reconciles</div>
+      <div class="reconcile-chat-body" id="reconcile-body"></div>
+    </div>
+
+    <div class="add-vendor-bar is-disabled" id="add-vendor-bar">
+      <div class="add-vendor-label">Add vendor:</div>
+      <select id="add-vendor-select" class="add-vendor-select" disabled>
+        <option value="">— start a race first —</option>
+      </select>
+      <button id="btn-add-vendor" class="btn" disabled>Add</button>
+    </div>
+  </main>
+
+  <aside class="sidebar">
+    <div class="sidebar-title">Audit Receipt Stack</div>
+    <div class="sidebar-sub">Every agent call gets a receipt. Click to inspect.</div>
+    <div class="receipt-list" id="receipt-list">
+      <div class="receipt-card-empty">No receipts yet — start a race to populate.</div>
+    </div>
+  </aside>
+</div>
+
+<div class="modal-backdrop" id="modal-backdrop">
+  <div class="modal">
+    <div class="modal-title" id="modal-title">Receipt</div>
+    <div class="modal-sub" id="modal-sub"></div>
+    <button class="modal-close" id="modal-close">close</button>
+    <div class="modal-section">
+      <div class="modal-section-title">Hashes</div>
+      <pre id="modal-hashes"></pre>
+    </div>
+    <div class="modal-section">
+      <div class="modal-section-title">Input</div>
+      <pre id="modal-input"></pre>
+    </div>
+    <div class="modal-section">
+      <div class="modal-section-title">Output</div>
+      <pre id="modal-output"></pre>
+    </div>
+  </div>
+</div>
+
+<script>
+(function(){
+  "use strict";
+  var DEMO_KEY = ${safeKey};
+  var state = {
+    raceId: null,
+    briefInput: "",
+    vendors: [],
+    responses: [],
+    receipts: [],
+    rowsByVendor: {},
+    raceComplete: false
+  };
+
+  // ── DOM refs ────────────────────────────────────────────────────────
+  var elBriefInput = document.getElementById("brief-input");
+  var elBtnStart = document.getElementById("btn-start");
+  var elBtnClear = document.getElementById("btn-clear");
+  var elRows = document.getElementById("vendor-rows");
+  var elReceipts = document.getElementById("receipt-list");
+  var elRaceMeta = document.getElementById("race-meta");
+  var elHalo = document.getElementById("halo-overlay");
+  var elReconcileChat = document.getElementById("reconcile-chat");
+  var elReconcileBody = document.getElementById("reconcile-body");
+  var elAddBar = document.getElementById("add-vendor-bar");
+  var elAddSelect = document.getElementById("add-vendor-select");
+  var elAddBtn = document.getElementById("btn-add-vendor");
+  var elModalBackdrop = document.getElementById("modal-backdrop");
+  var elModalTitle = document.getElementById("modal-title");
+  var elModalSub = document.getElementById("modal-sub");
+  var elModalClose = document.getElementById("modal-close");
+  var elModalHashes = document.getElementById("modal-hashes");
+  var elModalInput = document.getElementById("modal-input");
+  var elModalOutput = document.getElementById("modal-output");
+
+  // ── Number formatting ──────────────────────────────────────────────
+  function fmtAudience(n) {
+    if (n >= 1000000) return (n / 1000000).toFixed(1) + "M";
+    if (n >= 1000) return (n / 1000).toFixed(0) + "K";
+    return String(n);
+  }
+  function fmtFloor(cents) {
+    return "$" + (cents / 100).toFixed(2);
+  }
+
+  // ── Render helpers ─────────────────────────────────────────────────
+  function renderEmptyRows(vendors) {
+    elRows.innerHTML = "";
+    state.rowsByVendor = {};
+    vendors.forEach(function(v) {
+      var row = document.createElement("div");
+      row.className = "vendor-row";
+      row.setAttribute("data-vendor-id", v.id);
+      row.innerHTML =
+        "<div class=\\"vendor-name\\">" +
+        "  <div class=\\"vendor-name-primary\\">" + escapeHtml(v.name) + "</div>" +
+        "  <div class=\\"vendor-name-secondary\\">" + escapeHtml(v.vendor) + " &middot; " + escapeHtml(v.role) + "</div>" +
+        "</div>" +
+        "<div class=\\"vendor-progress\\">" +
+        "  <div class=\\"vendor-progress-fill\\" data-fill></div>" +
+        "  <div class=\\"vendor-stage-label\\" data-stage>queued</div>" +
+        "</div>" +
+        "<div class=\\"vendor-response\\" data-response>" +
+        "  <span class=\\"vendor-response-k\\">audience</span><span class=\\"vendor-response-empty\\">—</span>" +
+        "  <span class=\\"vendor-response-k\\">sensitivity</span><span class=\\"vendor-response-empty\\">—</span>" +
+        "  <span class=\\"vendor-response-k\\">bid floor</span><span class=\\"vendor-response-empty\\">—</span>" +
+        "  <span class=\\"vendor-response-k\\">governance</span><span class=\\"vendor-response-empty\\">—</span>" +
+        "</div>";
+      elRows.appendChild(row);
+      state.rowsByVendor[v.id] = row;
+    });
+  }
+
+  function updateVendorStage(vendorId, stage) {
+    var row = state.rowsByVendor[vendorId];
+    if (!row) return;
+    var fill = row.querySelector("[data-fill]");
+    var label = row.querySelector("[data-stage]");
+    if (!fill || !label) return;
+    if (stage === "probing") {
+      fill.style.width = "20%";
+      label.textContent = "probing";
+    } else if (stage === "calling") {
+      fill.style.width = "60%";
+      label.textContent = "calling";
+    } else if (stage === "responded") {
+      fill.style.width = "100%";
+      fill.classList.add("is-done");
+      label.textContent = "responded";
+    }
+  }
+
+  function fillVendorResponse(vendorId, resp) {
+    var row = state.rowsByVendor[vendorId];
+    if (!row) return;
+    var box = row.querySelector("[data-response]");
+    if (!box) return;
+    var sensClass = resp.sensitive_category_verdict === "elevated" ? "warn" : (resp.sensitive_category_verdict === "restricted" ? "block" : "");
+    var govClass = resp.governance_outcome === "warn" ? "warn" : (resp.governance_outcome === "block" ? "block" : "");
+    box.innerHTML =
+      "<span class=\\"vendor-response-k\\">audience</span><span class=\\"vendor-response-v\\">" + fmtAudience(resp.audience_size) + "</span>" +
+      "<span class=\\"vendor-response-k\\">sensitivity</span><span class=\\"vendor-response-v " + sensClass + "\\">" + escapeHtml(resp.sensitive_category_verdict) + "</span>" +
+      "<span class=\\"vendor-response-k\\">bid floor</span><span class=\\"vendor-response-v\\">" + fmtFloor(resp.recommended_bid_floor_cents) + "</span>" +
+      "<span class=\\"vendor-response-k\\">governance</span><span class=\\"vendor-response-v " + govClass + "\\">" + escapeHtml(resp.governance_outcome) + "</span>";
+  }
+
+  function appendReceipt(rcpt) {
+    if (state.receipts.length === 0) elReceipts.innerHTML = "";
+    state.receipts.push(rcpt);
+    var card = document.createElement("div");
+    card.className = "receipt-card";
+    card.innerHTML =
+      "<div class=\\"receipt-card-row\\">" +
+      "  <div class=\\"receipt-card-vendor\\">" + escapeHtml(rcpt.vendor_name) + "</div>" +
+      "  <span class=\\"receipt-card-pill\\">verified</span>" +
+      "</div>" +
+      "<div class=\\"receipt-card-row\\">" +
+      "  <div class=\\"receipt-card-action\\">" + escapeHtml(rcpt.action) + "</div>" +
+      "  <div class=\\"receipt-card-meta\\">" + rcpt.latency_ms + "ms</div>" +
+      "</div>" +
+      "<div class=\\"receipt-card-row\\">" +
+      "  <div class=\\"receipt-card-meta\\">in:" + escapeHtml(rcpt.input_hash) + "</div>" +
+      "  <div class=\\"receipt-card-meta\\">out:" + escapeHtml(rcpt.output_digest) + "</div>" +
+      "</div>";
+    card.addEventListener("click", function(){ openReceiptModal(rcpt); });
+    elReceipts.appendChild(card);
+    elReceipts.scrollTop = elReceipts.scrollHeight;
+  }
+
+  function openReceiptModal(rcpt) {
+    elModalTitle.textContent = rcpt.vendor_name + " - " + rcpt.action;
+    elModalSub.textContent = "receipt " + rcpt.receipt_id + " - " + rcpt.ts;
+    var hashLines = [
+      "input_hash:        " + rcpt.input_hash,
+      "output_digest:     " + rcpt.output_digest,
+      "idempotency_key:   " + rcpt.idempotency_key,
+      "latency_ms:        " + rcpt.latency_ms,
+      "verified:          " + (rcpt.verified ? "true" : "false")
+    ];
+    elModalHashes.textContent = hashLines.join("\\n");
+    elModalInput.textContent = rcpt.inspect ? JSON.stringify(rcpt.inspect.input, null, 2) : "(no input retained)";
+    elModalOutput.textContent = rcpt.inspect ? JSON.stringify(rcpt.inspect.output, null, 2) : "(no output retained)";
+    elModalBackdrop.classList.add("is-open");
+  }
+  elModalClose.addEventListener("click", function(){ elModalBackdrop.classList.remove("is-open"); });
+  elModalBackdrop.addEventListener("click", function(e){ if (e.target === elModalBackdrop) elModalBackdrop.classList.remove("is-open"); });
+
+  // ── Halo / disagreement rendering ──────────────────────────────────
+  // SVG arc connecting two vendor rows. We measure the rows' positions
+  // relative to the race-board container and draw a curved path between them.
+  function renderHaloArc(disagreement) {
+    if (!disagreement.conflict_pair || disagreement.conflict_pair.length < 2) return;
+    var rowA = state.rowsByVendor[disagreement.conflict_pair[0].vendor_id];
+    var rowB = state.rowsByVendor[disagreement.conflict_pair[1].vendor_id];
+    if (!rowA || !rowB) return;
+    var board = document.getElementById("race-board");
+    var bRect = board.getBoundingClientRect();
+    var aRect = rowA.getBoundingClientRect();
+    var rRect = rowB.getBoundingClientRect();
+    // Anchor points on the LEFT side of each row.
+    var ax = aRect.left - bRect.left + 4;
+    var ay = aRect.top - bRect.top + aRect.height / 2;
+    var bx = rRect.left - bRect.left + 4;
+    var by = rRect.top - bRect.top + rRect.height / 2;
+    // Curve control point — pulled left of both anchors.
+    var cx = Math.min(ax, bx) - 60;
+    var cy = (ay + by) / 2;
+
+    var color = disagreement.severity === "blocking" ? "#ff4d5e" :
+                disagreement.severity === "material" ? "#f0b400" : "#38b6ff";
+
+    // Draw a path. Use SVG namespace.
+    var ns = "http://www.w3.org/2000/svg";
+    var pathStr = "M" + ax + "," + ay + " Q" + cx + "," + cy + " " + bx + "," + by;
+    var path = document.createElementNS(ns, "path");
+    path.setAttribute("d", pathStr);
+    path.setAttribute("fill", "none");
+    path.setAttribute("stroke", color);
+    path.setAttribute("stroke-width", "3");
+    path.setAttribute("opacity", "0.85");
+    path.setAttribute("stroke-linecap", "round");
+    path.setAttribute("filter", "drop-shadow(0 0 8px " + color + ")");
+    path.classList.add("halo-arc");
+    elHalo.appendChild(path);
+
+    // Mark the conflicting rows with conflict styling.
+    rowA.classList.add(disagreement.severity === "blocking" ? "is-conflict" : "is-warn");
+    rowB.classList.add(disagreement.severity === "blocking" ? "is-conflict" : "is-warn");
+
+    // Render callout next to the curve control point.
+    var callout = document.createElement("div");
+    callout.className = "halo-callout " + (disagreement.severity === "minor" ? "minor" : disagreement.severity === "material" ? "warn" : "");
+    callout.style.left = Math.max(20, cx - 100) + "px";
+    callout.style.top = (cy - 30) + "px";
+    callout.innerHTML =
+      "<div class=\\"halo-callout-title\\">disagreement &middot; " + escapeHtml(disagreement.severity) + "</div>" +
+      "<div class=\\"halo-callout-body\\">" + escapeHtml(disagreement.field_label) + ": " + escapeHtml(disagreement.rationale) + "</div>";
+    callout.setAttribute("data-field", disagreement.field);
+    board.appendChild(callout);
+  }
+
+  function renderReconcile(field, rationale) {
+    if (!elReconcileChat.classList.contains("is-active")) {
+      elReconcileChat.classList.add("is-active");
+      elReconcileBody.innerHTML = "";
+    }
+    var line = document.createElement("div");
+    line.style.marginBottom = "6px";
+    line.innerHTML = "<strong>" + escapeHtml(field) + "</strong> &rarr; <em>" + escapeHtml(rationale) + "</em>";
+    elReconcileBody.appendChild(line);
+  }
+
+  function escapeHtml(s) {
+    if (s === undefined || s === null) return "";
+    return String(s).replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
+  }
+
+  // ── Stream consumer ─────────────────────────────────────────────────
+  // Reads NDJSON, parses each line, dispatches to handlers above.
+  async function consumeStream(resp) {
+    var reader = resp.body.getReader();
+    var decoder = new TextDecoder();
+    var buffer = "";
+    while (true) {
+      var chunk = await reader.read();
+      if (chunk.done) break;
+      buffer += decoder.decode(chunk.value, { stream: true });
+      var lines = buffer.split("\\n");
+      buffer = lines.pop() || "";
+      for (var i = 0; i < lines.length; i++) {
+        var line = lines[i].trim();
+        if (!line) continue;
+        try {
+          var ev = JSON.parse(line);
+          handleEvent(ev);
+        } catch (err) {
+          console.warn("parse failed", line, err);
+        }
+      }
+    }
+    if (buffer.trim()) {
+      try { handleEvent(JSON.parse(buffer)); } catch (err) { /* ignore */ }
+    }
+  }
+
+  function handleEvent(ev) {
+    switch (ev.event) {
+      case "race_started":
+        state.raceId = ev.race_id;
+        state.briefInput = ev.brief_input;
+        state.vendors = ev.vendors;
+        renderEmptyRows(ev.vendors);
+        elRaceMeta.textContent = "race " + ev.race_id + " - " + ev.vendors.length + " vendors";
+        break;
+      case "vendor_stage":
+        updateVendorStage(ev.vendor_id, ev.stage);
+        break;
+      case "vendor_response":
+        state.responses.push(ev.response);
+        fillVendorResponse(ev.vendor_id, ev.response);
+        break;
+      case "receipt":
+        appendReceipt(ev.receipt);
+        break;
+      case "all_vendors_responded":
+        elRaceMeta.textContent = "all " + ev.responses.length + " vendors responded - " + ev.total_latency_ms + "ms - detecting disagreements...";
+        break;
+      case "disagreement_detected":
+        renderHaloArc(ev.disagreement);
+        break;
+      case "reconcile_started":
+        elRaceMeta.textContent = "reconciling " + ev.field_label + "...";
+        break;
+      case "reconcile_done":
+        renderReconcile(ev.field_label, ev.reconcile_rationale);
+        // Update the callout to show reconciled value.
+        var existing = document.querySelector("[data-field=\\"" + ev.field + "\\"]");
+        if (existing) {
+          var rec = document.createElement("div");
+          rec.className = "halo-callout-reconcile";
+          rec.textContent = "reconciled: " + ev.reconcile_rationale;
+          existing.appendChild(rec);
+        }
+        break;
+      case "race_complete":
+        state.raceComplete = true;
+        elRaceMeta.textContent = "race complete - " + ev.summary.disagreement_count + " disagreement(s) reconciled, " + ev.summary.receipt_count + " receipts";
+        elBtnStart.disabled = false;
+        elBtnStart.textContent = "Run again";
+        // Enable add-vendor flow.
+        loadAvailableVendors();
+        break;
+      case "error":
+        console.error("server error", ev.error);
+        elRaceMeta.textContent = "error: " + ev.error;
+        elBtnStart.disabled = false;
+        break;
+      default:
+        // No-op for unknown events — forward-compatible with future event types.
+        break;
+    }
+  }
+
+  // ── Start race ──────────────────────────────────────────────────────
+  async function startRace() {
+    var brief = elBriefInput.value.trim();
+    if (!brief) { alert("Enter a brief first."); return; }
+    elBtnStart.disabled = true;
+    elBtnStart.textContent = "Running...";
+    state.responses = [];
+    state.receipts = [];
+    state.raceComplete = false;
+    elHalo.innerHTML = "";
+    var oldCallouts = document.querySelectorAll(".halo-callout");
+    oldCallouts.forEach(function(c){ c.remove(); });
+    elReceipts.innerHTML = "<div class=\\"receipt-card-empty\\">Receipts will appear here as vendors respond...</div>";
+    elReconcileChat.classList.remove("is-active");
+    elReconcileBody.innerHTML = "";
+    elAddBar.classList.add("is-disabled");
+    elAddSelect.disabled = true;
+    elAddBtn.disabled = true;
+
+    try {
+      var resp = await fetch("/race/start", {
+        method: "POST",
+        headers: { "Content-Type": "application/json", "Authorization": "Bearer " + DEMO_KEY },
+        body: JSON.stringify({ brief_input: brief })
+      });
+      if (!resp.ok || !resp.body) {
+        var txt = await resp.text();
+        throw new Error("server returned " + resp.status + " " + txt.slice(0, 200));
+      }
+      await consumeStream(resp);
+    } catch (err) {
+      console.error("startRace failed", err);
+      elRaceMeta.textContent = "fetch failed: " + (err.message || err);
+      elBtnStart.disabled = false;
+      elBtnStart.textContent = "Start race";
+    }
+  }
+
+  // ── Available vendors / add vendor ──────────────────────────────────
+  async function loadAvailableVendors() {
+    try {
+      var current = state.vendors.map(function(v){ return v.id; });
+      var resp = await fetch("/race/available-vendors", {
+        method: "POST",
+        headers: { "Content-Type": "application/json", "Authorization": "Bearer " + DEMO_KEY },
+        body: JSON.stringify({ current_vendor_ids: current })
+      });
+      if (!resp.ok) return;
+      var data = await resp.json();
+      elAddSelect.innerHTML = "";
+      var opt = document.createElement("option");
+      opt.value = "";
+      opt.textContent = "— pick a vendor to add —";
+      elAddSelect.appendChild(opt);
+      data.available.forEach(function(v) {
+        var o = document.createElement("option");
+        o.value = v.id;
+        o.textContent = v.name + " (" + v.role + ")";
+        elAddSelect.appendChild(o);
+      });
+      elAddBar.classList.remove("is-disabled");
+      elAddSelect.disabled = false;
+      elAddBtn.disabled = false;
+    } catch (err) {
+      console.warn("loadAvailableVendors failed", err);
+    }
+  }
+
+  async function addVendor() {
+    var vendorId = elAddSelect.value;
+    if (!vendorId) return;
+    elAddBtn.disabled = true;
+    elAddBtn.textContent = "Adding...";
+    try {
+      var resp = await fetch("/race/add-vendor", {
+        method: "POST",
+        headers: { "Content-Type": "application/json", "Authorization": "Bearer " + DEMO_KEY },
+        body: JSON.stringify({
+          brief_input: state.briefInput,
+          vendor_id: vendorId,
+          prior_responses: state.responses
+        })
+      });
+      if (!resp.ok) {
+        var txt = await resp.text();
+        throw new Error("server returned " + resp.status + " " + txt.slice(0, 200));
+      }
+      var data = await resp.json();
+      // Append the new row.
+      state.vendors.push(data.vendor);
+      var newVendorObj = data.vendor;
+      var row = document.createElement("div");
+      row.className = "vendor-row";
+      row.setAttribute("data-vendor-id", newVendorObj.id);
+      row.innerHTML =
+        "<div class=\\"vendor-name\\">" +
+        "  <div class=\\"vendor-name-primary\\">" + escapeHtml(newVendorObj.name) + "</div>" +
+        "  <div class=\\"vendor-name-secondary\\">" + escapeHtml(newVendorObj.vendor) + " &middot; " + escapeHtml(newVendorObj.role) + " &middot; added mid-flight</div>" +
+        "</div>" +
+        "<div class=\\"vendor-progress\\">" +
+        "  <div class=\\"vendor-progress-fill is-done\\" data-fill style=\\"width:100%\\"></div>" +
+        "  <div class=\\"vendor-stage-label\\" data-stage>responded</div>" +
+        "</div>" +
+        "<div class=\\"vendor-response\\" data-response></div>";
+      elRows.appendChild(row);
+      state.rowsByVendor[newVendorObj.id] = row;
+      fillVendorResponse(newVendorObj.id, data.response);
+      state.responses.push(data.response);
+      appendReceipt(data.receipt);
+
+      // Render any new disagreements.
+      if (data.new_disagreements && data.new_disagreements.length > 0) {
+        data.new_disagreements.forEach(function(d, i) {
+          setTimeout(function(){ renderHaloArc(d); }, 300 + i * 200);
+        });
+      }
+
+      // Refresh the dropdown.
+      loadAvailableVendors();
+    } catch (err) {
+      console.error("addVendor failed", err);
+      alert("Add vendor failed: " + (err.message || err));
+    } finally {
+      elAddBtn.disabled = false;
+      elAddBtn.textContent = "Add";
+    }
+  }
+
+  // ── Wiring ──────────────────────────────────────────────────────────
+  elBtnStart.addEventListener("click", startRace);
+  elBtnClear.addEventListener("click", function(){
+    elBriefInput.value = "";
+    elBriefInput.focus();
+  });
+  elAddBtn.addEventListener("click", addVendor);
+  elBriefInput.addEventListener("keydown", function(e) {
+    if (e.key === "Enter") startRace();
+  });
+
+  console.log("Race Canvas ready");
+})();
+</script>
+
+</body>
+</html>`;
+}

--- a/src/routes/raceRoutes.ts
+++ b/src/routes/raceRoutes.ts
@@ -1,0 +1,353 @@
+// src/routes/raceRoutes.ts
+//
+// Wave 6 — Vendor Race Canvas backend.
+//
+// Endpoints:
+//
+//   POST /race/start
+//     Streams NDJSON. Kicks off a parallel "race" across N vendors against
+//     the same brief, emits per-stage events, detects disagreements, and
+//     emits reconciliation events at the end. Receipts are emitted inline
+//     as each vendor responds.
+//
+//   POST /race/add-vendor
+//     One-shot endpoint (NOT streaming) — runs a single vendor against an
+//     existing race's brief and prior responses, returns response +
+//     receipt + any new disagreements detected. Used by the Canvas UI's
+//     "add a vendor mid-flight" feature.
+//
+// Demo posture:
+//   Both endpoints default to MOCK responses (synthesized via
+//   vendorRaceMock.ts) so the workshop narrative is reliable. A "live"
+//   mode flag is wired through but not used by the canvas — kept for
+//   when real vendors actually expose comparable cohort-sizing tools.
+//
+// Auth: public (same posture as /agentic/* and /dsp/*). The race
+// endpoints don't take paid actions, only synthesize comparison views.
+
+import type { Env } from "../types/env";
+import type { Logger } from "../utils/logger";
+import { jsonResponse, errorResponse } from "./shared";
+import { AGENT_REGISTRY } from "../domain/agentRegistry";
+import {
+  synthesizeVendorResponse,
+  inferBaselineAudience,
+  type VendorRaceResponse,
+} from "../domain/vendorRaceMock";
+import { detectDisagreements, type Disagreement } from "../domain/disagreementDetector";
+import { buildReceipt, type AuditReceipt } from "../domain/auditReceipts";
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+interface StartBody {
+  brief_input?: string;
+  vendor_ids?: string[];
+  /** "mock" (default, deterministic) or "live" (calls real MCP — not used by canvas). */
+  mode?: "mock" | "live";
+}
+
+const DEFAULT_RACE_VENDORS = [
+  "evgeny_signals",
+  "dstillery",
+  "celtra",
+  "swivel",
+  "claire_pub",
+  "adzymic_apx",
+];
+
+// ── POST /race/start ────────────────────────────────────────────────────────
+//
+// Event stream contract (NDJSON, one JSON object per line):
+//
+//   { event: "race_started", race_id, brief_input, vendors[] }
+//   { event: "vendor_stage", vendor_id, stage: "probing"|"calling"|"responded", t_ms }
+//   { event: "vendor_response", vendor_id, response: VendorRaceResponse }
+//   { event: "receipt", receipt: AuditReceipt }
+//   { event: "all_vendors_responded", responses: VendorRaceResponse[] }
+//   { event: "disagreement_detected", disagreement: Disagreement }
+//   { event: "reconcile_started", field, conflict_pair }
+//   { event: "reconcile_done", field, reconciled_value, reconcile_rationale }
+//   { event: "race_complete", race_id, summary }
+//
+// Timing: each vendor proceeds through probing -> calling -> responded
+// at staggered offsets so the waterfall renders as a race rather than
+// a synchronous blast. Per-vendor latency is taken from the mock's
+// personality table.
+
+export async function handleRaceStart(request: Request, env: Env, logger: Logger): Promise<Response> {
+  void env;
+  let body: StartBody = {};
+  try { body = await request.json(); } catch { /* empty */ }
+
+  const briefInput = (body.brief_input ?? "").trim();
+  if (!briefInput) {
+    return errorResponse("INVALID_INPUT", "brief_input (string) required", 400);
+  }
+  if (briefInput.length > 1000) {
+    return errorResponse("INVALID_INPUT", "brief_input max 1000 chars", 400);
+  }
+
+  const vendor_ids = Array.isArray(body.vendor_ids) && body.vendor_ids.length > 0
+    ? body.vendor_ids
+    : DEFAULT_RACE_VENDORS;
+  if (vendor_ids.length > 12) {
+    return errorResponse("INVALID_INPUT", "vendor_ids max 12 entries", 400);
+  }
+
+  const vendors = vendor_ids
+    .map((id) => AGENT_REGISTRY.find((a) => a.id === id))
+    .filter((a): a is typeof AGENT_REGISTRY[number] => !!a);
+  if (vendors.length === 0) {
+    return errorResponse("INVALID_INPUT", "no valid vendor_ids matched the registry", 400);
+  }
+
+  const baseline = inferBaselineAudience(briefInput);
+  const race_id = "race_" + Date.now().toString(36) + "_" + Math.random().toString(36).slice(2, 8);
+
+  logger.info("race_started", { race_id, vendor_count: vendors.length, briefInput: briefInput.slice(0, 80) });
+
+  const stream = new ReadableStream({
+    async start(controller) {
+      const enc = new TextEncoder();
+      const emit = (obj: unknown) => controller.enqueue(enc.encode(JSON.stringify(obj) + "\n"));
+
+      try {
+        emit({
+          event: "race_started",
+          race_id,
+          brief_input: briefInput,
+          baseline_audience: baseline,
+          vendors: vendors.map((v) => ({ id: v.id, name: v.name, vendor: v.vendor, role: v.role })),
+          ts: new Date().toISOString(),
+        });
+
+        // ── Stage 1: probing — all vendors start "probing" at staggered offsets.
+        // Stagger keeps the visual waterfall from blasting all rows simultaneously;
+        // 60ms increments feel natural without slowing the demo.
+        const t0 = Date.now();
+        const probeOffsets = vendors.map((_, i) => 60 * i);
+        for (let i = 0; i < vendors.length; i++) {
+          await sleep(i === 0 ? 50 : 60);
+          emit({
+            event: "vendor_stage",
+            vendor_id: vendors[i]!.id,
+            stage: "probing",
+            t_ms: Date.now() - t0,
+          });
+        }
+
+        // ── Stage 2 + 3: each vendor transitions probing → calling → responded
+        // independently after its synthesized latency. We schedule per-vendor
+        // promises and let them resolve at their own pace.
+        const responses: VendorRaceResponse[] = [];
+        const receipts: AuditReceipt[] = [];
+
+        const vendorTasks = vendors.map(async (v, i) => {
+          const probeDelay = probeOffsets[i] ?? 0;
+          // Probing → calling transition (small fixed delay).
+          await sleep(120);
+          emit({
+            event: "vendor_stage",
+            vendor_id: v.id,
+            stage: "calling",
+            t_ms: Date.now() - t0,
+          });
+
+          // Synthesize the response — this includes the vendor's
+          // engineered "personality latency" so different vendors
+          // visibly finish at different times.
+          const synthesized = synthesizeVendorResponse(v, briefInput, baseline);
+          await sleep(synthesized.latency_ms);
+
+          // Final stage — responded.
+          emit({
+            event: "vendor_stage",
+            vendor_id: v.id,
+            stage: "responded",
+            t_ms: Date.now() - t0,
+          });
+          emit({
+            event: "vendor_response",
+            vendor_id: v.id,
+            response: synthesized,
+          });
+
+          // Receipt for this vendor's call.
+          const receipt = buildReceipt({
+            vendor_id: v.id,
+            vendor_name: v.name,
+            action: "synthesize_cohort_assessment",
+            input: { brief: briefInput, vendor_id: v.id, baseline },
+            output: synthesized,
+            latency_ms: synthesized.latency_ms,
+            include_inspect: true,
+          });
+          emit({ event: "receipt", receipt });
+
+          return { synthesized, receipt };
+        });
+
+        const results = await Promise.all(vendorTasks);
+        for (const r of results) {
+          responses.push(r.synthesized);
+          receipts.push(r.receipt);
+        }
+
+        emit({
+          event: "all_vendors_responded",
+          responses,
+          total_latency_ms: Date.now() - t0,
+        });
+
+        // ── Stage 4: disagreement detection ───────────────────────────────────
+        const disagreements = detectDisagreements(responses);
+        for (const d of disagreements) {
+          // Small delay so the canvas can animate the halo appearance.
+          await sleep(450);
+          emit({ event: "disagreement_detected", disagreement: d });
+        }
+
+        // ── Stage 5: reconcile each disagreement ──────────────────────────────
+        // The "Claude reconciles" moment. We don't actually call Claude here —
+        // the disagreement detector pre-computed the median (numeric) or
+        // conservative pick (categorical). The reconcile_done event delivers
+        // that as if the agentic layer had decided it.
+        for (const d of disagreements) {
+          await sleep(600);
+          emit({
+            event: "reconcile_started",
+            field: d.field,
+            field_label: d.field_label,
+            conflict_pair: d.conflict_pair,
+          });
+          await sleep(900);
+          emit({
+            event: "reconcile_done",
+            field: d.field,
+            field_label: d.field_label,
+            reconciled_value: d.reconciled_value,
+            reconcile_rationale: d.reconcile_rationale,
+          });
+        }
+
+        // ── Final summary ─────────────────────────────────────────────────────
+        emit({
+          event: "race_complete",
+          race_id,
+          summary: {
+            vendor_count: vendors.length,
+            disagreement_count: disagreements.length,
+            blocking: disagreements.filter((d) => d.severity === "blocking").length,
+            material: disagreements.filter((d) => d.severity === "material").length,
+            minor: disagreements.filter((d) => d.severity === "minor").length,
+            total_latency_ms: Date.now() - t0,
+            receipt_count: receipts.length,
+          },
+          ts: new Date().toISOString(),
+        });
+      } catch (e) {
+        emit({ event: "error", error: String((e as Error).message || e) });
+      } finally {
+        controller.close();
+      }
+    },
+  });
+
+  return new Response(stream, {
+    status: 200,
+    headers: {
+      "Content-Type": "application/x-ndjson",
+      "Cache-Control": "no-cache",
+      "Connection": "keep-alive",
+      "X-Content-Type-Options": "nosniff",
+    },
+  });
+}
+
+// ── POST /race/add-vendor ───────────────────────────────────────────────────
+//
+// One-shot — synthesize a single vendor's response against the same brief
+// the race was started with, return the response + receipt + any newly
+// triggered disagreements when this vendor's response is added to the
+// existing set. The canvas appends a new row with a fade-in animation
+// and re-runs disagreement detection client-side using `disagreements`.
+
+interface AddVendorBody {
+  brief_input?: string;
+  vendor_id?: string;
+  /** Prior responses already on the canvas — used for disagreement diff. */
+  prior_responses?: VendorRaceResponse[];
+}
+
+export async function handleRaceAddVendor(request: Request, env: Env, logger: Logger): Promise<Response> {
+  void env;
+  let body: AddVendorBody = {};
+  try { body = await request.json(); } catch { /* empty */ }
+
+  const briefInput = (body.brief_input ?? "").trim();
+  const vendorId = (body.vendor_id ?? "").trim();
+  if (!briefInput || !vendorId) {
+    return errorResponse("INVALID_INPUT", "brief_input and vendor_id required", 400);
+  }
+  const vendor = AGENT_REGISTRY.find((a) => a.id === vendorId);
+  if (!vendor) return errorResponse("NOT_FOUND", `vendor_id "${vendorId}" not in registry`, 404);
+
+  const baseline = inferBaselineAudience(briefInput);
+  const synthesized = synthesizeVendorResponse(vendor, briefInput, baseline);
+
+  // Receipt
+  const receipt = buildReceipt({
+    vendor_id: vendor.id,
+    vendor_name: vendor.name,
+    action: "synthesize_cohort_assessment",
+    input: { brief: briefInput, vendor_id: vendor.id, baseline, mid_flight: true },
+    output: synthesized,
+    latency_ms: synthesized.latency_ms,
+    include_inspect: true,
+  });
+
+  // New disagreements: re-run detection on prior + new response, return only
+  // the disagreements that touch this newly added vendor (others were
+  // already shown).
+  const all = [...(body.prior_responses ?? []), synthesized];
+  const disagreements = detectDisagreements(all);
+  const newDisagreements = disagreements.filter((d) =>
+    d.conflict_pair.some((p) => p.vendor_id === vendor.id) ||
+    d.all_values.some((v) => v.vendor_id === vendor.id),
+  );
+
+  logger.info("race_add_vendor", { vendor_id: vendor.id, new_disagreements: newDisagreements.length });
+
+  return jsonResponse({
+    vendor: { id: vendor.id, name: vendor.name, vendor: vendor.vendor, role: vendor.role },
+    response: synthesized,
+    receipt,
+    new_disagreements: newDisagreements,
+    total_disagreements: disagreements.length,
+  });
+}
+
+// ── GET /race/available-vendors ─────────────────────────────────────────────
+//
+// Returns the list of vendors NOT currently in the race (for the
+// "add vendor" dropdown). The canvas POSTs the current vendor_id list
+// in the body for filtering.
+
+interface AvailableBody {
+  current_vendor_ids?: string[];
+}
+
+export async function handleRaceAvailableVendors(request: Request, env: Env, _logger: Logger): Promise<Response> {
+  void env;
+  let body: AvailableBody = {};
+  try { body = await request.json(); } catch { /* empty */ }
+  const current = new Set(Array.isArray(body.current_vendor_ids) ? body.current_vendor_ids : []);
+  const available = AGENT_REGISTRY
+    .filter((a) => a.stage === "live" && !current.has(a.id))
+    .map((a) => ({ id: a.id, name: a.name, vendor: a.vendor, role: a.role }));
+  return jsonResponse({ available, count: available.length });
+}
+
+// ── Disagreement type re-export ─────────────────────────────────────────────
+// The canvas-side TypeScript-of-the-future could import these.
+export type { Disagreement };


### PR DESCRIPTION
## Summary

Multi-agent orchestration wow factor for the May 7 workshop. Three stacked features on a new self-contained `/race-canvas` page:

1. **Vendor Race Waterfall** — 6 vendors fan out in parallel against the same brief; live progress bars per vendor, staggered probe → call → respond cadence
2. **Disagreement Halo** — SVG arc connects vendors that diverge on `audience_size` (±15%), `recommended_bid_floor_cents` (±20%), `sensitive_category_verdict` (categorical), or `governance_outcome` (categorical). Severity-colored callout + reconcile_done event delivers median (numeric) or conservative-pick (categorical) reconciled value. Engineered into the mock so one numeric + one categorical disagreement reliably fires per default vendor set
3. **Audit Receipt Stack** — every agent call emits a receipt (FNV-1a input/output hashes + idempotency_key + latency); receipts populate a right sidebar in real time; click → modal with full input/output JSON. Connects AdCP HEAD-spec idempotency to a visible artifact
4. **Bonus: Add-vendor mid-flight** — POST `/race/add-vendor` appends a new row, re-runs disagreement detection, animates any new halo connections

## Why a separate page

The main `demo.ts` SCRIPT_TAG template-literal trap class has bitten 3× recently (`\n`, regex `\/`, backtick-in-comment). New page = small blast radius, fresh code, all 3 features ship as one shippable unit.

Trap discipline on the new file: double-quoted strings only, no regex literals with `\/`, no backticks in embedded JS. Trap-audit equivalent run against `raceCanvas.ts`: **0 hits**.

## Files

| File | Purpose |
|---|---|
| `src/domain/vendorRaceMock.ts` | Deterministic per-vendor responses with engineered disagreements |
| `src/domain/disagreementDetector.ts` | Threshold logic + reconciliation (median / conservative-pick) |
| `src/domain/auditReceipts.ts` | FNV-1a receipt builder with canonicalized hash inputs |
| `src/routes/raceRoutes.ts` | `/race/start` NDJSON streaming + `/race/add-vendor` + `/race/available-vendors` |
| `src/routes/raceCanvas.ts` | Self-contained HTML page with embedded CSS/JS |
| `src/index.ts` | Route registration + publicPaths |
| `src/routes/demo.ts` | Sidebar link to `/race-canvas` |

## NDJSON event contract

```
race_started → vendor_stage[] → vendor_response[] → receipt[]
            → all_vendors_responded
            → disagreement_detected[] → reconcile_started → reconcile_done
            → race_complete
```

## Test plan

- [ ] `GET /race-canvas` renders without console errors
- [ ] Click "Start race" with default brief — 6 vendor rows appear, progress bars fill, all 6 respond
- [ ] At least 2 disagreements fire (audience_size + sensitive_category_verdict on adzymic_apx + celtra)
- [ ] SVG halo arc draws between conflicting rows; callout text readable
- [ ] Receipt sidebar fills with 6 cards; clicking one opens modal with input/output JSON
- [ ] Modal "close" button + backdrop click both dismiss the modal
- [ ] After race complete, "Add vendor" dropdown populates with non-race vendors
- [ ] Adding a vendor appends a new row with fade-in animation
- [ ] Sidebar nav link "Race Canvas" from main demo navigates to `/race-canvas`
- [ ] No console errors at any stage
- [ ] No SCRIPT_TAG trap warnings (audit clean)

## Workshop demo flow

1. Open `/race-canvas` → click "Start race" with the Coca-Cola brief
2. Audience watches the waterfall — 6 rows fanning out in parallel
3. ~3s in, two halos light up (numeric + categorical disagreement)
4. Reconcile callout: "Reconciled to median: 9.5M. Robust to outliers"
5. Receipt sidebar fills in real time — click any to inspect
6. Type-add a measurement vendor mid-flight → new row appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)