### PR TITLE
AAO signal_owned: fix MCP JSON-RPC envelope + signal shape for badge issuance

### DIFF
--- a/src/mappers/signalMapper.ts
+++ b/src/mappers/signalMapper.ts
@@ -287,12 +287,18 @@ export function toSignalSummary(signal: CanonicalSignal): SignalSummary {
     ? Math.min(99, Math.round((signal.estimatedAudienceSize / TOTAL_ADDRESSABLE) * 100 * 10) / 10)
     : 0;
 
+  // Sec-31w: AAO `signal_owned` storyboard requires `signal_type: "owned"`
+  // for first-party catalog signals. We're a first-party signals adaptor
+  // (declared via specialisms: ["signal-owned"] in get_adcp_capabilities),
+  // so static signals are "owned". Dynamic (brief-derived) signals stay
+  // "custom" — they're synthesized per-request, not part of the owned
+  // catalog the buyer can pre-license.
   const signalType: SignalSummary["signal_type"] =
-    signal.generationMode === "dynamic" ? "custom" : "marketplace";
+    signal.generationMode === "dynamic" ? "custom" : "owned";
 
-  const deployments: SignalDeployment[] = signal.destinations.map((dest) => {
+  const isLive = signal.status === "available";
+  const platformDeployments: SignalDeployment[] = signal.destinations.map((dest) => {
     const platform = DESTINATION_PLATFORM_MAP[dest] ?? { activationSupported: true };
-    const isLive = signal.status === "available";
     const platformSegmentId = `${dest}_${signal.signalId}`;
     return {
       type: "platform",
@@ -301,10 +307,37 @@ export function toSignalSummary(signal: CanonicalSignal): SignalSummary {
       decisioning_platform_segment_id: platformSegmentId,
       activation_supported: platform.activationSupported,
       ...(isLive
-        ? { activation_key: { type: "segment_id", segment_id: platformSegmentId } }
+        ? { activation_key: { type: "segment_id" as const, segment_id: platformSegmentId } }
         : {}),
     };
   });
+
+  // Sec-31w: AAO `signal_owned` storyboard's `activate_on_agent` step
+  // requires at least one deployment with `type: "agent"`,
+  // `activation_key: { type: "key_value", ... }`, and `is_live: true`.
+  // Since we ARE the agent (signal_id.source = "agent_native"), we
+  // expose every owned signal as activatable via our own /mcp endpoint
+  // — buyers call activate_signal with destinationType: "agent" and
+  // get a sync activation receipt. The key_value pair carries the
+  // segment id under the canonical "signal_agent_segment_id" key so a
+  // cross-agent buyer can just store the {key, value} pair and replay it.
+  const agentDeployment: SignalDeployment = {
+    type: "agent",
+    agent_url: SELF_AGENT_URL,
+    is_live: isLive,
+    decisioning_platform_segment_id: signal.signalId,
+    activation_supported: true,
+    ...(isLive
+      ? {
+          activation_key: {
+            type: "key_value" as const,
+            key: "signal_agent_segment_id",
+            value: signal.signalId,
+          },
+        }
+      : {}),
+  };
+  const deployments: SignalDeployment[] = [...platformDeployments, agentDeployment];
 
   const pricingCpm = signal.pricing?.model === "mock_cpm" ? signal.pricing.value ?? 0 : 0;
   const pricingCurrency = signal.pricing?.currency ?? "USD";
@@ -337,10 +370,15 @@ export function toSignalSummary(signal: CanonicalSignal): SignalSummary {
   return {
     // Universal signal_id required by the AdCP signals storyboard baseline.
     // We're an agent-native signals service (no upstream data-provider
-    // catalog), so source is always "agent". The internal signalId already
+    // catalog), so source is "agent_native". The internal signalId already
     // matches the schema's `^[a-zA-Z0-9_-]+$` pattern.
+    //
+    // Sec-31w: AAO's signal_owned storyboard's search_owned_signals step
+    // asserts literal "agent_native" (not "agent"). Two strings differ but
+    // mean the same thing for us; aligning here so the badge issuer
+    // accepts our shape.
     signal_id: {
-      source: "agent" as const,
+      source: "agent_native" as const,
       agent_url: SELF_AGENT_URL,
       id: signal.signalId,
     },

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -81,11 +81,17 @@ export interface CustomSignalProposal {
 /**
  * Universal signal identifier per /schemas/core/signal-id.json.
  * Discriminated by `source`. We're a self-contained signals agent (not a
- * data-provider catalog mirror), so every signal we expose is the `agent`
- * variant — schema requires `source`, `agent_url`, `id`.
+ * data-provider catalog mirror), so every signal we expose is the
+ * `agent_native` variant — schema requires `source`, `agent_url`, `id`.
+ *
+ * Sec-31w: AAO `signal_owned` storyboard requires `source: "agent_native"`
+ * (not `"agent"`). The two are semantically equivalent for our agent
+ * (we ARE the source, not a wrapper around an external data provider),
+ * but the storyboard's `search_owned_signals` step asserts the literal
+ * string. Aligned to spec here so the badge issuer accepts our shape.
  */
 export interface SignalIdAgent {
-  source: "agent";
+  source: "agent_native";
   agent_url: string;
   id: string;
 }
@@ -169,7 +175,18 @@ export interface SignalDeployment {
   is_live: boolean;
   decisioning_platform_segment_id: string;
   activation_supported: boolean;
-  activation_key?: { type: string; segment_id: string };
+  /**
+   * Activation key shape varies by deployment type per AdCP signals spec:
+   *   - platform deployments expose `{ type: "segment_id", segment_id }`
+   *   - agent deployments expose `{ type: "key_value", key, value }`
+   *
+   * Sec-31w: AAO `signal_owned` storyboard's `activate_on_agent` step
+   * asserts the key_value shape literal-by-literal. Both shapes are
+   * permitted by /schemas/core/signal-deployment.json.
+   */
+  activation_key?:
+    | { type: "segment_id"; segment_id: string }
+    | { type: "key_value"; key: string; value: string };
 }
 
 // ── Activation ────────────────────────────────────────────────────────────────

--- a/src/utils/trace.ts
+++ b/src/utils/trace.ts
@@ -92,12 +92,35 @@ function pathToOperationName(path: string): string {
  * Handlers that build their OWN _trace (richer steps, matches, etc.)
  * are detected and passed through unchanged.
  */
+// Sec-31w: paths whose response shape is constrained by an external
+// protocol spec — extra top-level fields like _trace can cause strict
+// clients to reject the envelope. JSON-RPC 2.0 (which MCP uses) is the
+// canonical example: { jsonrpc, id, result|error } is the entire
+// allowed shape, and conformance probes like @adcp/client reject
+// responses with sibling fields as "not MCP."
+//
+// Symptom that surfaced this: AAO's storyboard runner + npx
+// @adcp/client@latest both reported "Failed to discover MCP endpoint"
+// despite /mcp returning 200 + valid JSON-RPC body. Adding _trace
+// alongside `result` broke their MCP-protocol detection.
+//
+// Skip-list rather than allow-list because the demo surfaces (REST
+// /signals/*, /agents/*, /audience/*, etc.) all benefit from the
+// auto-trace and have no external schema constraint.
+const TRACE_INJECT_SKIP_PATHS: ReadonlySet<string> = new Set([
+  "/mcp",
+  "/mcp/",
+]);
+
 export async function injectTraceIfMissing(
   response: Response,
   path: string,
   start_ms: number,
   method: string,
 ): Promise<Response> {
+  // JSON-RPC envelope safety: skip MCP and any other path whose
+  // response shape is fixed by an external protocol contract.
+  if (TRACE_INJECT_SKIP_PATHS.has(path)) return response;
   const ct = response.headers.get("content-type") || "";
   if (!ct.toLowerCase().includes("application/json")) return response;
   // Skip non-2xx — caller wants the original error body intact.

--- a/tests/audienceMath.test.ts
+++ b/tests/audienceMath.test.ts
@@ -31,10 +31,10 @@ import {
 
 function sig(over: Partial<SignalSummary> & { signal_agent_segment_id: string }): SignalSummary {
   const base = {
-    signal_id: { source: "agent", agent_url: "https://x", id: over.signal_agent_segment_id },
+    signal_id: { source: "agent_native", agent_url: "https://x", id: over.signal_agent_segment_id },
     name: over.signal_agent_segment_id,
     description: "",
-    signal_type: "marketplace",
+    signal_type: "owned",
     data_provider: "test",
     coverage_percentage: 1,
     deployments: [],

--- a/tests/storyboard-conformance.test.ts
+++ b/tests/storyboard-conformance.test.ts
@@ -43,12 +43,16 @@ describe("get_signals response — storyboard signal_id requirement", () => {
     expect(summary.signal_id).toBeDefined();
   });
 
-  it("signals[].signal_id.source equals the agent discriminator", () => {
+  it("signals[].signal_id.source equals the agent_native discriminator", () => {
     // Per /schemas/core/signal-id.json — source is the discriminator. We're
     // an agent-native signals service (no upstream data-provider catalog),
-    // so the agent variant is the only correct value.
+    // so the agent_native variant is the only correct value.
+    //
+    // Sec-31w: AAO `signal_owned` storyboard's `search_owned_signals` step
+    // asserts the literal string "agent_native" (vs the older "agent"
+    // alias), so this test pins the spec-compliant value.
     const summary = toSignalSummary(makeFixtureSignal());
-    expect(summary.signal_id.source).toBe("agent");
+    expect(summary.signal_id.source).toBe("agent_native");
   });
 
   it("signals[].signal_id.agent_url is a valid https URL pointing at our MCP endpoint", () => {


### PR DESCRIPTION
## TL;DR

Two-part fix uncovered while diagnosing why AAO's `signal_owned` scenario track wouldn't run despite specialisms being correctly declared in #171/#172:

1. **CRITICAL:** Universal `injectTraceIfMissing` from #159 was adding `_trace` at the JSON-RPC top level on `/mcp` responses. **`@adcp/client` and AAO runner both reject this** as "Failed to discover MCP endpoint" because JSON-RPC 2.0 disallows sibling fields next to `result`. My hand-rolled curl tests didn't catch it (permissive parsers).
2. **Three signal-shape fixes** required by `signal_owned` storyboard per Addie's `get_storyboard_detail` output:
   - `signal_id.source` `"agent"` → `"agent_native"`
   - `signal_type` `"marketplace"` → `"owned"` for static catalog signals
   - Added agent-type deployment with `activation_key.type: "key_value"` alongside existing platform deployments

## Symptom (reproduced locally)

```
$ npx @adcp/client@latest https://adcp-signals-adaptor.evgeny-193.workers.dev/mcp get_adcp_capabilities '{}'
🔍 Auto-detecting protocol... ✓ Detected protocol: MCP
❌ ERROR: Failed to discover MCP endpoint.
  Tried: /mcp, /mcp/. None responded to MCP protocol.
```

The /mcp endpoint returned 200 + valid JSON-RPC body, but with `_trace` at the top level alongside `result`. Strict JSON-RPC parsers reject it. Curl was working only because I was inspecting the JSON manually rather than through the SDK.

## Part 1: MCP envelope (`src/utils/trace.ts`)

Added `TRACE_INJECT_SKIP_PATHS = new Set(["/mcp", "/mcp/"])`. Paths in this set bypass `injectTraceIfMissing` so JSON-RPC envelopes stay clean. Skip-list rather than allow-list because the demo surface (REST `/signals/*`, `/agents/*`, etc.) still benefits from auto-trace and has no protocol-shape constraint.

## Part 2: Signal shape (`src/mappers/signalMapper.ts` + `src/types/api.ts`)

Per AAO `get_storyboard_detail signal_owned`:

| Field | Was | Now |
|---|---|---|
| `signal_id.source` | `"agent"` | `"agent_native"` |
| `signal_type` (static signals) | `"marketplace"` | `"owned"` |
| Deployments | `[platform...]` | `[platform..., agent]` |
| Agent deployment shape | — | `{type:"agent", agent_url, is_live, activation_key:{type:"key_value", key:"signal_agent_segment_id", value:<sid>}}` |

`SignalDeployment.activation_key` type widened from `{type:string, segment_id:string}` to a discriminated union accepting both `segment_id` and `key_value` shapes per `/schemas/core/signal-deployment.json`.

## Tests updated

- `tests/audienceMath.test.ts` — fixture moved to new shape (no semantic test impact, just type compliance)
- `tests/storyboard-conformance.test.ts` — `expect(summary.signal_id.source).toBe("agent_native")` + comment explaining the AAO requirement

## Validation (all green)

```
npx tsc --noEmit                 → 0 errors
python tmp-mining/trap_audit.py  → CLEAN (0 traps × 37 files)
npx vitest run                   → 441 passed / 0 failed / 12 skipped
npx wrangler deploy --dry-run    → bundle ok
```

## Post-merge sanity

```bash
# Should now succeed (currently fails with "None responded to MCP protocol")
npx @adcp/client@latest https://adcp-signals-adaptor.evgeny-193.workers.dev/mcp get_adcp_capabilities '{}'
```

Then ask Addie to rerun `evaluate_agent_quality` / `run_storyboard` with `storyboard_id: "signal_owned"`. With both fixes live, the runner should:
1. Successfully handshake on `/mcp`
2. Read `specialisms: ["signal-owned"]`
3. Execute the four `signal_owned` phases (capabilities, search, filter, activate × 2)
4. Issue the **signal-owned specialty badge**

🤖 Generated with [Claude Code](https://claude.com/claude-code)