### PR TITLE
Trace: 3 more surfaces wired (NL Query, Federation, Orchestrate) + tab-switch reset

### DIFF
--- a/src/domain/nlQueryHandler.ts
+++ b/src/domain/nlQueryHandler.ts
@@ -95,6 +95,88 @@ export async function handleNLQuery(
     (result as any)._embedding_mode = engine.phase;
     (result as any)._embedding_space = engine.spaceId;
 
+    // Build a TraceData payload for the universal trace inspector.
+    // Real embedding cosine path — each AST leaf is embedded and matched
+    // against the catalog via cosine similarity. The trace surfaces
+    // every leaf's top matches with their actual cosine scores.
+    const traceSteps: Array<Record<string, unknown>> = [];
+
+    const astLeafCount = resolvedLeaves.length;
+    traceSteps.push({
+      id: "parse",
+      label: "Parse natural-language query into AST",
+      details: [
+        { k: "input_chars", v: String(body.query.length) },
+        { k: "ast_leaves", v: String(astLeafCount) },
+        { k: "ast_op", v: ast.root?.op ?? "leaf" },
+        { k: "unresolved_hints", v: String((ast.unresolved_hints ?? []).length) },
+        { k: "parser", v: "Anthropic Claude (queryParser.ts)" },
+      ],
+      note: "Boolean AST extraction via Claude — handles AND/OR/NOT, time scopes, exclusions.",
+    });
+
+    traceSteps.push({
+      id: "embed",
+      label: "Embedding engine init",
+      details: [
+        { k: "phase", v: String(engine.phase) },
+        { k: "space_id", v: String(engine.spaceId) },
+        { k: "catalog_size", v: String(catalog.length) },
+      ],
+      note: String(engine.phase).includes("llm")
+        ? "LLM-backed real embeddings (openai-text-embedding-3-small projected to 512-d)."
+        : "Pseudo embeddings — structurally valid but cosines are NOT semantically meaningful. Set EMBEDDING_ENGINE=llm + OPENAI_API_KEY for real cosine.",
+    });
+
+    // Per-leaf trace step. Each leaf is its own step with matches table
+    // showing real cosine scores from the semantic resolver.
+    for (let i = 0; i < resolvedLeaves.length; i++) {
+      const rl = resolvedLeaves[i];
+      if (!rl) continue;
+      const inner = rl.leaf;
+      const topN = rl.matches.slice(0, 8);
+      const labelText = (inner?.dimension ? String(inner.dimension) : "leaf") +
+        (inner?.value ? " · " + String(inner.value) : "");
+      traceSteps.push({
+        id: "leaf_" + i,
+        label: "Leaf " + (i + 1) + ": " + labelText,
+        note: inner?.description ? String(inner.description) : "",
+        details: [
+          { k: "dimension", v: inner?.dimension ? String(inner.dimension) : "—" },
+          { k: "value", v: inner?.value ? String(inner.value) : "—" },
+          { k: "is_exclusion", v: String(Boolean(inner?.is_exclusion)) },
+          { k: "matches_returned", v: String(rl.matches.length) },
+          { k: "top_match_score", v: topN[0] ? Number(topN[0].match_score).toFixed(3) : "—" },
+        ],
+        matches: topN.map((m) => ({
+          id: m.signal_agent_segment_id,
+          label: m.name ?? m.signal_agent_segment_id,
+          score: m.match_score,
+          meta: "method: " + m.match_method,
+        })),
+      });
+    }
+
+    traceSteps.push({
+      id: "compose",
+      label: "Compose audience via boolean set arithmetic",
+      details: [
+        { k: "matched_signals", v: String((result.matched_signals ?? []).length) },
+        { k: "warnings", v: String((result.warnings ?? []).length) },
+      ],
+      note: "Set arithmetic over leaf resolutions — AND intersects cohorts; OR unions; NOT subtracts.",
+    });
+
+    const trace = {
+      operation: "Natural-language query · query_signals_nl",
+      input: body.query,
+      duration_ms: Date.now() - start,
+      steps: traceSteps,
+      performance: { parse_ms: 0, embed_ms: 0, total_ms: Date.now() - start },
+      ts: new Date().toISOString(),
+    };
+    (result as unknown as Record<string, unknown>)._trace = trace;
+
     return json({ success: true, result, duration_ms: Date.now() - start });
 
   } catch (err: unknown) {

--- a/src/routes/agentsEndpoints.ts
+++ b/src/routes/agentsEndpoints.ts
@@ -294,6 +294,62 @@ export async function handleAgentsOrchestrate(request: Request, env: Env, logger
     max_per_agent: maxResults,
   });
 
