### PR TITLE
UI: brand-title wrap + replace prepopulated briefs with one-click try-chips

### DIFF
--- a/src/routes/demo.ts
+++ b/src/routes/demo.ts
@@ -128,7 +128,7 @@ ${STYLES}
     <div class="sidebar-brand">
       <div class="brand-mark"><img src="${BRAND_LOGO_DATA_URI}" alt="signal-stack"/></div>
       <div class="brand-text">
-        <div class="brand-title">Evgeny's <span class="dot">·</span> Marketplace Agent</div>
+        <div class="brand-title">Evgeny's <span class="brand-title-mp">Marketplace&nbsp;Agent</span></div>
         <div class="brand-sub">AdCP signals provider</div>
       </div>
     </div>
@@ -1356,7 +1356,13 @@ ${STYLES}
           <div class="lab-panel">
             <div class="lab-panel-title">Federated search</div>
             <label class="lab-label">Brief</label>
-            <textarea id="fed-brief" class="lab-input" rows="4" placeholder="automotive intenders in-market for EVs">automotive intenders in-market for EVs</textarea>
+            <textarea id="fed-brief" class="lab-input" rows="4" placeholder="automotive intenders in-market for EVs"></textarea>
+            <div class="canvas-quickpicks" style="margin-top:6px">
+              <span class="orch-small" style="margin-right:6px">try:</span>
+              <button class="canvas-quickpick" data-brief-target="fed-brief">automotive intenders in-market for EVs</button>
+              <button class="canvas-quickpick" data-brief-target="fed-brief">luxury travelers high HHI</button>
+              <button class="canvas-quickpick" data-brief-target="fed-brief">premium beauty 25-44</button>
+            </div>
             <label class="lab-label" style="margin-top:8px">Max results per agent</label>
             <input id="fed-max" type="number" min="1" max="20" value="5" class="lab-input"/>
             <button class="btn-primary" id="fed-run" style="margin-top:12px;width:100%;justify-content:center">
@@ -1397,7 +1403,13 @@ ${STYLES}
           <div class="lab-panel">
             <div class="lab-panel-title">Fan-out signals brief</div>
             <label class="lab-label">Brief</label>
-            <textarea id="orch-brief" class="lab-input" rows="3" placeholder="automotive intenders in-market for EVs">automotive intenders in-market for EVs</textarea>
+            <textarea id="orch-brief" class="lab-input" rows="3" placeholder="automotive intenders in-market for EVs"></textarea>
+            <div class="canvas-quickpicks" style="margin-top:6px">
+              <span class="orch-small" style="margin-right:6px">try:</span>
+              <button class="canvas-quickpick" data-brief-target="orch-brief">automotive intenders in-market for EVs</button>
+              <button class="canvas-quickpick" data-brief-target="orch-brief">luxury travelers high HHI</button>
+              <button class="canvas-quickpick" data-brief-target="orch-brief">premium beauty 25-44</button>
+            </div>
             <label class="lab-label" style="margin-top:8px">Max results per agent</label>
             <input id="orch-max" type="number" min="1" max="50" value="10" class="lab-input"/>
             <button class="btn-primary" id="orch-run" style="margin-top:12px;width:100%;justify-content:center">
@@ -1420,7 +1432,13 @@ ${STYLES}
           <div class="wf-controls">
             <div class="wf-control-row">
               <label class="lab-label">Brief</label>
-              <textarea id="wf-brief" class="lab-input" rows="2" placeholder="luxury travelers in-market for APAC trips">luxury travelers in-market for APAC trips</textarea>
+              <textarea id="wf-brief" class="lab-input" rows="2" placeholder="luxury travelers in-market for APAC trips"></textarea>
+              <div class="canvas-quickpicks" style="margin-top:6px">
+                <span class="orch-small" style="margin-right:6px">try:</span>
+                <button class="canvas-quickpick" data-brief-target="wf-brief">Coca-Cola Summer Refresh, $250K, 30 days</button>
+                <button class="canvas-quickpick" data-brief-target="wf-brief">luxury travelers APAC trips</button>
+                <button class="canvas-quickpick" data-brief-target="wf-brief">Nike running shoes launch, ROAS 3.0</button>
+              </div>
             </div>
             <div class="wf-control-row wf-activate-row">
               <div class="wf-activate-label">Stage 4 activation <span class="orch-small">(default: dry-run only)</span></div>
