### PR TITLE
AAO follow-up: bump capability cache key + tools/call get_adcp_capabilities is public

### DIFF
--- a/src/domain/capabilityService.ts
+++ b/src/domain/capabilityService.ts
@@ -62,6 +62,15 @@ type AdcpCapabilities = {
     idempotency: { supported: true; replay_ttl_seconds: number };
   };
   supported_protocols: string[];
+  /**
+   * AAO specialism declarations. Drives which specialist scenario tracks
+   * the AAO compliance runner executes when verifying badge eligibility.
+   * For a signals-only first-party adaptor, the relevant value is
+   * `signal-owned`. The legacy `signed-requests` value is deprecated in
+   * 3.1 — request-signing capabilities are declared via the
+   * `request_signing` block instead.
+   */
+  specialisms?: string[];
   signals?: unknown;
   media_buy?: unknown;
   governance?: unknown;
@@ -74,7 +83,6 @@ type AdcpCapabilities = {
   webhook_signing?: unknown;
   identity?: unknown;
   compliance_testing?: unknown;
-  specialisms?: unknown;
   experimental_features?: string[];
   ext?: Record<string, unknown>;
   /**
@@ -100,6 +108,14 @@ function buildStaticCapabilities(env: UcpCapabilityEnv): AdcpCapabilities {
       idempotency: { supported: true, replay_ttl_seconds: 86400 },
     },
     supported_protocols: ["signals"],
+    // Sec-31v (AAO compliance): specialism declaration. AAO's badge
+    // issuer reads this array to decide which specialist scenario tracks
+    // to run. For a first-party signals adaptor exposing owned segments
+    // (not reselling third-party marketplace data), the right value is
+    // `signal-owned`. The deprecated `signed-requests` value is NOT
+    // included — request-signing capabilities are declared via the
+    // `request_signing` block below.
+    specialisms: ["signal-owned"],
     // Sec-42 (AdCP 3.0 GA): top-level protocol-level capability blocks.
     // See /schemas/3.0.0/protocol/get-adcp-capabilities-response.json.
     // Declared honestly — we only claim what we actually implement.
@@ -659,6 +675,11 @@ export async function getCapabilities(
   const filtered: AdcpCapabilities = {
     adcp: full.adcp,
     supported_protocols: full.supported_protocols,
+    // Sec-31v: specialisms is a top-level declaration like
+    // supported_protocols and is always returned regardless of the
+    // requested-protocols filter (the AAO badge runner reads it
+    // independently of which protocol blocks are projected).
+    ...(full.specialisms ? { specialisms: full.specialisms } : {}),
     ...(full.ext ? { ext: full.ext } : {}),
   };
   for (const key of PROTOCOL_BLOCK_KEYS) {

--- a/src/domain/capabilityService.ts
+++ b/src/domain/capabilityService.ts
@@ -35,7 +35,12 @@
 // self-fetch short-circuit, URL corrections for content_ignite + claire_scope3).
 // The key version must be bumped any time the SHAPE of the capability response
 // changes, so clients that cache by key pick up the new fields.
-const CACHE_KEY = "adcp_capabilities_v23";
+// Cache key carries a monotonic version suffix. Bump on every change to
+// the static capability shape so already-warmed KV entries don't serve
+// stale fields after a deploy. Bumps:
+//   v23 → previous baseline
+//   v24 → Sec-31v: added top-level `specialisms` for AAO badge issuance
+const CACHE_KEY = "adcp_capabilities_v24";
 const CACHE_TTL_SECONDS = 3600;
 
 import { buildUcpCapability, type UcpCapabilityEnv } from "../ucp/vacDeclaration";

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -71,6 +71,19 @@ const RPC_UNAUTHORIZED = -32001;
 // return -32001 if no API key is present on the request.
 const AUTHENTICATED_MCP_METHODS = new Set(["tools/call"]);
 
+// Sec-31v: tools/call carve-out for AdCP capability discovery. The AAO
+// storyboard runner and similar conformance probes call
+// get_adcp_capabilities BEFORE any handshake / auth flow to learn what
+// the agent supports — they need the unauthed call to succeed in order
+// to issue specialty badges. Other discovery probes (compliance
+// evaluators, directory crawlers) follow the same pattern.
+//
+// Treating this single tool as public matches how `initialize` and
+// `tools/list` behave at the MCP layer, and keeps mutating tools
+// (activate_signal, get_signals, etc.) gated behind the bearer key.
+// All other tools/call invocations remain auth-gated.
+const PUBLIC_TOOL_CALL_NAMES = new Set(["get_adcp_capabilities"]);
+
 interface McpInitializeParams {
     protocolVersion: string;
     capabilities?: Record<string, unknown>;
@@ -181,15 +194,26 @@ async function handleSingleMessage(
     logger.info("mcp_request", { method, id });
 
     if (AUTHENTICATED_MCP_METHODS.has(method) && !isAuthed) {
-        // Log auth failures so spammy unauthenticated tool-call attempts are
-        // visible in the observability pipeline.
-        logger.warn("mcp_auth_required", { method, id });
-        if (id === undefined || id === null) return null;
-        return rpcError(
-            id,
-            RPC_UNAUTHORIZED,
-            "Authentication required for this method. Supply Authorization: Bearer <key>.",
-        );
+        // Sec-31v: tools/call → get_adcp_capabilities is public. The AAO
+        // and AdCP conformance probes call this tool unauthenticated to
+        // discover specialisms / supported_protocols before any handshake.
+        // Other tools/call invocations stay auth-gated.
+        const toolName = (params && typeof params === "object" && "name" in params)
+            ? (params as { name?: unknown }).name
+            : undefined;
+        if (method === "tools/call" && typeof toolName === "string" && PUBLIC_TOOL_CALL_NAMES.has(toolName)) {
+            logger.info("mcp_public_tool_call", { method, tool: toolName, id });
+        } else {
+            // Log auth failures so spammy unauthenticated tool-call attempts are
+            // visible in the observability pipeline.
+            logger.warn("mcp_auth_required", { method, id });
+            if (id === undefined || id === null) return null;
+            return rpcError(
+                id,
+                RPC_UNAUTHORIZED,
+                "Authentication required for this method. Supply Authorization: Bearer <key>.",
+            );
+        }
     }
 
     try {

--- a/src/routes/raceCanvas.ts
+++ b/src/routes/raceCanvas.ts
@@ -58,6 +58,9 @@ function renderRaceCanvas(demoKey: string): string {
     --text-faint: #5b6679;
     --accent: #38b6ff;
     --accent-glow: rgba(56, 182, 255, 0.35);
+    --accent-dim: rgba(56, 182, 255, 0.15);
+    --bg-input: #0d121a;
+    --border-faint: #1a2030;
     --warn: #f0b400;
     --warn-glow: rgba(240, 180, 0, 0.4);
     --block: #ff4d5e;
@@ -725,6 +728,131 @@ function renderRaceCanvas(demoKey: string): string {
     text-align: center;
     padding: 40px 20px;
   }
+
+  /* Sec-31u: Trace inspector — minimal port of the main demo's
+     trace inspector for the Race Canvas page. */
+  .race-trace-trigger {
+    position: fixed; bottom: 20px; right: 20px;
+    display: flex; align-items: center; gap: 6px;
+    padding: 9px 14px;
+    background: var(--bg-elevated);
+    border: 1px solid var(--border-strong);
+    border-radius: 999px;
+    color: var(--accent);
+    font: 11px var(--font-mono);
+    cursor: pointer;
+    box-shadow: 0 6px 18px rgba(0,0,0,0.32);
+    z-index: 90;
+    transition: all 0.15s;
+  }
+  .race-trace-trigger:hover { transform: translateY(-1px); border-color: var(--accent); }
+  .race-trace-trigger.is-pulsing {
+    animation: race-trace-pulse 1.6s ease-in-out 3;
+    border-color: var(--accent);
+  }
+  @keyframes race-trace-pulse {
+    0%   { box-shadow: 0 6px 18px rgba(0,0,0,0.32), 0 0 0 0 var(--accent); }
+    35%  { box-shadow: 0 6px 18px rgba(0,0,0,0.32), 0 0 0 14px transparent; }
+    100% { box-shadow: 0 6px 18px rgba(0,0,0,0.32), 0 0 0 0 transparent; }
+  }
+  .race-trace-panel {
+    position: fixed; top: 0; bottom: 0; right: 0;
+    width: 420px; max-width: 92vw;
+    background: var(--bg-elevated);
+    border-left: 1px solid var(--border-strong);
+    box-shadow: -8px 0 24px rgba(0,0,0,0.4);
+    z-index: 100;
+    transform: translateX(100%);
+    transition: transform 0.28s cubic-bezier(0.2, 0.8, 0.2, 1);
+    display: flex; flex-direction: column;
+    overflow: hidden;
+  }
+  .race-trace-panel.is-open { transform: translateX(0); }
+  .race-trace-panel-head {
+    display: flex; justify-content: space-between; align-items: center;
+    padding: 14px 18px;
+    border-bottom: 1px solid var(--border);
+    color: var(--text);
+  }
+  .race-trace-panel-head button {
+    background: transparent;
+    border: 1px solid var(--border);
+    color: var(--text);
+    padding: 4px 10px;
+    border-radius: 4px;
+    font: 11px var(--font-mono);
+    cursor: pointer;
+  }
+  .race-trace-panel-head button:hover { border-color: var(--accent); color: var(--accent); }
+  .race-trace-body {
+    flex: 1;
+    overflow-y: auto;
+    padding: 14px 18px;
+    color: var(--text);
+  }
+  .race-trace-empty {
+    color: var(--text-faint);
+    font: 12px var(--font-mono);
+    padding: 20px 0;
+  }
+  .race-trace-head {
+    margin-bottom: 14px;
+    padding-bottom: 10px;
+    border-bottom: 1px solid var(--border-faint);
+  }
+  .race-trace-head .op {
+    font-size: 14px; font-weight: 600; color: var(--text);
+    margin-bottom: 2px;
+  }
+  .race-trace-head .meta {
+    font: 11px var(--font-mono); color: var(--text-faint);
+  }
+  .race-trace-step {
+    background: var(--bg);
+    border: 1px solid var(--border-faint);
+    border-radius: 6px;
+    padding: 10px 12px;
+    margin-bottom: 8px;
+  }
+  .race-trace-step-head {
+    display: flex; align-items: center; gap: 10px;
+    margin-bottom: 6px;
+  }
+  .race-trace-step-head .step-idx {
+    font: 700 10px var(--font-mono);
+    background: var(--accent-dim);
+    color: var(--accent);
+    padding: 2px 7px;
+    border-radius: 999px;
+  }
+  .race-trace-step-head .step-label {
+    flex: 1;
+    font: 12.5px var(--font-mono);
+    color: var(--text);
+  }
+  .race-trace-step-head .step-dur {
+    font: 11px var(--font-mono);
+    color: var(--text-faint);
+  }
+  .race-trace-detail {
+    display: grid;
+    grid-template-columns: 100px 1fr;
+    gap: 6px;
+    font: 11px var(--font-mono);
+    line-height: 1.4;
+    padding: 2px 0;
+  }
+  .race-trace-detail .k { color: var(--text-faint); }
+  .race-trace-detail .v { color: var(--text); word-break: break-all; }
+  .race-trace-note {
+    margin-top: 6px;
+    font: 11px var(--font-mono);
+    color: var(--text-faint);
+    font-style: italic;
+    padding: 6px 8px;
+    background: var(--bg-input);
+    border-radius: 4px;
+  }
 </style>
 </head>
 <body>
@@ -1368,8 +1496,84 @@ function renderRaceCanvas(demoKey: string): string {
   });
 
   console.log("Race Canvas ready");
