### PR TITLE
Info popovers (?) across 10 logic-bearing pages

### DIFF
--- a/src/routes/demo.ts
+++ b/src/routes/demo.ts
@@ -361,7 +361,19 @@ ${STYLES}
       <section class="tab-pane active" data-tab="discover">
         <div class="pane-header">
           <div>
-            <h1 class="pane-title">Brief-driven discovery</h1>
+            <div class="pane-title-with-info">
+              <h1 class="pane-title">Brief-driven discovery</h1>
+              <button class="lane-info-btn" data-lane-info-toggle="page-discover" title="How this works" aria-label="How brief-driven discovery works"><svg class="ico"><use href="#icon-info"/></svg></button>
+              <div class="lane-info-popover" data-lane-info-panel="page-discover" role="dialog">
+                <div class="lane-info-title">How brief-driven discovery works</div>
+                <ol class="lane-info-steps">
+                  <li><strong>Vectorize.</strong> Brief or NL query is embedded via <code>openai-te3-small-d512</code> (512-dim). Same embedding model used for the catalog seed.</li>
+                  <li><strong>kNN retrieve.</strong> Top-K signals fetched by cosine similarity in 512-d space; threshold ≥ 0.45.</li>
+                  <li><strong>Score + rank.</strong> Each match returns coverage_percentage, freshness, and the cosine score. AI-generated proposals appear alongside catalog matches when no clean mapping exists.</li>
+                </ol>
+                <div class="lane-info-trace">Code: <code>handleNLQuery</code> → <code>searchSignalsService</code> → <code>cosineSimilarity</code></div>
+              </div>
+            </div>
             <p class="pane-subtitle">
               <strong id="discover-mode-subtitle">Brief mode</strong> —
               <span id="discover-mode-desc">semantic similarity via the UCP embedding engine. Returns catalog matches + AI-generated custom proposals alongside each other.</span>
@@ -501,7 +513,19 @@ ${STYLES}
       <section class="tab-pane" data-tab="concepts">
         <div class="pane-header">
           <div>
-            <h1 class="pane-title">UCP concept registry</h1>
+            <div class="pane-title-with-info">
+              <h1 class="pane-title">UCP concept registry</h1>
+              <button class="lane-info-btn" data-lane-info-toggle="page-concepts" title="How this works" aria-label="How UCP concept registry works"><svg class="ico"><use href="#icon-info"/></svg></button>
+              <div class="lane-info-popover" data-lane-info-panel="page-concepts" role="dialog">
+                <div class="lane-info-title">How the concept registry works</div>
+                <ol class="lane-info-steps">
+                  <li><strong>19 canonical concepts.</strong> Age, intent verticals, life-events, behaviors — each with a fixed 512-d embedding + accepted enums + transformer hints.</li>
+                  <li><strong>Cosine search.</strong> A search query embeds in the same space; top-K concepts ranked by cosine similarity to the query vector. Score ≥ 0.45 surfaces.</li>
+                  <li><strong>Composition.</strong> Concepts compose conjunctively — a buyer brief that names "luxury travelers" + "high HHI" hits 2 concepts which become AND-joined targeting filters with declared transformer rules.</li>
+                </ol>
+                <div class="lane-info-trace">Code: <code>handleConceptRoute</code> + <code>handleSearchConcepts</code> → <code>cosineSimilarity</code></div>
+              </div>
+            </div>
             <p class="pane-subtitle">Cross-taxonomy audience concepts. Each concept carries semantic mappings to IAB, LiveRamp, TradeDesk, and internal taxonomies. Click a concept to find matching signals on the Discover tab.</p>
           </div>
         </div>
@@ -724,7 +748,19 @@ ${STYLES}
       <section class="tab-pane" data-tab="embedding">
         <div class="pane-header">
           <div>
