### PR TITLE
Demo: sign-out button + 5-min idle auto-logout

### DIFF
--- a/src/demo/script/fragments/auth.ts
+++ b/src/demo/script/fragments/auth.ts
@@ -1,11 +1,16 @@
 // src/demo/script/fragments/auth.ts
 //
-// Auth overlay: SHA-256 password gate + form IIFE. Imports the hashed password constant from ../../config.
+// Auth overlay: SHA-256 password gate + form IIFE + manual sign-out
+// button + 5-min idle auto-logout. Imports the hashed password constant
+// from ../../config.
+//
+// Threat model context: this is UI gating to filter URL scrapers + casual
+// lurkers. Real auth (DEMO_API_KEY) is enforced independently by every
+// backend route. The idle-logout exists so a workshop laptop left on a
+// chair doesn't stay unlocked for the next person to walk by.
 //
 // Source range (in pre-refactor src/demo/script.ts): lines 295..352 (58 lines).
-// Concatenated by ../index.ts into the inlined <script> bundle. Byte-
-// equivalent to the pre-refactor monolith (verified by
-// tests/demo-render-snapshot.test.ts via SHA-256 hash).
+// Concatenated by ../index.ts into the inlined <script> bundle.
 //
 // SCRIPT_TAG_TRAP NOTE: this is browser JS embedded in a TS template
 // literal. All template-literal backticks and `${...}` inside the
@@ -70,5 +75,66 @@ async function _sha256Hex(str) {
       submit.textContent = "Unlock";
     }
   });
