### PR TITLE
Trace: streaming endpoints (Brand Canvas + Agentic chat + execute)

### DIFF
--- a/src/routes/agenticRoutes.ts
+++ b/src/routes/agenticRoutes.ts
@@ -232,6 +232,47 @@ export async function handleAgenticExecute(request: Request, env: Env, logger: L
         }
 
         emit({ event: "reasoning", step: newReasoningStep("complete", `Plan executed: ${stepResults.filter((s) => s.ok).length}/${stepResults.length} steps successful. Final picks: ${choices.signals.length} signals, ${choices.formats.length} formats, ${Object.keys(choices.products).length} product(s).`) });
+
+        // Streaming trace event — agentic execute compiles the
+        // reasoning trace into the universal TraceData shape so the
+        // panel can render the same way it does for sync endpoints.
+        const stepCount = stepResults.length;
+        const okCount = stepResults.filter((s) => s.ok).length;
+        emit({
+          event: "trace",
+          trace: {
+            operation: "Agentic Canvas · execute plan",
+            input: plan.brief.input,
+            duration_ms: 0, // executor doesn't track t0; per-step latencies cover it
+            steps: stepResults.map((s, i) => {
+              const agentResults = (s.agent_results || []) as Array<{ agent_id?: string; agent_name?: string; ok?: boolean; latency_ms?: number; error?: string }>;
+              const latencies = agentResults.map((r) => Number(r.latency_ms) || 0);
+              return {
+                id: "step_" + i,
+                label: "Step " + s.index + ": " + s.tool,
+                duration_ms: latencies.length > 0 ? Math.max(...latencies) : 0,
+                details: [
+                  { k: "tool", v: s.tool },
+                  { k: "ok", v: s.ok ? "yes" : "no" },
+                  { k: "agents_called", v: String(agentResults.length) },
+                  { k: "agents_succeeded", v: String(agentResults.filter((r) => r.ok).length) },
+                ],
+                matches: agentResults.map((r) => ({
+                  id: r.agent_id ?? "?",
+                  label: (r.agent_name ?? r.agent_id ?? "?") + " · " + (r.ok ? "ok" : "fail") + " · " + (r.latency_ms || 0) + "ms",
+                  score: Number(r.latency_ms) || 0,
+                  meta: r.ok ? "succeeded" : "error: " + (r.error ?? "?"),
+                })),
+              };
+            }),
+            performance: {
+              total_steps: stepCount,
+              succeeded: okCount,
+              failed: stepCount - okCount,
+            },
+            ts: new Date().toISOString(),
+          },
+        });
         emit({ event: "execution_complete", plan_id: plan.plan_id, choices, step_results: stepResults, ts: new Date().toISOString() });
 
         // Persist memory.