-            <h1 class="pane-title">Embedding space</h1>
+            <div class="pane-title-with-info">
+              <h1 class="pane-title">Embedding space</h1>
+              <button class="lane-info-btn" data-lane-info-toggle="page-embedding" title="How this works" aria-label="How embedding space works"><svg class="ico"><use href="#icon-info"/></svg></button>
+              <div class="lane-info-popover" data-lane-info-panel="page-embedding" role="dialog">
+                <div class="lane-info-title">How the 2D projection is built</div>
+                <ol class="lane-info-steps">
+                  <li><strong>Source vectors.</strong> Every signal in the catalog has a 512-dim embedding from <code>openai-te3-small-d512</code>; same model that scores brief queries.</li>
+                  <li><strong>Projection.</strong> 512-d → 2-d via Procrustes-SVD against a fixed UCP reference space. Distance is approximately preserved; clusters reflect semantic similarity.</li>
+                  <li><strong>Hover + neighbors.</strong> Hover any point for full signal metadata + top-K nearest by cosine. Spatial gaps are signal-coverage holes — surfaced separately as "coverage gaps" in the analytics tabs.</li>
+                </ol>
+                <div class="lane-info-trace">Code: <code>handleUcpProjection</code> → Procrustes-SVD; vectors served from <code>/signals/&lt;id&gt;/embedding</code></div>
+              </div>
+            </div>
             <p class="pane-subtitle">Live view of the UCP semantic space powering semantic discovery. Real 512-dim <code>text-embedding-3-small</code> vectors, projected for inspection. Tight clusters = semantically adjacent audiences.</p>
           </div>
           <div class="activations-controls">
@@ -1032,7 +1068,19 @@ ${STYLES}
       <section class="tab-pane" data-tab="composer">
         <div class="pane-header">
           <div>
-            <h1 class="pane-title">Audience Composer</h1>
+            <div class="pane-title-with-info">
+              <h1 class="pane-title">Audience Composer</h1>
+              <button class="lane-info-btn" data-lane-info-toggle="page-composer" title="How this works" aria-label="How audience composer works"><svg class="ico"><use href="#icon-info"/></svg></button>
+              <div class="lane-info-popover" data-lane-info-panel="page-composer" role="dialog">
+                <div class="lane-info-title">How audience composition works</div>
+                <ol class="lane-info-steps">
+                  <li><strong>Saturation model.</strong> P(seen ≥ 1 | F) = 1 − exp(−F) across F=1..15 frequency exposures. Knee detection flags the F at which marginal reach drops below 50% of the F=1 gain.</li>
+                  <li><strong>Lookalike expansion.</strong> Take chosen signal's 512-d vector, find top-K nearest in the catalog by cosine. Returns ranked candidates with cosine score + coverage_percentage.</li>
+                  <li><strong>Affinity audit + privacy gate.</strong> Composition checked against industry attestations (DTS labels) + minimum-cohort thresholds (≥1k by default). Stages with sub-threshold cohorts auto-drop.</li>
+                </ol>
+                <div class="lane-info-trace">Code: <code>handleAudienceCompose</code> + <code>handleAudienceSaturation</code> + <code>handleAudiencePrivacyCheck</code></div>
+              </div>
+            </div>
             <p class="pane-subtitle">Compose audiences from catalog signals with set operations (union \u222a, intersect \u2229, exclude \u2212), optionally expand with embedding-based lookalikes, then plan activation via frequency-saturation curves and affinity audits vs the catalog baseline.</p>
           </div>
         </div>
@@ -1348,7 +1396,19 @@ ${STYLES}
       <section class="tab-pane" data-tab="federation">
         <div class="pane-header">
           <div>
-            <h1 class="pane-title">Agent Federation <span class="pill pill-success" style="margin-left:8px;font-size:10px">A2A live</span></h1>
+            <div class="pane-title-with-info">
+              <h1 class="pane-title">Agent Federation <span class="pill pill-success" style="margin-left:8px;font-size:10px">A2A live</span></h1>
+              <button class="lane-info-btn" data-lane-info-toggle="page-federation" title="How this works" aria-label="How federation works"><svg class="ico"><use href="#icon-info"/></svg></button>
+              <div class="lane-info-popover" data-lane-info-panel="page-federation" role="dialog">
+                <div class="lane-info-title">How federated search works</div>
+                <ol class="lane-info-steps">
+                  <li><strong>Discover.</strong> Live agent registry pulled from <code>/agents/registry</code> — every signals agent we can reach.</li>
+                  <li><strong>Parallel fan-out.</strong> Brief sent simultaneously to every live signals agent's <code>get_signals</code>. Per-agent timeouts + circuit breaker.</li>
+                  <li><strong>Merge + tag.</strong> Results merged and each row tagged with <code>source_agent</code>. Sorted by coverage_percentage; agent badges visible inline. Bulk-shortlist + CSV export available.</li>
+                </ol>
+                <div class="lane-info-trace">Code: <code>handleFederatedSearch</code> → <code>Promise.all(agents.map(callAgentTool))</code></div>
+              </div>
+            </div>
             <p class="pane-subtitle">Cross-agent search across the AdCP Signals Discovery ecosystem. Live partner: Dstillery. More coming.</p>
           </div>
         </div>