@@ -2467,8 +2485,15 @@ svg.ico path, svg.ico circle, svg.ico rect, svg.ico line { vector-effect: non-sc
 }
 .brand-mark .ico { width: 18px; height: 18px; }
 .brand-text { line-height: 1.25; }
-.brand-title { font-size: 14px; font-weight: 600; letter-spacing: -0.01em; }
-.brand-title .dot { color: var(--accent); margin: 0 1px; }
+.brand-title {
+  font-size: 14px; font-weight: 600; letter-spacing: -0.01em;
+  line-height: 1.2;
+}
+/* Marketplace + Agent stay together (non-breaking space). When the
+   sidebar is narrow, the title wraps cleanly after "Evgeny's" instead
+   of breaking the phrase "Marketplace Agent" mid-air. The .brand-title-mp
+   span gets accent color for visual interest in place of the old dot. */
+.brand-title-mp { color: var(--accent); }
 .brand-sub { font-size: 11px; color: var(--text-mut); }
 
 .sidebar-nav { flex: 1; overflow-y: auto; padding-right: 2px; }
@@ -7952,6 +7977,23 @@ document.addEventListener("keydown", function(e) {
   }
 });
 _applySidebarCollapsed(_readSidebarCollapsed());
+
+//────────────────────────────────────────────────────────────────────────
+// Brief try-chips — one-click fill. Any element with [data-brief-target]
+// fills the input/textarea with that target id when clicked. Wired
+// globally (not gated on ensureCanvas) so chips on Federation /
+// Orchestrator / Workflow tabs work without visiting the Canvas tab
+// first.
+//────────────────────────────────────────────────────────────────────────
+document.querySelectorAll("[data-brief-target]").forEach(function(b) {
+  b.addEventListener("click", function() {
+    var targetId = b.getAttribute("data-brief-target");
+    var target = targetId ? document.getElementById(targetId) : null;
+    if (!target) return;
+    target.value = (b.textContent || "").trim();
+    target.focus();
+  });
+});
 
 //────────────────────────────────────────────────────────────────────────
 // Tab switching
@@ -15442,10 +15484,9 @@ async function ensureCanvas() {
   });
   // Quick-pick chips fire resolve directly.
   document.querySelectorAll(".canvas-quickpick").forEach(function (b) {
-    b.addEventListener("click", function () {
-      var d = b.getAttribute("data-domain");
-      if (d) _canvasResolveBrand(d);
-    });
+    var d = b.getAttribute("data-domain");
+    if (!d) return; // Skip brief-target chips; they're wired globally below.
+    b.addEventListener("click", function () { _canvasResolveBrand(d); });
   });
   // Wave 1: Demo mode — single-click canonical run for stage demos.
   var demoBtn = document.getElementById("canvas-demo-btn");

--- a/src/routes/raceCanvas.ts
+++ b/src/routes/raceCanvas.ts
@@ -161,6 +161,33 @@ function renderRaceCanvas(demoKey: string): string {
     outline: none;
     border-color: var(--accent);
   }