+  // Build a TraceData payload for the universal trace inspector.
+  const totalDuration = Math.max(...perAgent.map((p) => p.latency_ms || 0), 0);
+  const trace = {
+    operation: "Multi-agent orchestrate · " + tool,
+    input: body.brief,
+    duration_ms: totalDuration,
+    steps: [
+      {
+        id: "discover",
+        label: "Discover live signals agents",
+        details: [
+          { k: "role_filter", v: "signals" },
+          { k: "stage_filter", v: "live" },
+          { k: "agents_in_scope", v: String(targets.length) },
+          { k: "include_filter", v: (body.include_agents ?? []).join(", ") || "—" },
+          { k: "exclude_filter", v: (body.exclude_agents ?? []).join(", ") || "—" },
+        ],
+        note: "All agents in /agents/registry with stage=live and role=signals are eligible. Filters narrow the set.",
+      },
+      {
+        id: "fanout",
+        label: "Parallel " + tool + " across " + targets.length + " agent(s)",
+        duration_ms: totalDuration,
+        note: "Each agent gets the same brief, sequentially via Promise.all. Outbound args sanitized — no `pagination` envelope (Pydantic-strict vendors reject it).",
+        details: [
+          { k: "max_results_per_agent", v: String(maxResults) },
+          { k: "timeout_per_agent_ms", v: String(timeoutMs) },
+          { k: "succeeded", v: String(agentsSucceeded.length) },
+          { k: "failed", v: String(agentsFailed.length) },
+          { k: "total_signals_returned", v: String(merged.length) },
+        ],
+        matches: perAgent.map((p) => ({
+          id: p.id,
+          label: p.name + " · " + (p.ok ? "ok" : "fail") + " · " + p.latency_ms + "ms",
+          score: p.signal_count,
+          meta: "vendor: " + p.vendor + " · " + (p.ok ? "returned " + p.signal_count + " signals" : "error: " + (p.error ?? "?")),
+        })),
+      },
+      {
+        id: "merge",
+        label: "Merge across agents",
+        details: [
+          { k: "method", v: "flat concat with source_agent provenance" },
+          { k: "dedupe", v: "off (preserves duplicates so caller sees provenance)" },
+          { k: "total_returned", v: String(merged.length) },
+        ],
+        note: "For schema-normalized signals + Dstillery-specific mapping, use /agents/federated-search instead.",
+      },
+    ],
+    performance: {
+      slowest_agent_ms: totalDuration,
+      fastest_agent_ms: Math.min(...perAgent.map((p) => p.latency_ms || 0).filter((n) => n > 0), totalDuration),
+    },
+    ts: new Date().toISOString(),
+  };
+
   return jsonResponse({
     brief: body.brief,
     tool,
@@ -309,6 +365,7 @@ export async function handleAgentsOrchestrate(request: Request, env: Env, logger
     signals: merged,
     method: "parallel_mcp_tools_call_per_live_signals_agent",
     note: "Signals from each agent carry source_agent to preserve provenance. Failed agents don't block the merge. For schema-normalized signals use the existing /agents/federated-search which applies a Dstillery-specific mapper; this endpoint is transport-level only.",
+    _trace: trace,
   });
 }
 

--- a/src/routes/demo.ts
+++ b/src/routes/demo.ts
@@ -8751,6 +8751,32 @@ _applySidebarCollapsed(_readSidebarCollapsed());
 //────────────────────────────────────────────────────────────────────────
 window.__lastTrace = null;
 