+
+  // Sec-31u: trace inspector integration. Wraps window.fetch so any
+  // /race/* response with a _trace field is captured. Trigger button
+  // (bottom-right) opens a slide-in panel showing the most recent
+  // trace formatted as steps + raw JSON.
+  var __raceLastTrace = null;
+  var __raceOrigFetch = window.fetch;
+  window.fetch = async function () {
+    var resp = await __raceOrigFetch.apply(this, arguments);
+    try {
+      var ct = resp.headers && resp.headers.get && resp.headers.get("content-type") || "";
+      if (ct.toLowerCase().indexOf("application/json") >= 0 && resp.ok) {
+        var body = await resp.clone().json();
+        if (body && body._trace) {
+          __raceLastTrace = body._trace;
+          var trig = document.getElementById("race-trace-trigger");
+          if (trig) {
+            trig.style.display = "flex";
+            trig.classList.remove("is-pulsing");
+            void trig.offsetWidth;
+            trig.classList.add("is-pulsing");
+          }
+        }
+      }
+    } catch (e) { /* non-fatal */ }
+    return resp;
+  };
+
+  function _raceFmtMs(ms) {
+    if (typeof ms !== "number") return "—";
+    if (ms < 1) return ms.toFixed(2) + "ms";
+    if (ms < 1000) return Math.round(ms) + "ms";
+    return (ms / 1000).toFixed(2) + "s";
+  }
+  function _raceRenderTrace(t) {
+    if (!t) return "<div class=\\"race-trace-empty\\">No trace captured yet — run a race or add a vendor to see one.</div>";
+    var steps = (t.steps || []).map(function (s, i) {
+      var details = (s.details || []).map(function (d) {
+        return "<div class=\\"race-trace-detail\\"><span class=\\"k\\">" + escapeHtml(d.k) + "</span><span class=\\"v\\">" + escapeHtml(d.v) + "</span></div>";
+      }).join("");
+      return "<div class=\\"race-trace-step\\">" +
+        "<div class=\\"race-trace-step-head\\"><span class=\\"step-idx\\">" + (i + 1) + "</span><span class=\\"step-label\\">" + escapeHtml(s.label || s.id) + "</span><span class=\\"step-dur\\">" + _raceFmtMs(s.duration_ms) + "</span></div>" +
+        (details ? "<div class=\\"race-trace-details\\">" + details + "</div>" : "") +
+        (s.note ? "<div class=\\"race-trace-note\\">" + escapeHtml(s.note) + "</div>" : "") +
+      "</div>";
+    }).join("");
+    return "<div class=\\"race-trace-head\\">" +
+        "<div class=\\"op\\">" + escapeHtml(t.operation || "trace") + "</div>" +
+        "<div class=\\"meta mono\\">" + _raceFmtMs(t.duration_ms) + " · " + (t.steps || []).length + " step(s) · " + (t.ts || "") + "</div>" +
+      "</div>" +
+      "<div class=\\"race-trace-steps\\">" + steps + "</div>";
+  }
+  document.getElementById("race-trace-trigger").addEventListener("click", function () {
+    var panel = document.getElementById("race-trace-panel");
+    panel.classList.add("is-open");
+    document.getElementById("race-trace-body").innerHTML = _raceRenderTrace(__raceLastTrace);
+  });
+  document.getElementById("race-trace-close").addEventListener("click", function () {
+    document.getElementById("race-trace-panel").classList.remove("is-open");
+  });
+  function escapeHtml(s) { return String(s == null ? "" : s).replace(/[&<>\\"']/g, function (c) { return ({"&":"&amp;","<":"&lt;",">":"&gt;","\\"":"&quot;","'":"&#39;"})[c]; }); }
 })();
 </script>
