### PR TITLE
Fix: Dstillery err pill — stop sending pagination + surface MCP isError content

### DIFF
--- a/src/federation/dstilleryClient.ts
+++ b/src/federation/dstilleryClient.ts
@@ -123,9 +123,11 @@ async function callGetSignalsOnce(
       method: "tools/call",
       params: {
         name: "get_signals",
-        // AdCP 3.0.1: paginated form preferred; top-level kept for back-compat
-        // with 3.0.0-era agents (drop top-level on 4.0 cutover).
-        arguments: { signal_spec: brief, max_results: maxResults, pagination: { max_results: maxResults } },
+        // Top-level max_results only. Dstillery's get_signals validator
+        // (Pydantic 2.12) rejects the `pagination` envelope as an
+        // "Unexpected keyword argument" — strict-additionalProperties
+        // schemas don't tolerate forward-compat fields.
+        arguments: { signal_spec: brief, max_results: maxResults },
       },
     }),
     signal: AbortSignal.timeout(15_000),

--- a/src/federation/genericMcpClient.ts
+++ b/src/federation/genericMcpClient.ts
@@ -273,6 +273,22 @@ async function callToolOnce(url: string, sessionId: string, name: string, args: 
   if (body.result.content !== undefined) out.content = body.result.content;
   if (body.result.structuredContent !== undefined) out.structured_content = body.result.structuredContent;
   if (body.result.isError !== undefined) out.is_error = body.result.isError;
+  // When isError is true, MCP spec puts the error narrative in
+  // content[0].text. Surface it as out.error so upstream UI shows the
+  // diagnostic instead of a bare "err" pill. Without this, a vendor
+  // rejecting our payload (e.g. Dstillery's Pydantic validator on
+  // unknown `pagination` field) presents identically to a network drop.
+  if (body.result.isError) {
+    const content = body.result.content;
+    if (Array.isArray(content)) {
+      const firstText = content.find((c) => c && typeof c === "object" && (c as { type?: string }).type === "text");
+      const text = (firstText as { text?: string } | undefined)?.text;
+      if (typeof text === "string" && text.trim().length > 0) {
+        out.error = text.trim().slice(0, 500);
+      }
+    }
+    if (!out.error) out.error = "tool_error_no_message";
+  }
   return out;
 }
 

