### PR TITLE
Sidebar: default all groups collapsed except active (compact-on-arrival)

### DIFF
--- a/src/routes/demo.ts
+++ b/src/routes/demo.ts
@@ -7382,10 +7382,19 @@ function confidenceRange(size, tier) {
 
 //────────────────────────────────────────────────────────────────────────
 // Sidebar group collapse / expand (capability-grouped nav).
-// State persists in localStorage under "sidebar-group-state" as
-// { groupId: <bool collapsed> }. The active tab's parent group is always
-// force-expanded on render so the user never lands on a tab whose group
-// is collapsed.
+//
+// Default behavior: ALL groups collapsed EXCEPT the one containing the
+// active tab. This keeps the sidebar compact on first visit; users
+// expand the groups they want and that choice persists.
+//
+// State semantics (localStorage key sidebar-group-state):
+//   state[groupId] === true   user explicitly COLLAPSED this group
+//   state[groupId] === false  user explicitly EXPANDED this group
+//   state[groupId] === undef  never touched, falls through to default
+//                              (default is collapsed)
+//
+// The active tab's parent group is force-expanded regardless of state,
+// so the user never lands on a tab whose group is hidden.
 //────────────────────────────────────────────────────────────────────────
 const SIDEBAR_STATE_KEY = "sidebar-group-state";
 
@@ -7404,7 +7413,10 @@ function _applySidebarGroupState() {
   const state = _readSidebarState();
   document.querySelectorAll(".nav-group").forEach((g) => {
     const id = g.dataset.groupId;
-    const collapsed = state[id] === true;
+    // Default to collapsed UNLESS the user has explicitly expanded this
+    // group (state[id] === false). Untouched groups are treated as
+    // collapsed by default to keep the sidebar compact.
+    const collapsed = state[id] !== false;
     g.classList.toggle("is-collapsed", collapsed);
   });
   // Force-expand the group containing the currently active item so the


### PR DESCRIPTION
## Why

Your read was right — a fully-expanded grouped nav is just a re-skinned flat list. The compact-on-arrival pattern is what makes capability grouping actually useful.

## Behavior change

| | Before | After |
|---|---|---|
| First visit, no localStorage | All 7 groups expanded | Only the active group (Signals → Discover) expanded |
| User explicitly expanded a group, then reload | Stays expanded | Stays expanded ✓ |
| User explicitly collapsed a group, then reload | Stays collapsed | Stays collapsed ✓ |
| User active on a tab inside a collapsed group | Force-expanded | Force-expanded ✓ |

## Implementation

One-line behavior flip in `_applySidebarGroupState`:

```js
// Before: default expanded
const collapsed = state[id] === true;

// After: default collapsed
const collapsed = state[id] !== false;
```

State semantics now:
- `state[id] === true` → user explicitly collapsed
- `state[id] === false` → user explicitly expanded
- `state[id] === undefined` → never touched, defaults to **collapsed**

## Trap caught in flight (worth noting)

The first commit attempt failed tsc with a parse error 8000+ lines below my edit. Root cause: a backtick inside a JS comment inside the outer TS template literal:

```js
// State semantics (localStorage `sidebar-group-state`):
//                              ^^^ closes the outer template literal early
```

Replaced backticks with plain text. **This is the 4th SCRIPT_TAG trap class** — `trap_audit.py` only scans strings + regex literals, doesn't catch backticks-in-comments. Adding to my feedback notes; consider extending the audit script in a follow-up PR.

## Test plan

- [ ] Hard refresh `/` (clear localStorage if testing fresh)
- [ ] On first load: only "Signals" group expanded (Discover is the default active tab)
- [ ] All other 6 groups show with chevron pointing right (collapsed)
- [ ] Click "Analytics" header → expands; reload page → stays expanded
- [ ] Click "Analytics" header again → collapses; reload → stays collapsed
- [ ] Use keyboard shortcut to navigate to a tab inside a collapsed group → that group force-expands

## Pre-flight

- `tsc --noEmit` on demo.ts: 0 errors (after the backtick fix)
- `trap_audit.py` on demo.ts: 0 hits (existing 3 trap classes)
- Compilation succeeds end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)