@@ -741,6 +782,82 @@ export async function handleAgenticChat(request: Request, env: Env, _logger: Log
         if (memory.matches.length > 0) summaryParts.push(`Memory: ${memory.hint}`);
 
         emit({ event: "reasoning", step: newReasoningStep("complete", summaryParts.join(" ")) });
+
+        // Streaming trace — agentic chat compiles the 5 stages into a
+        // single TraceData. Surface in the universal panel so the same
+        // affordance covers every entry surface.
+        emit({
+          event: "trace",
+          trace: {
+            operation: "Agentic Canvas · chat · " + ctx.mode,
+            input: input,
+            duration_ms: 0,
+            steps: [
+              {
+                id: "brief",
+                label: "Stage 1 · brief expansion",
+                details: [
+                  { k: "mode", v: ctx.mode },
+                  { k: "brand_name", v: expanded.brand_name ?? "(unknown)" },
+                  { k: "industries", v: expanded.industries.slice(0, 5).join(", ") || "(none)" },
+                  { k: "kpi", v: expanded.kpi },
+                  { k: "kpi_target", v: expanded.kpi_target !== undefined ? String(expanded.kpi_target) : "—" },
+                  { k: "geo", v: (expanded.geo || []).join(", ") },
+                  { k: "confidence", v: expanded.confidence !== undefined ? String(expanded.confidence) : "—" },
+                ],
+                note: ctx.mode === "live" ? "Claude decomposed the brief into structured fields." : "Rule-based extractor (template fallback).",
+              },
+              {
+                id: "coverage",
+                label: "Stage 2 · live MCP coverage probe",
+                details: [
+                  { k: "agents_in_coverage", v: String(coverage.length) },
+                  { k: "tools_total", v: String(coverage.reduce((s, a) => s + a.tools_supported.length, 0)) },
+                ],
+                note: "Each live agent's tools/list pulled in parallel; planner sees only callable tools.",
+              },
+              {
+                id: "plan",
+                label: "Stage 3 · execution plan",
+                details: [
+                  { k: "step_count", v: String(plan.steps.length) },
+                  { k: "tools_in_order", v: plan.steps.map((s) => s.tool).join(" → ") },
+                  { k: "source", v: plan.source },
+                  { k: "confidence", v: String(plan.confidence) },
+                ],
+                matches: plan.steps.map((s, i) => ({
+                  id: s.step_id,
+                  label: (i + 1) + ". " + s.tool + " → " + s.agents.join(", "),
+                  score: i + 1,
+                  meta: s.rationale.slice(0, 140),
+                })),
+              },
+              {
+                id: "governance",
+                label: "Stage 4 · governance preview",
+                details: [
+                  { k: "outcome", v: compliance.advisory.outcome.toUpperCase() },
+                  { k: "blocks", v: compliance.advisory.restricted_attributes.join(", ") || "(none)" },
+                  { k: "policies_evaluated", v: String((compliance.advisory.advisories || []).length) },
+                  { k: "remediations", v: String((compliance.remediations || []).length) },
+                ],
+                note: "Predictive check_governance against brand industries × signal attestations. Mocked locally — no live vendor.",
+              },
+              {
+                id: "memory",
+                label: "Stage 5 · memory recall",
+                details: [
+                  { k: "matches_found", v: String(memory.matches.length) },
+                  { k: "hint", v: memory.hint ?? "(none)" },
+                ],
+                note: "Industry-overlap × KPI-match scoring against past workflow history (KV ring buffer).",
+              },
+            ],
+            performance: {},
+            ts: new Date().toISOString(),
+          },
+        });
+
         emit({ event: "session_complete", mode: ctx.mode, ts: new Date().toISOString() });
       } catch (e) {
         emit({ event: "error", error: String((e as Error).message || e) });

--- a/src/routes/agentsEndpoints.ts
+++ b/src/routes/agentsEndpoints.ts
@@ -882,6 +882,7 @@ type StreamEvent =
   | { type: "targeting_chosen"; chosen_signal_ids: string[] }
   | { type: "formats_chosen"; chosen_format_ids: string[] }
   | { type: "products_chosen"; chosen_product_per_agent: Record<string, string | null> }
+  | { type: "trace"; trace: import("../types/trace").TraceData }
   | { type: "workflow_complete"; mode: string; total_time_ms: number; warnings: string[] };
 
 export async function handleWorkflowRunStream(request: Request, env: Env, logger: Logger): Promise<Response> {
@@ -1150,6 +1151,111 @@ export async function handleWorkflowRunStream(request: Request, env: Env, logger
 
         const totalTimeMs = Date.now() - t0;
         const mode = activateSet.size === 0 ? "dry_run" : activateSet.size === buyingAgents.length ? "all_live" : "partial_live";
+
+        // Emit final trace event before workflow_complete. Streaming
+        // endpoints can't hang trace on a JSON response (no JSON body),
+        // so we emit a sentinel NDJSON event the frontend listens for
+        // and routes into the trace panel.
+        const sigCount = signalsResults.reduce((n, r) => n + r.payload.count, 0);
+        const crvCount = creativeResults.reduce((n, r) => n + r.payload.count, 0);
+        const prdCount = productsResults.reduce((n, r) => n + r.payload.count, 0);
+        const fanoutLatency = (rs: Array<{ id: string; latency_ms: number; payload: { count: number } }>) =>
+          Math.max(...rs.map((r) => r.latency_ms || 0), 0);
+        send({
+          type: "trace",
+          trace: {
+            operation: "Brand Canvas · workflow run (stream)",
+            input: body.brief!,
+            duration_ms: totalTimeMs,
+            steps: [
+              {
+                id: "plan",
+                label: "Plan & probe",
+                duration_ms: 0,
+                details: [
+                  { k: "workflow_id", v: workflowId },
+                  { k: "mode", v: mode },
+                  { k: "signals_agents", v: signalsAgents.map((a) => a.id).join(", ") },
+                  { k: "creative_agents", v: creativeAgents.map((a) => a.id).join(", ") },
+                  { k: "buying_agents", v: buyingAgents.map((a) => a.id).join(", ") },
+                  { k: "activate_targets", v: activateSet.size > 0 ? Array.from(activateSet).join(", ") : "(dry-run)" },
+                ],
+                note: "Stages 1+2 (signals + creative) run in parallel; 3 (products) consumes their picks; 4 (media buy) synthesizes payloads.",
+              },
+              {
+                id: "signals",
+                label: "Stage 1 · signals fan-out",
+                duration_ms: fanoutLatency(signalsResults as Array<{ id: string; latency_ms: number; payload: { count: number } }>),
+                details: [
+                  { k: "agents_called", v: String(signalsResults.length) },
+                  { k: "succeeded", v: String(signalsResults.filter((r) => r.ok).length) },
+                  { k: "total_signals_returned", v: String(sigCount) },
+                  { k: "chosen_top_3", v: chosenSignalIds.join(", ") || "(none)" },
+                ],
+                matches: signalsResults.map((r) => ({
+                  id: r.id,
+                  label: r.name + " · " + r.latency_ms + "ms · " + (r.ok ? "ok" : "fail"),
+                  score: r.payload.count,
+                  meta: r.ok ? "returned " + r.payload.count + " signals (" + r.vendor + ")" : "error: " + (r.error ?? "?"),
+                })),
+              },
+              {
+                id: "creative",
+                label: "Stage 2 · creative fan-out",
+                duration_ms: fanoutLatency(creativeResults as Array<{ id: string; latency_ms: number; payload: { count: number } }>),
+                details: [
+                  { k: "agents_called", v: String(creativeResults.length) },
+                  { k: "succeeded", v: String(creativeResults.filter((r) => r.ok).length) },
+                  { k: "total_formats_returned", v: String(crvCount) },
+                  { k: "chosen_format_ids", v: chosenFormatIds.join(", ") || "(none)" },
+                ],
+                matches: creativeResults.map((r) => ({
+                  id: r.id,
+                  label: r.name + " · " + r.latency_ms + "ms · " + (r.ok ? "ok" : "fail"),
+                  score: r.payload.count,
+                  meta: r.ok ? "returned " + r.payload.count + " formats (" + r.vendor + ")" : "error: " + (r.error ?? "?"),
+                })),
+              },
+              {
+                id: "products",
+                label: "Stage 3 · products fan-out",
+                duration_ms: fanoutLatency(productsResults as Array<{ id: string; latency_ms: number; payload: { count: number } }>),
+                details: [
+                  { k: "agents_called", v: String(productsResults.length) },
+                  { k: "succeeded", v: String(productsResults.filter((r) => r.ok).length) },
+                  { k: "total_products_returned", v: String(prdCount) },
+                  { k: "chosen_one_per_agent", v: Object.entries(chosenProductByAgent).map(([k, v]) => k + "=" + (v ?? "—")).join(", ") || "(none)" },
+                  { k: "filter_applied", v: JSON.stringify(productFilter).slice(0, 120) },
+                ],
+                note: "Each agent's products filtered by chosen signals + format_ids. One pick per agent by best CPM-floor match.",
+                matches: productsResults.map((r) => ({
+                  id: r.id,
+                  label: r.name + " · " + r.latency_ms + "ms · " + (r.ok ? "ok" : "fail"),
+                  score: r.payload.count,
+                  meta: r.ok ? "returned " + r.payload.count + " products (" + r.vendor + ")" : "error: " + (r.error ?? "?"),
+                })),
+              },
+              {
+                id: "media_buy",
+                label: "Stage 4 · media-buy synthesis" + (activateSet.size > 0 ? " + fire" : " (dry-run)"),
+                details: [
+                  { k: "buying_agents", v: String(buyingAgents.length) },
+                  { k: "activated", v: activateSet.size > 0 ? Array.from(activateSet).join(", ") : "(none — dry-run)" },
+                  { k: "warnings", v: activateWarnings.join("; ") || "(none)" },
+                ],
+                note: "Per-vendor adapter rules applied (Adzymic / Claire / Swivel schemas split). Idempotency-key derived from FNV-1a hash. Auth-gate failures surface inline (Sec-48 finding: no shared buy-side auth posture in 3.0 GA).",
+              },
+            ],
+            performance: {
+              signals_ms: fanoutLatency(signalsResults as Array<{ id: string; latency_ms: number; payload: { count: number } }>),
+              creative_ms: fanoutLatency(creativeResults as Array<{ id: string; latency_ms: number; payload: { count: number } }>),
+              products_ms: fanoutLatency(productsResults as Array<{ id: string; latency_ms: number; payload: { count: number } }>),
+              total_ms: totalTimeMs,
+            },
+            ts: new Date().toISOString(),
+          },
+        });
+
         send({ type: "workflow_complete", mode, total_time_ms: totalTimeMs, warnings: activateWarnings });
 
         logger.info("agents_workflow_run_stream", {

--- a/src/routes/demo.ts
+++ b/src/routes/demo.ts
@@ -16373,6 +16373,12 @@ function _wfApplyEvent(ev) {
     });
     return;
   }
+  if (ev.type === "trace") {
+    // Streaming trace event — emit by handleWorkflowRunStream just
+    // before workflow_complete. Routes into the universal trace panel.
+    _captureTrace(ev.trace);
+    return;
+  }
   if (ev.type === "workflow_complete") {
     _wfState.complete = true;
     _wfState.mode = ev.mode;
@@ -17449,6 +17455,12 @@ function _canvasApplyEvent(ev) {
   if (type === "products_chosen") {
     r.products.chosen = ev.chosen_product_per_agent || {};
     _canvasRenderLane("products");
+    return;
+  }
+  if (type === "trace") {
+    // Streaming trace event from /agents/workflow/run/stream. Routes
+    // into the universal trace panel; trigger pulses bottom-right.
+    _captureTrace(ev.trace);
     return;
   }
   if (type === "workflow_complete") {
@@ -19600,6 +19612,10 @@ function _agenticHandleStreamEvent(ev) {
     }
     return;
   }
+  if (ev.event === "trace") {
+    _captureTrace(ev.trace);
+    return;
+  }
   if (ev.event === "session_complete") {
     _agenticSetActiveStage(null);
     return;
@@ -19914,6 +19930,8 @@ async function _agenticExecute() {
           _agenticAppendExec(ev);
         } else if (ev.event === "agent_result") {
           _agenticAppendAgentResult(ev);
+        } else if (ev.event === "trace") {
+          _captureTrace(ev.trace);
         } else if (ev.event === "execution_complete") {
           if (status) status.textContent = "done · " + (ev.step_results ? ev.step_results.length + " steps" : "");
         } else if (ev.event === "error") {


### PR DESCRIPTION
## What

Tier C of the trace coverage plan. Three streaming NDJSON endpoints now emit a final `{event: "trace", trace: TraceData}` sentinel event before close. Frontend stream consumers in demo.ts route those into the universal trace panel — same UI as sync traces.

## Streaming endpoints wired

### (1) `/agents/workflow/run/stream` — Brand Canvas
**5-step trace:**
- plan/probe — workflow_id, mode, agents in scope per role
- Stage 1 signals fan-out — agent matches with latency + count + vendor
- Stage 2 creative fan-out — same
- Stage 3 products fan-out — filter applied + per-agent picks
- Stage 4 media-buy synthesis — activation set + warnings + auth-gate notes

Performance breakdown: signals_ms / creative_ms / products_ms / total_ms.

### (2) `/agentic/execute` — Agentic plan execution
Per-step trace mapped from the reasoning trace. Each plan step becomes a TraceStep with agent-call matches table.

### (3) `/agentic/chat` — Agentic Canvas unified chat
**5-stage trace:**
- Stage 1 brief expansion — extracted fields + confidence + mode (live/template)
- Stage 2 coverage probe — agents probed, total tools
- Stage 3 plan — tool sequence with rationale matches table
- Stage 4 governance preview — outcome + blocks + remediations
- Stage 5 memory recall — past workflow matches

## Frontend wiring

Four event handlers added (one per stream consumer):
- `_wfApplyEvent` (line 16376) — Brand Canvas workflow stream events
- `_canvasApplyStreamEvent` (line 17460) — Brand Canvas duplicate router
- `_agenticHandleStreamEvent` — Agentic chat
- Agentic execute inline consumer

All call `_captureTrace(ev.trace)` which lights up the universal panel.

## Coverage matrix after this PR

| Tier | Endpoints | Mechanism |
|---|---|---|
| Sync JSON (auto) | ~30 endpoints | Dispatch wrapper (#159) |
| Sync rich | Discover, NL Query, Federation, Orchestrate | Custom traces (#157+#158) |
| **Streaming (this PR)** | **Brand Canvas workflow, Agentic chat, Agentic execute** | **Final NDJSON event** |
| Streaming (held) | `/race/start` | Backend can emit, but `raceCanvas.ts` lacks the panel UI |
| Separate pages (held) | Race Canvas, Vendor Health | Tier D — copy panel scaffold per page (~150 lines each) |

## Test plan

- [ ] Hard-refresh `/`, login
- [ ] Brand Canvas → pick a brand (e.g. Coca-Cola) → "Run workflow with this brand" → workflow streams to completion → bottom-right Trace trigger pulses → click → 5-step trace with per-stage matches
- [ ] Agentic Canvas → enter a brief in the chat input → run → trigger pulses → click → 5-stage trace
- [ ] Agentic Canvas → execute a plan (after reviewing) → trigger pulses → click → per-step trace with agent matches
- [ ] Switch tabs — trigger resets correctly
- [ ] All 3 themes (Midnight / Daylight / Solar) render the panel cleanly

## Pre-flight

- `tsc --noEmit` on all 3 files: 0 errors
- Trap audit on demo.ts: 0 hits across all 4 SCRIPT_TAG escape classes

🤖 Generated with [Claude Code](https://claude.com/claude-code)