### PR TITLE
Wave 5: Vendor Health Dashboard — fleet status + sparklines + drill-down

### DIFF
--- a/src/domain/vendorHealthSnapshot.ts
+++ b/src/domain/vendorHealthSnapshot.ts
@@ -1,0 +1,254 @@
+// src/domain/vendorHealthSnapshot.ts
+//
+// Wave 5 — Vendor Health Dashboard backend logic.
+//
+// Single function `buildVendorHealthSnapshot()` that probes all live
+// agents in parallel, merges with the in-isolate circuit-breaker state,
+// and returns a per-vendor health row plus aggregate counters. The
+// dashboard route serializes this directly to JSON.
+//
+// What's surfaced per vendor:
+//   - registry metadata (id, name, vendor, role, stage, mcp_url)
+//   - probe outcome (alive, latency_ms, tools_count, server_info)
+//   - circuit state (closed/half_open/open + counters)
+//   - composite health (green/yellow/red traffic light)
+//
+// Aggregate counters at the top of the dashboard let the operator scan
+// the whole fleet in one glance — "13 alive · 4 known issues · 0 trips."
+//
+// Probes use a generous timeout (8s) because we want false-negatives
+// to be rare even when a vendor's edge is slow. A vendor that takes
+// 8s to handshake renders as alive-but-slow rather than dead.
+
+import { AGENT_REGISTRY, getLiveAgents, type RegisteredAgent } from "./agentRegistry";
+import { probeAgent, getCircuitSnapshot } from "../federation/genericMcpClient";
+
+export type CircuitStateName = "closed" | "open" | "half_open";
+export type HealthBucket = "healthy" | "degraded" | "down" | "unknown";
+
+export interface VendorHealthRow {
+  // Registry-side metadata.
+  agent_id: string;
+  agent_name: string;
+  vendor: string;
+  role: string;
+  stage: string;
+  mcp_url: string | null;
+  protocols: string[];
+  specialties: string[];
+  notes: string | null;
+
+  // Probe outcome (null if not probed in this snapshot).
+  probed: boolean;
+  alive: boolean;
+  latency_ms: number | null;
+  probe_error: string | null;
+  tools_count: number | null;
+  server_name: string | null;
+  protocol_version: string | null;
+
+  // Circuit-breaker state (from in-isolate map, may be missing for
+  // vendors we haven't called yet this isolate).
+  circuit_state: CircuitStateName | null;
+  circuit_failure_count: number;
+  circuit_success_count: number;
+  circuit_last_event_ts: number | null;
+
+  // Composite traffic-light bucket — what the dashboard renders as a pill.
+  health_bucket: HealthBucket;
+  health_reason: string;
+
+  // ISO-8601 wall-clock of when this snapshot was taken.
+  snapshot_ts: string;
+}
+
+export interface VendorHealthSnapshot {
+  ts: string;
+  total: number;
+  counts: {
+    healthy: number;
+    degraded: number;
+    down: number;
+    unknown: number;
+    by_stage: { live: number; known_issue: number; roadmap: number };
+    by_role: { signals: number; buying: number; creative: number; unclassified: number };
+    circuits: { closed: number; half_open: number; open: number };
+  };
+  rows: VendorHealthRow[];
+  // True if this snapshot ran live probes; false if it was metadata-only.
+  probed: boolean;
+}
+
+/**
+ * Bucket a vendor into a traffic-light state. Order of checks:
+ *
+ *   1. Known-issue / roadmap stage → `unknown` with stage reason
+ *   2. Circuit OPEN → `down` (we're tripping it, vendor is failing)
+ *   3. Probe failed → `down` (couldn't even handshake)
+ *   4. Latency > 5s → `degraded` (slow but alive)
+ *   5. Circuit half_open → `degraded` (recovering from a trip)
+ *   6. Otherwise → `healthy`
+ */
+function bucketHealth(
+  agent: RegisteredAgent,
+  probed: boolean,
+  alive: boolean,
+  latency_ms: number | null,
+  circuit_state: CircuitStateName | null,
+  probe_error: string | null,
+): { bucket: HealthBucket; reason: string } {
+  if (agent.stage === "known_issue") {
+    return { bucket: "unknown", reason: "Directory marks this vendor as known-issue; not probed." };
+  }
+  if (agent.stage === "roadmap") {
+    return { bucket: "unknown", reason: "Roadmap-only — no MCP endpoint advertised yet." };
+  }
+  if (!probed) {
+    return { bucket: "unknown", reason: "Not probed in this snapshot." };
+  }
+  if (circuit_state === "open") {
+    return { bucket: "down", reason: "Circuit breaker is OPEN — too many recent failures, requests short-circuit until cooldown." };
+  }
+  if (!alive) {
+    return { bucket: "down", reason: probe_error ? `Probe failed: ${probe_error.slice(0, 120)}` : "Probe failed (no error detail)." };
+  }
+  if (latency_ms !== null && latency_ms > 5000) {
+    return { bucket: "degraded", reason: `Slow handshake: ${latency_ms}ms exceeds the 5s degraded threshold.` };
+  }
+  if (circuit_state === "half_open") {
+    return { bucket: "degraded", reason: "Circuit half-open — recovering from a recent trip; one trial call in flight." };
+  }
+  return { bucket: "healthy", reason: "Probe alive within latency budget; circuit closed." };
+}
+
+/**
+ * Build a fresh vendor-health snapshot. Probes ALL live agents in
+ * parallel; known_issue + roadmap stages are reported metadata-only
+ * (no probe). Per-call timeout 8s; total wall-clock bounded by the
+ * slowest probe.
+ *
+ * @param probeLive when false, returns the snapshot WITHOUT probing
+ *                  (uses cached circuit state + registry metadata only).
+ *                  Used by the initial page-load to render quickly.
+ */
+export async function buildVendorHealthSnapshot(opts?: { probeLive?: boolean }): Promise<VendorHealthSnapshot> {
+  const probeLive = opts?.probeLive !== false; // default true
+  const ts = new Date().toISOString();
+
+  // Pull circuit state once at the top — same map serves all rows.
+  const circuitSnap = getCircuitSnapshot();
+  const circuitByUrl = new Map(circuitSnap.map((c) => [c.url, c]));
+
+  const liveAgents = getLiveAgents().filter((a) => !!a.mcp_url);
+  const otherAgents = AGENT_REGISTRY.filter((a) => !liveAgents.includes(a));
+
+  // Probe live agents in parallel. Each task is bounded by the
+  // probeAgent internal timeout; we don't add a Promise.race on top.
+  const probeResults = probeLive
+    ? await Promise.all(liveAgents.map(async (a) => {
+        const r = await probeAgent(a.mcp_url!, { timeoutMs: 8000 });
+        return { agent: a, result: r };
+      }))
+    : liveAgents.map((a) => ({ agent: a, result: null as Awaited<ReturnType<typeof probeAgent>> | null }));
+
+  const liveRows: VendorHealthRow[] = probeResults.map(({ agent, result }) => {
+    const circuit = agent.mcp_url ? circuitByUrl.get(agent.mcp_url) : undefined;
+    const probed = result !== null;
+    const alive = result?.alive ?? false;
+    const latency_ms = result?.latency_ms ?? null;
+    const tools_count = result?.tools?.length ?? null;
+    const server_name = result?.server_info?.name ?? null;
+    const probe_error = result?.error ?? null;
+    const protocol_version = result?.protocol_version ?? null;
+    const circuit_state = circuit?.state ?? null;
+    const { bucket, reason } = bucketHealth(agent, probed, alive, latency_ms, circuit_state, probe_error);
+
+    return {
+      agent_id: agent.id,
+      agent_name: agent.name,
+      vendor: agent.vendor,
+      role: agent.role,
+      stage: agent.stage,
+      mcp_url: agent.mcp_url,
+      protocols: agent.protocols ?? [],
+      specialties: agent.specialties ?? [],
+      notes: agent.notes ?? null,
+      probed,
+      alive,
+      latency_ms,
+      probe_error,
+      tools_count,
+      server_name,
+      protocol_version,
+      circuit_state,
+      circuit_failure_count: circuit?.failure_count ?? 0,
+      circuit_success_count: circuit?.success_count ?? 0,
+      circuit_last_event_ts: circuit?.last_event_ts ?? null,
+      health_bucket: bucket,
+      health_reason: reason,
+      snapshot_ts: ts,
+    };
+  });
+
+  const otherRows: VendorHealthRow[] = otherAgents.map((agent) => {
+    const { bucket, reason } = bucketHealth(agent, false, false, null, null, null);
+    return {
+      agent_id: agent.id,
+      agent_name: agent.name,
+      vendor: agent.vendor,
+      role: agent.role,
+      stage: agent.stage,
+      mcp_url: agent.mcp_url,
+      protocols: agent.protocols ?? [],
+      specialties: agent.specialties ?? [],
+      notes: agent.notes ?? null,
+      probed: false,
+      alive: false,
+      latency_ms: null,
+      probe_error: null,
+      tools_count: null,
+      server_name: null,
+      protocol_version: null,
+      circuit_state: null,
+      circuit_failure_count: 0,
+      circuit_success_count: 0,
+      circuit_last_event_ts: null,
+      health_bucket: bucket,
+      health_reason: reason,
+      snapshot_ts: ts,
+    };
+  });
+
+  const rows = [...liveRows, ...otherRows];
+
+  const counts = {
+    healthy: rows.filter((r) => r.health_bucket === "healthy").length,
+    degraded: rows.filter((r) => r.health_bucket === "degraded").length,
+    down: rows.filter((r) => r.health_bucket === "down").length,
+    unknown: rows.filter((r) => r.health_bucket === "unknown").length,
+    by_stage: {
+      live: rows.filter((r) => r.stage === "live").length,
+      known_issue: rows.filter((r) => r.stage === "known_issue").length,
+      roadmap: rows.filter((r) => r.stage === "roadmap").length,
+    },
+    by_role: {
+      signals: rows.filter((r) => r.role === "signals").length,
+      buying: rows.filter((r) => r.role === "buying").length,
+      creative: rows.filter((r) => r.role === "creative").length,
+      unclassified: rows.filter((r) => r.role === "unclassified").length,
+    },
+    circuits: {
+      closed: rows.filter((r) => r.circuit_state === "closed").length,
+      half_open: rows.filter((r) => r.circuit_state === "half_open").length,
+      open: rows.filter((r) => r.circuit_state === "open").length,
+    },
+  };
+
+  return {
+    ts,
+    total: rows.length,
+    counts,
+    rows,
+    probed: probeLive,
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -137,6 +137,11 @@ import {
   handleRaceAddVendor,
   handleRaceAvailableVendors,
 } from "./routes/raceRoutes";
+import { handleVendorHealthCanvas } from "./routes/vendorHealthCanvas";
+import {
+  handleVendorHealthSnapshot,
+  handleVendorHealthProbeOne,
+} from "./routes/vendorHealthRoutes";
 import { handleEstimate } from "./routes/estimate";
 import { handleListOperations } from "./routes/listOperations";
 import { handleGenerateSegment } from "./routes/generateSegment";
@@ -312,6 +317,12 @@ export default {
             "/race/start",
             "/race/add-vendor",
             "/race/available-vendors",
+            // Wave 5: Vendor Health Dashboard — fleet status with
+            // per-vendor sparklines + circuit state + drill-down.
+            // All read-only diagnostic; same posture as /dsp/circuits.
+            "/vendor-health",
+            "/vendor-health/snapshot",
+            "/vendor-health/probe-one",
             "/taxonomy/reverse",
             // Sec-43: audience composer + activation-planning analytics.
             // Read-only — same posture as /portfolio/* and /analytics/*.
@@ -384,6 +395,15 @@ export default {
 
             } else if (method === "POST" && path === "/race/available-vendors") {
                 response = await handleRaceAvailableVendors(request, env, logger);
+
+            } else if (method === "GET" && path === "/vendor-health") {
+                response = handleVendorHealthCanvas(env);
+
+            } else if (method === "GET" && path === "/vendor-health/snapshot") {
+                response = await handleVendorHealthSnapshot(request, env, logger);
+
+            } else if (method === "POST" && path === "/vendor-health/probe-one") {
+                response = await handleVendorHealthProbeOne(request, env, logger);
 
             } else if (method === "GET" && path === "/health") {
                 response = jsonResponse({ status: "ok", version: "3.0" });

--- a/src/routes/demo.ts
+++ b/src/routes/demo.ts
@@ -165,6 +165,10 @@ ${STYLES}
         <svg class="ico"><use href="#icon-network"/></svg><span>Race Canvas</span>
         <span class="nav-tag">new</span>
       </a>
+      <a class="nav-item" href="/vendor-health">
+        <svg class="ico"><use href="#icon-radar"/></svg><span>Vendor Health</span>
+        <span class="nav-tag">new</span>
+      </a>
       <button class="nav-item" data-tab="activations">
         <svg class="ico"><use href="#icon-activations"/></svg><span>Activations</span>
         <span class="nav-count" id="nav-activations-count">—</span>

--- a/src/routes/vendorHealthCanvas.ts
+++ b/src/routes/vendorHealthCanvas.ts
@@ -1,0 +1,912 @@
+// src/routes/vendorHealthCanvas.ts
+//
+// Wave 5 — Vendor Health Dashboard HTML page (served at /vendor-health).
+//
+// Self-contained single-page UI for the fleet health view. Same pattern
+// as Race Canvas (separate from demo.ts to keep the SCRIPT_TAG escape
+// blast radius small).
+//
+// Initial paint: GET /vendor-health/snapshot?probe=false — instant
+// render from registry metadata + cached circuit state.
+//
+// Live probe: button kicks off GET /vendor-health/snapshot — fans out
+// to all 13 live agents in parallel, ~8s wall-clock upper bound,
+// updates cards in place and writes history datapoints.
+//
+// Single-vendor re-probe: per-card "Re-probe" button hits POST
+// /vendor-health/probe-one — patches just that card without re-fanning.
+//
+// Escape-trap discipline (see feedback_script_tag_template_trap.md):
+//   - Double-quoted JS strings only
+//   - No regex literals containing \\/
+//   - No backticks in embedded JS
+//   - Audit before commit
+
+export function handleVendorHealthCanvas(env: { DEMO_API_KEY: string }): Response {
+  return new Response(renderVendorHealthCanvas(env.DEMO_API_KEY), {
+    status: 200,
+    headers: {
+      "Content-Type": "text/html; charset=utf-8",
+      "Cache-Control": "public, max-age=300",
+      "Content-Security-Policy":
+        "default-src 'self'; style-src 'self' 'unsafe-inline'; " +
+        "script-src 'self' 'unsafe-inline'; " +
+        "img-src 'self' data:; connect-src 'self';",
+    },
+  });
+}
+
+function renderVendorHealthCanvas(demoKey: string): string {
+  const safeKey = JSON.stringify(demoKey);
+  return `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>Vendor Health — Fleet Dashboard</title>
+<link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Ccircle cx='8' cy='8' r='3' fill='%232ed573'/%3E%3Ccircle cx='8' cy='8' r='6' fill='none' stroke='%232ed573' stroke-width='0.8' opacity='0.5'/%3E%3C/svg%3E"/>
+<style>
+  :root {
+    --bg: #0a0d12;
+    --bg-elevated: #11161e;
+    --bg-panel: #161c26;
+    --border: #232b38;
+    --border-strong: #2e3947;
+    --text: #e6ebf2;
+    --text-dim: #8a95a8;
+    --text-faint: #5b6679;
+    --accent: #38b6ff;
+    --healthy: #2ed573;
+    --healthy-glow: rgba(46, 213, 115, 0.3);
+    --degraded: #f0b400;
+    --degraded-glow: rgba(240, 180, 0, 0.3);
+    --down: #ff4d5e;
+    --down-glow: rgba(255, 77, 94, 0.3);
+    --unknown: #6b7689;
+    --font-mono: "JetBrains Mono", "SF Mono", Consolas, Menlo, monospace;
+    --font-ui: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  }
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  html, body { height: 100%; }
+  body {
+    background: var(--bg);
+    color: var(--text);
+    font: 14px/1.5 var(--font-ui);
+  }
+
+  .header {
+    padding: 16px 24px;
+    border-bottom: 1px solid var(--border);
+    background: var(--bg-elevated);
+    display: flex;
+    align-items: center;
+    gap: 16px;
+  }
+  .header-back {
+    color: var(--text-dim);
+    text-decoration: none;
+    font-size: 13px;
+    border: 1px solid var(--border);
+    padding: 6px 12px;
+    border-radius: 6px;
+    transition: all 0.15s;
+  }
+  .header-back:hover { border-color: var(--accent); color: var(--accent); }
+  .header-title {
+    font-size: 18px;
+    font-weight: 600;
+    letter-spacing: -0.01em;
+  }
+  .header-title .accent { color: var(--accent); }
+  .header-sub {
+    font: 12px/1.4 var(--font-mono);
+    color: var(--text-faint);
+  }
+  .header-spacer { flex: 1; }
+  .btn {
+    background: var(--accent);
+    color: #0a0d12;
+    border: none;
+    padding: 9px 16px;
+    border-radius: 6px;
+    font: 600 13px var(--font-ui);
+    cursor: pointer;
+    transition: all 0.15s;
+  }
+  .btn:hover { filter: brightness(1.1); }
+  .btn:disabled { opacity: 0.4; cursor: not-allowed; }
+  .btn-ghost {
+    background: transparent;
+    border: 1px solid var(--border-strong);
+    color: var(--text);
+  }
+  .btn-ghost:hover { border-color: var(--accent); color: var(--accent); }
+
+  .main {
+    padding: 24px;
+    max-width: 1500px;
+    margin: 0 auto;
+  }
+
+  /* ── Aggregate strip ───────────────────────────────────────────────── */
+  .aggregate-strip {
+    display: grid;
+    grid-template-columns: repeat(5, 1fr);
+    gap: 12px;
+    margin-bottom: 18px;
+  }
+  .agg-card {
+    background: var(--bg-panel);
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    padding: 14px 16px;
+  }
+  .agg-card.healthy { border-left: 4px solid var(--healthy); }
+  .agg-card.degraded { border-left: 4px solid var(--degraded); }
+  .agg-card.down { border-left: 4px solid var(--down); }
+  .agg-card.unknown { border-left: 4px solid var(--unknown); }
+  .agg-card.total { border-left: 4px solid var(--accent); }
+  .agg-num {
+    font: 700 28px/1 var(--font-mono);
+    color: var(--text);
+  }
+  .agg-label {
+    font: 11px/1 var(--font-mono);
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--text-faint);
+    margin-top: 6px;
+  }
+  .agg-card .agg-num.healthy { color: var(--healthy); }
+  .agg-card .agg-num.degraded { color: var(--degraded); }
+  .agg-card .agg-num.down { color: var(--down); }
+  .agg-card .agg-num.unknown { color: var(--unknown); }
+
+  /* ── Filter chips ──────────────────────────────────────────────────── */
+  .filter-row {
+    display: flex;
+    gap: 8px;
+    flex-wrap: wrap;
+    margin-bottom: 18px;
+    padding: 12px 14px;
+    background: var(--bg-panel);
+    border: 1px solid var(--border);
+    border-radius: 10px;
+  }
+  .filter-group-label {
+    font: 11px/1 var(--font-mono);
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--text-faint);
+    align-self: center;
+    margin-right: 4px;
+  }
+  .chip {
+    padding: 6px 12px;
+    border-radius: 14px;
+    background: var(--bg);
+    border: 1px solid var(--border);
+    color: var(--text-dim);
+    font: 11px/1 var(--font-mono);
+    cursor: pointer;
+    transition: all 0.15s;
+  }
+  .chip:hover { border-color: var(--accent); color: var(--accent); }
+  .chip.is-active {
+    background: var(--accent);
+    color: #0a0d12;
+    border-color: var(--accent);
+  }
+  .filter-divider {
+    width: 1px;
+    background: var(--border);
+    margin: 0 4px;
+  }
+  .filter-status-meta {
+    margin-left: auto;
+    align-self: center;
+    font: 11px/1 var(--font-mono);
+    color: var(--text-faint);
+  }
+
+  /* ── Vendor grid ───────────────────────────────────────────────────── */
+  .vendor-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(420px, 1fr));
+    gap: 14px;
+  }
+  .vendor-card {
+    background: var(--bg-panel);
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    padding: 14px 16px;
+    cursor: pointer;
+    transition: all 0.15s;
+    position: relative;
+  }
+  .vendor-card:hover {
+    border-color: var(--accent);
+    transform: translateY(-1px);
+  }
+  .vendor-card.healthy { border-left: 4px solid var(--healthy); }
+  .vendor-card.degraded { border-left: 4px solid var(--degraded); }
+  .vendor-card.down { border-left: 4px solid var(--down); }
+  .vendor-card.unknown { border-left: 4px solid var(--unknown); }
+  .vendor-card.is-hidden { display: none; }
+  .vendor-card.is-probing {
+    opacity: 0.5;
+    pointer-events: none;
+  }
+  .vc-head {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    margin-bottom: 4px;
+    gap: 12px;
+  }
+  .vc-name {
+    font-size: 14px;
+    font-weight: 600;
+    color: var(--text);
+    line-height: 1.3;
+  }
+  .vc-vendor {
+    font: 11px/1.4 var(--font-mono);
+    color: var(--text-faint);
+  }
+  .vc-status-pill {
+    flex-shrink: 0;
+    display: inline-block;
+    padding: 3px 9px;
+    border-radius: 4px;
+    font: 700 10px var(--font-mono);
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+  }
+  .vc-status-pill.healthy { background: var(--healthy); color: #0a0d12; }
+  .vc-status-pill.degraded { background: var(--degraded); color: #0a0d12; }
+  .vc-status-pill.down { background: var(--down); color: #0a0d12; }
+  .vc-status-pill.unknown { background: var(--unknown); color: var(--text); }
+  .vc-stage {
+    display: inline-block;
+    padding: 2px 6px;
+    border-radius: 3px;
+    background: var(--bg);
+    border: 1px solid var(--border);
+    font: 9px/1 var(--font-mono);
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--text-faint);
+    margin-right: 4px;
+  }
+  .vc-stage.live { color: var(--healthy); border-color: var(--healthy); }
+  .vc-stage.known_issue { color: var(--down); border-color: var(--down); }
+  .vc-stage.roadmap { color: var(--unknown); border-color: var(--unknown); }
+
+  .vc-metrics {
+    display: grid;
+    grid-template-columns: 1fr 1fr 1fr;
+    gap: 12px;
+    margin: 10px 0;
+    padding: 10px 0;
+    border-top: 1px solid var(--border);
+    border-bottom: 1px solid var(--border);
+  }
+  .vc-metric {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  }
+  .vc-metric-label {
+    font: 10px/1 var(--font-mono);
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--text-faint);
+  }
+  .vc-metric-value {
+    font: 600 13px var(--font-mono);
+    color: var(--text);
+  }
+  .vc-metric-value.muted { color: var(--text-faint); }
+  .vc-metric-value.warn { color: var(--degraded); }
+  .vc-metric-value.bad { color: var(--down); }
+
+  .vc-spark {
+    height: 24px;
+    margin-top: 4px;
+  }
+  .vc-spark-empty {
+    font: 10px var(--font-mono);
+    color: var(--text-faint);
+    line-height: 24px;
+  }
+
+  .vc-foot {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-top: 8px;
+    gap: 8px;
+  }
+  .vc-foot-meta {
+    font: 10px/1.4 var(--font-mono);
+    color: var(--text-faint);
+  }
+  .vc-foot-actions {
+    display: flex;
+    gap: 6px;
+  }
+  .vc-btn {
+    background: var(--bg);
+    border: 1px solid var(--border);
+    color: var(--text-dim);
+    padding: 4px 10px;
+    border-radius: 4px;
+    font: 10px/1 var(--font-mono);
+    cursor: pointer;
+    transition: all 0.15s;
+  }
+  .vc-btn:hover {
+    border-color: var(--accent);
+    color: var(--accent);
+  }
+
+  /* ── Drill-down modal ──────────────────────────────────────────────── */
+  .modal-backdrop {
+    position: fixed;
+    inset: 0;
+    background: rgba(0,0,0,0.6);
+    display: none;
+    align-items: center;
+    justify-content: center;
+    z-index: 100;
+  }
+  .modal-backdrop.is-open { display: flex; }
+  .modal {
+    background: var(--bg-elevated);
+    border: 1px solid var(--border-strong);
+    border-radius: 10px;
+    padding: 24px;
+    width: 90%;
+    max-width: 760px;
+    max-height: 85vh;
+    overflow-y: auto;
+    position: relative;
+  }
+  .modal-title {
+    font-size: 17px;
+    font-weight: 600;
+    margin-bottom: 4px;
+  }
+  .modal-sub {
+    font: 12px/1.4 var(--font-mono);
+    color: var(--text-faint);
+    margin-bottom: 16px;
+  }
+  .modal-section {
+    margin-top: 16px;
+  }
+  .modal-section-title {
+    font: 11px/1 var(--font-mono);
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--text-faint);
+    margin-bottom: 8px;
+  }
+  .modal-grid {
+    display: grid;
+    grid-template-columns: 160px 1fr;
+    gap: 6px 16px;
+    font: 12px/1.5 var(--font-mono);
+  }
+  .modal-grid-key { color: var(--text-faint); }
+  .modal-grid-val { color: var(--text); word-break: break-all; }
+  .modal pre {
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    padding: 10px;
+    font: 11px/1.5 var(--font-mono);
+    color: var(--text);
+    overflow-x: auto;
+    white-space: pre-wrap;
+    word-break: break-all;
+  }
+  .modal-close {
+    position: absolute;
+    top: 16px;
+    right: 16px;
+    background: transparent;
+    border: 1px solid var(--border);
+    color: var(--text);
+    padding: 6px 10px;
+    border-radius: 4px;
+    cursor: pointer;
+    font: 11px var(--font-mono);
+  }
+  .modal-tools-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+  }
+  .modal-tool {
+    padding: 3px 8px;
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: 3px;
+    font: 11px var(--font-mono);
+    color: var(--text);
+  }
+
+  .empty-state {
+    color: var(--text-faint);
+    font-size: 13px;
+    text-align: center;
+    padding: 60px 20px;
+    grid-column: 1 / -1;
+  }
+
+  .loading-bar {
+    height: 3px;
+    background: var(--accent);
+    width: 0;
+    transition: width 0.3s;
+    position: fixed;
+    top: 0; left: 0;
+    z-index: 200;
+  }
+  .loading-bar.is-active { animation: progress 8s ease-out forwards; }
+  @keyframes progress {
+    0% { width: 0; }
+    50% { width: 70%; }
+    100% { width: 95%; }
+  }
+</style>
+</head>
+<body>
+
+<div class="loading-bar" id="loading-bar"></div>
+
+<header class="header">
+  <a class="header-back" href="/">&larr; Back to Signals</a>
+  <div>
+    <div class="header-title">Vendor <span class="accent">Health</span></div>
+    <div class="header-sub">live fleet status / circuit state / per-vendor sparklines</div>
+  </div>
+  <div class="header-spacer"></div>
+  <button id="btn-refresh" class="btn">Live probe (all)</button>
+  <button id="btn-meta" class="btn btn-ghost">Reload metadata only</button>
+</header>
+
+<main class="main">
+  <div class="aggregate-strip" id="aggregate-strip"></div>
+
+  <div class="filter-row">
+    <span class="filter-group-label">Status:</span>
+    <button class="chip is-active" data-filter-bucket="all">All</button>
+    <button class="chip" data-filter-bucket="healthy">Healthy</button>
+    <button class="chip" data-filter-bucket="degraded">Degraded</button>
+    <button class="chip" data-filter-bucket="down">Down</button>
+    <button class="chip" data-filter-bucket="unknown">Unknown</button>
+    <span class="filter-divider"></span>
+    <span class="filter-group-label">Stage:</span>
+    <button class="chip is-active" data-filter-stage="all">All</button>
+    <button class="chip" data-filter-stage="live">Live</button>
+    <button class="chip" data-filter-stage="known_issue">Known issue</button>
+    <button class="chip" data-filter-stage="roadmap">Roadmap</button>
+    <span class="filter-divider"></span>
+    <span class="filter-group-label">Role:</span>
+    <button class="chip is-active" data-filter-role="all">All</button>
+    <button class="chip" data-filter-role="signals">Signals</button>
+    <button class="chip" data-filter-role="buying">Buying</button>
+    <button class="chip" data-filter-role="creative">Creative</button>
+    <span class="filter-status-meta" id="filter-meta">—</span>
+  </div>
+
+  <div class="vendor-grid" id="vendor-grid">
+    <div class="empty-state">Loading fleet metadata...</div>
+  </div>
+</main>
+
+<div class="modal-backdrop" id="modal-backdrop">
+  <div class="modal">
+    <div class="modal-title" id="modal-title">Vendor</div>
+    <div class="modal-sub" id="modal-sub"></div>
+    <button class="modal-close" id="modal-close">close</button>
+    <div class="modal-section">
+      <div class="modal-section-title">Identity</div>
+      <div class="modal-grid" id="modal-identity"></div>
+    </div>
+    <div class="modal-section">
+      <div class="modal-section-title">Probe</div>
+      <div class="modal-grid" id="modal-probe"></div>
+    </div>
+    <div class="modal-section">
+      <div class="modal-section-title">Circuit Breaker</div>
+      <div class="modal-grid" id="modal-circuit"></div>
+    </div>
+    <div class="modal-section">
+      <div class="modal-section-title">Tools advertised</div>
+      <div class="modal-tools-list" id="modal-tools"></div>
+    </div>
+    <div class="modal-section">
+      <div class="modal-section-title">Recent history</div>
+      <pre id="modal-history">no history</pre>
+    </div>
+  </div>
+</div>
+
+<script>
+(function(){
+  "use strict";
+  var DEMO_KEY = ${safeKey};
+  var state = {
+    rows: [],
+    histories: {},
+    counts: null,
+    filter: { bucket: "all", stage: "all", role: "all" },
+    isProbing: false
+  };
+
+  // ── DOM refs ────────────────────────────────────────────────────────
+  var elGrid = document.getElementById("vendor-grid");
+  var elAgg = document.getElementById("aggregate-strip");
+  var elBtnRefresh = document.getElementById("btn-refresh");
+  var elBtnMeta = document.getElementById("btn-meta");
+  var elFilterMeta = document.getElementById("filter-meta");
+  var elLoadingBar = document.getElementById("loading-bar");
+  var elModalBackdrop = document.getElementById("modal-backdrop");
+  var elModalTitle = document.getElementById("modal-title");
+  var elModalSub = document.getElementById("modal-sub");
+  var elModalClose = document.getElementById("modal-close");
+  var elModalIdentity = document.getElementById("modal-identity");
+  var elModalProbe = document.getElementById("modal-probe");
+  var elModalCircuit = document.getElementById("modal-circuit");
+  var elModalTools = document.getElementById("modal-tools");
+  var elModalHistory = document.getElementById("modal-history");
+
+  // ── Format helpers ─────────────────────────────────────────────────
+  function fmtLatency(ms) {
+    if (ms === null || ms === undefined) return "—";
+    if (ms < 1000) return ms + "ms";
+    return (ms / 1000).toFixed(2) + "s";
+  }
+  function fmtRelTime(iso) {
+    if (!iso) return "never";
+    var diff = Date.now() - new Date(iso).getTime();
+    if (diff < 0) return "just now";
+    if (diff < 60000) return Math.floor(diff / 1000) + "s ago";
+    if (diff < 3600000) return Math.floor(diff / 60000) + "m ago";
+    if (diff < 86400000) return Math.floor(diff / 3600000) + "h ago";
+    return Math.floor(diff / 86400000) + "d ago";
+  }
+  function escapeHtml(s) {
+    if (s === undefined || s === null) return "";
+    return String(s).replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
+  }
+
+  // ── Aggregate strip ────────────────────────────────────────────────
+  function renderAggregate(counts, total) {
+    if (!counts) { elAgg.innerHTML = ""; return; }
+    elAgg.innerHTML =
+      "<div class=\\"agg-card total\\"><div class=\\"agg-num\\">" + total + "</div><div class=\\"agg-label\\">total agents</div></div>" +
+      "<div class=\\"agg-card healthy\\"><div class=\\"agg-num healthy\\">" + counts.healthy + "</div><div class=\\"agg-label\\">healthy</div></div>" +
+      "<div class=\\"agg-card degraded\\"><div class=\\"agg-num degraded\\">" + counts.degraded + "</div><div class=\\"agg-label\\">degraded</div></div>" +
+      "<div class=\\"agg-card down\\"><div class=\\"agg-num down\\">" + counts.down + "</div><div class=\\"agg-label\\">down / known issue</div></div>" +
+      "<div class=\\"agg-card unknown\\"><div class=\\"agg-num unknown\\">" + counts.unknown + "</div><div class=\\"agg-label\\">unknown / roadmap</div></div>";
+  }
+
+  // ── Sparkline rendering ────────────────────────────────────────────
+  // SVG path drawn from latency history. Color matches most recent
+  // health bucket. Path is normalized: x evenly distributed, y inverted
+  // because SVG y grows downward.
+  function renderSparkline(history) {
+    if (!history || history.length === 0) {
+      return "<div class=\\"vc-spark-empty\\">no probe history yet</div>";
+    }
+    if (history.length === 1) {
+      var bucket = history[0].health_bucket || "unknown";
+      var dotColor = bucket === "healthy" ? "#2ed573" : bucket === "degraded" ? "#f0b400" : bucket === "down" ? "#ff4d5e" : "#6b7689";
+      return "<svg class=\\"vc-spark\\" width=\\"100%\\" height=\\"24\\" viewBox=\\"0 0 100 24\\" preserveAspectRatio=\\"none\\">" +
+        "<circle cx=\\"50\\" cy=\\"12\\" r=\\"3\\" fill=\\"" + dotColor + "\\"/></svg>";
+    }
+    var maxLat = 0;
+    for (var i = 0; i < history.length; i++) {
+      var l = history[i].latency_ms;
+      if (typeof l === "number" && l > maxLat) maxLat = l;
+    }
+    if (maxLat === 0) maxLat = 1;
+    var w = 100, h = 24;
+    var step = w / (history.length - 1);
+    var pts = [];
+    for (var j = 0; j < history.length; j++) {
+      var x = j * step;
+      var lat = history[j].latency_ms;
+      var y = (typeof lat === "number") ? (h - (lat / maxLat) * h * 0.85 - 2) : (h / 2);
+      pts.push(x.toFixed(1) + "," + y.toFixed(1));
+    }
+    var lastBucket = history[history.length - 1].health_bucket || "unknown";
+    var color = lastBucket === "healthy" ? "#2ed573" :
+                lastBucket === "degraded" ? "#f0b400" :
+                lastBucket === "down" ? "#ff4d5e" : "#6b7689";
+    return "<svg class=\\"vc-spark\\" width=\\"100%\\" height=\\"24\\" viewBox=\\"0 0 100 24\\" preserveAspectRatio=\\"none\\">" +
+      "<polyline fill=\\"none\\" stroke=\\"" + color + "\\" stroke-width=\\"1.5\\" points=\\"" + pts.join(" ") + "\\"/></svg>";
+  }
+
+  // ── Vendor grid ────────────────────────────────────────────────────
+  function renderGrid() {
+    if (!state.rows || state.rows.length === 0) {
+      elGrid.innerHTML = "<div class=\\"empty-state\\">No vendors loaded yet.</div>";
+      return;
+    }
+    var html = "";
+    var visible = 0;
+    for (var i = 0; i < state.rows.length; i++) {
+      var r = state.rows[i];
+      var passes = filterMatches(r);
+      if (!passes) continue;
+      visible++;
+      var hist = state.histories[r.agent_id] || [];
+      html += renderCard(r, hist);
+    }
+    elGrid.innerHTML = html || "<div class=\\"empty-state\\">No vendors match the current filters.</div>";
+    elFilterMeta.textContent = visible + " of " + state.rows.length + " visible";
+
+    // Wire card click + re-probe button.
+    var cards = elGrid.querySelectorAll(".vendor-card");
+    cards.forEach(function(card) {
+      card.addEventListener("click", function(e) {
+        if ((e.target).closest && (e.target).closest("[data-action]")) return;
+        var id = card.getAttribute("data-agent-id");
+        openModal(id);
+      });
+    });
+    var reprobeButtons = elGrid.querySelectorAll("[data-action=reprobe]");
+    reprobeButtons.forEach(function(btn) {
+      btn.addEventListener("click", function(e) {
+        e.stopPropagation();
+        var id = btn.getAttribute("data-agent-id");
+        reprobeOne(id);
+      });
+    });
+  }
+
+  function renderCard(r, history) {
+    var bucket = r.health_bucket || "unknown";
+    var latencyClass = "";
+    if (typeof r.latency_ms === "number") {
+      if (r.latency_ms > 5000) latencyClass = "bad";
+      else if (r.latency_ms > 2500) latencyClass = "warn";
+    }
+    if (!r.alive && r.probed) latencyClass = "bad";
+    var circuitDisplay = r.circuit_state ? r.circuit_state : "—";
+    var circuitClass = r.circuit_state === "open" ? "bad" :
+                       r.circuit_state === "half_open" ? "warn" :
+                       r.circuit_state === "closed" ? "" : "muted";
+    var toolsDisplay = (typeof r.tools_count === "number") ? String(r.tools_count) : "—";
+
+    return "<div class=\\"vendor-card " + bucket + "\\" data-agent-id=\\"" + escapeHtml(r.agent_id) + "\\" data-bucket=\\"" + bucket + "\\" data-stage=\\"" + escapeHtml(r.stage) + "\\" data-role=\\"" + escapeHtml(r.role) + "\\">" +
+      "  <div class=\\"vc-head\\">" +
+      "    <div>" +
+      "      <div class=\\"vc-name\\">" + escapeHtml(r.agent_name) + "</div>" +
+      "      <div class=\\"vc-vendor\\"><span class=\\"vc-stage " + escapeHtml(r.stage) + "\\">" + escapeHtml(r.stage) + "</span> " + escapeHtml(r.vendor) + " &middot; " + escapeHtml(r.role) + "</div>" +
+      "    </div>" +
+      "    <span class=\\"vc-status-pill " + bucket + "\\">" + escapeHtml(bucket) + "</span>" +
+      "  </div>" +
+      "  <div class=\\"vc-metrics\\">" +
+      "    <div class=\\"vc-metric\\">" +
+      "      <div class=\\"vc-metric-label\\">Latency</div>" +
+      "      <div class=\\"vc-metric-value " + latencyClass + "\\">" + fmtLatency(r.latency_ms) + "</div>" +
+      "    </div>" +
+      "    <div class=\\"vc-metric\\">" +
+      "      <div class=\\"vc-metric-label\\">Tools</div>" +
+      "      <div class=\\"vc-metric-value\\">" + toolsDisplay + "</div>" +
+      "    </div>" +
+      "    <div class=\\"vc-metric\\">" +
+      "      <div class=\\"vc-metric-label\\">Circuit</div>" +
+      "      <div class=\\"vc-metric-value " + circuitClass + "\\">" + circuitDisplay + "</div>" +
+      "    </div>" +
+      "  </div>" +
+      "  " + renderSparkline(history) +
+      "  <div class=\\"vc-foot\\">" +
+      "    <div class=\\"vc-foot-meta\\">probed " + (r.probed ? fmtRelTime(r.snapshot_ts) : "never (this snapshot)") + "</div>" +
+      "    <div class=\\"vc-foot-actions\\">" +
+      (r.mcp_url ? "      <button class=\\"vc-btn\\" data-action=\\"reprobe\\" data-agent-id=\\"" + escapeHtml(r.agent_id) + "\\">re-probe</button>" : "") +
+      "    </div>" +
+      "  </div>" +
+      "</div>";
+  }
+
+  function filterMatches(r) {
+    if (state.filter.bucket !== "all" && r.health_bucket !== state.filter.bucket) return false;
+    if (state.filter.stage !== "all" && r.stage !== state.filter.stage) return false;
+    if (state.filter.role !== "all" && r.role !== state.filter.role) return false;
+    return true;
+  }
+
+  // ── Filter chip wiring ─────────────────────────────────────────────
+  document.querySelectorAll("[data-filter-bucket]").forEach(function(chip) {
+    chip.addEventListener("click", function() {
+      var val = chip.getAttribute("data-filter-bucket");
+      state.filter.bucket = val;
+      document.querySelectorAll("[data-filter-bucket]").forEach(function(c) { c.classList.toggle("is-active", c === chip); });
+      renderGrid();
+    });
+  });
+  document.querySelectorAll("[data-filter-stage]").forEach(function(chip) {
+    chip.addEventListener("click", function() {
+      var val = chip.getAttribute("data-filter-stage");
+      state.filter.stage = val;
+      document.querySelectorAll("[data-filter-stage]").forEach(function(c) { c.classList.toggle("is-active", c === chip); });
+      renderGrid();
+    });
+  });
+  document.querySelectorAll("[data-filter-role]").forEach(function(chip) {
+    chip.addEventListener("click", function() {
+      var val = chip.getAttribute("data-filter-role");
+      state.filter.role = val;
+      document.querySelectorAll("[data-filter-role]").forEach(function(c) { c.classList.toggle("is-active", c === chip); });
+      renderGrid();
+    });
+  });
+
+  // ── Modal ──────────────────────────────────────────────────────────
+  function openModal(agentId) {
+    var r = state.rows.find ? state.rows.find(function(x) { return x.agent_id === agentId; }) : null;
+    if (!r) return;
+    elModalTitle.textContent = r.agent_name;
+    elModalSub.textContent = r.vendor + " - " + r.role + " - stage:" + r.stage;
+
+    elModalIdentity.innerHTML =
+      kvRow("agent_id", r.agent_id) +
+      kvRow("mcp_url", r.mcp_url || "(none)") +
+      kvRow("protocols", (r.protocols || []).join(", ") || "—") +
+      kvRow("specialties", (r.specialties || []).join(", ") || "—") +
+      kvRow("notes", r.notes || "—");
+
+    elModalProbe.innerHTML =
+      kvRow("probed", r.probed ? "yes" : "no") +
+      kvRow("alive", r.alive ? "yes" : "no") +
+      kvRow("latency", fmtLatency(r.latency_ms)) +
+      kvRow("tools_count", (r.tools_count !== null && r.tools_count !== undefined) ? String(r.tools_count) : "—") +
+      kvRow("server_name", r.server_name || "—") +
+      kvRow("protocol_version", r.protocol_version || "—") +
+      kvRow("error", r.probe_error || "—") +
+      kvRow("snapshot_ts", r.snapshot_ts ? r.snapshot_ts + " (" + fmtRelTime(r.snapshot_ts) + ")" : "—") +
+      kvRow("health_reason", r.health_reason || "—");
+
+    elModalCircuit.innerHTML =
+      kvRow("state", r.circuit_state || "(no circuit yet — vendor not called this isolate)") +
+      kvRow("failure_count", String(r.circuit_failure_count || 0)) +
+      kvRow("success_count", String(r.circuit_success_count || 0)) +
+      kvRow("last_event", r.circuit_last_event_ts ? fmtRelTime(new Date(r.circuit_last_event_ts).toISOString()) : "—");
+
+    var hist = state.histories[r.agent_id] || [];
+    if (hist.length === 0) {
+      elModalHistory.textContent = "no probe history (history fills as you click Live probe)";
+    } else {
+      var lines = hist.map(function(d) {
+        return d.ts + "  " + (d.alive ? "alive" : "dead") + "  " + fmtLatency(d.latency_ms) + "  bucket=" + d.health_bucket + "  circuit=" + (d.circuit_state || "—");
+      });
+      elModalHistory.textContent = lines.join("\\n");
+    }
+    elModalTools.innerHTML = "<span class=\\"modal-tool\\">tools list captured at probe time, see /agents/registry for full list</span>";
+
+    elModalBackdrop.classList.add("is-open");
+  }
+  function kvRow(k, v) {
+    return "<div class=\\"modal-grid-key\\">" + escapeHtml(k) + "</div><div class=\\"modal-grid-val\\">" + escapeHtml(v) + "</div>";
+  }
+  elModalClose.addEventListener("click", function() { elModalBackdrop.classList.remove("is-open"); });
+  elModalBackdrop.addEventListener("click", function(e) { if (e.target === elModalBackdrop) elModalBackdrop.classList.remove("is-open"); });
+
+  // ── Snapshot fetch ─────────────────────────────────────────────────
+  async function loadSnapshot(probeLive) {
+    if (state.isProbing) return;
+    state.isProbing = true;
+    elBtnRefresh.disabled = true;
+    elBtnMeta.disabled = true;
+    elBtnRefresh.textContent = probeLive ? "Probing..." : "Loading...";
+    if (probeLive) elLoadingBar.classList.add("is-active");
+    try {
+      var url = "/vendor-health/snapshot" + (probeLive ? "" : "?probe=false");
+      var resp = await fetch(url, { headers: { "Authorization": "Bearer " + DEMO_KEY } });
+      if (!resp.ok) {
+        var txt = await resp.text();
+        throw new Error("server " + resp.status + ": " + txt.slice(0, 160));
+      }
+      var data = await resp.json();
+      state.rows = data.rows || [];
+      state.histories = data.histories || {};
+      state.counts = data.counts || null;
+      renderAggregate(state.counts, data.total || state.rows.length);
+      renderGrid();
+    } catch (err) {
+      console.error("loadSnapshot failed", err);
+      elGrid.innerHTML = "<div class=\\"empty-state\\">Snapshot failed: " + escapeHtml(err.message || String(err)) + "</div>";
+    } finally {
+      state.isProbing = false;
+      elBtnRefresh.disabled = false;
+      elBtnMeta.disabled = false;
+      elBtnRefresh.textContent = "Live probe (all)";
+      elLoadingBar.classList.remove("is-active");
+      elLoadingBar.style.width = "0";
+    }
+  }
+
+  async function reprobeOne(agentId) {
+    var card = elGrid.querySelector("[data-agent-id=\\"" + agentId + "\\"]");
+    if (card) card.classList.add("is-probing");
+    try {
+      var resp = await fetch("/vendor-health/probe-one", {
+        method: "POST",
+        headers: { "Content-Type": "application/json", "Authorization": "Bearer " + DEMO_KEY },
+        body: JSON.stringify({ agent_id: agentId })
+      });
+      if (!resp.ok) {
+        var txt = await resp.text();
+        throw new Error("server " + resp.status + ": " + txt.slice(0, 160));
+      }
+      var updated = await resp.json();
+      // Patch the row in state.rows.
+      var i = -1;
+      for (var k = 0; k < state.rows.length; k++) {
+        if (state.rows[k].agent_id === agentId) { i = k; break; }
+      }
+      if (i >= 0) {
+        // Preserve registry-side fields; merge probe-side fields from response.
+        var existing = state.rows[i];
+        state.rows[i] = Object.assign({}, existing, updated);
+        // Append a synthetic datapoint to local history so the sparkline updates.
+        if (!state.histories[agentId]) state.histories[agentId] = [];
+        state.histories[agentId].push({
+          ts: updated.snapshot_ts,
+          alive: updated.alive,
+          latency_ms: updated.latency_ms,
+          health_bucket: updated.health_bucket,
+          circuit_state: updated.circuit_state
+        });
+        if (state.histories[agentId].length > 24) {
+          state.histories[agentId] = state.histories[agentId].slice(-24);
+        }
+        // Recompute aggregate.
+        recomputeCounts();
+      }
+      renderGrid();
+    } catch (err) {
+      console.error("reprobeOne failed", err);
+      alert("Re-probe failed: " + (err.message || String(err)));
+    } finally {
+      if (card) card.classList.remove("is-probing");
+    }
+  }
+
+  function recomputeCounts() {
+    var c = { healthy: 0, degraded: 0, down: 0, unknown: 0 };
+    for (var i = 0; i < state.rows.length; i++) {
+      var b = state.rows[i].health_bucket;
+      if (c[b] !== undefined) c[b]++;
+    }
+    if (state.counts) {
+      state.counts.healthy = c.healthy;
+      state.counts.degraded = c.degraded;
+      state.counts.down = c.down;
+      state.counts.unknown = c.unknown;
+    } else {
+      state.counts = c;
+    }
+    renderAggregate(state.counts, state.rows.length);
+  }
+
+  // ── Wiring ──────────────────────────────────────────────────────────
+  elBtnRefresh.addEventListener("click", function() { loadSnapshot(true); });
+  elBtnMeta.addEventListener("click", function() { loadSnapshot(false); });
+
+  // Initial load: metadata-only for fast paint. Operator clicks "Live probe" for the slow fan-out.
+  loadSnapshot(false);
+})();
+</script>
+
+</body>
+</html>`;
+}

--- a/src/routes/vendorHealthRoutes.ts
+++ b/src/routes/vendorHealthRoutes.ts
@@ -1,0 +1,136 @@
+// src/routes/vendorHealthRoutes.ts
+//
+// Wave 5 — Vendor Health Dashboard endpoints.
+//
+//   GET  /vendor-health/snapshot
+//        Live snapshot: probes all live agents in parallel (8s/agent
+//        timeout), merges with circuit state + registry, appends one
+//        datapoint per probed vendor to the KV history ring buffer,
+//        returns the snapshot + history map.
+//
+//   GET  /vendor-health/snapshot?probe=false
+//        Metadata-only: skip live probes, use cached circuit state +
+//        registry metadata. Used for fast initial page-load before
+//        the user clicks "Refresh now."
+//
+//   POST /vendor-health/probe-one
+//        Single-vendor live probe. The dashboard sends this when the
+//        operator clicks "Re-probe" on a specific row, so they don't
+//        have to wait for the full fan-out again.
+//
+// All endpoints are GET-or-POST and unauth (same posture as Race Canvas
+// and Agentic routes — no paid actions, only diagnostic views).
+//
+// The `probe=true` snapshot is on the slow side (~8s upper bound bound
+// by the slowest agent's handshake). The dashboard renders a loading
+// state while it's in flight.
+
+import type { Env } from "../types/env";
+import type { Logger } from "../utils/logger";
+import { jsonResponse, errorResponse } from "./shared";
+import { buildVendorHealthSnapshot } from "../domain/vendorHealthSnapshot";
+import { appendSnapshotDatapoints, readHistories, appendDatapoint, type HealthDatapoint } from "../storage/vendorHealthHistory";
+import { AGENT_REGISTRY } from "../domain/agentRegistry";
+import { probeAgent, getCircuitSnapshot } from "../federation/genericMcpClient";
+
+// ── GET /vendor-health/snapshot ─────────────────────────────────────────────
+
+export async function handleVendorHealthSnapshot(request: Request, env: Env, logger: Logger): Promise<Response> {
+  const url = new URL(request.url);
+  const probeLive = url.searchParams.get("probe") !== "false";
+
+  const snap = await buildVendorHealthSnapshot({ probeLive });
+
+  // Append to KV history (best-effort, fire-and-await but failures
+  // don't propagate). Only append when we actually probed; metadata-only
+  // snapshots don't add useful history.
+  if (probeLive) {
+    await appendSnapshotDatapoints(env, snap.rows);
+  }
+
+  // Read history for all vendors so the dashboard can render sparklines
+  // in one round-trip.
+  const histories = await readHistories(env, snap.rows.map((r) => r.agent_id));
+
+  logger.info("vendor_health_snapshot", {
+    probed: snap.probed,
+    total: snap.total,
+    healthy: snap.counts.healthy,
+    degraded: snap.counts.degraded,
+    down: snap.counts.down,
+  });
+
+  return jsonResponse({
+    ...snap,
+    histories,
+  });
+}
+
+// ── POST /vendor-health/probe-one ───────────────────────────────────────────
+
+interface ProbeOneBody {
+  agent_id?: string;
+}
+
+export async function handleVendorHealthProbeOne(request: Request, env: Env, logger: Logger): Promise<Response> {
+  let body: ProbeOneBody = {};
+  try { body = await request.json(); } catch { /* empty */ }
+
+  const agentId = (body.agent_id ?? "").trim();
+  if (!agentId) {
+    return errorResponse("INVALID_INPUT", "agent_id required", 400);
+  }
+
+  const agent = AGENT_REGISTRY.find((a) => a.id === agentId);
+  if (!agent) {
+    return errorResponse("NOT_FOUND", `agent_id "${agentId}" not in registry`, 404);
+  }
+  if (!agent.mcp_url) {
+    return errorResponse("INVALID_INPUT", `agent ${agentId} has no mcp_url (stage=${agent.stage})`, 400);
+  }
+
+  const ts = new Date().toISOString();
+  const result = await probeAgent(agent.mcp_url, { timeoutMs: 8000 });
+
+  // Refresh circuit state into the row.
+  const circuit = getCircuitSnapshot().find((c) => c.url === agent.mcp_url);
+
+  // Compute a quick health bucket — same logic as the snapshot module
+  // but inline because we only have one row to evaluate.
+  let bucket: HealthDatapoint["health_bucket"];
+  if (circuit?.state === "open") bucket = "down";
+  else if (!result.alive) bucket = "down";
+  else if ((result.latency_ms ?? 0) > 5000) bucket = "degraded";
+  else if (circuit?.state === "half_open") bucket = "degraded";
+  else bucket = "healthy";
+
+  const dp: HealthDatapoint = {
+    ts,
+    alive: result.alive,
+    latency_ms: result.latency_ms,
+    health_bucket: bucket,
+    circuit_state: circuit?.state ?? null,
+  };
+  await appendDatapoint(env, agent.id, dp);
+
+  logger.info("vendor_health_probe_one", { agent_id: agentId, alive: result.alive, latency_ms: result.latency_ms });
+
+  return jsonResponse({
+    agent_id: agent.id,
+    agent_name: agent.name,
+    vendor: agent.vendor,
+    role: agent.role,
+    probed: true,
+    alive: result.alive,
+    latency_ms: result.latency_ms,
+    probe_error: result.error ?? null,
+    tools_count: result.tools?.length ?? null,
+    server_name: result.server_info?.name ?? null,
+    protocol_version: result.protocol_version ?? null,
+    circuit_state: circuit?.state ?? null,
+    circuit_failure_count: circuit?.failure_count ?? 0,
+    circuit_success_count: circuit?.success_count ?? 0,
+    health_bucket: bucket,
+    snapshot_ts: ts,
+  });
+}

--- a/src/storage/vendorHealthHistory.ts
+++ b/src/storage/vendorHealthHistory.ts
@@ -1,0 +1,104 @@
+// src/storage/vendorHealthHistory.ts
+//
+// Wave 5 — KV-backed ring buffer for per-vendor health history.
+//
+// Each `/vendor-health/snapshot` call appends one datapoint per probed
+// vendor. The ring buffer keeps the last N points (default 24) so the
+// dashboard can render a sparkline showing recent health trend.
+//
+// Storage layout:
+//   key:  vendor_health:v1:<agent_id>
+//   val:  JSON array of HealthDatapoint, oldest first, max 24 entries
+//   ttl:  7 days (re-set on every write, so frequently probed vendors
+//         stay around indefinitely while abandoned ones expire)
+//
+// Why per-vendor key (vs one big "all" key):
+//   - KV write granularity: when one vendor's history grows, we don't
+//     rewrite the other 16. Cheaper.
+//   - Read parallelism: the dashboard fans out reads when it needs to
+//     show all sparklines. Each read is small.
+//
+// Ring-buffer trim: we drop the OLDEST entry on overflow. New points
+// always go to the end of the array; the dashboard reads in order.
+
+import type { Env } from "../types/env";
+import type { VendorHealthRow } from "../domain/vendorHealthSnapshot";
+
+export interface HealthDatapoint {
+  ts: string;            // ISO-8601
+  alive: boolean;
+  latency_ms: number | null;
+  health_bucket: string; // healthy | degraded | down | unknown
+  circuit_state: string | null;
+}
+
+const KEY_PREFIX = "vendor_health:v1:";
+const HISTORY_MAX = 24;
+const HISTORY_TTL_SECONDS = 7 * 24 * 60 * 60; // 7 days
+
+function keyFor(agent_id: string): string {
+  return KEY_PREFIX + agent_id;
+}
+
+/**
+ * Read history for one vendor. Returns [] if nothing stored yet.
+ */
+export async function readHistory(env: Env, agent_id: string): Promise<HealthDatapoint[]> {
+  try {
+    const raw = await env.SIGNALS_CACHE.get(keyFor(agent_id), "json");
+    if (!Array.isArray(raw)) return [];
+    return (raw as HealthDatapoint[]).slice(-HISTORY_MAX);
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Read history for many vendors in parallel. Returns a map keyed by
+ * agent_id; vendors with no history map to [].
+ */
+export async function readHistories(env: Env, agent_ids: string[]): Promise<Record<string, HealthDatapoint[]>> {
+  const out: Record<string, HealthDatapoint[]> = {};
+  const results = await Promise.all(agent_ids.map((id) => readHistory(env, id).then((h) => ({ id, h }))));
+  for (const { id, h } of results) out[id] = h;
+  return out;
+}
+
+/**
+ * Append one datapoint to a vendor's history, trim to HISTORY_MAX,
+ * write back with TTL refresh. Best-effort — failures are logged
+ * but don't propagate (the dashboard works without history).
+ */
+export async function appendDatapoint(env: Env, agent_id: string, dp: HealthDatapoint): Promise<void> {
+  try {
+    const existing = await readHistory(env, agent_id);
+    const updated = [...existing, dp].slice(-HISTORY_MAX);
+    await env.SIGNALS_CACHE.put(keyFor(agent_id), JSON.stringify(updated), {
+      expirationTtl: HISTORY_TTL_SECONDS,
+    });
+  } catch {
+    // Best-effort — history is decorative.
+  }
+}
+
+/**
+ * After a snapshot, write one datapoint per probed vendor in parallel.
+ * Skips rows that weren't probed in this snapshot.
+ */
+export async function appendSnapshotDatapoints(env: Env, rows: VendorHealthRow[]): Promise<void> {
+  const tasks = rows
+    .filter((r) => r.probed)
+    .map((r) => {
+      const dp: HealthDatapoint = {
+        ts: r.snapshot_ts,
+        alive: r.alive,
+        latency_ms: r.latency_ms,
+        health_bucket: r.health_bucket,
+        circuit_state: r.circuit_state,
+      };
+      return appendDatapoint(env, r.agent_id, dp);
+    });
+  // Don't await — fire and forget so the snapshot route returns fast.
+  // The Workers runtime will resolve in the background.
+  await Promise.allSettled(tasks);
+}


### PR DESCRIPTION
## Summary

Self-contained `/vendor-health` page — fleet view of all 17 registry agents at a glance.

## What you see

**Aggregate strip** (5 cards at top):
- total · **healthy** (green) · **degraded** (yellow) · **down** (red) · **unknown** (grey)

**Filter row** (chips, multi-axis):
- Status: All / Healthy / Degraded / Down / Unknown
- Stage: All / Live / Known issue / Roadmap
- Role: All / Signals / Buying / Creative

**Vendor cards** (2-col responsive grid):
- Name + vendor + role + stage badge
- Status pill (traffic-light bucket)
- Metrics: latency / tools count / circuit state
- Sparkline of last 24 probes (latency trend, color follows most recent health bucket)
- Last-probed relative time + per-card "re-probe" button

**Drill-down modal** (click any card):
- Identity (mcp_url, protocols, specialties, notes)
- Probe details (alive, latency, tools count, server name, protocol version, error)
- Circuit breaker state (failure/success counts, last event)
- Recent history table

## Health bucketing precedence

| Check | Bucket |
|---|---|
| Stage `known_issue` or `roadmap` | unknown |
| Circuit OPEN | down |
| Probe failed | down |
| Latency > 5s | degraded |
| Circuit half_open | degraded |
| Else | healthy |

## Initial paint vs live probe

- Page load: `GET /vendor-health/snapshot?probe=false` — instant, metadata + cached circuit state
- Click "Live probe (all)": fans out to 13 live agents in parallel, ~8s upper bound, writes one history datapoint per probed vendor to KV
- Per-card "re-probe": one-vendor refresh, patches just that card

## Files

| File | Purpose |
|---|---|
| `src/domain/vendorHealthSnapshot.ts` | Parallel probe + circuit merge + bucket logic |
| `src/storage/vendorHealthHistory.ts` | KV ring buffer (24 entries, 7-day TTL) |
| `src/routes/vendorHealthRoutes.ts` | 3 endpoints (snapshot + probe-one) |
| `src/routes/vendorHealthCanvas.ts` | Self-contained HTML page |
| `src/index.ts` | Route registration + 3 publicPaths entries |
| `src/routes/demo.ts` | Sidebar link |

## Test plan

- [ ] `GET /vendor-health` renders without console errors
- [ ] Initial paint shows all 17 agents with `unknown` status (metadata-only)
- [ ] Click "Live probe (all)" — loading bar animates, ~5-8s later cards update with real probe data
- [ ] Aggregate strip updates: e.g., "13 healthy · 0 degraded · 0 down · 4 unknown"
- [ ] Sparklines render after 2+ probes (call live probe twice to populate)
- [ ] Click a card → modal opens with full identity + probe details + circuit history
- [ ] Re-probe button on a card patches just that row (other rows unchanged)
- [ ] Filter chips combine: e.g., "Live × Buying × Healthy" shows only live buying agents that just probed healthy
- [ ] Sidebar nav link "Vendor Health" from main demo navigates correctly

## Pre-flight

- `npx tsc --noEmit` on changed files: 0 errors
- Trap audit on `vendorHealthCanvas.ts`: 0 hits (all 3 traps clean)
- Trap audit on `demo.ts` after sidebar edit: 0 hits

🤖 Generated with [Claude Code](https://claude.com/claude-code)