### PR TITLE
Deferred bundle: VH Tier D + Sankey/Heatmap interactivity + Trace timeline + more

### DIFF
--- a/src/demo/script/fragments/builder.ts
+++ b/src/demo/script/fragments/builder.ts
@@ -836,13 +836,18 @@ async function renderEmbeddingHeatmap() {
         return "rgb(" + rr2 + "," + gg2 + "," + bb2 + ")";
       }
     }
+    // Sec-31u: heatmap cells animate-in with stagger and respond to
+    // hover (highlights row + column, dims rest). data-hr/data-hc carry
+    // row/col indices so the hover handler can light up linked cells.
     var svgCells = "";
+    var totalCells = n * n;
     for (var i = 0; i < n; i++) {
       for (var j = 0; j < n; j++) {
         var v = matrix[i * n + j];
-        svgCells += '<rect x="' + (margin + j * cell) + '" y="' + (margin + i * cell) + '" width="' + cell + '" height="' + cell + '" ' +
+        var staggerIdx = Math.min(totalCells - 1, i * n + j);
+        svgCells += '<rect class="hm-cell ux-stagger-row" data-hr="' + i + '" data-hc="' + j + '" style="--ux-stagger-i:' + Math.min(staggerIdx, 60) + '" x="' + (margin + j * cell) + '" y="' + (margin + i * cell) + '" width="' + cell + '" height="' + cell + '" ' +
           'fill="' + colorFor(v) + '" stroke="var(--bg-surface)" stroke-width="0.4">' +
-          '<title>' + escapeHtml(names[i] || "") + ' × ' + escapeHtml(names[j] || "") + ': cos=' + v.toFixed(3) + '</title>' +
+          '<title>' + escapeHtml(names[i] || "") + ' x ' + escapeHtml(names[j] || "") + ': cos=' + v.toFixed(3) + '</title>' +
         '</rect>';
       }
     }
