### PR TITLE
adcp-watch: refresh context for adcp#2916 (half-shipped 2026-04-30)

### DIFF
--- a/.github/adcp-watch-config.json
+++ b/.github/adcp-watch-config.json
@@ -16,7 +16,7 @@
       "repo": "adcontextprotocol/adcp",
       "number": 2916,
       "kind": "issue",
-      "context": "Q3 systemic FAIL→SKIP applicability bug — runner conflates 'media-buy agent' with 'any agent'. Deferred to adcp 3.1.0; resurfaces when capability-derived skip_if grammar lands runner-side in @adcp/client. Until then, error_handling / validation / schema_compliance stay skipped on signals-only agents."
+      "context": "Q3 systemic FAIL→SKIP applicability bug, half-shipped 2026-04-30. Phase 1 (runner gate): adcp-client#1063 merged into @adcp/sdk 5.25.0+; runner now honors Storyboard.required_tools and emits clean skip_reason:'missing_tool' when no required tool is advertised. We're on 5.25.1 — already have it. Phase 2 (storyboard annotations, the remaining maintainer task): past_start_enforcement + peer media-buy storyboards still need required_tools:[create_media_buy,update_media_buy] in their YAML. Doesn't affect us — we're applicability-gated out of those storyboards via supported_protocols:[signals] before the tool gate fires. Status downgraded from needs-wg-review (bokelley, 2026-05-01); milestone still 3.1.0. Drop after phase 2 lands."
     },
     {
       "repo": "adcontextprotocol/adcp-client",


### PR DESCRIPTION
## Summary

Refresh the watcher's context line for adcp#2916 to reflect bokelley's 2026-05-01 update:

- **Before**: framed as "deferred to 3.1.0; resurfaces when capability-derived skip_if grammar lands runner-side in @adcp/client"
- **After**: framed as "half-shipped 2026-04-30 — phase 1 (runner gate via adcp-client#1063) shipped in @adcp/sdk 5.25.0+; phase 2 (storyboard YAML annotations) is the remaining maintainer task and doesn't affect us"

## Why

`needs-wg-review` label was removed; the issue is now a small implementation task, not a working-group call. Old context implied 3.1.0-blocked, which is no longer accurate. Keeps future watcher diffs read against an honest baseline.

## Verified upstream

```
adcp-client#1063: closed, merged 2026-04-30 02:30 UTC
First release with fix: @adcp/client@5.25.0 (published 2026-04-30 02:50 UTC)
Our pin: 5.25.1 — past it
```

Past_start_enforcement is media-buy-protocol; we're applicability-gated out via `supported_protocols: [signals]` before the new tool gate fires. **No adapter changes needed.**

## Test plan

- [ ] `python -m json.tool .github/adcp-watch-config.json` parses cleanly (already verified)
- [ ] Next watcher cron run will diff on the `needs-wg-review` label removal — that's real movement, comment expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)