### PR TITLE
Trace: universal coverage via dispatch wrapper + global fetch interceptor

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -109,6 +109,7 @@ import { handleMcpRequest } from "./mcp/server";
 import { jsonResponse, errorResponse, requireAuth } from "./routes/shared";
 import { createLogger } from "./utils/logger";
 import { requestId } from "./utils/ids";
+import { injectTraceIfMissing } from "./utils/trace";
 import { runSeedPipeline } from "./domain/seedPipeline";
 import { getDb } from "./storage/db";
 import { getAllSignalsForCatalog } from "./domain/signalService";
@@ -178,6 +179,7 @@ export default {
         const url = new URL(request.url);
         const path = url.pathname;
         const method = request.method.toUpperCase();
+        const _traceStart = Date.now();
 
         // CORS preflight
         if (method === "OPTIONS") {
@@ -803,6 +805,13 @@ export default {
                     404
                 );
             }
+
+            // Universal trace inject — every JSON 2xx response gets a
+            // baseline _trace if the handler didn't build one. Handlers
+            // that DO build a richer trace (Discover, NL Query, federation,
+            // orchestrate, etc.) are detected and passed through unchanged.
+            // See src/utils/trace.ts for the implementation.
+            response = await injectTraceIfMissing(response, path, _traceStart, method);
 
             return withCors(response);
         } catch (err) {

--- a/src/routes/demo.ts
+++ b/src/routes/demo.ts
@@ -8751,12 +8751,61 @@ _applySidebarCollapsed(_readSidebarCollapsed());
 //────────────────────────────────────────────────────────────────────────
 window.__lastTrace = null;
 
-// Universal helper: any response that has a _trace field auto-populates
-// the panel + lights up the floating button. Call from any fetch handler:
-//   var data = await resp.json();
-//   _captureTrace(data._trace);
-// Returns true if a trace was captured. Designed to be a one-liner per
-// fetch site.
+// Global fetch interceptor — any JSON response from /signals, /agents,
+// /audience, /portfolio, /analytics, /ucp, /registry, /dsp, /agentic
+// is sniffed for a _trace field. If present, it auto-populates the
+// panel and pulses the trigger. Means every backend endpoint that
+// emits _trace gets free trace UI without per-site frontend wiring.
+//
+// Implementation: monkey-patch window.fetch. Clone the response so the
+// caller can still consume the body normally. Body sniff happens off
+// the critical path. Failures are silent (trace is decorative).
+(function() {
+  if (window.__traceInterceptorInstalled) return;
+  window.__traceInterceptorInstalled = true;
+  var origFetch = window.fetch.bind(window);
+  // Path prefixes worth sniffing for _trace. Backslash-slash in regex
+  // literals is a Trap-3 hazard inside this template literal — we use
+  // string-prefix matching instead. Order doesn't matter; matching is
+  // O(n) over a tiny list.
+  var TRACE_PREFIXES = [
+    "/signals", "/agents", "/audience", "/portfolio", "/analytics",
+    "/ucp", "/registry", "/dsp", "/agentic", "/race", "/vendor-health",
+    "/brands"
+  ];
+  function _isTracePath(p) {
+    for (var i = 0; i < TRACE_PREFIXES.length; i++) {
+      var pre = TRACE_PREFIXES[i];
+      if (p === pre || p.indexOf(pre + "/") === 0) return true;
+    }
+    return false;
+  }
+  window.fetch = function(input, init) {
+    var resp = origFetch(input, init);
+    return resp.then(function(r) {
+      try {
+        var url = typeof input === "string" ? input : (input && input.url) || "";
+        var path = url;
+        try { path = new URL(url, window.location.origin).pathname; } catch (e) {}
+        if (!_isTracePath(path)) return r;
+        var ct = r.headers && r.headers.get && r.headers.get("content-type") || "";
+        if (ct.indexOf("application/json") < 0) return r;
+        // Clone so the caller can still .json() / .text() the original.
+        var cloned = r.clone();
+        cloned.json().then(function(j) {
+          if (j && j._trace) _captureTrace(j._trace);
+          // Some handlers wrap result under .result (e.g. nlQueryHandler)
+          else if (j && j.result && j.result._trace) _captureTrace(j.result._trace);
+        }).catch(function() {});
+      } catch (e) {}
+      return r;
+    });
+  };
+})();
+
+// Per-site capture (kept as no-op safety net; the interceptor above
+// usually beats this to the trace). Call sites added in #157/#158
+// remain harmless.
 function _captureTrace(trace) {
   if (!trace || typeof trace !== "object") return false;
   if (!trace.operation && !trace.steps) return false;

--- a/src/utils/trace.ts
+++ b/src/utils/trace.ts
@@ -1,0 +1,139 @@
+// src/utils/trace.ts
+//
+// Helper for building TraceData payloads on backend handlers. Reduces
+// per-endpoint boilerplate to ~5 lines:
+//
+//   const t0 = Date.now();
+//   ...do the work...
+//   const trace = buildTrace({
+//     operation: "Composer · saturation",
+//     input: body.brief,
+//     start_ms: t0,
+//     steps: [...],   // operation-specific
+//   });
+//   return jsonResponse({ ...result, _trace: trace });
+//
+// Pair with the global fetch interceptor in demo.ts which auto-extracts
+// `_trace` from any JSON response and pulses the trace inspector.
+
+import type { TraceData, TraceStep } from "../types/trace";
+
+export interface TraceBuilderArgs {
+  /** Display name for the panel header. */
+  operation: string;
+  /** Original input string (brief, query, etc.). Optional. */
+  input?: string;
+  /** When the operation started — Date.now() before the work. */
+  start_ms: number;
+  /** Operation-specific steps. Defaults to a single "compute" step
+   *  if none provided. */
+  steps?: TraceStep[];
+  /** Optional aggregated performance buckets. total_ms is auto-added. */
+  performance?: Record<string, number>;
+}
+
+export function buildTrace(args: TraceBuilderArgs): TraceData {
+  const duration = Date.now() - args.start_ms;
+  const steps = args.steps && args.steps.length > 0 ? args.steps : [{
+    id: "compute",
+    label: "Compute",
+    duration_ms: duration,
+    details: [],
+  }];
+  const trace: TraceData = {
+    operation: args.operation,
+    duration_ms: duration,
+    steps,
+    performance: { ...(args.performance ?? {}), total_ms: duration },
+    ts: new Date().toISOString(),
+  };
+  if (args.input !== undefined) trace.input = args.input;
+  return trace;
+}
+
+/** Convenience: produce a single-step trace from key-value details.
+ *  Use this for endpoints that don't have rich multi-step structure
+ *  but still want the trigger to fire. */
+export function singleStepTrace(
+  operation: string,
+  input: string | undefined,
+  start_ms: number,
+  label: string,
+  details: Array<{ k: string; v: string }>,
+  note?: string,
+): TraceData {
+  const step: TraceStep = {
+    id: "compute",
+    label,
+    duration_ms: Date.now() - start_ms,
+    details,
+  };
+  if (note) step.note = note;
+  const args: TraceBuilderArgs = { operation, start_ms, steps: [step] };
+  if (input !== undefined) args.input = input;
+  return buildTrace(args);
+}
+
+/** Path → display operation name. "/audience/compose" → "Audience · compose". */
+function pathToOperationName(path: string): string {
+  const parts = path.replace(/^\//, "").split("/");
+  if (parts.length === 0 || !parts[0]) return path;
+  const head = parts[0].charAt(0).toUpperCase() + parts[0].slice(1);
+  if (parts.length === 1) return head;
+  return head + " · " + parts.slice(1).join(" / ");
+}
+
+/**
+ * Auto-inject a default _trace into any JSON response that doesn't
+ * already have one. Called once at the dispatch level in index.ts so
+ * every API endpoint gets baseline trace coverage without touching the
+ * handler code.
+ *
+ * Handlers that build their OWN _trace (richer steps, matches, etc.)
+ * are detected and passed through unchanged.
+ */
+export async function injectTraceIfMissing(
+  response: Response,
+  path: string,
+  start_ms: number,
+  method: string,
+): Promise<Response> {
+  const ct = response.headers.get("content-type") || "";
+  if (!ct.toLowerCase().includes("application/json")) return response;
+  // Skip non-2xx — caller wants the original error body intact.
+  if (response.status < 200 || response.status >= 300) return response;
+  try {
+    const body = await response.clone().json() as Record<string, unknown>;
+    if (!body || typeof body !== "object") return response;
+    if ((body as { _trace?: unknown })._trace) return response; // handler already built one
+    const opName = pathToOperationName(path);
+    const trace: TraceData = {
+      operation: method.toUpperCase() + " " + opName,
+      duration_ms: Date.now() - start_ms,
+      steps: [{
+        id: "handler",
+        label: "Handler · " + path,
+        duration_ms: Date.now() - start_ms,
+        details: [
+          { k: "method", v: method.toUpperCase() },
+          { k: "path", v: path },
+          { k: "status", v: String(response.status) },
+          { k: "duration_ms", v: String(Date.now() - start_ms) },
+        ],
+        note: "Default auto-trace (handler did not emit a richer one). Drop a buildTrace() call into the handler for step-level detail.",
+      }],
+      performance: { total_ms: Date.now() - start_ms },
+      ts: new Date().toISOString(),
+    };
+    (body as { _trace: TraceData })._trace = trace;
+    // Rebuild headers to keep CORS / content-type intact.
+    const headers = new Headers(response.headers);
+    return new Response(JSON.stringify(body), {
+      status: response.status,
+      statusText: response.statusText,
+      headers,
+    });
+  } catch {
+    return response;
+  }
+}


### PR DESCRIPTION
## What

Closes the "every query has a trace" rule with **two universal layers** that auto-cover ALL endpoints — zero per-handler edits.

### Layer 1 — backend dispatch wrapper

`src/utils/trace.ts → injectTraceIfMissing()`

Called once at the end of fetch() in `src/index.ts`. For any 2xx JSON response that doesn't already carry a `_trace` field, builds a default `TraceData`:

- `operation`: derived from path → `"/audience/compose"` becomes `"Audience · compose"`
- `duration_ms`: total request wall-clock
- One "Handler" step with method/path/status/duration

Handlers that already build their own richer trace (Discover, NL Query, Federation, Orchestrate from #157+#158) are detected by `body._trace` and passed through **unchanged**.

### Layer 2 — frontend fetch interceptor

Monkey-patches `window.fetch` in demo.ts. Every JSON response from a whitelisted prefix (`/signals`, `/agents`, `/audience`, `/portfolio`, `/analytics`, `/ucp`, `/registry`, `/dsp`, `/agentic`, `/race`, `/vendor-health`, `/brands`) is auto-sniffed for `_trace`. Found → panel populates, trigger pulses. **Zero per-fetch-site wiring**.

`Response.clone()` keeps the body consumable for the original caller.

## Coverage matrix after deploy

| Tier | Endpoints | Trace richness |
|---|---|---|
| **Auto-traced (dispatch wrapper)** | ~30 sync JSON endpoints | Default 1-step trace with path/method/duration |
| **Rich custom (#157, #158)** | Discover, NL Query, Federation, Orchestrate | Multi-step with matches + histograms |
| **Drop-in upgrade path** | Any handler | Call `buildTrace()` and attach to response — auto-detected, replaces default |

## Helpers added

```ts
import { buildTrace, singleStepTrace } from "./utils/trace";

// Per-handler richer trace:
const t0 = Date.now();
// ... do work ...
return jsonResponse({ ...result, _trace: buildTrace({
  operation: "Composer · saturation",
  input: body.brief,
  start_ms: t0,
  steps: [/* operation-specific */],
})});

// Or just singleStepTrace for a quick win:
return jsonResponse({ ...result, _trace: singleStepTrace(
  "Portfolio · optimize", body.brief, t0, "Greedy optimization",
  [{k: "candidates", v: String(N)}, ...]
)});
```

## Bug-class memory (caught mid-build)

- **Trap-3 caught**: regex literal `` /^\/(signals|...)/ `` in the interceptor would have been collapsed to invalid syntax by the outer template literal. Replaced with string-prefix array. Reinforces "no regex literals in embedded JS."
- **Candidate Trap-5**: `exactOptionalPropertyTypes` + optional field where source is `undefined`. Required conditional assignment in `singleStepTrace`. Pattern noted for future.

## Pre-flight

- `tsc --noEmit` on all 3 files: 0 errors
- Trap audit: 0 hits across all 4 classes

## Out of scope (next PRs)

- **Streaming endpoints** — `workflow/run/stream` (Brand Canvas), `agentic/chat`, `agentic/execute`, `race/start`. Need final-event NDJSON pattern; the dispatch wrapper only handles JSON responses.
- **Separate pages** — Race Canvas, Vendor Health. Need their own panel scaffolds (the panel UI lives in demo.ts only).
- **Deeper per-endpoint traces** — any handler can opt-in by calling `buildTrace()`. Composer/optimize/from-brief are the highest-value upgrades.

## Test plan

- [ ] Hard-refresh `/`
- [ ] Discover — run, trigger pulses (rich trace from #157)
- [ ] Concepts (NL Query) — run, trigger pulses (rich trace from #158)
- [ ] Federation — fan out, trigger pulses (rich trace from #158)
- [ ] Orchestrator — fan out, trigger pulses (rich trace from #158)
- [ ] **Audience > Composer** — run a composition, trigger pulses (default auto-trace from this PR)
- [ ] **Portfolio > Optimize / From-brief** — run, trigger pulses (auto)
- [ ] **Audience > Journey / Saturation / Compose AST** — run, trigger pulses (auto)
- [ ] **Analytics > Seasonality / Lorenz / KNN-graph** — run, trigger pulses (auto)
- [ ] **UCP > Projection / Similarity / Arithmetic / Analogy / Neighborhood** — run, trigger pulses (auto)
- [ ] **Brand Canvas > governance/brand-rights/SI preview cards** — fetch, trigger pulses (auto)
- [ ] Tab-switch — trigger resets correctly across all surfaces
- [ ] All themes (Midnight / Daylight / Solar) render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)