@@ -1385,7 +1445,19 @@ ${STYLES}
       <section class="tab-pane" data-tab="orchestrator">
         <div class="pane-header">
           <div>
-            <h1 class="pane-title">Multi-Agent Orchestrator <span class="pill pill-accent" style="margin-left:8px;font-size:10px">Sec-48</span></h1>
+            <div class="pane-title-with-info">
+              <h1 class="pane-title">Multi-Agent Orchestrator <span class="pill pill-accent" style="margin-left:8px;font-size:10px">Sec-48</span></h1>
+              <button class="lane-info-btn" data-lane-info-toggle="page-orchestrator" title="How this works" aria-label="How orchestration works"><svg class="ico"><use href="#icon-info"/></svg></button>
+              <div class="lane-info-popover" data-lane-info-panel="page-orchestrator" role="dialog">
+                <div class="lane-info-title">How multi-agent orchestration works</div>
+                <ol class="lane-info-steps">
+                  <li><strong>Probe.</strong> Every live agent's <code>tools/list</code> is pulled in parallel; capabilities matrix built from the union of advertised tools.</li>
+                  <li><strong>4-stage workflow.</strong> Run sequentially: signals (fan-out across signals agents) → creative (list_creative_formats) → products (filtered by chosen signals + formats) → media buy (synthesize payload, optionally fire).</li>
+                  <li><strong>Picks thread between stages.</strong> Top-3 signals from stage 1 become <code>filters.signals</code> for stage 3; top-2 formats from stage 2 become <code>filters.format_ids</code>. Stage 4 returns a dry-run payload preview per buying agent; checkboxes opt agents into a real <code>create_media_buy</code> fire.</li>
+                </ol>
+                <div class="lane-info-trace">Code: <code>handleAgentsOrchestrate</code> + <code>handleWorkflowRun</code> → <code>runSignalsStage</code> / <code>runCreativeStage</code> / <code>runProductsStage</code> / <code>runMediaBuyStage</code></div>
+              </div>
+            </div>
             <p class="pane-subtitle">Live view of every AdCP agent we know about. Probe each MCP endpoint in parallel to see who's up, what they expose, and how fast they respond. Fan out a signals brief to all live signals agents with one click, or compare tool surfaces side-by-side.</p>
           </div>
           <div class="activations-controls">
@@ -1718,7 +1790,19 @@ ${STYLES}
       <section class="tab-pane" data-tab="campaign">
         <div class="pane-header">
           <div>