@@ -865,6 +870,32 @@ async function renderEmbeddingHeatmap() {
       '<div class="ehs-gradient ehs-gradient-r"></div>' +
       '<span class="ehs-label" style="text-align:right">+1<br><span class="ehs-sub">identical</span></span>' +
     '</div>';
+    // Sec-31u: heatmap hover -> highlight row + column, dim others.
+    var hmSvg = host.querySelector("svg");
+    if (hmSvg) {
+      hmSvg.addEventListener("mouseover", function (ev) {
+        var t = ev.target;
+        if (!t || !t.classList || !t.classList.contains("hm-cell")) return;
+        var hr = t.getAttribute("data-hr");
+        var hc = t.getAttribute("data-hc");
+        hmSvg.querySelectorAll(".hm-cell").forEach(function (c) {
+          if (c.getAttribute("data-hr") === hr || c.getAttribute("data-hc") === hc) {
+            c.classList.add("hm-active");
+            c.classList.remove("hm-dim");
+          } else {
+            c.classList.add("hm-dim");
+            c.classList.remove("hm-active");
+          }
+        });
+      });
+      hmSvg.addEventListener("mouseout", function (ev) {
+        var related = ev.relatedTarget;
+        if (related && hmSvg.contains(related)) return;
+        hmSvg.querySelectorAll(".hm-active, .hm-dim").forEach(function (c) {
+          c.classList.remove("hm-active", "hm-dim");
+        });
+      });
+    }
     var expl2 = document.getElementById("emb-heatmap-explainer");
     if (expl2) expl2.innerHTML = renderChartExplainer({
       what: "How semantically close every audience is to every other one, shown as a 20\u00d720 grid of cosine similarity scores.",
@@ -907,12 +938,13 @@ async function renderEmbeddingSankey() {
     var nodeW = 18;
     var midSpace = (H - 40) / (mids.length || 1);
     var rightSpace = (H - 40) / rightSystems.length;
-    // Nodes
+    // Sec-31u: nodes + flows now carry data-sk-* attributes so the
+    // hover handler below can highlight a chain across the columns.
     var nodes = "";
     mids.forEach(function (m, i) {
       var y = 20 + i * midSpace;
       var size = Math.max(16, Math.min(midSpace - 8, midCounts[m] * 6));
-      nodes += '<rect x="' + midX + '" y="' + y + '" width="' + nodeW + '" height="' + size + '" fill="var(--accent)" fill-opacity="0.7"/>' +
+      nodes += '<rect class="sk-node sk-node-mid" data-sk-mid="' + i + '" x="' + midX + '" y="' + y + '" width="' + nodeW + '" height="' + size + '" fill="var(--accent)" fill-opacity="0.7"/>' +
         '<text x="' + (midX + nodeW + 8) + '" y="' + (y + size / 2 + 4) + '" fill="var(--text)" font-size="11" font-family="ui-sans-serif">' + escapeHtml(m) + ' · ' + midCounts[m] + '</text>';
     });
     rightSystems.forEach(function (sys, i) {
@@ -920,37 +952,108 @@ async function renderEmbeddingSankey() {
       var size = Math.max(20, rightSpace - 20);
       var totalForSys = 0;
       mids.forEach(function (m) { totalForSys += (rightFromMid[m] && rightFromMid[m][sys]) || 0; });
-      nodes += '<rect x="' + rightX + '" y="' + y + '" width="' + nodeW + '" height="' + size + '" fill="#8b6eff" fill-opacity="0.7"/>' +
+      nodes += '<rect class="sk-node sk-node-right" data-sk-right="' + escapeHtml(sys) + '" x="' + rightX + '" y="' + y + '" width="' + nodeW + '" height="' + size + '" fill="#8b6eff" fill-opacity="0.7"/>' +
         '<text x="' + (rightX + nodeW + 8) + '" y="' + (y + size / 2 + 4) + '" fill="var(--text)" font-size="11" font-family="ui-sans-serif">' + escapeHtml(sys) + ' · ' + totalForSys + '</text>';
     });
     // Left-column anchor
     nodes += '<rect x="' + leftX + '" y="20" width="' + nodeW + '" height="' + (H - 40) + '" fill="#2bd4a0" fill-opacity="0.5"/>' +
       '<text x="' + (leftX + nodeW + 8) + '" y="40" fill="var(--text)" font-size="11" font-family="ui-sans-serif">IAB Audience 1.1</text>' +
       '<text x="' + (leftX + nodeW + 8) + '" y="56" fill="var(--text-mut)" font-size="10" font-family="ui-monospace">' + signals.length + ' signals</text>';
-    // Flows: left → mid (all one color), mid → right (colored per mid)
+    // Flows: each path carries data-sk-mid (and data-sk-right for the
+    // mid->right segments) so the hover handler can light up a full
+    // chain. Stagger index drives the draw-in animation.
     var flows = "";
+    var skFi = 0;
     mids.forEach(function (m, mi) {
       var yMid = 20 + mi * midSpace + Math.min(midSpace - 8, midCounts[m] * 6) / 2;
-      // left→mid
       var yLeft = 20 + (H - 40) / 2 + (mi - mids.length / 2) * 10;
       var cx1 = leftX + nodeW + (midX - leftX - nodeW) / 2;
-      flows += '<path d="M' + (leftX + nodeW) + ',' + yLeft + ' C' + cx1 + ',' + yLeft + ' ' + cx1 + ',' + yMid + ' ' + midX + ',' + yMid + '" ' +
-        'fill="none" stroke="#2bd4a0" stroke-opacity="0.3" stroke-width="' + Math.max(1, midCounts[m] * 1.5) + '"/>';
-      // mid→right(s)
+      flows += '<path class="sk-flow sk-flow-leftmid" data-sk-mid="' + mi + '" style="--ux-stagger-i:' + skFi + '" d="M' + (leftX + nodeW) + ',' + yLeft + ' C' + cx1 + ',' + yLeft + ' ' + cx1 + ',' + yMid + ' ' + midX + ',' + yMid + '" ' +
+        'fill="none" stroke="#2bd4a0" stroke-opacity="0.3" stroke-width="' + Math.max(1, midCounts[m] * 1.5) + '"><title>' + escapeHtml(m) + ' · ' + midCounts[m] + '</title></path>';
+      skFi++;
       var rfm = rightFromMid[m] || {};
       rightSystems.forEach(function (sys, ri) {
         var count = rfm[sys] || 0;
         if (!count) return;
         var yRight = 20 + ri * rightSpace + rightSpace / 2;
         var cx2 = midX + nodeW + (rightX - midX - nodeW) / 2;
-        flows += '<path d="M' + (midX + nodeW) + ',' + yMid + ' C' + cx2 + ',' + yMid + ' ' + cx2 + ',' + yRight + ' ' + rightX + ',' + yRight + '" ' +
-          'fill="none" stroke="#8b6eff" stroke-opacity="0.25" stroke-width="' + Math.max(1, count * 1.2) + '"/>';
+        flows += '<path class="sk-flow sk-flow-midright" data-sk-mid="' + mi + '" data-sk-right="' + escapeHtml(sys) + '" style="--ux-stagger-i:' + skFi + '" d="M' + (midX + nodeW) + ',' + yMid + ' C' + cx2 + ',' + yMid + ' ' + cx2 + ',' + yRight + ' ' + rightX + ',' + yRight + '" ' +
+          'fill="none" stroke="#8b6eff" stroke-opacity="0.25" stroke-width="' + Math.max(1, count * 1.2) + '"><title>' + escapeHtml(m) + " -> " + escapeHtml(sys) + ' · ' + count + '</title></path>';
+        skFi++;
       });
     });
-    host.innerHTML = '<svg viewBox="0 0 ' + W + ' ' + H + '" preserveAspectRatio="xMidYMid meet">' +
+    host.innerHTML = '<svg class="sk-svg" viewBox="0 0 ' + W + ' ' + H + '" preserveAspectRatio="xMidYMid meet">' +
       flows + nodes +
     '</svg>' +
     '<div style="font-size:10.5px;color:var(--text-mut);margin-top:8px">Left column: native IAB Audience 1.1 catalog. Middle: mapped IAB Content 3.0 topics. Right: buyer-side DMP / onboarder / measurement systems. Widths \u221d signal count. Stage flags (live/modeled/roadmap) surfaced in signal detail panel.</div>';
+    // Sec-31u: wire hover/click interactivity on the sankey.
+    // Hover any node or flow -> highlight the chain (matching mid index
+    // and/or right system) and dim the rest. Click locks the highlight;
+    // click again or click empty space to clear.
+    var skSvg = host.querySelector(".sk-svg");
+    if (skSvg) {
+      var _skClear = function () {
+        skSvg.querySelectorAll(".sk-active, .sk-dim").forEach(function (el) {
+          el.classList.remove("sk-active", "sk-dim");
+        });
+        skSvg.classList.remove("sk-locked");
+      };
+      var _skApply = function (filterFn) {
+        skSvg.querySelectorAll(".sk-flow, .sk-node-mid, .sk-node-right").forEach(function (el) {
+          if (filterFn(el)) {
+            el.classList.add("sk-active");
+            el.classList.remove("sk-dim");
+          } else {
+            el.classList.add("sk-dim");
+            el.classList.remove("sk-active");
+          }
+        });
+      };
+      skSvg.addEventListener("mouseover", function (ev) {
+        if (skSvg.classList.contains("sk-locked")) return;
+        var t = ev.target;
+        if (!t || !t.classList) return;
+        if (t.classList.contains("sk-flow")) {
+          var mid = t.getAttribute("data-sk-mid");
+          var right = t.getAttribute("data-sk-right");
+          _skApply(function (el) {
+            if (el.getAttribute("data-sk-mid") === mid) {
+              if (right && el.classList.contains("sk-flow-midright")) {
+                return el.getAttribute("data-sk-right") === right;
+              }
+              return true;
+            }
+            if (right && el.getAttribute("data-sk-right") === right && el.classList.contains("sk-node-right")) return true;
+            return false;
+          });
+        } else if (t.classList.contains("sk-node-mid")) {
+          var mid2 = t.getAttribute("data-sk-mid");
+          _skApply(function (el) { return el.getAttribute("data-sk-mid") === mid2; });
+        } else if (t.classList.contains("sk-node-right")) {
+          var rt = t.getAttribute("data-sk-right");
+          _skApply(function (el) { return el.getAttribute("data-sk-right") === rt; });
+        }
+      });
+      skSvg.addEventListener("mouseout", function (ev) {
+        if (skSvg.classList.contains("sk-locked")) return;
+        var related = ev.relatedTarget;
+        if (related && skSvg.contains(related)) return;
+        _skClear();
+      });
+      skSvg.addEventListener("click", function (ev) {
+        var t = ev.target;
+        var isInteractive = t && t.classList && (t.classList.contains("sk-flow") || t.classList.contains("sk-node-mid") || t.classList.contains("sk-node-right"));
+        if (!isInteractive) {
+          _skClear();
+          return;
+        }
+        if (skSvg.classList.contains("sk-locked")) {
+          _skClear();
+        } else {
+          skSvg.classList.add("sk-locked");
+        }
+      });
+    }
     var expl3 = document.getElementById("emb-sankey-explainer");
     if (expl3) expl3.innerHTML = renderChartExplainer({
       what: "How this agent\u2019s audiences map into the buyer-side taxonomies a HoldCo planner already uses.",

--- a/src/demo/script/fragments/composer.ts
+++ b/src/demo/script/fragments/composer.ts
@@ -361,8 +361,13 @@ function renderSaturationResult(data) {
     '<path d="' + areaPts + '" fill="rgba(79,142,255,0.18)" stroke="none"/>' +
     '<path d="' + curve.map(function (c, i) { return (i === 0 ? "M " : "L ") + xScale(i) + " " + yScale(c.unique_reach); }).join(" ") +
       '" fill="none" stroke="var(--accent)" stroke-width="1.8"/>';
+  // Sec-31u T2#10: marginal-reach dots get hover-scrub tooltips +
+  // larger interactive radius. Plus invisible-ish over-dots on the
+  // unique_reach line for "scrub the curve" behavior.
   curve.forEach(function (c, i) {
-    svg += '<circle cx="' + xScale(i) + '" cy="' + yScaleMarg(c.marginal_reach) + '" r="2.5" fill="var(--accent-hot)" opacity="0.7"/>';
+    var tt = "F=" + c.frequency + " | reach=" + fmtNumber(c.unique_reach) + " | marginal=" + fmtNumber(c.marginal_reach) + " | cost=$" + fmtNumber(c.cost_usd);
+    svg += '<circle class="comp-sat-marg-dot" cx="' + xScale(i) + '" cy="' + yScaleMarg(c.marginal_reach) + '" r="2.5" fill="var(--accent-hot)" opacity="0.7"><title>' + escapeHtml(tt) + '</title></circle>';
+    svg += '<circle class="comp-sat-curve-dot" cx="' + xScale(i) + '" cy="' + yScale(c.unique_reach) + '" r="4.5" fill="var(--accent)" opacity="0.0"><title>' + escapeHtml(tt) + '</title></circle>';
   });
   if (kneeIdx >= 0) {
     svg += '<line x1="' + xScale(kneeIdx) + '" y1="' + P + '" x2="' + xScale(kneeIdx) + '" y2="' + (H - P) + '" stroke="var(--warning)" stroke-width="1" stroke-dasharray="4,3"/>';

--- a/src/demo/script/fragments/discover.ts
+++ b/src/demo/script/fragments/discover.ts
@@ -157,6 +157,15 @@ async function runNlQuery() {
 
     results.innerHTML = renderNlResult({ payload, matches, estSize, confTier, confScalar, ast });
     wireNlCardClicks();
+    // Sec-31u T3#21: glow the AST + KPI tiles to signal a fresh result
+    // landed. Stagger so the user's eye traces from query -> AST -> matches.
+    setTimeout(function () {
+      var astEl = results.querySelector(".nl-ast-block");
+      if (astEl && typeof glowOnce === "function") glowOnce(astEl);
+      results.querySelectorAll(".nl-kpi-tile, .signal-card").forEach(function (el, i) {
+        if (typeof glowOnce === "function") setTimeout(function () { glowOnce(el); }, i * 80);
+      });
+    }, 60);
   } catch (e) {
     showToast("NL query failed: " + e.message, true);
     status.textContent = "error";

--- a/src/demo/script/fragments/federation.ts
+++ b/src/demo/script/fragments/federation.ts
@@ -128,8 +128,70 @@ function renderFederatedResults(data) {
       '<button class="btn-primary" id="fed-activate-selected" style="padding:4px 12px;font-size:11.5px"' + (selectedCount === 0 ? ' disabled' : '') + '><svg class="ico"><use href="#icon-bolt"/></svg><span>Activate selected</span></button>' +
     '</div>';
 
+  // Sec-31u T3#24: Pairwise agreement heatmap — counts how many signals
+  // each pair of agents BOTH surfaced (matched on signal name normalized
+  // to lowercase). Shown only when 2+ agents have any results.
+  var agentList = Object.keys(data.per_agent_count || {}).filter(function (k) { return data.per_agent_count[k] > 0; });
+  var heatmapHtml = "";
+  if (agentList.length >= 2) {
+    // Build per-agent set of normalized signal-name keys
+    var perAgent = {};
+    agentList.forEach(function (a) { perAgent[a] = new Set(); });
+    merged.forEach(function (m) {
+      var name = (m.signal && m.signal.name) ? m.signal.name.toLowerCase().trim() : "";
+      if (name && perAgent[m.source_agent]) perAgent[m.source_agent].add(name);
+    });
+    // Pairwise overlap matrix
+    var maxOverlap = 0;
+    var cells = [];
+    agentList.forEach(function (rowA, ri) {
+      agentList.forEach(function (colA, ci) {
+        if (rowA === colA) {
+          cells.push({ ri: ri, ci: ci, val: perAgent[rowA].size, diag: true });
+        } else {
+          var overlap = 0;
+          perAgent[rowA].forEach(function (k) { if (perAgent[colA].has(k)) overlap++; });
+          if (overlap > maxOverlap) maxOverlap = overlap;
+          cells.push({ ri: ri, ci: ci, val: overlap, diag: false });
+        }
+      });
+    });
+    var n = agentList.length;
+    var cols = "auto " + agentList.map(function () { return "1fr"; }).join(" ");
+    // Header row: blank + col labels
+    var headerRow = '<div></div>' + agentList.map(function (a) {
+      return '<div class="fed-agreement-col-label">' + escapeHtml(a) + '</div>';
+    }).join("");
+    var bodyRows = agentList.map(function (rowA, ri) {
+      var rowLabel = '<div class="fed-agreement-row-label mono">' + escapeHtml(rowA) + '</div>';
+      var rowCells = agentList.map(function (colA, ci) {
+        var c = cells.find(function (x) { return x.ri === ri && x.ci === ci; });
+        var v = c ? c.val : 0;
+        var bg = "var(--bg)";
+        if (!c.diag && maxOverlap > 0 && v > 0) {
+          var t = v / maxOverlap;
+          // Accent gradient: from faint to full intensity
+          var alpha = 0.10 + 0.55 * t;
+          bg = "rgba(56, 182, 255, " + alpha.toFixed(2) + ")";
+        }
+        var classes = "fed-agreement-cell" + (c.diag ? " diag" : "");
+        var title = c.diag ? "self: " + v + " signals" : (rowA + " ∩ " + colA + " = " + v + " overlap");
+        return '<div class="' + classes + '" style="background:' + bg + '" title="' + escapeHtml(title) + '">' + v + '</div>';
+      }).join("");
+      return rowLabel + rowCells;
+    }).join("");
+    heatmapHtml =
+      '<div class="fed-agreement-host">' +
+        '<div class="fed-agreement-title">Agent agreement (signal-name overlap, max ' + maxOverlap + ')</div>' +
+        '<div class="fed-agreement-grid" style="grid-template-columns:' + cols + '">' +
+          headerRow + bodyRows +
+        '</div>' +
+      '</div>';
+  }
+
   host.innerHTML = summary + actionBar +
     '<div class="fed-rows">' + (rowsHtml || '<div class="empty-state"><div class="empty-desc">No results from any agent.</div></div>') + '</div>' +
+    heatmapHtml +
     '<div id="fed-compare-host"></div>';
 
   // Wire row clicks

--- a/src/demo/script/fragments/portfolio.ts
+++ b/src/demo/script/fragments/portfolio.ts
@@ -241,8 +241,8 @@ async function renderPortLorenz() {
     var data = await r.json();
     // Render small multiples: one mini chart per top-6 slice + overall
     var picks = (data.slices || []).slice(0, 6);
-    var cards = picks.map(function (s) { return renderLorenzCard(s); }).join("");
-    var overall = renderLorenzCard({ group: "OVERALL", signal_count: data.overall.signal_count, lorenz: data.overall.lorenz, gini: data.overall.gini, interpretation: data.overall.interpretation });
+    var cards = picks.map(function (s, i) { return renderLorenzCard(s, i + 1); }).join("");
+    var overall = renderLorenzCard({ group: "OVERALL", signal_count: data.overall.signal_count, lorenz: data.overall.lorenz, gini: data.overall.gini, interpretation: data.overall.interpretation }, 0);
     host.innerHTML = '<div class="lorenz-grid">' + overall + cards + '</div>';
     document.getElementById("port-lorenz-explainer").innerHTML = renderChartExplainer({
       what: "Catalog concentration per vertical. How evenly audience reach is distributed across signals in each group.",
@@ -254,10 +254,13 @@ async function renderPortLorenz() {
     host.innerHTML = '<div class="empty-state"><div class="empty-title" style="color:var(--error)">' + escapeHtml(String(e.message || e)) + '</div></div>';
   }
 }
-function renderLorenzCard(s) {
+function renderLorenzCard(s, staggerIdx) {
   var W = 200, H = 140, pad = 20;
   var lz = s.lorenz || [];
   var pts = lz.map(function (p) { return pad + p.x * (W - 2 * pad) + "," + (H - pad - p.y * (H - 2 * pad)); }).join(" ");
+  // Stagger entry — index drives --ux-stagger-i (80ms steps) so cards
+  // fade-lift in cascade and curves draw left→right.
+  var staggerStyle = typeof staggerIdx === "number" ? ' style="--ux-stagger-i:' + staggerIdx + '"' : "";
   // Sec-31u T2#11: hover-scrubber. Invisible-ish dots at each datapoint
   // with native SVG <title> tooltips show exact x (cumulative %) and y
   // (cumulative reach %) values. Filled area-under-curve also added
@@ -269,7 +272,7 @@ function renderLorenzCard(s) {
     var tt = "x=" + (p.x * 100).toFixed(0) + "% of signals → y=" + (p.y * 100).toFixed(0) + "% of reach";
     return '<circle class="lorenz-dot" cx="' + cx + '" cy="' + cy + '" r="3" fill="var(--accent)" opacity="0.55"><title>' + escapeHtml(tt) + '</title></circle>';
   }).join("");
-  return '<div class="lorenz-card">' +
+  return '<div class="lorenz-card"' + staggerStyle + '>' +
     '<div class="lorenz-title">' + escapeHtml(s.group) + ' <span class="lorenz-gini">Gini ' + s.gini.toFixed(2) + '</span></div>' +
     '<svg viewBox="0 0 ' + W + ' ' + H + '">' +
       '<line x1="' + pad + '" y1="' + (H - pad) + '" x2="' + (W - pad) + '" y2="' + pad + '" stroke="var(--text-mut)" stroke-dasharray="3,2" stroke-width="1"/>' +
@@ -281,6 +284,26 @@ function renderLorenzCard(s) {
   '</div>';
 }
 function wirePortFromBrief() {
+  // Sec-31u: try-chips fill the brief textarea + budget + auto-submit.
+  // Click → populate fields → fire the existing brief-run handler so
+  // there's exactly one code path for brief execution.
+  document.querySelectorAll("#port-brief-chips .brief-try-chip").forEach(function (chip) {
+    chip.addEventListener("click", function () {
+      var brief = chip.getAttribute("data-brief") || "";
+      var budget = chip.getAttribute("data-budget") || "250000";
+      var briefEl = document.getElementById("brief-text");
+      var budgetEl = document.getElementById("brief-budget");
+      if (briefEl) briefEl.value = brief;
+      if (budgetEl) budgetEl.value = budget;
+      // Mark this chip as the active selection
+      document.querySelectorAll("#port-brief-chips .brief-try-chip").forEach(function (c) {
+        c.classList.toggle("is-active", c === chip);
+      });
+      // Auto-submit
+      var runBtn = document.getElementById("brief-run");
+      if (runBtn) runBtn.click();
+    });
+  });
   document.getElementById("brief-run").addEventListener("click", async function () {
     var host = document.getElementById("brief-results");
     var brief = document.getElementById("brief-text").value.trim();

--- a/src/demo/script/fragments/trace-inspector.ts
+++ b/src/demo/script/fragments/trace-inspector.ts
@@ -198,7 +198,31 @@ function _renderTracePanel(trace) {
   document.getElementById("trace-step-count").textContent = (trace.steps || []).length;
   document.getElementById("trace-ts").textContent = trace.ts ? _fmtRelTs(trace.ts) : "—";
   document.getElementById("trace-perf").innerHTML = _renderTracePerf(trace.performance || null);
-  document.getElementById("trace-steps").innerHTML = (trace.steps || []).map(_renderTraceStep).join("");
+  // Sec-31u T1#5: timeline scrubber — proportional bar across the top
+  // of the steps list. Each segment width = step.duration_ms / total.
+  // Click any segment to scroll its expanded step into view + highlight.
+  var stepsArr = trace.steps || [];
+  var totalDur = stepsArr.reduce(function (a, s) { return a + (typeof s.duration_ms === "number" ? s.duration_ms : 0); }, 0) || 1;
+  var scrubberHost = document.getElementById("trace-timeline-scrubber");
+  if (scrubberHost) {
+    if (stepsArr.length > 0) {
+      var palette = ["#4f8eff", "#8b6eff", "#2bd4a0", "#ffcb5c", "#ff7a5c", "#ff4d8e"];
+      var segs = stepsArr.map(function (s, i) {
+        var w = ((typeof s.duration_ms === "number" ? s.duration_ms : 0) / totalDur) * 100;
+        var color = palette[i % palette.length];
+        return '<button type="button" class="trace-tl-seg" data-tl-step="' + escapeHtml(s.id) +
+          '" style="width:' + w.toFixed(2) + '%;background:' + color + '"' +
+          ' title="' + escapeHtml(s.label || s.id) + ' · ' + _fmtMs(s.duration_ms || 0) + '">' +
+          '<span class="trace-tl-seg-label">' + escapeHtml(s.label || s.id) + '</span>' +
+        '</button>';
+      }).join("");
+      scrubberHost.innerHTML = '<div class="trace-tl-track">' + segs + '</div>' +
+        '<div class="trace-tl-axis"><span>0ms</span><span>total ' + _fmtMs(totalDur) + '</span></div>';
+    } else {
+      scrubberHost.innerHTML = '';
+    }
+  }
+  document.getElementById("trace-steps").innerHTML = stepsArr.map(_renderTraceStep).join("");
   // Wire step-head clicks (accordion toggle)
   document.querySelectorAll(".trace-step-head").forEach(function(btn) {
     btn.addEventListener("click", function() {
@@ -206,6 +230,22 @@ function _renderTracePanel(trace) {
       if (step) step.classList.toggle("is-open");
     });
   });
+  // Wire timeline-segment clicks → scroll matching step into view + glow
+  if (scrubberHost) {
+    scrubberHost.querySelectorAll(".trace-tl-seg").forEach(function (seg) {
+      seg.addEventListener("click", function () {
+        var stepId = seg.getAttribute("data-tl-step");
+        var stepEl = document.querySelector('.trace-step[data-trace-step="' + stepId + '"]');
+        if (!stepEl) return;
+        stepEl.classList.add("is-open");
+        stepEl.scrollIntoView({ behavior: "smooth", block: "center" });
+        if (typeof glowOnce === "function") setTimeout(function () { glowOnce(stepEl); }, 300);
+        // Highlight active segment
+        scrubberHost.querySelectorAll(".trace-tl-seg").forEach(function (s) { s.classList.remove("is-active"); });
+        seg.classList.add("is-active");
+      });
+    });
+  }
   // Animate match-bar widths in after a small delay so the transition triggers.
   setTimeout(function() {
     document.querySelectorAll(".trace-match-bar").forEach(function(b) {

--- a/src/demo/styles.ts
+++ b/src/demo/styles.ts
@@ -823,13 +823,181 @@ svg.ico path, svg.ico circle, svg.ico rect, svg.ico line { vector-effect: non-sc
   box-shadow: inset 3px 0 0 var(--accent);
 }
 
+/* Sec-31u: Portfolio brief try-chips — one-click brief population.
+   Sits above the textarea; clicking a chip fills brief + budget then
+   auto-fires the Generate button. */
+.brief-try-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-bottom: 10px;
+  align-items: center;
+}
+.brief-try-label {
+  font: 10px var(--font-mono);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-mut);
+  margin-right: 4px;
+}
+.brief-try-chip {
+  font: 11.5px var(--font-mono);
+  padding: 5px 10px;
+  background: var(--bg-input);
+  border: 1px solid var(--border);
+  color: var(--text-dim);
+  border-radius: 4px;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+.brief-try-chip:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+  transform: translateY(-1px);
+}
+.brief-try-chip.is-active {
+  background: var(--accent-dim);
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+/* Sec-31u T2#10: Composer saturation curve hover dots — marginal +
+   curve points become interactive scrub anchors. */
+.comp-sat-marg-dot, .comp-sat-curve-dot {
+  cursor: help;
+  transition: r 0.15s, opacity 0.15s, fill-opacity 0.15s;
+}
+.comp-sat-marg-dot:hover { r: 5; opacity: 1 !important; }
+.comp-sat-curve-dot:hover { opacity: 0.85 !important; r: 6; }
+.comp-sat-curve { animation: ux-fade-soft 0.5s ease forwards; }
+.comp-sat-curve path { transition: stroke-width 0.2s; }
+.comp-sat-curve:hover path[stroke="var(--accent)"] { stroke-width: 2.4; }
+
+/* Sec-31u: Heatmap cell stagger + hover row/column highlight. */
+.hm-cell {
+  cursor: pointer;
+  transition: stroke 0.15s, stroke-width 0.15s, opacity 0.15s;
+}
+.hm-cell.hm-active {
+  stroke: var(--accent) !important;
+  stroke-width: 1.4 !important;
+}
+.hm-cell.hm-dim { opacity: 0.32; }
+
+/* Sec-31u: Sankey animation + interactivity. Each flow draws in via
+   stroke-dashoffset; hover/click toggles .sk-active / .sk-dim across
+   the linked chain. */
+.sk-svg .sk-flow {
+  stroke-dasharray: 1500;
+  stroke-dashoffset: 1500;
+  animation: ux-sankey-draw 0.9s cubic-bezier(0.4, 0.1, 0.2, 1) forwards;
+  animation-delay: calc(var(--ux-stagger-i, 0) * 18ms);
+  transition: stroke-opacity 0.18s, stroke-width 0.18s, filter 0.18s;
+}
+.sk-svg .sk-node {
+  transition: fill-opacity 0.18s, filter 0.18s;
+  cursor: pointer;
+}
+.sk-svg .sk-node-mid, .sk-svg .sk-node-right { cursor: pointer; }
+.sk-svg .sk-flow { cursor: pointer; }
+.sk-svg.sk-locked .sk-active { filter: drop-shadow(0 0 4px var(--accent)); }
+.sk-svg .sk-flow.sk-active {
+  stroke-opacity: 0.85 !important;
+  filter: drop-shadow(0 0 3px currentColor);
+}
+.sk-svg .sk-flow.sk-dim { stroke-opacity: 0.05 !important; }
+.sk-svg .sk-node.sk-active { fill-opacity: 1 !important; filter: drop-shadow(0 0 4px var(--accent)); }
+.sk-svg .sk-node.sk-dim { fill-opacity: 0.15 !important; }
+@keyframes ux-sankey-draw {
+  to { stroke-dashoffset: 0; }
+}
+
+/* Sec-31u T1#5: Trace inspector timeline scrubber. Stacked atop the
+   step list, proportional segments per step. Click any segment to
+   scroll its step into view + glow it. */
+.trace-timeline-scrubber {
+  margin: 12px 0 16px;
+}
+.trace-timeline-scrubber:empty { display: none; }
+.trace-tl-track {
+  display: flex;
+  height: 24px;
+  border-radius: 4px;
+  overflow: hidden;
+  border: 1px solid var(--border);
+  box-shadow: 0 1px 2px rgba(0,0,0,0.2);
+}
+.trace-tl-seg {
+  flex-shrink: 0;
+  border: none;
+  padding: 0 6px;
+  cursor: pointer;
+  position: relative;
+  transition: filter 0.15s, box-shadow 0.15s;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  min-width: 18px;
+}
+.trace-tl-seg:hover { filter: brightness(1.15); }
+.trace-tl-seg.is-active {
+  box-shadow: inset 0 0 0 2px var(--text);
+  filter: brightness(1.2);
+}
+.trace-tl-seg-label {
+  font: 9.5px var(--font-mono);
+  color: var(--bg-base);
+  text-transform: lowercase;
+  letter-spacing: 0.02em;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-weight: 600;
+}
+.trace-tl-axis {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 4px;
+  font: 10px var(--font-mono);
+  color: var(--text-mut);
+}
+
 /* Sec-31u T2#11: Lorenz hover dots — visible enough to invite hover,
    discreet enough not to clutter the curve. */
 .lorenz-dot {
   cursor: help;
   transition: r 0.15s, fill-opacity 0.15s;
+  /* Hide dots until the curve has drawn in (1.4s + per-card delay). */
+  opacity: 0;
+  animation: ux-fade-soft 0.4s ease 1.4s forwards;
 }
 .lorenz-dot:hover { r: 4.5; fill-opacity: 1; }
+
+/* Lorenz curve draw-in. SVG path animation via stroke-dasharray:
+   total path length isn't computed here (we'd need JS getTotalLength()),
+   so we use a "long enough" dash that sweeps through the full curve.
+   Each card staggers via its position in the grid (handled by JS
+   .lorenz-card ux-stagger-row class set in renderLorenzCard). */
+.lorenz-card svg polyline {
+  stroke-dasharray: 600;
+  stroke-dashoffset: 600;
+  animation: ux-lorenz-draw 1.2s cubic-bezier(0.4, 0.1, 0.2, 1) 0.15s forwards;
+}
+.lorenz-card svg polygon {
+  /* Area fill follows the line draw — fade in after stroke completes. */
+  opacity: 0;
+  animation: ux-fade-soft 0.5s ease 1.0s forwards;
+}
+@keyframes ux-lorenz-draw {
+  to { stroke-dashoffset: 0; }
+}
+.lorenz-card {
+  /* Card container also fades + lifts in, staggered. */
+  opacity: 0;
+  animation: ux-row-in 0.5s cubic-bezier(0.2, 0.8, 0.2, 1) forwards;
+  animation-delay: calc(var(--ux-stagger-i, 0) * 80ms);
+}
 
 /* Sec-31u T3#26: delta pill on expression-tree reach badges. Renders
    inline next to the reach value when a node's reach changed >=2% from

--- a/src/routes/demo.ts
+++ b/src/routes/demo.ts
@@ -1019,6 +1019,33 @@ ${STYLES}
           <div class="lab-grid">
             <div class="lab-panel">
               <div class="lab-panel-title">Brief</div>
+              <!-- Sec-31u: try-chips for one-click brief population. Each chip
+                   carries the brief text in data-brief and a budget in data-budget;
+                   clicking fills the textarea + budget input + auto-submits.
+                   Wired in fragments/portfolio.ts. -->
+              <div class="brief-try-chips" id="port-brief-chips">
+                <span class="brief-try-label">Try</span>
+                <button type="button" class="brief-try-chip" data-budget="250000"
+                        data-brief="Launch campaign for affluent urban millennials interested in premium fitness + wellness. Target CTV + podcast.">
+                  Premium fitness · CTV + podcast
+                </button>
+                <button type="button" class="brief-try-chip" data-budget="180000"
+                        data-brief="Cord-cutter parents 35-44 with kids at home, household income $100K+. Drama + family streaming on connected TV.">
+                  Cord-cutter parents · streaming
+                </button>
+                <button type="button" class="brief-try-chip" data-budget="500000"
+                        data-brief="High-net-worth professionals 35-54 in top-10 DMAs interested in luxury travel, fine dining, business news. Premium audio + video.">
+                  HNW professionals · luxury
+                </button>
+                <button type="button" class="brief-try-chip" data-budget="120000"
+                        data-brief="Gen Z college students interested in gaming, esports, and music streaming. Mobile-first, short-form video.">
+                  Gen Z gamers · mobile video
+                </button>
+                <button type="button" class="brief-try-chip" data-budget="300000"
+                        data-brief="DIY homeowners 35-64 with high household spend on home improvement. Daypart-aware: weekend mornings, weekday evenings.">
+                  DIY homeowners · daypart
+                </button>
+              </div>
               <textarea id="brief-text" class="lab-input" rows="6" placeholder="Launch campaign for affluent urban millennials interested in premium fitness + wellness. Target CTV + podcast..."></textarea>
               <label class="lab-label" style="margin-top:8px">Budget</label>
               <input id="brief-budget" type="number" min="1000" value="250000" step="10000" class="lab-input"/>
@@ -2359,6 +2386,10 @@ ${STYLES}
   <div class="trace-body">
     <section class="trace-tab-pane is-active" data-trace-pane="overview">
       <div class="trace-perf" id="trace-perf"></div>
+      <!-- Sec-31u T1#5: timeline scrubber. Proportional bar across the
+           steps; click a segment to jump to that step. Wired in
+           fragments/trace-inspector.ts. Empty until first trace lands. -->
+      <div class="trace-timeline-scrubber" id="trace-timeline-scrubber"></div>
       <div class="trace-steps" id="trace-steps"></div>
     </section>
     <section class="trace-tab-pane" data-trace-pane="json">

--- a/src/routes/vendorHealthCanvas.ts
+++ b/src/routes/vendorHealthCanvas.ts
@@ -610,10 +610,15 @@ function renderVendorHealthCanvas(demoKey: string): string {
     width: 14px;
     border-top: 1px dashed currentColor;
   }
-  .modal-close {
+  .modal-actions {
     position: absolute;
     top: 16px;
     right: 16px;
+    display: flex;
+    gap: 6px;
+  }
+  .modal-close,
+  .modal-reprobe {
     background: transparent;
     border: 1px solid var(--border);
     color: var(--text);
@@ -621,6 +626,56 @@ function renderVendorHealthCanvas(demoKey: string): string {
     border-radius: 4px;
     cursor: pointer;
     font: 11px var(--font-mono);
+    transition: all 0.15s;
+  }
+  .modal-reprobe:hover { border-color: var(--accent); color: var(--accent); }
+  .modal-reprobe:disabled { opacity: 0.5; cursor: progress; }
+  .modal-reprobe.is-loading::after {
+    content: "";
+    display: inline-block;
+    width: 8px; height: 8px;
+    margin-left: 6px;
+    border: 1.5px solid currentColor;
+    border-right-color: transparent;
+    border-radius: 50%;
+    animation: spin 0.7s linear infinite;
+    vertical-align: -1px;
+  }
+  @keyframes spin { to { transform: rotate(360deg); } }
+  /* Time-window filter (applies in modal chart). Lives in the same row
+     as the chart stats; selecting a window re-renders the chart with
+     the matching slice of history. */
+  .modal-chart-window {
+    display: flex;
+    gap: 4px;
+    margin-bottom: 8px;
+    align-items: center;
+  }
+  .modal-chart-window-label {
+    font: 10px var(--font-mono);
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--text-faint);
+    margin-right: 6px;
+  }
+  .modal-chart-window-btn {
+    padding: 4px 9px;
+    background: var(--bg);
+    border: 1px solid var(--border);
+    color: var(--text-dim);
+    border-radius: 4px;
+    font: 10.5px var(--font-mono);
+    cursor: pointer;
+    transition: all 0.15s;
+  }
+  .modal-chart-window-btn:hover {
+    border-color: var(--accent);
+    color: var(--accent);
+  }
+  .modal-chart-window-btn.is-active {
+    background: var(--accent);
+    color: #0a0d12;
+    border-color: var(--accent);
   }
   .modal-tools-list {
     display: flex;
@@ -724,7 +779,10 @@ function renderVendorHealthCanvas(demoKey: string): string {
   <div class="modal">
     <div class="modal-title" id="modal-title">Vendor</div>
     <div class="modal-sub" id="modal-sub"></div>
-    <button class="modal-close" id="modal-close">close</button>
+    <div class="modal-actions">
+      <button class="modal-reprobe" id="modal-reprobe" type="button" title="Re-probe this vendor and refresh the modal in place">↻ Re-probe</button>
+      <button class="modal-close" id="modal-close">close</button>
+    </div>
     <div class="modal-section">
       <div class="modal-section-title">Identity</div>
       <div class="modal-grid" id="modal-identity"></div>
@@ -743,6 +801,15 @@ function renderVendorHealthCanvas(demoKey: string): string {
     </div>
     <div class="modal-section">
       <div class="modal-section-title">Recent history</div>
+      <!-- Time-window filter: time-based slices (relative to NOW). Each
+           button keeps datapoints whose ts is within the window — "1h"
+           = last 60 min, "24h" = last 1440 min, "all" = full ring. -->
+      <div class="modal-chart-window" id="modal-chart-window">
+        <span class="modal-chart-window-label">window</span>
+        <button class="modal-chart-window-btn" data-window="60" type="button">1h</button>
+        <button class="modal-chart-window-btn" data-window="1440" type="button">24h</button>
+        <button class="modal-chart-window-btn is-active" data-window="all" type="button">all</button>
+      </div>
       <!-- Stats row computed from KV ring buffer (24-entry, 7-day TTL).
            Empty until first probe lands. -->
       <div id="modal-chart-stats"></div>
@@ -1249,14 +1316,78 @@ function renderVendorHealthCanvas(demoKey: string): string {
 
     // Time-series chart + stat row (replaces the old <pre> text dump).
     // Both render from the same KV ring buffer; the chart fades in the
-    // moment a probe lands.
-    var hist = state.histories[r.agent_id] || [];
-    var stats = computeTrendStats(hist);
-    elModalChartStats.innerHTML = renderChartStats(stats);
-    elModalChartHost.innerHTML = renderHistoryChart(hist);
+    // moment a probe lands. The window filter slices the tail of the
+    // history before rendering — "all" = full 24, "12" = last 12, etc.
+    state._modalAgentId = agentId;
+    state._modalWindow = state._modalWindow || "all";
+    _renderModalChartForWindow();
     elModalTools.innerHTML = "<span class=\\"modal-tool\\">tools list captured at probe time, see /agents/registry for full list</span>";
+    // Sync window-filter button active state
+    document.querySelectorAll("[data-window]").forEach(function (b) {
+      b.classList.toggle("is-active", b.getAttribute("data-window") === state._modalWindow);
+    });
 
     elModalBackdrop.classList.add("is-open");
+  }
+  // Time-window-aware chart re-render. Driven by state._modalAgentId
+  // and state._modalWindow; called on modal open, window switch, and
+  // reprobe completion.
+  function _renderModalChartForWindow() {
+    var agentId = state._modalAgentId;
+    if (!agentId) return;
+    var hist = state.histories[agentId] || [];
+    var window = state._modalWindow || "all";
+    // Time-based slice: window value is "all" or a minute count
+    // ("60" = last hour, "1440" = last 24 hours). Filters by ts.
+    var sliced;
+    if (window === "all" || isNaN(parseInt(window, 10))) {
+      sliced = hist;
+    } else {
+      var minutes = parseInt(window, 10);
+      var cutoffMs = Date.now() - minutes * 60 * 1000;
+      sliced = hist.filter(function (d) {
+        if (!d || !d.ts) return false;
+        var t = Date.parse(d.ts);
+        return !isNaN(t) && t >= cutoffMs;
+      });
+    }
+    var stats = computeTrendStats(sliced);
+    elModalChartStats.innerHTML = renderChartStats(stats);
+    elModalChartHost.innerHTML = renderHistoryChart(sliced);
+  }
+  // Wire window-filter buttons (one-time)
+  document.querySelectorAll("[data-window]").forEach(function (btn) {
+    btn.addEventListener("click", function () {
+      state._modalWindow = btn.getAttribute("data-window");
+      document.querySelectorAll("[data-window]").forEach(function (b) {
+        b.classList.toggle("is-active", b === btn);
+      });
+      _renderModalChartForWindow();
+    });
+  });
+  // Wire in-modal re-probe button — runs reprobeOne for the open agent,
+  // shows loading state, refreshes the modal in place when done.
+  var elModalReprobe = document.getElementById("modal-reprobe");
+  if (elModalReprobe) {
+    elModalReprobe.addEventListener("click", async function () {
+      var agentId = state._modalAgentId;
+      if (!agentId) return;
+      elModalReprobe.disabled = true;
+      elModalReprobe.classList.add("is-loading");
+      var origText = elModalReprobe.textContent;
+      elModalReprobe.textContent = "Probing";
+      try {
+        await reprobeOne(agentId);
+        // Re-render the open modal with fresh data
+        openModal(agentId);
+      } catch (e) {
+        console.error("modal reprobe failed", e);
+      } finally {
+        elModalReprobe.disabled = false;
+        elModalReprobe.classList.remove("is-loading");
+        elModalReprobe.textContent = origText;
+      }
+    });
   }
   function kvRow(k, v) {
     return "<div class=\\"modal-grid-key\\">" + escapeHtml(k) + "</div><div class=\\"modal-grid-val\\">" + escapeHtml(v) + "</div>";
@@ -1285,6 +1416,13 @@ function renderVendorHealthCanvas(demoKey: string): string {
       state.counts = data.counts || null;
       renderAggregate(state.counts, data.total || state.rows.length);
       renderGrid();
+      // Sec-31u: auto-refresh open modal so its chart picks up the new
+      // datapoint without requiring the user to close + reopen.
+      if (elModalBackdrop.classList.contains("is-open") && state._modalAgentId) {
+        // Re-render via openModal() so all sections (probe, circuit,
+        // chart) reflect the updated row + history.
+        openModal(state._modalAgentId);
+      }
     } catch (err) {
       console.error("loadSnapshot failed", err);
       elGrid.innerHTML = "<div class=\\"empty-state\\">Snapshot failed: " + escapeHtml(err.message || String(err)) + "</div>";

--- a/tests/__snapshots__/demo-render-snapshot.test.ts.snap
+++ b/tests/__snapshots__/demo-render-snapshot.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`handleDemo byte-equivalence > matches the committed golden hash (LF-normalized SHA-256 of body) 1`] = `
 {
-  "hash": "46a9dd55693ffce41c218e081519b1039baa73cd6452e68daa32d834b73d39f6",
-  "length": 1074817,
+  "hash": "4229c4b83cf3a61be6801eb04de55c407198566784eba3291324f2058bc76718",
+  "length": 1095004,
 }
 `;


### PR DESCRIPTION
## TL;DR

Rips through the long-deferred Tier 1/2/3 + Tier D items in one PR. Several "static" visualizations the user flagged became animated and interactive; Vendor Health drill-down got the full Tier D treatment.

## What ships

### Vendor Health Tier D
- **In-modal re-probe button** (↻) — spins the open vendor in place + re-renders the modal with fresh probe + history. No need to close + reopen.
- **Auto-refresh on global "Live probe (all)"** — when a snapshot lands and the modal is open, openModal() re-fires so the chart picks up the new datapoint instantly.
- **Time-window filter (1h / 24h / all)** — time-based slice (not sample-count) using `ts ≥ Date.now() - window_min*60_000`.

### Embedding Sankey — animated + interactive (was: static)
- Stagger draw-in via `stroke-dashoffset`, 18ms-stepped per flow.
- Hover any node → highlight all flows touching it, dim rest.
- Hover any flow → highlight just that flow's chain (mid + right).
- Click to lock highlight; click empty/locked → clear.
- Native `<title>` tooltips on every flow.

### Embedding Heatmap — animated + interactive (was: static)
- Cells stagger-fade in.
- Hover any cell → row + column glow with accent stroke; rest dim.

### Trace Inspector timeline (T1#5)
Proportional segment bar above the step list. Click any segment → scroll matching step into view + glow it.

### Discover NL (T3#21)
On result, glow-pulse the AST card + stagger-glow each KPI/match card.

### Portfolio brief workshop UX
- **5 try-chips** above the brief textarea (Premium fitness, Cord-cutter parents, HNW professionals, Gen Z gamers, DIY homeowners). Click populates brief + budget + auto-fires Generate.
- **Lorenz draw-in animation** — stroke-dasharray sweep, area fade-in, 80ms-staggered card entry.

### Composer saturation curve (T2#10)
Hover tooltips with F / reach / marginal / cost breakdown via invisible-ish over-dots. Marginal-reach dots scale on hover. Curve highlights on host hover.

### Federation agreement heatmap (T3#24)
Pairwise agent-agreement matrix rendered when 2+ agents return results. Diagonal = self-count; off-diagonal = signal-name overlap, color intensity ∝ overlap.

## Genuinely deferred (post-workshop, with rationale)

- **Race Canvas trace panel integration** — needs full trace inspector port to a separate-page canvas (~3-4h). Out of workshop window.
- **T3#23 Composer weighted-blend 2D vector arrows** — needs server-side projection of input vectors not currently exposed in the API.
- **Sub-divide brand-canvas/campaign/builder fragments** — pure code-quality cosmetic, no user-visible benefit. Biggest fragments are still navigable.
- **d3-hierarchy local bundle** — CSP tightening with no user-visible benefit. CDN allowance is fine for a workshop demo.

## Validation (all green)

```
npx tsc --noEmit                 → 0 new errors in refactor scope
python tmp-mining/trap_audit.py  → CLEAN (0 traps × 37 files)
npx vitest run                   → 440 passed / 0 failed / 12 skipped
npx wrangler deploy --dry-run    → bundle ok
```

Snapshot golden updated: hash `33a5c932 → 4229c4b8`, body length `1,074,817 → 1,095,004` (+20,187 bytes for sankey/heatmap attrs + interactivity + VH modal + brief chips + lorenz draw + saturation hover + federation heatmap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)