+
+<!-- Sec-31u: trace inspector for Race Canvas. Trigger appears bottom-right
+     once the first traced response lands; panel slides in from right with
+     steps formatted from the captured _trace. -->
+<button id="race-trace-trigger" class="race-trace-trigger" style="display:none" type="button" aria-label="View trace">
+  <svg viewBox="0 0 20 20" width="14" height="14"><circle cx="10" cy="10" r="3" fill="currentColor"/><circle cx="10" cy="10" r="6" fill="none" stroke="currentColor" stroke-width="1.4" opacity="0.6"/></svg>
+  <span>View trace</span>
+</button>
+<div id="race-trace-panel" class="race-trace-panel" aria-hidden="true">
+  <div class="race-trace-panel-head">
+    <strong>Trace inspector</strong>
+    <button id="race-trace-close" type="button">close</button>
+  </div>
+  <div id="race-trace-body" class="race-trace-body"></div>
+</div>
 
 </body>
 </html>`;

--- a/tests/security.test.ts
+++ b/tests/security.test.ts
@@ -795,12 +795,15 @@ describe("handleMcpRequest — auth gate", () => {
     // Sec-23: single-request auth failures surface at the HTTP layer per
     // RFC 6750 so standard MCP clients and conformance probes detect the
     // auth failure via transport. JSON-RPC body still carries -32001.
+    // Sec-31v: get_adcp_capabilities is now public (carve-out for AAO
+    // discovery probes), so this test uses get_signals which remains
+    // auth-gated. See PUBLIC_TOOL_CALL_NAMES in mcp/server.ts.
     const { status, body, res } = await callAndParse(
       mcpReq({
         jsonrpc: "2.0",
         id: 3,
         method: "tools/call",
-        params: { name: "get_adcp_capabilities", arguments: {} },
+        params: { name: "get_signals", arguments: {} },
       }),
     );
     expect(status).toBe(401);
@@ -812,7 +815,7 @@ describe("handleMcpRequest — auth gate", () => {
   it("tools/call with wrong API key returns HTTP 401 + -32001", async () => {
     const { status, body } = await callAndParse(
       mcpReq(
-        { jsonrpc: "2.0", id: 4, method: "tools/call", params: { name: "get_adcp_capabilities", arguments: {} } },
+        { jsonrpc: "2.0", id: 4, method: "tools/call", params: { name: "get_signals", arguments: {} } },
         "Bearer not-the-key",
       ),
     );
@@ -827,7 +830,7 @@ describe("handleMcpRequest — auth gate", () => {
     const { status, body } = await callAndParse(
       mcpReq([
         { jsonrpc: "2.0", id: 10, method: "tools/list", params: {} },
-        { jsonrpc: "2.0", id: 11, method: "tools/call", params: { name: "get_adcp_capabilities", arguments: {} } },
+        { jsonrpc: "2.0", id: 11, method: "tools/call", params: { name: "get_signals", arguments: {} } },
       ]),
     );
     expect(status).toBe(200);
@@ -837,16 +840,42 @@ describe("handleMcpRequest — auth gate", () => {
     expect(byId[11].error?.code).toBe(-32001);
   });
 
+  it("Sec-31v: tools/call get_adcp_capabilities is PUBLIC (carve-out for AAO discovery)", async () => {
+    // The AAO storyboard runner and similar conformance probes call
+    // get_adcp_capabilities BEFORE any auth handshake to learn what the
+    // agent supports. This single tool is public; mutating tools
+    // (get_signals, activate_signal, etc.) stay auth-gated. See
+    // PUBLIC_TOOL_CALL_NAMES in mcp/server.ts.
+    const { status, body } = await callAndParse(
+      mcpReq({
+        jsonrpc: "2.0",
+        id: 100,
+        method: "tools/call",
+        params: { name: "get_adcp_capabilities", arguments: {} },
+      }),
+    );
+    expect(status).toBe(200);
+    expect(body.error).toBeUndefined();
+    expect(body.result?.content).toBeDefined();
+    // Capability response must include specialisms for AAO badge issuance
+    const text = body.result.content[0].text;
+    const caps = JSON.parse(text);
+    expect(caps.specialisms).toEqual(["signal-owned"]);
+    expect(caps.supported_protocols).toContain("signals");
+  });
+
   // Sec-26b: broaden mixed-auth batch isolation coverage beyond tools/list.
   // The existing tools/list+tools/call test proves per-message isolation
   // for one public-method pair. These pin the invariant across the other
   // public methods (initialize, ping) so a refactor that special-cases
   // tools/list accidentally would still fail here.
   it("Sec-26b: mixed batch [initialize, tools/call] — public succeeds, tool-call gets -32001", async () => {
+    // Sec-31v: get_adcp_capabilities is now public; using get_signals
+    // here so this test still validates the auth-gate path.
     const { status, body } = await callAndParse(
       mcpReq([
         { jsonrpc: "2.0", id: 40, method: "initialize", params: { protocolVersion: "2024-11-05", clientInfo: { name: "t", version: "1" } } },
-        { jsonrpc: "2.0", id: 41, method: "tools/call", params: { name: "get_adcp_capabilities", arguments: {} } },
+        { jsonrpc: "2.0", id: 41, method: "tools/call", params: { name: "get_signals", arguments: {} } },
       ]),
     );
     expect(status).toBe(200);
@@ -885,8 +914,10 @@ describe("handleMcpRequest — auth gate", () => {
     // response array; HTTP stays 200.
     const { status, body, res } = await callAndParse(
       mcpReq([
-        { jsonrpc: "2.0", id: 30, method: "tools/call", params: { name: "get_adcp_capabilities", arguments: {} } },
-        { jsonrpc: "2.0", id: 31, method: "tools/call", params: { name: "get_signals", arguments: {} } },
+        // Sec-31v: get_adcp_capabilities is public — using non-public
+        // tools here so all three messages exercise the auth-gate path.
+        { jsonrpc: "2.0", id: 30, method: "tools/call", params: { name: "get_signals", arguments: {} } },
+        { jsonrpc: "2.0", id: 31, method: "tools/call", params: { name: "search_signals", arguments: {} } },
         { jsonrpc: "2.0", id: 32, method: "tools/call", params: { name: "activate_signal", arguments: {} } },
       ]),
     );


### PR DESCRIPTION
## TL;DR

Two follow-ups surfaced post-merge of #171 when I curl-verified prod:

1. **REST `/capabilities` still returned no `specialisms`** — the KV cache held the pre-deploy shape and the new code only repopulates on miss. **Fix: bumped `CACHE_KEY` v23 → v24.**
2. **MCP `tools/call get_adcp_capabilities` returned `-32001 auth required`** — making it impossible for AAO's discovery probe to read `specialisms` in the first place. Chicken-and-egg. **Fix: added `PUBLIC_TOOL_CALL_NAMES` carve-out for the discovery tool only.**

## Why this carve-out is safe

`get_adcp_capabilities` is a **read-only metadata** call returning the same static declaration AdCP agents are expected to publish openly. Same risk profile as the existing public MCP methods (`initialize`, `tools/list`, `ping`). All mutating tools (`get_signals`, `activate_signal`, `search_signals`, etc.) **remain auth-gated**.

## Test changes

`tests/security.test.ts` — 70 tests (was 69):
- **5 existing tests** switched their tool-call probe from `get_adcp_capabilities` to `get_signals`. Test intent unchanged — they validate the auth gate, not the specific tool.
- **1 new test** — `"Sec-31v: tools/call get_adcp_capabilities is PUBLIC (carve-out for AAO discovery)"`. Asserts 200, `result.content` present, response carries `specialisms: ["signal-owned"]` and `supported_protocols` includes `"signals"`.

## Validation

```
npx tsc --noEmit                 → 0 errors
python tmp-mining/trap_audit.py  → CLEAN (0 traps × 37 files)
npx vitest run                   → 441 passed / 0 failed / 12 skipped (+1 vs prior)
npx wrangler deploy --dry-run    → bundle ok
```

## Post-merge sanity

```bash
# REST
curl -s https://adcp-signals-adaptor.evgeny-193.workers.dev/capabilities | jq .specialisms
# → ["signal-owned"]

# MCP unauthed
curl -s -X POST -H 'Content-Type: application/json' \
  -d '{"jsonrpc":"2.0","method":"tools/call","id":1,"params":{"name":"get_adcp_capabilities","arguments":{}}}' \
  https://adcp-signals-adaptor.evgeny-193.workers.dev/mcp \
  | jq -r '.result.content[0].text | fromjson | .specialisms'
# → ["signal-owned"]
```

Then rerun `evaluate_agent_quality` on AAO so the runner picks up the specialism and the signal-owned badge gets issued.

🤖 Generated with [Claude Code](https://claude.com/claude-code)