+})();
+
+//────────────────────────────────────────────────────────────────────────
+// Sign-out + 5-min idle auto-logout.
+//
+// Manual: click the "Sign out" button in the sidebar footer.
+// Automatic: any 5-minute window without mousemove/keydown/click/scroll/
+//   touchstart triggers logout. We update _lastActivity on each user
+//   event and re-check every 30s. (setInterval keeps firing across tab
+//   visibility changes — when a backgrounded tab returns, the next tick
+//   sees a stale lastActivity and logs out promptly.)
+//
+// Logout flow: clear sessionStorage flag → re-add is-locked → reset
+// overlay inline-style override (set on successful auth) → clear form
+// → focus password input. The overlay reappears via the existing
+// CSS rule "html:not(.is-locked) .auth-overlay { display: none; }".
+//────────────────────────────────────────────────────────────────────────
+const SESSION_IDLE_MS = 5 * 60 * 1000;
+let _lastActivity = Date.now();
+function _markActivity() { _lastActivity = Date.now(); }
+function _logout(reason) {
+  try { sessionStorage.removeItem("demo-authed"); } catch (e) {}
+  document.documentElement.classList.add("is-locked");
+  // The auth flow sets overlay.style.display = "none" inline on success.
+  // We must clear that override so the CSS gate ("html:not(.is-locked)")
+  // takes effect again. Setting to "" (not "flex") preserves the
+  // stylesheet's default display value if it ever changes.
+  const overlay = document.getElementById("auth-overlay");
+  if (overlay) overlay.style.display = "";
+  const input = document.getElementById("auth-password");
+  if (input) {
+    input.value = "";
+    setTimeout(function() { try { input.focus(); } catch (e) {} }, 50);
+  }
+  const errEl = document.getElementById("auth-error");
+  if (errEl) errEl.textContent = "";
+  if (typeof showToast === "function") {
+    showToast(reason === "idle" ? "Session timed out — please re-enter password" : "Signed out", reason === "idle");
+  }
+  _lastActivity = Date.now();
+}
+// Track user activity to keep the session alive while in use.
+["mousemove", "keydown", "click", "scroll", "touchstart"].forEach(function(ev) {
+  document.addEventListener(ev, _markActivity, { passive: true, capture: true });
+});
+// Periodic check — fires logout when idle window exceeded. We only
+// auto-logout when the user IS authed (no point timing out the auth
+// overlay itself, which is already the locked state).
+setInterval(function() {
+  try {
+    if (sessionStorage.getItem("demo-authed") !== "1") return;
+  } catch (e) { return; }
+  if (Date.now() - _lastActivity > SESSION_IDLE_MS) {
+    _logout("idle");
+  }
+}, 30 * 1000);
+// Manual sign-out button (sidebar footer).
+(function() {
+  const btn = document.getElementById("logout-btn");
+  if (!btn) return;
+  btn.addEventListener("click", function() { _logout("manual"); });
 })();
 `;

--- a/src/demo/styles.ts
+++ b/src/demo/styles.ts
@@ -475,6 +475,36 @@ svg.ico path, svg.ico circle, svg.ico rect, svg.ico line { vector-effect: non-sc
 .status-dot.ok { background: var(--success); box-shadow: 0 0 6px var(--success); animation: pulse 2.4s ease-in-out infinite; }
 @keyframes pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.45; } }
 
+/* Sign out button — sits below the theme picker in the sidebar footer.
+   Low visual weight (no fill, just a thin border on hover). Paired with
+   a 5-minute idle auto-logout wired in fragments/auth.ts. The collapsed-
+   sidebar rule below hides the label + reduces the button to icon-only,
+   matching the theme-picker's collapse behavior. */
+.logout-btn {
+  display: flex; align-items: center; gap: 8px;
+  width: 100%;
+  padding: 7px 8px;
+  margin-top: 6px;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: var(--radius-md);
+  color: var(--text-mut);
+  font: 12px var(--font-stack);
+  cursor: pointer;
+  transition: background 0.12s, color 0.12s, border-color 0.12s;
+}
+.logout-btn:hover {
+  background: var(--bg-hover);
+  color: var(--text);
+  border-color: var(--border);
+}
+.logout-btn:active { transform: translateY(0.5px); }
+.logout-btn .ico { width: 14px; height: 14px; flex-shrink: 0; }
+.logout-btn:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 1px;
+}
+
 /* ── Topbar ──────────────────────────────────────────────────────────── */
 .main {
   display: flex; flex-direction: column;
@@ -521,6 +551,12 @@ svg.ico path, svg.ico circle, svg.ico rect, svg.ico line { vector-effect: non-sc
 .app.is-sidebar-collapsed .sidebar-footer .theme-picker {
   display: none;
 }
+.app.is-sidebar-collapsed .logout-btn {
+  /* Icon-only when sidebar is collapsed — hide label, center icon. */
+  justify-content: center;
+  padding: 7px 4px;
+}
+.app.is-sidebar-collapsed .logout-btn span { display: none; }
 .app.is-sidebar-collapsed .nav-group.is-collapsed .nav-group-items {
   display: flex !important;
 }

--- a/src/routes/demo.ts
+++ b/src/routes/demo.ts
@@ -121,6 +121,7 @@ ${STYLES}
     <symbol id="icon-plus" viewBox="0 0 20 20"><line x1="10" y1="4" x2="10" y2="16" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"/><line x1="4" y1="10" x2="16" y2="10" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"/></symbol>
     <symbol id="icon-minus" viewBox="0 0 20 20"><line x1="4" y1="10" x2="16" y2="10" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"/></symbol>
     <symbol id="icon-chevron-down" viewBox="0 0 20 20"><path d="M5 8 L10 13 L15 8" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></symbol>
+    <symbol id="icon-logout" viewBox="0 0 20 20"><path d="M9 4 L4 4 L4 16 L9 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/><path d="M12 7 L16 10 L12 13 M16 10 L8 10" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></symbol>
   </defs>
 </svg>
 
@@ -336,6 +337,13 @@ ${STYLES}
         <button class="theme-swatch" data-theme-pick="daylight" title="Daylight (light)" aria-label="Daylight theme"></button>
         <button class="theme-swatch" data-theme-pick="solar" title="Solar (warm)" aria-label="Solar theme"></button>
       </div>
+      <!-- Sign out: manual logout button + paired with 5-min idle auto-logout
+           wired in src/demo/script/fragments/auth.ts. Both clear the
+           sessionStorage 'demo-authed' flag and re-show the auth overlay. -->
+      <button class="logout-btn" id="logout-btn" type="button" title="Sign out (also auto after 5 min idle)" aria-label="Sign out">
+        <svg class="ico" aria-hidden="true"><use href="#icon-logout"/></svg>
+        <span>Sign out</span>
+      </button>
     </div>
   </aside>
 

--- a/tests/__snapshots__/demo-render-snapshot.test.ts.snap
+++ b/tests/__snapshots__/demo-render-snapshot.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`handleDemo byte-equivalence > matches the committed golden hash (LF-normalized SHA-256 of body) 1`] = `
 {
-  "hash": "2fbddc6056d8852eab91257f5ffe07dd91432f16ad71fe5ef20d509023578b89",
-  "length": 1040148,
+  "hash": "905176cc9c5c041a8558a8a5270b99bba26b82e7de893f568febdefc3f4fca9a",
+  "length": 1045029,
 }
 `;

--- a/tests/demo-render-snapshot.test.ts
+++ b/tests/demo-render-snapshot.test.ts
@@ -89,6 +89,12 @@ describe("handleDemo byte-equivalence", () => {
       "_agenticHandleStreamEvent",
       "renderTreemap",
       "_captureTrace",
+      // Sign-out + 5-min idle auto-logout (Sec-31s).
+      'id="logout-btn"',
+      'id="icon-logout"',
+      "SESSION_IDLE_MS",
+      "function _logout(",
+      "function _markActivity(",
     ];
     for (const frag of expectedFragments) {
       expect(body, `expected to contain ${frag}`).toContain(frag);


### PR DESCRIPTION
## TL;DR

Manual sign-out button in the sidebar footer + a 5-minute idle auto-logout. Both clear the `sessionStorage` auth flag and re-show the password gate.

## Why

The viewer-auth gate keeps URL scrapers and casual lurkers off the demo URL, but once you've unlocked, the page stays unlocked until the tab closes. **A workshop laptop left on a chair stays open for the next person to walk by.** Idle-timeout fixes that without nagging the active presenter.

## What changes

### Sidebar footer (`src/routes/demo.ts`)
- New `icon-logout` SVG sprite symbol (door + arrow-out)
- `<button id="logout-btn">` below the theme-picker, icon + label

### Styles (`src/demo/styles.ts`)
- `.logout-btn` — low visual weight (transparent → bordered on hover)
- Collapsed-sidebar rule reduces it to icon-only, matching theme-picker

### Auth fragment (`src/demo/script/fragments/auth.ts`)
- `_logout(reason)` — clears sessionStorage, re-adds `is-locked`, **resets the inline `overlay.style.display = "none"`** that the auth success path sets, clears + refocuses the password input, fires a toast.
- `_markActivity` + capture-phase listeners on `mousemove` / `keydown` / `click` / `scroll` / `touchstart` updates the last-activity timestamp.
- `setInterval` every 30s — when authed AND idle > 5 min → `_logout("idle")`.
- Click binding on `#logout-btn` → `_logout("manual")`.

