### PR TITLE
AAO signal_owned #174: revert source to agent + wire filter_by_criteria keys

### DIFF
--- a/src/mappers/signalMapper.ts
+++ b/src/mappers/signalMapper.ts
@@ -370,15 +370,17 @@ export function toSignalSummary(signal: CanonicalSignal): SignalSummary {
   return {
     // Universal signal_id required by the AdCP signals storyboard baseline.
     // We're an agent-native signals service (no upstream data-provider
-    // catalog), so source is "agent_native". The internal signalId already
+    // catalog), so source is "agent". The internal signalId already
     // matches the schema's `^[a-zA-Z0-9_-]+$` pattern.
     //
-    // Sec-31w: AAO's signal_owned storyboard's search_owned_signals step
-    // asserts literal "agent_native" (not "agent"). Two strings differ but
-    // mean the same thing for us; aligning here so the badge issuer
-    // accepts our shape.
+    // Sec-31w (PR #174): reverted from "agent_native" back to "agent"
+    // after Addie/AAO confirmed the schema's enum is { "catalog", "agent" }
+    // and AJV strict mode rejects any other value. The storyboard's prose
+    // description said "agent_native" but the schema is authority. AAO's
+    // run_storyboard signal_owned step 2 was failing on signal_id schema
+    // validation against all 5 signals before this revert.
     signal_id: {
-      source: "agent_native" as const,
+      source: "agent" as const,
       agent_url: SELF_AGENT_URL,
       id: signal.signalId,
     },

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -443,6 +443,22 @@ async function callGetSignals(
     const filters = args["filters"] as Record<string, unknown> | undefined;
     const pagination = args["pagination"] as Record<string, unknown> | undefined;
 
+    // Sec-31w: AAO `signal_owned` storyboard's `filter_by_criteria` step
+    // sends three filter keys we didn't previously honour:
+    //   - filters.max_cpm                — numeric ceiling on CPM ($)
+    //   - filters.min_coverage_percentage — numeric floor 0..1 or 0..100
+    //   - filters.signal_type             — "owned" | "marketplace" | "custom"
+    // Captured here for post-search filtering (the search service doesn't
+    // know about CPM/coverage thresholds; cheaper to filter the shaped
+    // SignalSummary payload than to thread three more args through it).
+    // Empty result is a valid response per storyboard spec — we don't
+    // throw on no-match, just return `signals: []`.
+    const maxCpm = numArgOrNull(filters?.["max_cpm"]);
+    const minCoveragePct = numArgOrNull(filters?.["min_coverage_percentage"]);
+    const signalTypeFilter = typeof filters?.["signal_type"] === "string"
+        ? (filters!["signal_type"] as string)
+        : null;
+
     const req = {
         ...compactObj({
             brief: (args["signal_spec"] ?? args["brief"]) as string | undefined,
@@ -472,6 +488,36 @@ async function callGetSignals(
     // canonical AdCP enum members — cast to satisfy the stricter typed
     // signature on searchSignalsService.
     const result = await searchSignalsService(db, env.SIGNALS_CACHE, req as SearchSignalsRequest);
+
+    // Sec-31w: post-search filter pass for the storyboard filter keys
+    // captured above. Each predicate is a no-op when its filter is null,
+    // so callers that omit these keys see the unfiltered result. Storyboard
+    // requires an empty array on no-match (NOT an error).
+    if (maxCpm !== null || minCoveragePct !== null || signalTypeFilter !== null) {
+        // min_coverage_percentage is documented as 0..1 in some places
+        // (decimal fraction) and 0..100 in others. Detect by magnitude:
+        // values >1 are treated as 0..100 percent, values 0..1 as fraction.
+        // Our coverage_percentage field is 0..100 (rounded one decimal).
+        const minCovPctNormalized = minCoveragePct !== null
+            ? (minCoveragePct <= 1 ? minCoveragePct * 100 : minCoveragePct)
+            : null;
+        result.signals = result.signals.filter((s) => {
+            if (signalTypeFilter !== null && s.signal_type !== signalTypeFilter) return false;
+            if (minCovPctNormalized !== null && (s.coverage_percentage ?? 0) < minCovPctNormalized) return false;
+            if (maxCpm !== null) {
+                const cheapest = (s.pricing_options ?? [])
+                    .filter((p): p is { pricing_option_id: string; model: "cpm"; cpm: number; currency: string } =>
+                        p.model === "cpm")
+                    .reduce((min, p) => (p.cpm < min ? p.cpm : min), Number.POSITIVE_INFINITY);
+                if (Number.isFinite(cheapest) && cheapest > maxCpm) return false;
+            }
+            return true;
+        });
+        // Recount totalCount + hasMore against the filtered set so the
+        // pagination contract stays internally consistent.
+        result.totalCount = result.signals.length;
+        result.hasMore = false;
+    }
 
     // Echo back the request's context block. Signals storyboard validates
     // `context.correlation_id` round-trips. Per /schemas/core/context.json,
@@ -735,6 +781,19 @@ export function numArg(v: unknown, fallback: number): number {
     if (v == null) return fallback;
     const n = Number(v);
     return Number.isNaN(n) ? fallback : n;
+}
+
+/**
+ * Variant of numArg() that returns `null` when the value is absent or
+ * non-numeric, instead of falling back to a default. Used by filter
+ * predicates where "filter not provided" is semantically distinct from
+ * "filter set to 0" (e.g. max_cpm = 0 means "free signals only" — not
+ * "no filter").
+ */
+function numArgOrNull(v: unknown): number | null {
+    if (v == null) return null;
+    const n = Number(v);
+    return Number.isNaN(n) ? null : n;
 }
 
 function rpcSuccess(id: string | number | null, result: unknown): JsonRpcSuccess {

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -81,17 +81,17 @@ export interface CustomSignalProposal {
 /**
  * Universal signal identifier per /schemas/core/signal-id.json.
  * Discriminated by `source`. We're a self-contained signals agent (not a
- * data-provider catalog mirror), so every signal we expose is the
- * `agent_native` variant — schema requires `source`, `agent_url`, `id`.
+ * data-provider catalog mirror), so every signal we expose is the `agent`
+ * variant — schema requires `source`, `agent_url`, `id`.
  *
- * Sec-31w: AAO `signal_owned` storyboard requires `source: "agent_native"`
- * (not `"agent"`). The two are semantically equivalent for our agent
- * (we ARE the source, not a wrapper around an external data provider),
- * but the storyboard's `search_owned_signals` step asserts the literal
- * string. Aligned to spec here so the badge issuer accepts our shape.
+ * Sec-31w: PR #173 briefly flipped this to "agent_native" based on the
+ * AAO `signal_owned` storyboard's prose description; PR #174 reverted
+ * after Addie confirmed the schema's enum is { "catalog", "agent" } and
+ * AJV strict mode rejects any other value. Storyboard description was
+ * prose, not normative. Schema is authority.
  */
 export interface SignalIdAgent {
-  source: "agent_native";
+  source: "agent";
   agent_url: string;
   id: string;
 }

--- a/tests/audienceMath.test.ts
+++ b/tests/audienceMath.test.ts
@@ -31,7 +31,7 @@ import {
 
 function sig(over: Partial<SignalSummary> & { signal_agent_segment_id: string }): SignalSummary {
   const base = {
-    signal_id: { source: "agent_native", agent_url: "https://x", id: over.signal_agent_segment_id },
+    signal_id: { source: "agent", agent_url: "https://x", id: over.signal_agent_segment_id },
     name: over.signal_agent_segment_id,
     description: "",
     signal_type: "owned",

--- a/tests/storyboard-conformance.test.ts
+++ b/tests/storyboard-conformance.test.ts
@@ -43,16 +43,17 @@ describe("get_signals response — storyboard signal_id requirement", () => {
     expect(summary.signal_id).toBeDefined();
   });
 
-  it("signals[].signal_id.source equals the agent_native discriminator", () => {
-    // Per /schemas/core/signal-id.json — source is the discriminator. We're
-    // an agent-native signals service (no upstream data-provider catalog),
-    // so the agent_native variant is the only correct value.
+  it("signals[].signal_id.source equals the agent discriminator", () => {
+    // Per /schemas/core/signal-id.json — source enum is {"catalog","agent"}.
+    // We're an agent-native signals service (no upstream data-provider
+    // catalog), so the "agent" variant is the only correct value.
     //
-    // Sec-31w: AAO `signal_owned` storyboard's `search_owned_signals` step
-    // asserts the literal string "agent_native" (vs the older "agent"
-    // alias), so this test pins the spec-compliant value.
+    // Sec-31w (PR #174): pinned to "agent" after PR #173 had briefly
+    // flipped to "agent_native" based on storyboard prose. AJV strict
+    // validation against the published schema rejects "agent_native";
+    // the schema enum is the authority.
     const summary = toSignalSummary(makeFixtureSignal());
-    expect(summary.signal_id.source).toBe("agent_native");
+    expect(summary.signal_id.source).toBe("agent");
   });
 
   it("signals[].signal_id.agent_url is a valid https URL pointing at our MCP endpoint", () => {


### PR DESCRIPTION
## TL;DR

Two-part fix from Addie's `run_storyboard signal_owned` output on the post-#173 deploy:

1. **Revert `signal_id.source`** `"agent_native"` → `"agent"`. Schema authority: enum is `{"catalog","agent"}`. AJV strict was rejecting all 5 signals on step 2 (`search_owned_signals`). PR #173 set it to `"agent_native"` based on storyboard prose; Addie pulled the schema and confirmed prose was wrong.
2. **Wire three storyboard filter keys** (`max_cpm`, `min_coverage_percentage`, `signal_type`) so step 3 `filter_by_criteria` demonstrates real filter behaviour instead of unfiltered passthrough.

Everything else from #173 stays — `signal_type: "owned"`, agent deployment with `key_value` activation_key, MCP envelope `_trace` skip-list. All correct per schema.

## Part 1: signal_id.source revert

| File | Change |
|---|---|
| `src/types/api.ts` | `SignalIdAgent.source: "agent_native"` → `"agent"` + comment |
| `src/mappers/signalMapper.ts` | emitter literal + comment |
| `tests/audienceMath.test.ts` | fixture |
| `tests/storyboard-conformance.test.ts` | assertion + comment |

Storyboard description was prose, schema is authority. Schema enum is `{"catalog","agent"}` only. Logged in commit message so this isn't relitigated.

## Part 2: filter_by_criteria support

`src/mcp/server.ts callGetSignals()` now honors three additional filter keys per the `filter_by_criteria` scenario:

| Filter | Behaviour |
|---|---|
| `filters.max_cpm` | Numeric ceiling on cheapest CPM pricing option ($) |
| `filters.min_coverage_percentage` | Numeric floor; auto-detects 0..1 fraction vs 0..100 percent (we emit 0..100) |
| `filters.signal_type` | `"owned"` \| `"marketplace"` \| `"custom"` exact match |

Implementation: post-search filter pass on the `SignalSummary` array. Cheaper than threading three more args through `searchSignalsService` (which knows query/category/taxonomy, not pricing/coverage). Each predicate is a no-op when its filter is null, so existing callers see unchanged behaviour.

Empty result is a valid response (storyboard explicitly NOT an error). `totalCount` + `hasMore` are recomputed against the filtered set so pagination contract stays internally consistent.

New `numArgOrNull()` helper because `max_cpm: 0` semantically means "free signals only" and must be distinct from "no filter."

## Validation (all green)

```
npx tsc --noEmit                 → 0 errors
python tmp-mining/trap_audit.py  → CLEAN (0 traps × 37 files)
npx vitest run                   → 441 passed / 0 failed / 12 skipped
npx wrangler deploy --dry-run    → bundle ok
```

## Post-merge

```bash
# Filter sanity
curl -s -X POST -H 'Content-Type: application/json' \
  -d '{"jsonrpc":"2.0","method":"tools/call","id":1,"params":{"name":"get_signals","arguments":{"filters":{"max_cpm":5,"signal_type":"owned"}}}}' \
  https://adcp-signals-adaptor.evgeny-193.workers.dev/mcp \
  | jq '.result.content[0].text | fromjson | .signals | length'
# → fewer than 5 (filtered)
```

Then ask Addie to rerun `run_storyboard signal_owned`. Step 2 should pass schema validation; step 3 should exercise real filtering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)