### PR TITLE
Fix: rich traces no longer clobbered by auto-default traces from side-effect calls

### DIFF
--- a/src/routes/demo.ts
+++ b/src/routes/demo.ts
@@ -8806,9 +8806,23 @@ window.__lastTrace = null;
 // Per-site capture (kept as no-op safety net; the interceptor above
 // usually beats this to the trace). Call sites added in #157/#158
 // remain harmless.
+//
+// Replacement rule: a rich trace (multi-step, OR single step with id !=
+// "handler" — i.e. NOT the default auto-trace from injectTraceIfMissing)
+// is sticky. Default auto-traces from background side-effect endpoints
+// (workflow/save, annotation writes, brand resolves) can't overwrite a
+// rich trace from the user's just-completed primary operation.
+function _isAutoDefaultTrace(t) {
+  if (!t || !Array.isArray(t.steps)) return false;
+  return t.steps.length === 1 && t.steps[0] && t.steps[0].id === "handler";
+}
 function _captureTrace(trace) {
   if (!trace || typeof trace !== "object") return false;
   if (!trace.operation && !trace.steps) return false;
+  // Preserve rich existing trace from being clobbered by auto-default.
+  if (window.__lastTrace && !_isAutoDefaultTrace(window.__lastTrace) && _isAutoDefaultTrace(trace)) {
+    return false;
+  }
   window.__lastTrace = trace;
   _showTraceTrigger();
   return true;


### PR DESCRIPTION
## Symptom

You ran "Run workflow with this brand" on Brand Canvas. Workflow streamed to completion. Trace trigger pulsed. **But the panel shows `POST Agents · workflow / save` with a single auto-default Handler step — not the rich 5-step workflow trace.**

## Root cause — race in `_captureTrace`

Brand Canvas flow:
1. Workflow stream runs → rich 5-step `_trace` event emitted
2. `_captureTrace(richTrace)` → `window.__lastTrace = richTrace` ✓
3. `workflow_complete` → triggers `_canvasSaveRun()`
4. POST `/agents/workflow/save`
5. Dispatch wrapper (#159) auto-traces save's response
6. Frontend fetch interceptor catches the auto-default trace
7. `_captureTrace(autoTrace)` → **OVERWRITES** `window.__lastTrace`
8. User clicks trigger → sees save trace, not workflow

Same hazard applies to **any** primary operation followed by a side-effect — brand logo fetch, annotation write, run-list fetch, etc. All auto-traced, all clobber the rich trace.

## Fix — rich traces are sticky

`_captureTrace` now refuses to replace a rich trace (multi-step, OR single step with `id !== "handler"`) with a default auto-trace.

Detection: `_isAutoDefaultTrace(t)` — single step, `step.id === "handler"`. That's the canonical shape of the trace injected by `injectTraceIfMissing` in #159.

## Replacement matrix

| Existing | New | Result |
|---|---|---|
| none | rich | replace (rich) |
| none | auto-default | replace (auto-default) |
| rich | rich | replace (newer rich wins) |
| **rich** | **auto-default** | **PRESERVE existing** ⬅ the fix |
| auto-default | rich | replace (rich) |
| auto-default | auto-default | replace (newer) |

Right semantics: user just ran workflow → that's their intent; subsequent side-effect saves/annotations are background noise the panel shouldn't surface.

Tab-switch reset (#158) still clears `window.__lastTrace`, so rich traces don't dangle when the user navigates — fresh tab, fresh capture.

## Test plan

- [ ] Hard-refresh `/`, login
- [ ] Brand Canvas → pick Coca-Cola → "Run workflow with this brand"
- [ ] Workflow streams to completion
- [ ] Trigger pulses → click → **panel shows 5-step workflow trace** (not save trace) ✓
- [ ] Switch to Discover tab → trigger resets
- [ ] Run Discover query → trigger pulses → click → Discover trace
- [ ] Switch back to Brand Canvas → trigger reset
- [ ] Run another workflow → fresh rich trace lands

## Pre-flight

- `tsc --noEmit` on demo.ts: 0 errors
- Trap audit: 0 hits across all 4 SCRIPT_TAG escape classes

🤖 Generated with [Claude Code](https://claude.com/claude-code)