## Why a few of these design choices matter

1. **Reset the inline `display` override**: the auth success flow sets `overlay.style.display = "none"` for a smooth hide. Without explicitly clearing it (`= ""`), the CSS gate `html:not(.is-locked) .auth-overlay { display: none }` can't re-show the overlay on logout. Caught this by reading the existing flow before writing logout.
2. **`{ capture: true }` on activity listeners**: ensures we see the events even if a child element calls `stopPropagation()`.
3. **`setInterval` (not `setTimeout`)**: keeps firing across tab visibility changes. When a backgrounded tab returns, the next 30s tick promptly logs out a stale session.
4. **`showToast` is defined in `fragments/utils.ts`** which loads BEFORE `auth.ts` in the bundle order, so it's in scope. `typeof showToast === "function"` guard for defense-in-depth.

## Validation (all green)

```
npx tsc --noEmit                 → 0 errors in refactor scope
python tmp-mining/trap_audit.py  → CLEAN (0 traps × 35 files)
npx vitest run                   → 434 passed / 0 failed / 12 skipped
npx wrangler deploy --dry-run    → bundle ok (533 KiB gzip range)
```

### Snapshot test golden hash

| | hash | length |
|---|---|---|
| Before | `2fbddc60…78b89` | 1,040,148 |
| After  | `905176cc…fca9a` | 1,045,029 |

Delta: **+4,881 bytes** = HTML (~150) + CSS (~700) + SVG icon (~1,000) + JS (~3,000). On the wire, sub-1KB gzipped.

Five new structural anchors added to `tests/demo-render-snapshot.test.ts`:
```
id="logout-btn", id="icon-logout", SESSION_IDLE_MS,
function _logout(, function _markActivity(
```

## Test plan

- [x] `tsc --noEmit` 0 errors in refactor scope
- [x] `trap_audit.py` clean across all 35 files
- [x] Full vitest suite passes (434/0 failed)
- [x] Snapshot golden updated and re-verified
- [x] `wrangler deploy --dry-run` succeeds
- [ ] **Manual smoke on deployed preview**: log in, click "Sign out" → overlay reappears, password reset; log in, idle 5 min → toast appears, overlay reappears

## Risk

Surgical change; 5 files / +122 / -6 lines. Confined to the auth surface. The byte-equivalence snapshot test guards against accidental side-effects to any other UI surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)