--- a/src/routes/agentsEndpoints.ts
+++ b/src/routes/agentsEndpoints.ts
@@ -254,15 +254,16 @@ export async function handleAgentsOrchestrate(request: Request, env: Env, logger
   if (targets.length === 0) return errorResponse("NO_TARGETS", "No live signals agents matched filters.", 400);
 
   const perAgent: OrchestratePerAgent[] = await Promise.all(targets.map(async (a): Promise<OrchestratePerAgent> => {
-    // AdCP 3.0.1: send both top-level + pagination.max_results.
-    // Spec says agents honor `pagination.max_results` when both are present
-    // (top-level deprecated, removed in 4.0); we keep the top-level form
-    // for back-compat with 3.0.0-era agents that don't read the paginated
-    // form. Drop the top-level on the 4.0 cutover.
+    // AdCP 3.0.1 introduced a `pagination` request envelope ({ max_results })
+    // alongside top-level max_results. We previously sent BOTH for forward
+    // compat, but in practice some vendors validate strictly with Pydantic
+    // and reject the extra `pagination` keyword (Dstillery's get_signals
+    // surfaces "Unexpected keyword argument" on pagination). Send only
+    // top-level until the paginated form becomes universal — re-add when
+    // we observe vendors actually requiring it.
     const res = await callAgentTool(a.mcp_url!, tool, {
       signal_spec: body.brief,
       max_results: maxResults,
-      pagination: { max_results: maxResults },
     }, { timeoutMs });
     const structured = res.structured_content as { signals?: unknown[] } | undefined;
     const signals = structured?.signals ?? [];
@@ -521,8 +522,10 @@ async function runSignalsStage(
     const res = await callAgentTool(
       a.mcp_url!,
       "get_signals",
-      // AdCP 3.0.1 paginated form + top-level back-compat (see comment above).
-      { signal_spec: brief, max_results: maxResults, pagination: { max_results: maxResults } },
+      // Top-level max_results only — see handleAgentsOrchestrate comment
+      // on why we dropped the `pagination` envelope (Pydantic-strict
+      // vendors like Dstillery reject the unknown keyword).
+      { signal_spec: brief, max_results: maxResults },
       { timeoutMs },
     );
     const signals = extractMcpToolArray<SignalLite>(res.structured_content, res.content, ["signals"])
@@ -889,8 +892,8 @@ export async function handleWorkflowRunStream(request: Request, env: Env, logger
           const res = await callAgentTool(
             a.mcp_url!,
             "get_signals",
-            // AdCP 3.0.1 paginated form + top-level back-compat.
-            { signal_spec: body.brief, max_results: maxSignals, pagination: { max_results: maxSignals } },
+            // Top-level max_results only (see handleAgentsOrchestrate comment).
+            { signal_spec: body.brief, max_results: maxSignals },
             { timeoutMs },
           );
           const signals = extractMcpToolArray<SignalLite>(res.structured_content, res.content, ["signals"])

--- a/src/routes/dspRoutes.ts
+++ b/src/routes/dspRoutes.ts
@@ -576,7 +576,8 @@ export async function handleDspCampaignSignalsLive(
     const r = await callAgentToolWithCircuit(a.mcp_url!, "get_signals", {
       signal_spec: c.audience_brief,
       max_results: 10,
-      pagination: { max_results: 10 },
+      // pagination envelope intentionally NOT sent — see agentsEndpoints
+      // comment about Pydantic-strict vendors rejecting unknown keywords.
       deliver_to: { deployments: [{ type: "platform", platform: "mock_dsp" }], countries: ["US"] },
     }, { timeoutMs: 10_000 });
     const latency = Date.now() - start;


### PR DESCRIPTION
## Symptom

From your screenshot: dstillery card on the Brand Canvas signals fan-out shows red **err** pill, no diagnostic. Workshop-day cosmetic but actually a real bug.

## Diagnosis (verified end-to-end)

**Latency was the smoking gun: 34ms.** A real handshake to Dstillery's Google-Frontend takes ~600ms. Fast failure means the call hit the vendor and got rejected fast.

Reproduced via direct curl against `https://adcp-signals-agent.dstillery.com/mcp` with our exact orchestrator args. Vendor returned:

```
isError: true
content: [{ type: "text", text: "1 validation error for call[get_signals]\npagination\n  Unexpected keyword argument [type=unexpected_keyword_argument, input_value={'max_results': 5}, input_type=dict]" }]
```

Two things wrong on our side:

1. We were sending `pagination: { max_results: N }` outbound on every signals fan-out — forward-compat per AdCP 3.0.1, but vendors that validate strictly (Pydantic 2.12 with rejected additionalProperties) reject it as an unknown keyword. **Dstillery is one such vendor; others will be too as the directory grows.**

2. When MCP returned `isError: true`, our `callToolOnce` didn't extract `content[0].text` into `res.error` — `out.error` stayed undefined, so the UI just rendered "err" with no diagnostic. **The actual rejection message was completely invisible.**

## Fix

**1. Drop `pagination` outbound** in 4 call sites:
- `src/routes/agentsEndpoints.ts` × 3 (orchestrate, signals stage sync, signals stage stream)
- `src/federation/dstilleryClient.ts` (legacy client)
- `src/routes/dspRoutes.ts` (DSP campaign signals)

Keep top-level `max_results` which every vendor supports. Re-add `pagination` when it's universal.

**2. Surface MCP error content** in `genericMcpClient.callToolOnce`: when `result.isError` is true, extract `content[0].text`, trim, cap at 500 chars, set as `out.error`. Falls back to `"tool_error_no_message"` when content is missing.

Our INBOUND `get_signals` still accepts `pagination` — that's for runner compatibility, unchanged.

## What you'll see after deploy

- Dstillery card flips from `err` → `0` (their dataset doesn't have signals matching food_beverage briefs, but the call succeeds with `signals: []`)
- Future MCP errors render with the actual rejection text instead of bare "err" — much faster triage when vendors flag things

## Bug-class

Adding to feedback notes alongside `publicPaths-miss` and `self-probe-hook-miss`: **outbound-args-strict-vendor**. Any forward-compat field we add to outbound calls needs to be diffed against `tools/list.properties` first, or it'll break on Pydantic-strict vendors. Pagination was the canonical case here.

## Pre-flight

- `npx tsc --noEmit` on changed files: 0 errors
- Trap audit (demo.ts unchanged): 0 hits
- Direct curl reproduces the bug + confirms the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)