-            <h1 class="pane-title">Campaign Canvas <span class="pill pill-warning mono" style="font-size:9.5px;margin-left:8px;letter-spacing:0.04em">DSP buy-side · all primitives mocked</span></h1>
+            <div class="pane-title-with-info">
+              <h1 class="pane-title">Campaign Canvas <span class="pill pill-warning mono" style="font-size:9.5px;margin-left:8px;letter-spacing:0.04em">DSP buy-side · all primitives mocked</span></h1>
+              <button class="lane-info-btn" data-lane-info-toggle="page-campaign" title="How this works" aria-label="How campaign canvas works"><svg class="ico"><use href="#icon-info"/></svg></button>
+              <div class="lane-info-popover" data-lane-info-panel="page-campaign" role="dialog">
+                <div class="lane-info-title">How Campaign Canvas works</div>
+                <ol class="lane-info-steps">
+                  <li><strong>Buy-side primitives.</strong> Four AdCP buy-side tools are unspec'd in 3.0 GA: <code>submit_bid_strategy</code>, <code>get_bid_opportunities</code>, <code>get_pacing_status</code>, <code>optimize_strategy</code>. Each lane below mocks one — same playbook as governanceMock.</li>
+                  <li><strong>Deterministic mock.</strong> Per-campaign data keyed off campaign_id (FNV-1a hash). Bid streams, SSP performance distributions, and pacing classifications are reproducible across reloads.</li>
+                  <li><strong>Resilience layer.</strong> Live calls (where they exist) wrapped in a per-URL circuit breaker (open after 3 fails, 60s cooldown, half-open recovery). Wave 4 spend allocator splits budget across vendors via 4 strategies: equal_split / score_weighted / priority_first / cap_then_split.</li>
+                </ol>
+                <div class="lane-info-trace">Code: <code>dspMock.ts</code> + <code>callAgentToolWithCircuit</code> + <code>allocateSpend</code></div>
+              </div>
+            </div>
             <p class="pane-subtitle">
               Real-time control loop: bid strategy → bid stream → inventory match → brand-safety filter → delivery + attribution → optimization signals fed BACK into strategy.
               <br/>
@@ -1840,7 +1924,19 @@ ${STYLES}
       <section class="tab-pane" data-tab="agentic">
         <div class="pane-header">
           <div>
