### PR TITLE
Fix: Vendor Health probes own MCP URL as DOWN (missing self-fetch hook)

### DIFF
--- a/src/routes/vendorHealthRoutes.ts
+++ b/src/routes/vendorHealthRoutes.ts
@@ -32,10 +32,20 @@ import { buildVendorHealthSnapshot } from "../domain/vendorHealthSnapshot";
 import { appendSnapshotDatapoints, readHistories, appendDatapoint, type HealthDatapoint } from "../storage/vendorHealthHistory";
 import { AGENT_REGISTRY } from "../domain/agentRegistry";
 import { probeAgent, getCircuitSnapshot } from "../federation/genericMcpClient";
+// ensureSelfHooksInstalled wires the Cloudflare self-fetch shim into
+// the generic MCP client. Without it, probeAgent against our own /mcp
+// URL is blocked by Cloudflare (worker-can't-fetch-its-own-public-hostname,
+// CF error 1042) and returns alive:false ~25ms in — which the dashboard
+// renders as DOWN even though our agent is fine. Every other route that
+// probes agents (agenticRoutes, dspRoutes, agentsEndpoints) calls this;
+// the Wave 5 ship missed it.
+import { ensureSelfHooksInstalled } from "./agentsEndpoints";
 
 // ── GET /vendor-health/snapshot ─────────────────────────────────────────────
 
 export async function handleVendorHealthSnapshot(request: Request, env: Env, logger: Logger): Promise<Response> {
+  ensureSelfHooksInstalled(env, logger);
+
   const url = new URL(request.url);
   const probeLive = url.searchParams.get("probe") !== "false";
 
@@ -73,6 +83,8 @@ interface ProbeOneBody {
 }
 
 export async function handleVendorHealthProbeOne(request: Request, env: Env, logger: Logger): Promise<Response> {
+  ensureSelfHooksInstalled(env, logger);
+
   let body: ProbeOneBody = {};
   try { body = await request.json(); } catch { /* empty */ }
 


### PR DESCRIPTION
## Bug

From your screenshot: **"Evgeny AdCP Signals adapter" rendered with red DOWN pill**, latency 25ms (suspiciously fast for a real failure), tools count "—".

## Root cause

Wave 5 (#143) missed wiring `ensureSelfHooksInstalled(env, logger)` into the vendor-health routes. Without it:
- `probeAgent` calls `fetch()` against our own `https://...workers.dev/mcp`
- Cloudflare Workers blocks the worker fetching its own public hostname (CF error 1042/522)
- The fetch fails fast (~25ms) → `alive:false` → bucketed as `down`

## Why every other route handles this

`agenticRoutes`, `dspRoutes`, `agentsEndpoints` all call `ensureSelfHooksInstalled` first. The hook installs a self-probe shim that returns our canonical tool list from `ADCP_TOOLS` in-process when the URL matches `SELF_URL`. I missed this on the Wave 5 ship.

## Fix

Two lines added to `vendorHealthRoutes.ts`:
- `ensureSelfHooksInstalled(env, logger)` at the top of `handleVendorHealthSnapshot`
- Same at the top of `handleVendorHealthProbeOne`

Plus the import.

## What you'll see after merge + deploy

- "Evgeny AdCP Signals adapter" → green **HEALTHY** pill
- Latency 0-5ms (in-process dispatch, no network)
- Tools count: 8 (`get_adcp_capabilities`, `get_signals`, `activate_signal`, `get_operation_status`, `get_similar_signals`, `query_signals_nl`, `get_concept`, `search_concepts`)
- Aggregate count flips: ~22 total, **12 healthy** (was 11), 0 degraded, 4 down/known_issue, 7 unknown

## Bug-class memory

Adding to feedback notes alongside "publicPaths-miss":
- **publicPaths-miss**: new auth'd-but-shouldn't-be route → 401 errors
- **self-probe-hook-miss**: new route that fans out to agents → own URL renders DOWN

Both have the same fix pattern: copy the boilerplate from a sibling route. Should add a one-line check to PR template / pre-flight.

## Test plan

- [ ] After deploy, hit `/vendor-health` → click "Live probe (all)"
- [ ] Confirm Evgeny adapter shows HEALTHY (green pill)
- [ ] Confirm tools count is 8 for the adapter
- [ ] Aggregate "healthy" count went up by 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)