+  /* Try-chips: one-click brief examples below the input. Same pattern
+     as demo.ts canvas-quickpicks; reuses [data-brief-target] handler. */
+  .try-chips {
+    display: flex; flex-wrap: wrap; align-items: center; gap: 6px;
+    margin-top: 10px;
+  }
+  .try-chips-label {
+    font: 10px var(--font-mono);
+    color: var(--text-faint);
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    margin-right: 2px;
+  }
+  .try-chip {
+    background: var(--bg-elevated);
+    border: 1px solid var(--border);
+    color: var(--text-dim);
+    font: 11px var(--font-mono);
+    padding: 4px 9px;
+    border-radius: 4px;
+    cursor: pointer;
+    transition: all 0.12s;
+  }
+  .try-chip:hover {
+    color: var(--accent);
+    border-color: var(--accent);
+  }
   .btn {
     background: var(--accent);
     color: #0a0d12;
@@ -625,9 +652,15 @@ function renderRaceCanvas(demoKey: string): string {
     <div class="controls">
       <div class="controls-label">Brief</div>
       <div class="controls-row">
-        <input id="brief-input" class="brief-input" placeholder="e.g., Coca-Cola Summer Refresh, $250K, 30 days, ROAS 3.5x" value="Coca-Cola Summer Refresh, $250K, 30 days, ROAS 3.5x"/>
+        <input id="brief-input" class="brief-input" placeholder="e.g., Coca-Cola Summer Refresh, $250K, 30 days, ROAS 3.5x"/>
         <button id="btn-start" class="btn">Start race</button>
         <button id="btn-clear" class="btn btn-ghost">Clear</button>
+      </div>
+      <div class="try-chips">
+        <span class="try-chips-label">try:</span>
+        <button class="try-chip" data-brief-target="brief-input">Coca-Cola Summer Refresh, $250K, 30 days, ROAS 3.5x</button>
+        <button class="try-chip" data-brief-target="brief-input">luxury travelers APAC trips, $500K, 60 days</button>
+        <button class="try-chip" data-brief-target="brief-input">Nike running shoes launch, ROAS 3.0</button>
       </div>
     </div>
 
@@ -1189,6 +1222,16 @@ function renderRaceCanvas(demoKey: string): string {
   elBtnClear.addEventListener("click", function(){
     elBriefInput.value = "";
     elBriefInput.focus();
+  });
+  // Try-chips: one-click fill the brief input.
+  document.querySelectorAll("[data-brief-target]").forEach(function(b) {
+    b.addEventListener("click", function() {
+      var targetId = b.getAttribute("data-brief-target");
+      var t = targetId ? document.getElementById(targetId) : null;
+      if (!t) return;
+      t.value = (b.textContent || "").trim();
+      t.focus();
+    });
   });
   elAddBtn.addEventListener("click", addVendor);
   elBriefInput.addEventListener("keydown", function(e) {


### PR DESCRIPTION
## Two fixes from screenshot review

### (1) Brand title wraps cleanly

**Before**: `Evgeny's · Marketplace Agent` wrapped to break the phrase mid-air:
```
Evgeny's · Marketplace
Agent
```

**After**: `Evgeny's Marketplace Agent` — non-breaking space between "Marketplace" and "Agent" keeps them together. Title now wraps cleanly **after** "Evgeny's" when the sidebar is narrow:
```
Evgeny's
Marketplace Agent
```

Also dropped the bullet (`·`) separator. The second word picks up accent color via `.brand-title-mp` for visual interest without the middle-dot gimmick.

### (2) Pre-populated briefs → one-click try-chips

**Problem**: PR #152 pre-filled brief textareas with placeholder values. To type their own, users had to backspace-clear first. Friction. Defeats the "one click away" goal.

**Fix**: textareas empty; **try-chip row below each** fills the input on click. Same UX as brand-picker chips.

| Surface | Where | Chips |
|---|---|---|
| `fed-brief` | Federation > Federated search | automotive / luxury / beauty |
| `orch-brief` | Orchestrator > Fan-out brief | automotive / luxury / beauty |
| `wf-brief` | Orchestrator > End-to-end workflow | Coca-Cola / luxury / Nike |
| `brief-input` | Race Canvas | Coca-Cola / luxury / Nike |

### Implementation

Click handler wired via `[data-brief-target]` attribute — chip's `textContent` fills the targeted input/textarea by `id`. Works on every tab without depending on per-tab init code paths.

```html
<button class="canvas-quickpick" data-brief-target="fed-brief">automotive intenders in-market for EVs</button>
```

Race Canvas is a separate HTML page → gets its own `.try-chip` CSS block + a local click handler (mirrors demo.ts, scoped to that page's IIFE).

## Test plan

- [ ] Hard refresh `/`
- [ ] Sidebar title: "Evgeny's" + accent-color "Marketplace Agent"; wraps cleanly when collapsed
- [ ] Federation tab: brief textarea is empty; click any chip below → fills the textarea + focuses
- [ ] Orchestrator tab: same for fan-out brief AND end-to-end workflow brief
- [ ] Brand picker chips on Canvas tab still work (resolve brand, no regression)
- [ ] Race Canvas (`/race-canvas`): brief input empty; chips fill on click
- [ ] No console errors

## Pre-flight

- `tsc --noEmit` on both files: 0 errors
- Trap audit on `demo.ts`: 0 hits across all 4 classes
- Trap audit on `raceCanvas.ts`: 0 hits

🤖 Generated with [Claude Code](https://claude.com/claude-code)