-            <h1 class="pane-title">Agentic Canvas <span class="pill pill-warning mono" style="font-size:9.5px;margin-left:8px;letter-spacing:0.04em" id="agentic-mode-pill">probing mode…</span></h1>
+            <div class="pane-title-with-info">
+              <h1 class="pane-title">Agentic Canvas <span class="pill pill-warning mono" style="font-size:9.5px;margin-left:8px;letter-spacing:0.04em" id="agentic-mode-pill">probing mode…</span></h1>
+              <button class="lane-info-btn" data-lane-info-toggle="page-agentic" title="How this works" aria-label="How agentic canvas works"><svg class="ico"><use href="#icon-info"/></svg></button>
+              <div class="lane-info-popover" data-lane-info-panel="page-agentic" role="dialog">
+                <div class="lane-info-title">How the agentic planner works</div>
+                <ol class="lane-info-steps">
+                  <li><strong>Brief expansion.</strong> Live mode → Claude Sonnet decomposes a one-line brief into structured fields (industries, KPI, geo, flight). Template fallback uses regex + 30-brand registry. Both produce the same shape.</li>
+                  <li><strong>Tool planning.</strong> Planner picks an ordered sequence (signals → creative → products → governance → media-buy), filtered by which agents actually advertise each tool. Live mode → Claude chooses; template → 5-stage default.</li>
+                  <li><strong>Streaming execution + Wave 3 tools.</strong> NDJSON-streamed reasoning trace + per-step results. Args sanitized (#149: allowlist + required-arg backfill) before fan-out. Refine, self-critique, and correction memory let the operator iterate without restarting from scratch.</li>
+                </ol>
+                <div class="lane-info-trace">Code: <code>expandBrief</code> → <code>planExecution</code> → <code>handleAgenticExecute</code> + <code>sanitizeArgsForVendor</code></div>
+              </div>
+            </div>
             <p class="pane-subtitle">
               Type a brief in plain English. The agent expands it, plans the call sequence dynamically, executes against live MCP agents, and narrates every decision.
               <br/>
@@ -2801,6 +2897,30 @@ svg.ico path, svg.ico circle, svg.ico rect, svg.ico line { vector-effect: non-sc
 .pane-title {
   margin: 0 0 6px; font-size: 22px; font-weight: 600;
   letter-spacing: -0.015em;
+}
+/* Wraps a pane title + (?) info icon + popover. The popover overrides
+   the default right-anchored position from .lane-info-popover so it
+   reads left-to-right under the icon. */
+.pane-title-with-info {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  position: relative;
+}
+.pane-title-with-info .lane-info-btn {
+  margin-left: 0;
+  width: 26px; height: 26px;
+}
+.pane-title-with-info .lane-info-btn .ico { width: 15px; height: 15px; }
+.pane-title-with-info .lane-info-popover {
+  right: auto;
+  left: 0;
+  top: calc(100% + 4px);
+  width: 420px;
+}
+.pane-title-with-info .lane-info-popover::before {
+  right: auto;
+  left: 18px;
 }
 .pane-subtitle {
   margin: 0; font-size: 13.5px; color: var(--text-dim);

--- a/src/routes/raceCanvas.ts
+++ b/src/routes/raceCanvas.ts
@@ -115,6 +115,98 @@ function renderRaceCanvas(demoKey: string): string {
     color: var(--accent);
   }
   .header-spacer { flex: 1; }
+  /* Page info popover — same pattern as the main demo's lane-info-*. */
+  .header-title-block { position: relative; }
+  .header-title-row { display: flex; align-items: center; gap: 8px; }
+  .page-info-btn {
+    width: 24px; height: 24px;
+    display: inline-flex; align-items: center; justify-content: center;
+    border-radius: 50%;
+    background: transparent;
+    border: 1px solid transparent;
+    color: var(--text-faint);
+    cursor: pointer;
+    transition: all 0.12s;
+  }
+  .page-info-btn:hover {
+    background: var(--bg-panel);
+    color: var(--accent);
+    border-color: var(--accent);
+  }
+  .page-info-btn.is-open {
+    background: rgba(56,182,255,0.14);
+    color: var(--accent);
+    border-color: var(--accent);
+  }
+  .page-info-popover {
+    position: absolute;
+    top: calc(100% + 8px);
+    left: 0;
+    z-index: 50;
+    width: 420px;
+    max-width: calc(100vw - 32px);
+    background: var(--bg-panel);
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    padding: 16px 18px 14px;
+    box-shadow: 0 12px 36px rgba(0, 0, 0, 0.45);
+    display: none;
+    animation: pageInfoFade 0.15s ease-out;
+  }
+  .page-info-popover.is-open { display: block; }
+  @keyframes pageInfoFade {
+    from { opacity: 0; transform: translateY(-4px); }
+    to   { opacity: 1; transform: translateY(0); }
+  }
+  .page-info-popover::before {
+    content: "";
+    position: absolute;
+    top: -7px; left: 18px;
+    width: 12px; height: 12px;
+    background: var(--bg-panel);
+    border-top: 1px solid var(--border);
+    border-left: 1px solid var(--border);
+    transform: rotate(45deg);
+  }
+  .page-info-title {
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--text);
+    margin-bottom: 10px;
+  }
+  .page-info-steps {
+    margin: 0 0 12px;
+    padding: 0 0 0 22px;
+    font-size: 12.5px;
+    line-height: 1.55;
+    color: var(--text-dim);
+  }
+  .page-info-steps li { margin-bottom: 8px; }
+  .page-info-steps li:last-child { margin-bottom: 0; }
+  .page-info-steps strong { color: var(--text); }
+  .page-info-steps code {
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: 3px;
+    padding: 1px 5px;
+    font-size: 11px;
+    color: var(--accent);
+  }
+  .page-info-trace {
+    margin-top: 10px;
+    padding-top: 10px;
+    border-top: 1px solid var(--border);
+    font: 11px var(--font-mono);
+    color: var(--text-faint);
+    line-height: 1.5;
+  }
+  .page-info-trace code {
+    color: var(--text-dim);
+    background: transparent;
+    border: none;
+    padding: 0;
+    font-size: 11px;
+  }
   .main {
     overflow-y: auto;
     padding: 24px;
@@ -640,8 +732,22 @@ function renderRaceCanvas(demoKey: string): string {
 <div class="app">
   <header class="header">
     <a class="header-back" href="/">&larr; Back to Signals</a>
-    <div>
-      <div class="header-title">Race <span class="accent">Canvas</span></div>
+    <div class="header-title-block">
+      <div class="header-title-row">
+        <div class="header-title">Race <span class="accent">Canvas</span></div>
+        <button class="page-info-btn" id="page-info-btn" title="How this works" aria-label="How Race Canvas works">
+          <svg viewBox="0 0 20 20" width="14" height="14"><circle cx="10" cy="10" r="7.5" fill="none" stroke="currentColor" stroke-width="1.4"/><line x1="10" y1="9" x2="10" y2="14" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"/><circle cx="10" cy="6.5" r="0.8" fill="currentColor"/></svg>
+        </button>
+        <div class="page-info-popover" id="page-info-popover" role="dialog">
+          <div class="page-info-title">How Race Canvas works</div>
+          <ol class="page-info-steps">
+            <li><strong>Parallel race.</strong> 6 vendor agents probed in parallel against the same brief; each returns audience_size, sensitive_category_verdict, recommended_bid_floor, governance_outcome.</li>
+            <li><strong>Disagreement halo.</strong> Detector compares responses on 4 fields. Numeric: ±15% threshold (audience), ±20% (bid floor). Categorical: any difference triggers. Severity: blocking / material / minor maps to red / yellow / blue arc.</li>
+            <li><strong>Reconciliation.</strong> Median across vendors for numeric; conservative-pick (worst-of) for categorical. Audit receipts (FNV-1a hash of input/output) stack in the right sidebar — click any to inspect raw payload.</li>
+          </ol>
+          <div class="page-info-trace">Code: <code>/race/start</code> → <code>synthesizeVendorResponse</code> → <code>detectDisagreements</code></div>
+        </div>
+      </div>
       <div class="header-sub">multi-agent orchestration / disagreement halo / audit receipts</div>
     </div>
     <div class="header-spacer"></div>
@@ -1233,6 +1339,29 @@ function renderRaceCanvas(demoKey: string): string {
       t.focus();
     });
   });
+
+  // Page info popover toggle.
+  var infoBtn = document.getElementById("page-info-btn");
+  var infoPopover = document.getElementById("page-info-popover");
+  if (infoBtn && infoPopover) {
+    infoBtn.addEventListener("click", function(e) {
+      e.stopPropagation();
+      var open = infoPopover.classList.toggle("is-open");
+      infoBtn.classList.toggle("is-open", open);
+    });
+    document.addEventListener("click", function(e) {
+      var t = e.target;
+      if (t === infoBtn || (t && t.closest && (t.closest("#page-info-btn") || t.closest("#page-info-popover")))) return;
+      infoPopover.classList.remove("is-open");
+      infoBtn.classList.remove("is-open");
+    });
+    document.addEventListener("keydown", function(e) {
+      if (e.key === "Escape") {
+        infoPopover.classList.remove("is-open");
+        infoBtn.classList.remove("is-open");
+      }
+    });
+  }
   elAddBtn.addEventListener("click", addVendor);
   elBriefInput.addEventListener("keydown", function(e) {
     if (e.key === "Enter") startRace();

--- a/src/routes/vendorHealthCanvas.ts
+++ b/src/routes/vendorHealthCanvas.ts
@@ -103,6 +103,74 @@ function renderVendorHealthCanvas(demoKey: string): string {
     color: var(--text-faint);
   }
   .header-spacer { flex: 1; }
+  /* Page info popover — same pattern as Race Canvas. */
+  .header-title-block { position: relative; }
+  .header-title-row { display: flex; align-items: center; gap: 8px; }
+  .page-info-btn {
+    width: 24px; height: 24px;
+    display: inline-flex; align-items: center; justify-content: center;
+    border-radius: 50%;
+    background: transparent;
+    border: 1px solid transparent;
+    color: var(--text-faint);
+    cursor: pointer;
+    transition: all 0.12s;
+  }
+  .page-info-btn:hover {
+    background: var(--bg-panel);
+    color: var(--accent);
+    border-color: var(--accent);
+  }
+  .page-info-btn.is-open {
+    background: rgba(56,182,255,0.14);
+    color: var(--accent);
+    border-color: var(--accent);
+  }
+  .page-info-popover {
+    position: absolute;
+    top: calc(100% + 8px);
+    left: 0;
+    z-index: 50;
+    width: 420px;
+    max-width: calc(100vw - 32px);
+    background: var(--bg-panel);
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    padding: 16px 18px 14px;
+    box-shadow: 0 12px 36px rgba(0, 0, 0, 0.45);
+    display: none;
+    animation: pageInfoFade 0.15s ease-out;
+  }
+  .page-info-popover.is-open { display: block; }
+  @keyframes pageInfoFade {
+    from { opacity: 0; transform: translateY(-4px); }
+    to   { opacity: 1; transform: translateY(0); }
+  }
+  .page-info-popover::before {
+    content: "";
+    position: absolute;
+    top: -7px; left: 18px;
+    width: 12px; height: 12px;
+    background: var(--bg-panel);
+    border-top: 1px solid var(--border);
+    border-left: 1px solid var(--border);
+    transform: rotate(45deg);
+  }
+  .page-info-title { font-size: 13px; font-weight: 600; color: var(--text); margin-bottom: 10px; }
+  .page-info-steps { margin: 0 0 12px; padding: 0 0 0 22px; font-size: 12.5px; line-height: 1.55; color: var(--text-dim); }
+  .page-info-steps li { margin-bottom: 8px; }
+  .page-info-steps li:last-child { margin-bottom: 0; }
+  .page-info-steps strong { color: var(--text); }
+  .page-info-steps code {
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: 3px;
+    padding: 1px 5px;
+    font-size: 11px;
+    color: var(--accent);
+  }
+  .page-info-trace { margin-top: 10px; padding-top: 10px; border-top: 1px solid var(--border); font: 11px var(--font-mono); color: var(--text-faint); line-height: 1.5; }
+  .page-info-trace code { color: var(--text-dim); background: transparent; border: none; padding: 0; font-size: 11px; }
   .btn {
     background: var(--accent);
     color: #0a0d12;
@@ -469,8 +537,22 @@ function renderVendorHealthCanvas(demoKey: string): string {
 
 <header class="header">
   <a class="header-back" href="/">&larr; Back to Signals</a>
-  <div>
-    <div class="header-title">Vendor <span class="accent">Health</span></div>
+  <div class="header-title-block">
+    <div class="header-title-row">
+      <div class="header-title">Vendor <span class="accent">Health</span></div>
+      <button class="page-info-btn" id="page-info-btn" title="How this works" aria-label="How Vendor Health works">
+        <svg viewBox="0 0 20 20" width="14" height="14"><circle cx="10" cy="10" r="7.5" fill="none" stroke="currentColor" stroke-width="1.4"/><line x1="10" y1="9" x2="10" y2="14" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"/><circle cx="10" cy="6.5" r="0.8" fill="currentColor"/></svg>
+      </button>
+      <div class="page-info-popover" id="page-info-popover" role="dialog">
+        <div class="page-info-title">How Vendor Health works</div>
+        <ol class="page-info-steps">
+          <li><strong>Parallel probe.</strong> Every registry agent's MCP <code>initialize</code> handshake fired in parallel (8s timeout per agent). Self-fetch shim used for our own URL (CF Workers blocks self-fetch — see #144).</li>
+          <li><strong>Bucket precedence.</strong> known_issue/roadmap → unknown · circuit OPEN → down · probe failed → down · latency &gt;5s → degraded · circuit half_open → degraded · else healthy. Aggregate counters at top reflect the buckets.</li>
+          <li><strong>Sparkline + drill-down.</strong> Per-vendor history stored in KV ring buffer (24-entry, 7-day TTL); each card renders a latency sparkline. Click a card for full identity + probe details + circuit history. Re-probe button refreshes one row without re-fanning the fleet.</li>
+        </ol>
+        <div class="page-info-trace">Code: <code>buildVendorHealthSnapshot</code> → <code>bucketHealth</code> + <code>vendorHealthHistory</code> KV</div>
+      </div>
+    </div>
     <div class="header-sub">live fleet status / circuit state / per-vendor sparklines</div>
   </div>
   <div class="header-spacer"></div>
@@ -901,6 +983,29 @@ function renderVendorHealthCanvas(demoKey: string): string {
   // ── Wiring ──────────────────────────────────────────────────────────
   elBtnRefresh.addEventListener("click", function() { loadSnapshot(true); });
   elBtnMeta.addEventListener("click", function() { loadSnapshot(false); });
+
+  // Page info popover toggle.
+  var infoBtn = document.getElementById("page-info-btn");
+  var infoPopover = document.getElementById("page-info-popover");
+  if (infoBtn && infoPopover) {
+    infoBtn.addEventListener("click", function(e) {
+      e.stopPropagation();
+      var open = infoPopover.classList.toggle("is-open");
+      infoBtn.classList.toggle("is-open", open);
+    });
+    document.addEventListener("click", function(e) {
+      var t = e.target;
+      if (t === infoBtn || (t && t.closest && (t.closest("#page-info-btn") || t.closest("#page-info-popover")))) return;
+      infoPopover.classList.remove("is-open");
+      infoBtn.classList.remove("is-open");
+    });
+    document.addEventListener("keydown", function(e) {
+      if (e.key === "Escape") {
+        infoPopover.classList.remove("is-open");
+        infoBtn.classList.remove("is-open");
+      }
+    });
+  }
 
   // Initial load: metadata-only for fast paint. Operator clicks "Live probe" for the slow fan-out.
   loadSnapshot(false);


### PR DESCRIPTION
## What

Extends #155's per-lane "How this works" pattern to **page-level** explainers on every workshop-critical surface with substantive logic. Each page gets a `(?)` icon next to its title; click opens a 360-420px floating popover with a 3-step explainer + a code-trace line.

## 10 surfaces covered

| Page | Logic explained |
|---|---|
| **Discover** | Semantic kNN over `openai-te3-small-d512` (≥0.45 cosine threshold) |
| **Concepts** | UCP concept registry + cosine search + AND-composition |
| **Embedding** | Procrustes-SVD 512-d → 2-d projection |
| **Composer** | Saturation model `1 - exp(-F)` + lookalike kNN + privacy gate |
| **Federation** | A2A fan-out across `/agents/registry` + tagged merge |
| **Orchestrator** | 4-stage workflow (signals → creative → products → buy) |
| **Campaign Canvas** | 4 unspec'd buy-side primitives + circuit breaker + allocator |
| **Agentic Canvas** | Brief expansion → planner → sanitized executor |
| **Race Canvas** *(separate page)* | Disagreement halo + receipts |
| **Vendor Health** *(separate page)* | Bucket precedence + KV sparkline ring |

## Pattern

Reuses #155's `.lane-info-*` CSS + global `[data-lane-info-toggle]` handler for the 8 demo.ts pages.

New helpers:
- **`.pane-title-with-info`** wrapper (demo.ts) — anchors popover left-of-icon with adjusted pointer triangle
- **Self-contained `.page-info-*` CSS + JS** in raceCanvas.ts and vendorHealthCanvas.ts (separate HTML pages, no shared scope with demo.ts)

Each popover stays tight:
```
<ol>3 numbered steps explaining the algorithm</ol>
<div>Code: function → function → function</div>
```

Steps emphasize **why** (algorithm) not just **what** (API call).

## Out of scope (logic-thin / display-only)

Catalog, Capabilities, Dev kit, Tool Log, Activations, Destinations — these are read-only displays without distinctive logic to explain.

## Follow-up candidates

These also have distinctive logic and would benefit from the same pattern (~25 lines each):

- Treemap, Overlap, Emb. Lab, Portfolio, Seasonality
- Builder, Expression, Journey, Scenario, Snapshots, Freshness

Ping me and I'll do them in a follow-up.

## Test plan

- [ ] After Cloudflare deploys, hard-refresh `/`
- [ ] Each of the 8 main demo tabs shows `(?)` next to its title — click opens popover with content + code-trace
- [ ] Click `(?)` on another page → previous popover closes, new one opens (single-open invariant from #155 applies globally)
- [ ] Click outside any popover or hit Esc → all dismissed
- [ ] `/race-canvas` page shows `(?)` in top header — click opens, shape + content match the demo.ts pattern
- [ ] `/vendor-health` page shows `(?)` in top header — same
- [ ] All 3 themes (Midnight / Daylight / Solar) — popover bg, border, code pills theme correctly

## Pre-flight

- `tsc --noEmit` on all 3 files: 0 errors
- Trap audit on `demo.ts`: 0 hits across all 4 SCRIPT_TAG classes
- Trap audit on `raceCanvas.ts` + `vendorHealthCanvas.ts`: 0 hits

🤖 Generated with [Claude Code](https://claude.com/claude-code)