+// Universal helper: any response that has a _trace field auto-populates
+// the panel + lights up the floating button. Call from any fetch handler:
+//   var data = await resp.json();
+//   _captureTrace(data._trace);
+// Returns true if a trace was captured. Designed to be a one-liner per
+// fetch site.
+function _captureTrace(trace) {
+  if (!trace || typeof trace !== "object") return false;
+  if (!trace.operation && !trace.steps) return false;
+  window.__lastTrace = trace;
+  _showTraceTrigger();
+  return true;
+}
+
+// Reset on tab switch so stale traces don't carry across pages.
+function _resetTrace() {
+  window.__lastTrace = null;
+  var t = document.getElementById("trace-trigger");
+  if (t) {
+    t.classList.remove("is-visible");
+    t.classList.remove("is-pulsing");
+  }
+  var p = document.getElementById("trace-panel");
+  if (p && p.classList.contains("is-open")) _closeTracePanel();
+}
+
 function _showTraceTrigger() {
   var t = document.getElementById("trace-trigger");
   if (!t) return;
@@ -9037,6 +9063,9 @@ document.querySelectorAll(".nav-item[data-tab]").forEach((btn) => {
 });
 
 function switchTab(name) {
+  // Reset trace on tab change — stale context from a prior page shouldn't
+  // dangle. New operation on the new tab pulses the trigger fresh.
+  _resetTrace();
   document.querySelectorAll(".nav-item[data-tab]").forEach((b) => {
     b.classList.toggle("active", b.dataset.tab === name);
   });
@@ -9261,6 +9290,9 @@ async function runNlQuery() {
     // query_signals_nl response lives under data.result (handler wraps
     // the tool output in {success,result}). Unwrap carefully.
     const payload = data?.result ?? data;
+    // Capture _trace from the unwrapped payload — NL Query is the
+    // most algorithmically rich trace target (real cosine per leaf).
+    _captureTrace(payload?._trace);
     const matches = payload?.matched_signals || [];
     const estSize = payload?.estimated_size;
     const confTier = payload?.confidence_tier;
@@ -15946,6 +15978,7 @@ async function runOrchFanout() {
     var data = await r.json();
     if (!r.ok || data.error) throw new Error(data.error || "HTTP " + r.status);
     state.orchestrator.orchestrate = data;
+    _captureTrace(data._trace);
     _orchRenderFanoutResult(data);
   } catch (e) {
     host.innerHTML = '<div class="empty-state" style="border-color:var(--error)"><div class="empty-title" style="color:var(--error)">' + escapeHtml(e.message) + '</div></div>';
@@ -18105,6 +18138,7 @@ async function runFederatedSearch() {
     var r = await fetch("/agents/federated-search", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ brief: brief, max_results_per_agent: parseInt(document.getElementById("fed-max").value, 10) || 5 }) });
     var data = await r.json();
     _fedLastResults = data.merged || [];
+    _captureTrace(data._trace);
     renderFederatedResults(data);
   } catch (e) {
     host.innerHTML = '<div class="empty-state"><div class="empty-title" style="color:var(--error)">' + escapeHtml(String(e.message || e)) + '</div><div class="empty-desc">Federation endpoints may not be deployed yet.</div></div>';

--- a/src/routes/federationEndpoints.ts
+++ b/src/routes/federationEndpoints.ts
@@ -200,6 +200,64 @@ export async function handleFederatedSearch(
     if (r.ok) perAgentCount[r.agent] = r.signals.length;
   }
 
+  const totalDur = Date.now() - start;
+
+  // Universal trace payload — federation fan-out is core multi-agent
+  // workshop content. Make it dense + visual.
+  const trace = {
+    operation: "Agent federation · /agents/federated-search",
+    input: body.brief,
+    duration_ms: totalDur,
+    steps: [
+      {
+        id: "select",
+        label: "Select live A2A signals partners",
+        details: [
+          { k: "registry_endpoint", v: "/agents/registry" },
+          { k: "agents_requested", v: targetAgents.join(", ") },
+          { k: "agents_count", v: String(targetAgents.length) },
+          { k: "max_results_per_agent", v: String(maxPerAgent) },
+        ],
+        note: "Default trio: Evgeny (us, in-process) + Dstillery (live MCP). Roadmap partners surface in /agents/registry but lack mcp_url.",
+      },
+      {
+        id: "fanout",
+        label: "Parallel fan-out — same brief, different catalogs",
+        duration_ms: totalDur,
+        note: "Each partner's get_signals fired in parallel via Promise.all; outbound args sanitized so Pydantic-strict vendors don't reject.",
+        details: [
+          { k: "succeeded", v: succeeded.join(", ") || "(none)" },
+          { k: "failed", v: failed.join(", ") || "(none)" },
+          { k: "merge_strategy", v: "interleaved round-robin (preserves provenance)" },
+        ],
+        matches: results.map((r) => ({
+          id: r.agent,
+          label: r.agent + " · " + (r.ok ? "ok" : "fail") + " · " + r.elapsed_ms + "ms",
+          score: r.ok ? r.signals.length : 0,
+          meta: r.ok
+            ? "returned " + r.signals.length + " signals (catalog: " + (r.agent === "evgeny_signals" ? "Evgeny IAB-aligned" : r.agent === "dstillery" ? "Dstillery behavioral" : "vendor catalog") + ")"
+            : "error: " + (r.error ?? "?"),
+        })),
+      },
+      {
+        id: "merge",
+        label: "Interleave + tag merged ranking",
+        details: [
+          { k: "total_merged", v: String(merged.length) },
+          { k: "merge_method", v: "round-robin: pull nth from each agent in turn" },
+          { k: "rank_field", v: "merge_rank (1-based, global) + agent_rank (1-based, per-agent)" },
+          { k: "provenance", v: "every signal carries source_agent" },
+        ],
+        note: "Round-robin merge guarantees each partner gets representation in the top-N regardless of how many results each returned.",
+      },
+    ],
+    performance: {
+      ...Object.fromEntries(results.map((r) => [r.agent + "_ms", r.elapsed_ms])),
+      total_ms: totalDur,
+    },
+    ts: new Date().toISOString(),
+  };
+
   return jsonResponse({
     brief: body.brief,
     agents_queried: targetAgents,
@@ -210,8 +268,9 @@ export async function handleFederatedSearch(
     per_agent_errors: Object.fromEntries(results.filter((r) => r.error).map((r) => [r.agent, r.error])),
     merged,
     merge_strategy: "interleaved_round_robin_by_agent",
-    total_time_ms: Date.now() - start,
+    total_time_ms: totalDur,
     method: "parallel_fanout_mcp_tools_call",
+    _trace: trace,
   });
 }
 


### PR DESCRIPTION
## Foundation for "every query has a trace"

Adds three high-value backend surfaces, a universal frontend helper, and tab-switch reset behavior. Lays the groundwork for batching the remaining ~20 endpoints in follow-up PRs.

## Surfaces wired

**1. NL Query (`query_signals_nl`)** — most algorithmically rich. Real embedding cosine per AST leaf:
- `parse` — input chars, AST leaves, root op, parser used
- `embed` — engine phase, space_id, catalog size + explicit warning if pseudo embeddings in use
- `leaf_N` — one step per AST leaf with top-8 matches by **real cosine score**
- `compose` — boolean set arithmetic that produced the final cohort

Workshop value: type "premium beauty 25-44" → trace shows actual leaf-by-leaf cosine math.

**2. Federation (`/agents/federated-search`)** — multi-agent fan-out:
- `select` — registry source, agents requested, max per agent
- `fanout` — per-agent matches with latency + count + catalog characterization
- `merge` — round-robin interleave + provenance

Workshop value: makes the A2A story visceral — same brief, different vendors' catalogs, comparable scoring.

**3. Orchestrate (`/agents/orchestrate`)** — generic fan-out across all signals agents.

## Tab-switch reset

`switchTab()` now calls `_resetTrace()`:
- Stale trace from prior page no longer dangles
- Trigger button hides
- Open panel auto-closes
- Fresh operation on new tab → trigger pulses again

## Universal frontend helper

```js
var data = await resp.json();
_captureTrace(data._trace);   // one-liner per fetch site
```

Returns `true` if it captured; populates `window.__lastTrace` and pulses the trigger.

## Roadmap (drop-in extensions, ~30 lines per endpoint)

**Tier B sync endpoints (~20 left):**
composer, portfolio (4 routes), audience-* (5 routes), seasonality, best-for, lorenz, knn-graph, overlap, info-overlap, ucp/projection, ucp/similarity, ucp/arithmetic, ucp/analogy, ucp/neighborhood, governance-preview, brand-rights-preview, si-preview, workflow/run (sync)

**Tier C streaming (4):**
workflow/run/stream (Brand Canvas), agentic/chat, agentic/execute, race/start

**Tier D separate pages (2):**
Race Canvas + Vendor Health — need their own panel scaffold

## Test plan

- [ ] Hard-refresh `/`, log in
- [ ] Discover tab — type a brief, run, trigger pulses (still working from #157)
- [ ] Switch to Concepts tab — trigger hides
- [ ] Concepts tab — switch to NL Query mode if needed, run a query → trigger pulses; click → panel shows leaves with real cosine scores
- [ ] Switch to Federation tab — trigger hides
- [ ] Federation — type brief, click "Fan out" → trigger pulses; click → panel shows per-agent fanout
- [ ] Switch to Orchestrator tab — trigger hides
- [ ] Orchestrator — fan-out → trigger pulses; click → panel shows full agent fanout matrix
- [ ] Switch tabs randomly: trigger consistently resets, panel auto-closes if open
- [ ] All three themes still render the panel cleanly

## Pre-flight

- `tsc --noEmit` on all 4 files: 0 errors
- Trap audit: 0 hits across all 4 classes (caught one Trap-4 mid-build — backticks in JS doc comment — fixed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)