### PR TITLE
Trace inspector — universal slide-in panel (workshop wow-factor design)

### DIFF
--- a/src/domain/signalService.ts
+++ b/src/domain/signalService.ts
@@ -16,6 +16,7 @@ import { estimateAudienceSize } from "../utils/estimation";
 import { dynamicSignalId } from "../utils/ids";
 import { requestId } from "../utils/ids";
 import type { CatalogSignal } from "./queryResolver";
+import type { TraceData, TraceStep } from "../types/trace";
 
 const DEFAULT_LIMIT = 20;
 const MAX_LIMIT = 100;
@@ -39,12 +40,17 @@ export async function searchSignalsService(
   kv: KVNamespace,
   req: SearchSignalsRequest
 ): Promise<SearchSignalsResponse> {
+  const t0 = Date.now();
+  const traceSteps: TraceStep[] = [];
+  const performance: Record<string, number> = {};
+
   const limit = Math.min(req.limit ?? DEFAULT_LIMIT, MAX_LIMIT);
   const offset = req.offset ?? 0;
 
   // When a brief is present, fetch a larger window so we can re-rank by relevance
   const fetchLimit = req.brief ? Math.min(200, MAX_LIMIT * 4) : limit;
 
+  const tDb0 = Date.now();
   const { signals, totalCount } = await searchSignals(db, {
     ...compactObj({
       query: req.query,
@@ -57,12 +63,60 @@ export async function searchSignalsService(
     limit: fetchLimit,
     offset: req.brief ? 0 : offset,  // always fetch from top when re-ranking
   });
+  performance.db_read = Date.now() - tDb0;
+  traceSteps.push({
+    id: "fetch",
+    label: "Fetch candidates from D1",
+    duration_ms: performance.db_read,
+    note: req.brief
+      ? "Wide window (up to 200) so we can re-rank by relevance after."
+      : `Catalog window of ${fetchLimit} starting at offset ${offset}.`,
+    details: [
+      { k: "filter.query", v: String(req.query ?? "—") },
+      { k: "filter.category_type", v: String(req.categoryType ?? "—") },
+      { k: "filter.generation_mode", v: String(req.generationMode ?? "—") },
+      { k: "filter.taxonomy_id", v: String(req.taxonomyId ?? "—") },
+      { k: "filter.destination", v: String(req.destination ?? "—") },
+      { k: "fetch_limit", v: String(fetchLimit) },
+      { k: "rows_returned", v: String(signals.length) },
+      { k: "total_in_catalog", v: String(totalCount) },
+    ],
+  });
 
   // If brief/signal_spec present, re-rank catalog results by relevance to brief
   // Fetch broader window, score, sort, then slice to limit
-  let summaries = toSignalSummaries(
-    req.brief ? rankByRelevance(signals, req.brief).slice(0, limit) : signals
-  );
+  const tRank0 = Date.now();
+  const ranked = req.brief ? rankByRelevance(signals, req.brief).slice(0, limit) : signals;
+  performance.rank = Date.now() - tRank0;
+
+  if (req.brief) {
+    // Build a detailed trace step for the keyword scoring pass. We re-run
+    // the scorer here so the panel has access to the per-signal scores +
+    // matched keywords that the production scorer doesn't normally surface.
+    const traceData = explainKeywordRanking(signals, req.brief, limit);
+    traceSteps.push({
+      id: "keyword_score",
+      label: "Score by keyword match (current implementation)",
+      duration_ms: performance.rank,
+      note: "Each catalog signal is scored against extracted keywords. Embedding-based cosine ranking lives at /signals/query (UCP path) — see Concepts tab for that flow.",
+      details: [
+        { k: "keywords_extracted", v: traceData.keywords.join(", ") || "(none)" },
+        { k: "category_hint", v: traceData.categoryHint ?? "—" },
+        { k: "scoring", v: "name match: +4 · description match: +2 · category hint: +3 · derived/dynamic boosts" },
+        { k: "ranked", v: String(ranked.length) },
+        { k: "tie_break", v: "estimated_audience_size desc" },
+      ],
+      matches: traceData.topScored.map((s) => ({
+        id: s.id,
+        label: s.name,
+        score: s.score,
+        meta: `${s.category_type} · ${(s.estimated_audience_size / 1_000_000).toFixed(1)}M audience`,
+      })),
+      histogram: traceData.histogram,
+    });
+  }
+
+  let summaries = toSignalSummaries(ranked);
 
   // Filter deployments by requested platforms. The request field is
   // `deployments` on SearchSignalsRequest (not `destinations` — that was
@@ -109,6 +163,31 @@ export async function searchSignalsService(
     ? `in category "${req.categoryType}"`
     : "from catalog";
 
+  if (req.brief && proposals && proposals.length > 0) {
+    traceSteps.push({
+      id: "proposal",
+      label: "Custom proposal generation",
+      duration_ms: 1, // synth, sub-millisecond
+      note: "Top match weak (or coverage gap detected). Synthesizing a custom segment definition from brief components.",
+      details: [
+        { k: "proposals_generated", v: String(proposals.length) },
+        { k: "first_proposal_id", v: proposals[0]?.signal_agent_segment_id ?? "—" },
+      ],
+    });
+  }
+
+  performance.total = Date.now() - t0;
+  performance.other = Math.max(0, performance.total - (performance.db_read ?? 0) - (performance.rank ?? 0));
+
+  const trace: TraceData = {
+    operation: req.brief ? "Discover query · brief mode" : "Discover query · catalog mode",
+    input: req.brief ?? req.query ?? "(no input)",
+    duration_ms: performance.total,
+    steps: traceSteps,
+    performance,
+    ts: new Date().toISOString(),
+  };
+
   return {
     message: `Found ${summaries.length} signal(s) ${filterDesc}. Review pricing and deployment status before activating.`,
     context_id: requestId(),
@@ -118,6 +197,109 @@ export async function searchSignalsService(
     totalCount,
     offset,
     hasMore: offset + summaries.length < totalCount,
+    _trace: trace,
+  } as SearchSignalsResponse & { _trace: TraceData };
+}
+
+// ── Keyword ranking explainer ─────────────────────────────────────────────────
+//
+// Re-runs the scoring pass with bookkeeping enabled so the trace panel
+// can show: extracted keywords, category hint, per-signal score (top-N),
+// score distribution histogram. Production rankByRelevance discards this
+// after sorting — explainKeywordRanking is a sibling that retains it.
+
+interface KeywordTraceMatch {
+  id: string;
+  name: string;
+  score: number;
+  category_type: string;
+  estimated_audience_size: number;
+}
+
+interface KeywordTraceData {
+  keywords: string[];
+  categoryHint: string | null;
+  topScored: KeywordTraceMatch[];
+  histogram: { bins: number[]; max: number; threshold?: number; axis_range: string };
+}
+
+function explainKeywordRanking(
+  signals: CanonicalSignal[],
+  brief: string,
+  topN: number,
+): KeywordTraceData {
+  const lower = brief.toLowerCase();
+  const STOP_WORDS = new Set([
+    "a","an","the","and","or","in","on","of","to","for","with","by",
+    "at","from","as","is","are","who","that","this","be","have","do",
+    "not","but","so","if","its","it","my","we","our","they","their",
+    "me","us","you","your","he","she","him","her","i","am","was","were",
+    "will","would","could","should","may","might","can",
+  ]);
+  const keywords = lower
+    .replace(/[^a-z0-9\s$]/g, " ")
+    .split(/\s+/)
+    .filter((w) => w.length > 2 && !STOP_WORDS.has(w));
+
+  const categoryHints: Record<string, string[]> = {
+    demographic: ["age","income","education","household","family","senior","adult","young","boomer","millennial"],
+    interest: ["fan","viewer","streaming","content","genre","movie","show","music","gaming","sports"],
+    purchase_intent: ["buy","purchase","intent","shopping","luxury","goods","product","brand","market"],
+    geo: ["dma","city","metro","market","area","region","state","zip","national","local"],
+    composite: ["affluent","high income","premium","professional","educated","urban"],
+  };
+  let categoryHint: string | null = null;
+  for (const [cat, hints] of Object.entries(categoryHints)) {
+    if (hints.some((h) => lower.includes(h))) { categoryHint = cat; break; }
+  }
+
+  const scored = signals.map((signal) => {
+    const nameLower = signal.name.toLowerCase();
+    const descLower = signal.description.toLowerCase();
+    let score = 0;
+    for (const kw of keywords) {
+      if (nameLower.includes(kw)) score += 4;
+      if (descLower.includes(kw)) score += 2;
+    }
+    if (categoryHint && signal.categoryType === categoryHint) score += 3;
+    if (signal.generationMode === "derived") score += 1;
+    if (signal.generationMode === "dynamic") score += 2;
+    return { signal, score };
+  });
+
+  const topScored: KeywordTraceMatch[] = scored
+    .filter((s) => s.score > 0)
+    .sort((a, b) => b.score - a.score || (b.signal.estimatedAudienceSize ?? 0) - (a.signal.estimatedAudienceSize ?? 0))
+    .slice(0, topN)
+    .map((s) => ({
+      id: s.signal.signalId,
+      name: s.signal.name,
+      score: s.score,
+      category_type: s.signal.categoryType,
+      estimated_audience_size: s.signal.estimatedAudienceSize ?? 0,
+    }));
+
+  // Score distribution histogram — 10 bins from 0 to maxScore
+  const maxScore = scored.reduce((m, s) => s.score > m ? s.score : m, 0);
+  const binCount = 10;
+  const bins: number[] = Array(binCount).fill(0);
+  for (const s of scored) {
+    if (s.score <= 0) continue;
+    const idx = Math.min(binCount - 1, Math.floor((s.score / Math.max(1, maxScore)) * binCount));
+    bins[idx] = (bins[idx] ?? 0) + 1;
+  }
+  const binMax = bins.reduce((m, b) => b > m ? b : m, 1);
+
+  return {
+    keywords,
+    categoryHint,
+    topScored,
+    histogram: {
+      bins,
+      max: binMax,
+      threshold: 0.3 * binCount,  // visually mark "weak match" zone
+      axis_range: `0 → ${maxScore} score`,
+    },
   };
 }
 

--- a/src/routes/demo.ts
+++ b/src/routes/demo.ts
@@ -2313,6 +2313,50 @@ ${STYLES}
 
 <div id="toast" class="toast"></div>
 
+<!-- Trace panel: slide-in detail view for any traced operation.
+     Content filled by JS from the latest _trace field on any traced
+     response. Universal schema, so new surfaces are drop-in. -->
+<button class="trace-trigger" id="trace-trigger" type="button" aria-label="Open trace inspector" title="Open trace (last operation)">
+  <svg viewBox="0 0 20 20" width="18" height="18" aria-hidden="true">
+    <path d="M3 10 L8 10 L9.5 6 L10.5 14 L12 10 L17 10" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+  </svg>
+  <span class="trace-trigger-label">Trace</span>
+  <span class="trace-trigger-badge" id="trace-trigger-badge" hidden>1</span>
+</button>
+
+<div class="trace-backdrop" id="trace-backdrop" aria-hidden="true"></div>
+
+<aside class="trace-panel" id="trace-panel" role="dialog" aria-label="Trace inspector" aria-hidden="true">
+  <div class="trace-head">
+    <div class="trace-head-eyebrow" id="trace-eyebrow">trace inspector</div>
+    <div class="trace-head-row">
+      <h2 class="trace-title" id="trace-operation">No trace yet</h2>
+      <button class="trace-close" id="trace-close" type="button" aria-label="Close trace panel">×</button>
+    </div>
+    <div class="trace-input mono" id="trace-input"></div>
+    <div class="trace-meta">
+      <span class="trace-meta-pill mono"><span class="trace-meta-k">duration</span><span class="trace-meta-v" id="trace-duration">—</span></span>
+      <span class="trace-meta-pill mono"><span class="trace-meta-k">steps</span><span class="trace-meta-v" id="trace-step-count">—</span></span>
+      <span class="trace-meta-pill mono"><span class="trace-meta-k">at</span><span class="trace-meta-v" id="trace-ts">—</span></span>
+    </div>
+  </div>
+  <div class="trace-tabs" role="tablist">
+    <button class="trace-tab is-active" data-trace-tab="overview" role="tab" aria-selected="true">Overview</button>
+    <button class="trace-tab" data-trace-tab="json" role="tab">JSON</button>
+    <span class="trace-tab-indicator" id="trace-tab-indicator"></span>
+  </div>
+  <div class="trace-body">
+    <section class="trace-tab-pane is-active" data-trace-pane="overview">
+      <div class="trace-perf" id="trace-perf"></div>
+      <div class="trace-steps" id="trace-steps"></div>
+    </section>
+    <section class="trace-tab-pane" data-trace-pane="json">
+      <button class="trace-copy-btn" id="trace-copy-json" type="button">Copy JSON</button>
+      <pre class="trace-json mono" id="trace-json"></pre>
+    </section>
+  </div>
+</aside>
+
 <!-- Keyboard shortcuts cheat-sheet (Sec-38 A7). Opened via \`?\`. -->
 <div id="kbd-overlay" class="kbd-overlay" role="dialog" aria-modal="true" aria-label="Keyboard shortcuts">
   <div class="kbd-card">
@@ -3667,6 +3711,465 @@ svg.ico path, svg.ico circle, svg.ico rect, svg.ico line { vector-effect: non-sc
 .activation-keys .ak-row { padding: 3px 0; }
 .activation-keys .ak-platform { color: var(--text-mut); }
 .activation-keys .ak-key { color: var(--success); font-weight: 500; }
+
+/* ── Trace inspector — slide-in panel + trigger button ───────────────────
+   Wow-factor build: backdrop blur, stagger-fade step entry, glow-stroke
+   score bars, gradient histogram, animated duration counter, sliding
+   tab indicator. Theme-aware via CSS vars. */
+
+.trace-trigger {
+  position: fixed;
+  bottom: 22px; right: 22px;
+  z-index: 9000;
+  display: inline-flex; align-items: center; gap: 8px;
+  padding: 10px 16px 10px 14px;
+  border-radius: 999px;
+  background: var(--bg-surface);
+  border: 1px solid var(--border-strong);
+  color: var(--text-dim);
+  font: 600 12px var(--font-sans);
+  cursor: pointer;
+  box-shadow: 0 6px 18px rgba(0,0,0,0.32);
+  transform: translateY(60px);
+  opacity: 0;
+  pointer-events: none;
+  transition: transform 0.35s cubic-bezier(0.2, 0.9, 0.3, 1.2),
+              opacity 0.25s ease,
+              border-color 0.15s, color 0.15s, background 0.15s;
+}
+.trace-trigger.is-visible {
+  transform: translateY(0);
+  opacity: 1;
+  pointer-events: auto;
+}
+.trace-trigger:hover {
+  border-color: var(--accent);
+  color: var(--text-bright);
+  background: var(--bg-raised);
+}
+.trace-trigger.is-pulsing {
+  animation: tracePulse 1.6s ease-in-out 3;
+  border-color: var(--accent);
+  color: var(--accent);
+}
+@keyframes tracePulse {
+  0%, 100% { box-shadow: 0 6px 18px rgba(0,0,0,0.32), 0 0 0 0 var(--accent-dim); }
+  50%      { box-shadow: 0 6px 18px rgba(0,0,0,0.32), 0 0 0 10px transparent; }
+}
+.trace-trigger svg { color: var(--accent); }
+.trace-trigger-label { letter-spacing: 0.02em; }
+.trace-trigger-badge {
+  display: inline-flex; align-items: center; justify-content: center;
+  min-width: 18px; height: 18px; padding: 0 5px;
+  border-radius: 9px;
+  background: var(--accent);
+  color: #fff;
+  font: 700 10px var(--font-mono);
+}
+
+.trace-backdrop {
+  position: fixed; inset: 0; z-index: 9990;
+  background: rgba(0, 0, 0, 0.45);
+  backdrop-filter: blur(6px) saturate(0.85);
+  -webkit-backdrop-filter: blur(6px) saturate(0.85);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.22s ease;
+}
+.trace-backdrop.is-open {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.trace-panel {
+  position: fixed; top: 0; right: 0; bottom: 0;
+  width: 540px; max-width: 92vw;
+  z-index: 9995;
+  background: var(--bg-surface);
+  border-left: 1px solid var(--border-strong);
+  box-shadow: -24px 0 60px rgba(0,0,0,0.4);
+  display: flex; flex-direction: column;
+  transform: translateX(102%);
+  transition: transform 0.32s cubic-bezier(0.2, 0.9, 0.3, 1);
+  font-family: var(--font-sans);
+}
+.trace-panel.is-open {
+  transform: translateX(0);
+}
+
+.trace-head {
+  padding: 22px 24px 14px;
+  border-bottom: 1px solid var(--border);
+  /* Subtle scanline gradient — workshop "scientific instrument" feel */
+  background:
+    linear-gradient(180deg, rgba(255,255,255,0.02), transparent),
+    var(--bg-surface);
+}
+.trace-head-eyebrow {
+  font: 10px/1 var(--font-mono);
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--accent);
+  margin-bottom: 8px;
+}
+.trace-head-row {
+  display: flex; align-items: flex-start; justify-content: space-between;
+  gap: 12px;
+}
+.trace-title {
+  margin: 0; font: 600 18px/1.25 var(--font-sans);
+  color: var(--text-bright);
+  letter-spacing: -0.015em;
+}
+.trace-close {
+  width: 32px; height: 32px;
+  border-radius: 50%;
+  background: transparent;
+  border: 1px solid var(--border);
+  color: var(--text-dim);
+  font: 200 22px/1 var(--font-sans);
+  cursor: pointer;
+  flex-shrink: 0;
+  display: flex; align-items: center; justify-content: center;
+  transition: all 0.15s;
+}
+.trace-close:hover {
+  background: var(--bg-hover);
+  color: var(--text);
+  border-color: var(--accent);
+}
+.trace-input {
+  margin-top: 8px;
+  font-size: 12px;
+  color: var(--text-dim);
+  word-break: break-word;
+  background: var(--bg-input);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 6px 10px;
+  display: inline-block;
+  max-width: 100%;
+}
+.trace-meta {
+  display: flex; flex-wrap: wrap; gap: 8px;
+  margin-top: 12px;
+}
+.trace-meta-pill {
+  display: inline-flex; align-items: center; gap: 6px;
+  padding: 4px 9px;
+  border-radius: 4px;
+  background: var(--bg-input);
+  border: 1px solid var(--border);
+  font-size: 11px;
+}
+.trace-meta-k { color: var(--text-mut); text-transform: uppercase; letter-spacing: 0.06em; font-size: 10px; }
+.trace-meta-v { color: var(--text); }
+
+.trace-tabs {
+  display: flex; align-items: center; gap: 4px;
+  padding: 4px 16px 0;
+  border-bottom: 1px solid var(--border);
+  position: relative;
+}
+.trace-tab {
+  background: transparent; border: none;
+  padding: 10px 14px;
+  color: var(--text-dim);
+  font: 500 12px var(--font-sans);
+  cursor: pointer;
+  border-radius: 0;
+  position: relative;
+  transition: color 0.12s;
+}
+.trace-tab:hover { color: var(--text); }
+.trace-tab.is-active { color: var(--text-bright); }
+.trace-tab-indicator {
+  position: absolute;
+  bottom: -1px;
+  height: 2px;
+  background: var(--accent);
+  border-radius: 1px;
+  transition: left 0.22s cubic-bezier(0.2, 0.9, 0.3, 1), width 0.22s ease;
+  box-shadow: 0 0 8px var(--accent-border);
+}
+
+.trace-body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 18px 22px 28px;
+}
+.trace-body::-webkit-scrollbar { width: 8px; }
+.trace-body::-webkit-scrollbar-thumb { background: var(--border-strong); border-radius: 4px; }
+.trace-body::-webkit-scrollbar-thumb:hover { background: var(--text-mut); }
+.trace-tab-pane { display: none; animation: traceFadeIn 0.2s ease; }
+.trace-tab-pane.is-active { display: block; }
+@keyframes traceFadeIn {
+  from { opacity: 0; transform: translateY(4px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+/* Performance flame-bar at the top of Overview. */
+.trace-perf {
+  margin-bottom: 18px;
+  padding: 12px 14px;
+  background: var(--bg-input);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+}
+.trace-perf-label {
+  font: 10px/1 var(--font-mono);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-mut);
+  margin-bottom: 8px;
+}
+.trace-perf-bar {
+  display: flex;
+  height: 14px;
+  border-radius: 3px;
+  overflow: hidden;
+  background: var(--bg);
+  border: 1px solid var(--border);
+}
+.trace-perf-segment {
+  height: 100%;
+  position: relative;
+  border-right: 1px solid rgba(0,0,0,0.18);
+  transition: opacity 0.2s;
+}
+.trace-perf-segment:last-child { border-right: none; }
+.trace-perf-legend {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+  gap: 4px 12px;
+  margin-top: 10px;
+  font: 11px var(--font-mono);
+}
+.trace-perf-legend-row {
+  display: flex; align-items: center; gap: 6px;
+  color: var(--text-dim);
+}
+.trace-perf-legend-swatch {
+  width: 9px; height: 9px;
+  border-radius: 2px;
+  flex-shrink: 0;
+}
+.trace-perf-legend-k { color: var(--text-dim); }
+.trace-perf-legend-v { color: var(--text); margin-left: auto; }
+
+/* Steps accordion. */
+.trace-steps {
+  display: flex; flex-direction: column; gap: 10px;
+}
+.trace-step {
+  background: var(--bg-input);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  opacity: 0;
+  transform: translateY(8px);
+  animation: traceStepIn 0.4s cubic-bezier(0.2, 0.9, 0.3, 1) forwards;
+}
+@keyframes traceStepIn {
+  to { opacity: 1; transform: translateY(0); }
+}
+.trace-step-head {
+  display: flex; align-items: center; gap: 10px;
+  padding: 11px 14px;
+  cursor: pointer;
+  background: transparent;
+  border: none;
+  width: 100%;
+  text-align: left;
+  color: var(--text);
+  transition: background 0.12s;
+}
+.trace-step-head:hover { background: var(--bg-hover); }
+.trace-step-num {
+  display: inline-flex; align-items: center; justify-content: center;
+  width: 22px; height: 22px;
+  border-radius: 50%;
+  background: var(--bg-raised);
+  border: 1px solid var(--border-strong);
+  font: 700 10px var(--font-mono);
+  color: var(--accent);
+  flex-shrink: 0;
+}
+.trace-step-label {
+  flex: 1;
+  font: 600 13px var(--font-sans);
+  color: var(--text-bright);
+  letter-spacing: -0.005em;
+}
+.trace-step-duration {
+  font: 11px var(--font-mono);
+  color: var(--text-mut);
+}
+.trace-step-chevron {
+  width: 12px; height: 12px;
+  color: var(--text-mut);
+  transition: transform 0.18s;
+}
+.trace-step.is-open .trace-step-chevron { transform: rotate(180deg); }
+
+.trace-step-body {
+  display: none;
+  padding: 4px 16px 16px;
+  border-top: 1px solid var(--border);
+  background: var(--bg);
+}
+.trace-step.is-open .trace-step-body { display: block; }
+
+.trace-step-note {
+  font: 12px/1.5 var(--font-sans);
+  color: var(--text-dim);
+  font-style: italic;
+  padding: 10px 0 6px;
+}
+
+.trace-detail-grid {
+  display: grid;
+  grid-template-columns: minmax(120px, max-content) 1fr;
+  gap: 4px 14px;
+  font: 11.5px/1.5 var(--font-mono);
+  margin: 8px 0;
+}
+.trace-detail-k { color: var(--text-mut); }
+.trace-detail-v { color: var(--text); word-break: break-word; }
+
+/* Match list with score bars — the headline visualization. */
+.trace-match-list {
+  margin: 10px 0 0;
+  padding: 0;
+  list-style: none;
+  display: flex; flex-direction: column; gap: 6px;
+}
+.trace-match {
+  display: grid;
+  grid-template-columns: 32px 1fr 56px;
+  gap: 8px;
+  align-items: center;
+  padding: 5px 0;
+}
+.trace-match-rank {
+  font: 11px var(--font-mono);
+  color: var(--text-mut);
+  text-align: right;
+}
+.trace-match-bar-wrap {
+  position: relative;
+  background: var(--bg-input);
+  border: 1px solid var(--border);
+  border-radius: 3px;
+  height: 22px;
+  overflow: hidden;
+}
+.trace-match-bar {
+  position: absolute;
+  top: 0; left: 0; bottom: 0;
+  background: linear-gradient(90deg, var(--accent-dim), var(--accent));
+  border-right: 1px solid var(--accent-hot);
+  box-shadow: 0 0 8px var(--accent-border);
+  transition: width 0.4s cubic-bezier(0.2, 0.9, 0.3, 1);
+  width: 0;
+}
+.trace-match-text {
+  position: absolute;
+  inset: 0;
+  display: flex; align-items: center;
+  padding: 0 8px;
+  font: 11px var(--font-mono);
+  color: var(--text-bright);
+  text-shadow: 0 1px 2px rgba(0,0,0,0.45);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.trace-match-meta {
+  font: 10px var(--font-mono);
+  color: var(--text-mut);
+  padding-left: 38px;
+  margin-top: -2px;
+}
+.trace-match-score {
+  font: 600 12px var(--font-mono);
+  color: var(--accent);
+  text-align: right;
+}
+
+/* Histogram with gradient + threshold marker. */
+.trace-histo {
+  margin-top: 12px;
+  padding: 10px 12px 8px;
+  background: var(--bg-input);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+}
+.trace-histo-label {
+  font: 10px var(--font-mono);
+  color: var(--text-mut);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  margin-bottom: 6px;
+}
+.trace-histo-bars {
+  display: flex; align-items: flex-end; gap: 2px;
+  height: 50px;
+  position: relative;
+}
+.trace-histo-bar {
+  flex: 1;
+  background: linear-gradient(180deg, var(--accent), var(--accent-dim));
+  border-radius: 1px 1px 0 0;
+  min-height: 2px;
+  transition: height 0.4s cubic-bezier(0.2, 0.9, 0.3, 1);
+  box-shadow: inset 0 1px 0 rgba(255,255,255,0.18);
+}
+.trace-histo-threshold {
+  position: absolute;
+  top: 0; bottom: 0;
+  width: 1px;
+  background: var(--warning);
+  box-shadow: 0 0 6px var(--warning);
+}
+.trace-histo-axis {
+  display: flex; justify-content: space-between;
+  font: 10px var(--font-mono);
+  color: var(--text-mut);
+  margin-top: 4px;
+}
+
+/* JSON tab. */
+.trace-copy-btn {
+  position: sticky; top: 0;
+  float: right;
+  margin-bottom: 8px;
+  background: var(--bg-input);
+  border: 1px solid var(--border);
+  color: var(--text-dim);
+  padding: 5px 10px;
+  border-radius: 4px;
+  font: 11px var(--font-mono);
+  cursor: pointer;
+  transition: all 0.12s;
+}
+.trace-copy-btn:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+.trace-json {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  padding: 12px;
+  font: 11px/1.55 var(--font-mono);
+  color: var(--text);
+  white-space: pre-wrap;
+  word-break: break-word;
+  max-height: calc(100vh - 280px);
+  overflow: auto;
+  clear: both;
+}
 
 /* ── Toast ────────────────────────────────────────────────────────────── */
 .toast {
@@ -8242,6 +8745,236 @@ document.addEventListener("keydown", function(e) {
 _applySidebarCollapsed(_readSidebarCollapsed());
 
 //────────────────────────────────────────────────────────────────────────
+// Trace inspector — slide-in panel that renders any operation's _trace
+// payload. Universal renderer; new traced surfaces just need to populate
+// window.__lastTrace and trigger _showTraceTrigger().
+//────────────────────────────────────────────────────────────────────────
+window.__lastTrace = null;
+
+function _showTraceTrigger() {
+  var t = document.getElementById("trace-trigger");
+  if (!t) return;
+  t.classList.add("is-visible");
+  // Pulse 3 times to telegraph "new info available."
+  t.classList.remove("is-pulsing");
+  void t.offsetWidth; // force restart
+  t.classList.add("is-pulsing");
+}
+
+function _openTracePanel() {
+  if (!window.__lastTrace) return;
+  _renderTracePanel(window.__lastTrace);
+  document.getElementById("trace-backdrop").classList.add("is-open");
+  document.getElementById("trace-panel").classList.add("is-open");
+  document.getElementById("trace-panel").setAttribute("aria-hidden", "false");
+}
+function _closeTracePanel() {
+  document.getElementById("trace-backdrop").classList.remove("is-open");
+  document.getElementById("trace-panel").classList.remove("is-open");
+  document.getElementById("trace-panel").setAttribute("aria-hidden", "true");
+}
+
+function _fmtMs(ms) {
+  if (typeof ms !== "number") return "—";
+  if (ms < 1000) return ms + "ms";
+  return (ms / 1000).toFixed(2) + "s";
+}
+function _fmtRelTs(iso) {
+  try {
+    var diff = Date.now() - new Date(iso).getTime();
+    if (diff < 5000) return "just now";
+    if (diff < 60000) return Math.floor(diff / 1000) + "s ago";
+    if (diff < 3600000) return Math.floor(diff / 60000) + "m ago";
+    return new Date(iso).toLocaleTimeString();
+  } catch (e) { return iso; }
+}
+
+// Animate the duration counter from 0 to the final value over 600ms.
+function _animateDuration(el, targetMs) {
+  if (!el) return;
+  var start = performance.now();
+  var dur = 600;
+  function tick(t) {
+    var pct = Math.min(1, (t - start) / dur);
+    var eased = 1 - Math.pow(1 - pct, 3); // ease-out cubic
+    var v = Math.round(targetMs * eased);
+    el.textContent = _fmtMs(v);
+    if (pct < 1) requestAnimationFrame(tick);
+    else el.textContent = _fmtMs(targetMs);
+  }
+  requestAnimationFrame(tick);
+}
+
+function _renderTraceStep(step, idx) {
+  var details = (step.details || []).map(function(d) {
+    return '<div class="trace-detail-k">' + escapeHtml(d.k) + '</div>' +
+           '<div class="trace-detail-v">' + escapeHtml(d.v) + '</div>';
+  }).join("");
+  var detailsBlock = details ? '<div class="trace-detail-grid">' + details + '</div>' : "";
+
+  var matchesBlock = "";
+  if (Array.isArray(step.matches) && step.matches.length > 0) {
+    var maxScore = step.matches.reduce(function(m, x) { return x.score > m ? x.score : m; }, 0);
+    if (maxScore <= 0) maxScore = 1;
+    var rows = step.matches.map(function(m, i) {
+      var pct = Math.max(2, Math.min(100, (m.score / maxScore) * 100));
+      var rank = '<div class="trace-match-rank">#' + (i + 1) + '</div>';
+      var bar = '<div class="trace-match-bar-wrap">' +
+                '  <div class="trace-match-bar" style="width:' + pct.toFixed(1) + '%"></div>' +
+                '  <div class="trace-match-text">' + escapeHtml(m.label) + '</div>' +
+                '</div>';
+      var sc = '<div class="trace-match-score">' + (typeof m.score === "number" ? m.score.toFixed(2) : "—") + '</div>';
+      var meta = m.meta ? '<div class="trace-match-meta">' + escapeHtml(m.meta) + '</div>' : "";
+      return '<li class="trace-match-li">' +
+             '  <div class="trace-match">' + rank + bar + sc + '</div>' +
+             meta +
+             '</li>';
+    }).join("");
+    matchesBlock = '<ol class="trace-match-list">' + rows + '</ol>';
+  }
+
+  var histoBlock = "";
+  if (step.histogram && Array.isArray(step.histogram.bins)) {
+    var h = step.histogram;
+    var maxBin = h.max || h.bins.reduce(function(m, b) { return b > m ? b : m; }, 1) || 1;
+    var bars = h.bins.map(function(b) {
+      var hp = (b / maxBin) * 100;
+      return '<div class="trace-histo-bar" style="height:' + Math.max(2, hp) + '%" title="count: ' + b + '"></div>';
+    }).join("");
+    var thresh = "";
+    if (typeof h.threshold === "number") {
+      var tp = (h.threshold / h.bins.length) * 100;
+      thresh = '<div class="trace-histo-threshold" style="left:' + tp + '%"></div>';
+    }
+    histoBlock = '<div class="trace-histo">' +
+                 '  <div class="trace-histo-label">distribution</div>' +
+                 '  <div class="trace-histo-bars">' + bars + thresh + '</div>' +
+                 '  <div class="trace-histo-axis"><span>' + escapeHtml(h.axis_range || "") + '</span></div>' +
+                 '</div>';
+  }
+
+  var note = step.note ? '<div class="trace-step-note">' + escapeHtml(step.note) + '</div>' : "";
+  var dur = (typeof step.duration_ms === "number") ? '<span class="trace-step-duration">' + _fmtMs(step.duration_ms) + '</span>' : "";
+
+  // Stagger entry: each step gets an animation-delay so they cascade in.
+  var delay = (idx * 0.08).toFixed(2) + "s";
+
+  return '<div class="trace-step is-open" style="animation-delay:' + delay + '" data-trace-step="' + escapeHtml(step.id) + '">' +
+         '  <button class="trace-step-head" type="button">' +
+         '    <span class="trace-step-num">' + (idx + 1) + '</span>' +
+         '    <span class="trace-step-label">' + escapeHtml(step.label) + '</span>' +
+         '    ' + dur +
+         '    <svg class="trace-step-chevron" viewBox="0 0 16 16"><path d="M4 6 L8 10 L12 6" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></svg>' +
+         '  </button>' +
+         '  <div class="trace-step-body">' +
+              note + detailsBlock + matchesBlock + histoBlock +
+         '  </div>' +
+         '</div>';
+}
+
+function _renderTracePerf(perf) {
+  if (!perf || typeof perf !== "object") return "";
+  var keys = Object.keys(perf).filter(function(k) { return k !== "total"; });
+  var total = perf.total || keys.reduce(function(s, k) { return s + (perf[k] || 0); }, 0);
+  if (total <= 0) return "";
+  var palette = ["var(--accent)", "var(--violet)", "var(--cyan)", "var(--success)", "var(--warning)"];
+  var segments = keys.map(function(k, i) {
+    var pct = (perf[k] / total) * 100;
+    var color = palette[i % palette.length];
+    return '<div class="trace-perf-segment" style="width:' + pct.toFixed(1) + '%; background:' + color + '" title="' + escapeHtml(k) + ': ' + _fmtMs(perf[k]) + '"></div>';
+  }).join("");
+  var legend = keys.map(function(k, i) {
+    var color = palette[i % palette.length];
+    return '<div class="trace-perf-legend-row">' +
+           '  <span class="trace-perf-legend-swatch" style="background:' + color + '"></span>' +
+           '  <span class="trace-perf-legend-k">' + escapeHtml(k) + '</span>' +
+           '  <span class="trace-perf-legend-v">' + _fmtMs(perf[k]) + '</span>' +
+           '</div>';
+  }).join("");
+  return '<div class="trace-perf-label">timing breakdown · total ' + _fmtMs(total) + '</div>' +
+         '<div class="trace-perf-bar">' + segments + '</div>' +
+         '<div class="trace-perf-legend">' + legend + '</div>';
+}
+
+function _renderTracePanel(trace) {
+  document.getElementById("trace-eyebrow").textContent = "trace inspector";
+  document.getElementById("trace-operation").textContent = trace.operation || "Trace";
+  var inputEl = document.getElementById("trace-input");
+  if (trace.input) {
+    inputEl.textContent = '"' + trace.input + '"';
+    inputEl.style.display = "inline-block";
+  } else {
+    inputEl.style.display = "none";
+  }
+  _animateDuration(document.getElementById("trace-duration"), trace.duration_ms || 0);
+  document.getElementById("trace-step-count").textContent = (trace.steps || []).length;
+  document.getElementById("trace-ts").textContent = trace.ts ? _fmtRelTs(trace.ts) : "—";
+  document.getElementById("trace-perf").innerHTML = _renderTracePerf(trace.performance || null);
+  document.getElementById("trace-steps").innerHTML = (trace.steps || []).map(_renderTraceStep).join("");
+  // Wire step-head clicks (accordion toggle)
+  document.querySelectorAll(".trace-step-head").forEach(function(btn) {
+    btn.addEventListener("click", function() {
+      var step = btn.closest(".trace-step");
+      if (step) step.classList.toggle("is-open");
+    });
+  });
+  // Animate match-bar widths in after a small delay so the transition triggers.
+  setTimeout(function() {
+    document.querySelectorAll(".trace-match-bar").forEach(function(b) {
+      var w = b.style.width; b.style.width = "0";
+      requestAnimationFrame(function() { b.style.width = w; });
+    });
+  }, 50);
+  // JSON tab content
+  document.getElementById("trace-json").textContent = JSON.stringify(trace, null, 2);
+  // Reset to overview tab
+  _selectTraceTab("overview");
+}
+
+function _selectTraceTab(name) {
+  document.querySelectorAll("[data-trace-tab]").forEach(function(b) {
+    var on = b.getAttribute("data-trace-tab") === name;
+    b.classList.toggle("is-active", on);
+    b.setAttribute("aria-selected", on ? "true" : "false");
+  });
+  document.querySelectorAll("[data-trace-pane]").forEach(function(p) {
+    p.classList.toggle("is-active", p.getAttribute("data-trace-pane") === name);
+  });
+  // Slide the indicator under the active tab.
+  var active = document.querySelector(".trace-tab.is-active");
+  var ind = document.getElementById("trace-tab-indicator");
+  if (active && ind) {
+    ind.style.left = active.offsetLeft + "px";
+    ind.style.width = active.offsetWidth + "px";
+  }
+}
+
+(function() {
+  var trigger = document.getElementById("trace-trigger");
+  var close = document.getElementById("trace-close");
+  var backdrop = document.getElementById("trace-backdrop");
+  if (trigger) trigger.addEventListener("click", _openTracePanel);
+  if (close) close.addEventListener("click", _closeTracePanel);
+  if (backdrop) backdrop.addEventListener("click", _closeTracePanel);
+  document.addEventListener("keydown", function(e) {
+    if (e.key === "Escape") _closeTracePanel();
+  });
+  document.querySelectorAll("[data-trace-tab]").forEach(function(b) {
+    b.addEventListener("click", function() { _selectTraceTab(b.getAttribute("data-trace-tab")); });
+  });
+  var copyBtn = document.getElementById("trace-copy-json");
+  if (copyBtn) copyBtn.addEventListener("click", function() {
+    var pre = document.getElementById("trace-json");
+    if (!pre) return;
+    try {
+      navigator.clipboard.writeText(pre.textContent || "");
+      copyBtn.textContent = "Copied!";
+      setTimeout(function() { copyBtn.textContent = "Copy JSON"; }, 1200);
+    } catch (e) {}
+  });
+})();
+
+//────────────────────────────────────────────────────────────────────────
 // Brief try-chips — one-click fill. Any element with [data-brief-target]
 // fills the input/textarea with that target id when clicked. Wired
 // globally (not gated on ensureCanvas) so chips on Federation /
@@ -8451,6 +9184,22 @@ async function runDiscover() {
   btn.disabled = true;
   status.innerHTML = '<span class="spinner"></span>scanning catalog + generating proposals…';
   results.innerHTML = '<div class="empty-state"><span class="spinner"></span><div class="empty-title">Searching…</div></div>';
+
+  // Fire a parallel /signals/search call to capture the universal _trace
+  // payload. Doesn't block the main UI render — when it lands we light up
+  // the floating Trace button so the operator can inspect.
+  fetch("/signals/search", {
+    method: "POST",
+    headers: { "Content-Type": "application/json", "Authorization": "Bearer " + DEMO_KEY },
+    body: JSON.stringify({ brief: brief, limit: 8 }),
+  }).then(function(r) { return r.ok ? r.json() : null; })
+    .then(function(j) {
+      if (j && j._trace) {
+        window.__lastTrace = j._trace;
+        _showTraceTrigger();
+      }
+    })
+    .catch(function() { /* trace is decorative; failure is silent */ });
 
   try {
     const t0 = performance.now();

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -56,6 +56,9 @@ export interface SearchSignalsResponse {
   totalCount: number;
   offset: number;
   hasMore: boolean;
+  /** Universal trace payload for the slide-in panel UI. Every traceable
+   *  endpoint emits this shape; renderer is generic. See types/trace.ts. */
+  _trace?: import("./trace").TraceData;
 }
 
 // A proposed custom signal — not persisted until activated. Shares the

--- a/src/types/trace.ts
+++ b/src/types/trace.ts
@@ -1,0 +1,91 @@
+// src/types/trace.ts
+//
+// Universal trace schema. Every traceable backend operation emits this
+// shape on its response (in a `_trace` field) so the universal trace
+// panel can render it without per-surface custom logic.
+//
+// Renderer responsibilities:
+//   - Header: operation name + input + total duration
+//   - Steps: accordion of TraceStep entries
+//     - For each step: details rows, matches table (with score bars),
+//       histogram (with threshold marker), notes
+//   - Performance: timing breakdown chart
+//   - JSON tab: pretty-print full payload
+//
+// Backend responsibilities:
+//   - Wrap the work in timing markers (Date.now() at start/each step)
+//   - Build steps[] with whatever level of detail makes the operation
+//     legible to a workshop attendee. "Why this came back" wins over
+//     raw mechanics.
+//
+// Adding a new traced operation:
+//   1. Wrap the operation handler with timing hooks
+//   2. Build a TraceData and attach to response under `_trace`
+//   3. Done — panel renders it automatically.
+
+export interface TraceDetailRow {
+  /** Key — left column, monospace, dim color. */
+  k: string;
+  /** Value — right column, monospace, brighter color. May be a number
+   *  formatted as a string. */
+  v: string;
+}
+
+export interface TraceMatch {
+  /** Stable id — usually a signal id, vendor id, etc. */
+  id: string;
+  /** Human label rendered alongside the id. */
+  label: string;
+  /** Score in [-1, 1] (cosine) or [0, 100] (percentage). The renderer
+   *  draws a horizontal bar; the absolute scale is operation-specific. */
+  score: number;
+  /** Optional one-line context (e.g. "category: interest", "vendor: Dstillery"). */
+  meta?: string;
+}
+
+export interface TraceHistogram {
+  /** Counts per bin, left-to-right. The renderer normalizes by `max`. */
+  bins: number[];
+  /** Max bin count (for normalization). */
+  max: number;
+  /** Optional threshold line drawn vertically. Position is relative to
+   *  the bin range (0..bins.length). */
+  threshold?: number;
+  /** X-axis label range, e.g. "0.0 → 1.0" for cosine. */
+  axis_range?: string;
+}
+
+export interface TraceStep {
+  /** Stable id — used for accordion expand state. */
+  id: string;
+  /** Human label, e.g. "Embed query", "kNN search". */
+  label: string;
+  /** Step wall-clock duration. */
+  duration_ms?: number;
+  /** Key-value rows. Renders as a 2-column table. */
+  details?: TraceDetailRow[];
+  /** Ranked matches table with score bars. */
+  matches?: TraceMatch[];
+  /** Score distribution histogram. */
+  histogram?: TraceHistogram;
+  /** One-line context shown under the label. */
+  note?: string;
+}
+
+export interface TraceData {
+  /** Operation name, e.g. "Discover query", "Federation fan-out". */
+  operation: string;
+  /** Original input — query string, brief, etc. */
+  input?: string;
+  /** Total wall-clock duration. */
+  duration_ms: number;
+  /** Ordered steps. */
+  steps: TraceStep[];
+  /** Optional aggregated performance buckets, summing to ~duration_ms. */
+  performance?: Record<string, number>;
+  /** Optional raw response (for the JSON tab). Renderer truncates after
+   *  100KB to keep the panel responsive. */
+  raw?: unknown;
+  /** ISO timestamp the trace was captured. */
+  ts: string;
+}


### PR DESCRIPTION
## What

A polished slide-in panel that shows **exactly what happened** during any operation — query embedding, kNN ranking, vendor fan-out, governance check, whatever. Universal schema, every traced surface fits.

This PR ships:
1. The schema (`src/types/trace.ts`)
2. The panel UI (HTML + CSS + JS in demo.ts) with full wow-factor design polish
3. **Discover tab** wired end-to-end — type a brief, run, watch the floating Trace button pulse, click for the full breakdown

Other surfaces (federation, orchestrator, agentic, race, vendor health) are drop-in extensions — backend just emits a `TraceData`, panel renders.

## UX design choices (the "wow factor")

| Move | Why |
|---|---|
| **Backdrop blur** + saturate when panel opens | Modern depth; user knows the panel is the focus |
| **Slide-in from right** with cubic-bezier ease | Familiar (Stripe / Linear / Vercel pattern) |
| **Floating Trace button** bottom-right with 3-pulse "new info" animation | Telegraphs that fresh data is ready without disrupting flow |
| **Stagger-fade step entry** (80ms apart) | Feels like the trace is replaying live |
| **Animated 0 → final-ms duration counter** | Numerical wow on open |
| **Score bars: gradient fill + glow** | Makes ranking viscerally readable |
| **Score bars animate width on render** | Subtle but lands |
| **Histogram with gradient + glowing threshold marker** | Distribution viz at a glance |
| **Performance flame-bar at top** | Where did the time go? Color-cycled stacked horizontal bar with legend |
| **Sliding tab indicator** under Overview/JSON | Polish detail; you'll notice if it's missing |
| **Custom monospace scrollbar** for the body | Cohesion with the data-density aesthetic |
| **Copy JSON** button on the raw tab | Inspect / share / debug |

## Universal schema

```ts
interface TraceData {
  operation: string;       // "Discover query · brief mode"
  input?: string;          // "premium beauty 25-44"
  duration_ms: number;
  steps: TraceStep[];
  performance?: Record<string, number>;
  ts: string;
}
interface TraceStep {
  id: string;
  label: string;
  duration_ms?: number;
  details?: { k: string; v: string }[];
  matches?: { id: string; label: string; score: number; meta?: string }[];
  histogram?: { bins: number[]; max: number; threshold?: number; axis_range?: string };
  note?: string;
}
```

Every traced operation produces this shape. Renderer is generic.

## What you see in Discover

Run "premium beauty 25-44" through the Discover tab. The trace panel shows:

**Step 1: Fetch candidates from D1**
- Filters applied, fetch limit, rows returned, total catalog size, db_read time

**Step 2: Score by keyword match**
- Extracted keywords (after stop-word removal)
- Detected category hint
- Scoring algorithm explanation (name +4, description +2, category hint +3, derived/dynamic boosts)
- **Top-N matches with score bars** (gradient + glow + animated width)
- **Score distribution histogram** (gradient bars + threshold marker)
- Tie-break rule

**Step 3 (if applicable): Custom proposal generation**
- Why a synthesis was triggered + what got proposed

**Performance bar at top:**
- `db_read | rank | other` segmented horizontal bar with legend showing exact ms per bucket

**JSON tab:**
- Full pretty-printed payload, copy-to-clipboard

## Honest framing on the math

Discover currently uses **keyword scoring** in `searchSignalsService`. The trace shows that faithfully — extracted keywords, per-signal additive scores, histogram. The embedding-based cosine path lives at `/signals/query` (UCP / NLAQ). When we wire that path next, the trace surfaces real cosine scores + 512-d vector norm + neighbor distances.

This PR is honest about what's actually happening today. No fake cosine numbers.

## Roadmap (each surface ~50 lines on the backend, zero UI code)

- Federation fan-out: per-agent timings + merge stats
- Orchestrator: 4 stages, each as a step
- Agentic execute: existing reasoning trace → map to TraceStep[]
- Race Canvas: vendor responses + disagreement detection
- Vendor Health: probe details + bucketing decision

## Test plan

- [ ] Hard-refresh `/`, log in
- [ ] Discover tab → enter a brief like "premium beauty 25-44" → click Run
- [ ] Bottom-right: floating "Trace" button slides in + pulses 3 times
- [ ] Click button → backdrop blurs, panel slides from right
- [ ] Header shows operation name, input string, duration animating 0 → final
- [ ] Performance bar at top shows segmented timing breakdown
- [ ] Step 1 (Fetch): expand → details rows render
- [ ] Step 2 (Score): top matches table with animated score bars; histogram with threshold marker
- [ ] Click any step header → accordion toggles
- [ ] Click "JSON" tab → indicator slides; raw payload pretty-printed
- [ ] Click Copy JSON → button says "Copied!"
- [ ] Click outside panel (backdrop) → closes smoothly
- [ ] Esc key → also closes
- [ ] Try across all 3 themes (Midnight / Daylight / Solar) — all visualizations theme correctly

## Pre-flight

- `tsc --noEmit` on all 4 files: 0 errors
- Trap audit on demo.ts: 0 hits across all 4 SCRIPT_TAG escape classes
- (Caught one Trap-4 backtick-in-HTML-comment via tsc mid-build — audit only scans inside `<script>`. Worth extending in a follow-up.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)