### PR TITLE
AAO #178: accept signal_spec object form + fix demo pagination read

### DIFF
--- a/src/demo/script/fragments/discover.ts
+++ b/src/demo/script/fragments/discover.ts
@@ -376,7 +376,13 @@ async function loadCatalog() {
       });
       const batch = (data.signals || []).filter((s) => s.signal_type !== "custom");
       all.push(...batch);
-      if (!data.hasMore || batch.length === 0) break;
+      // Sec-31z: read pagination defensively — MCP responses now use
+      // the v3 nested shape (data.pagination.has_more) per AAO
+      // pagination_walk requirements; legacy v2 shape (data.hasMore)
+      // is read as a fallback so this loop survives any future shape
+      // revert. Either shape signals "fetch more" via boolean truthy.
+      const hasMore = data.pagination?.has_more ?? data.hasMore;
+      if (!hasMore || batch.length === 0) break;
       offset += 100;
       if (offset > 1000) break; // safety — catalog shouldn't exceed this
     }

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -459,9 +459,26 @@ async function callGetSignals(
         ? (filters!["signal_type"] as string)
         : null;
 
+    // Sec-31z: AAO v3 sends `signal_spec` as an OBJECT — { brief: "..." }
+    // — not a bare string. Older callers (and our REST surface) still
+    // send a plain string. Accept both, plus the older `brief` arg, and
+    // collapse to a string for the search service.
+    //
+    // Without this normalisation, `(args["signal_spec"] ?? args["brief"])
+    // as string` cast through an object → downstream toLowerCase / regex
+    // etc. throws → the whole MCP tools/call request returns a -32603
+    // Internal error. AAO's pagination_walk check failed on this exact
+    // crash (NOT on the pagination shape itself).
+    const rawSignalSpec = args["signal_spec"];
+    const briefFromSpec = typeof rawSignalSpec === "string"
+        ? rawSignalSpec
+        : (rawSignalSpec && typeof rawSignalSpec === "object" && !Array.isArray(rawSignalSpec)
+            ? (rawSignalSpec as Record<string, unknown>)["brief"] as string | undefined
+            : undefined);
+
     const req = {
         ...compactObj({
-            brief: (args["signal_spec"] ?? args["brief"]) as string | undefined,
+            brief: briefFromSpec ?? (args["brief"] as string | undefined),
             query: (filters?.["query"] ?? args["query"]) as string | undefined,
             categoryType: (filters?.["category_type"] ?? args["categoryType"]) as string | undefined,
             generationMode: (filters?.["generation_mode"] ?? args["generationMode"]) as string | undefined,

--- a/tests/__snapshots__/demo-render-snapshot.test.ts.snap
+++ b/tests/__snapshots__/demo-render-snapshot.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`handleDemo byte-equivalence > matches the committed golden hash (LF-normalized SHA-256 of body) 1`] = `
 {
-  "hash": "4229c4b83cf3a61be6801eb04de55c407198566784eba3291324f2058bc76718",
-  "length": 1095004,
+  "hash": "099ecb9dec6606601d548c9a4b2e9502ec1bf3f20d272f54c8737be379b8c68a",
+  "length": 1095409,
 }
 `;


### PR DESCRIPTION
## TL;DR (and direct answer to your "will this break my demo" question)

**Yes #177 broke ONE place in the demo — fixed in this PR.** Net effect after #178 merges: demo works AND AAO compliance works.

**Root cause finally found** for AAO's repeating failures: `get_signals` was crashing with `-32603 Internal error` because v3 sends `signal_spec` as an OBJECT (`{ brief: "test" }`) and our handler cast it to string blindly. Downstream `toLowerCase`/regex blew up on the object. AAO's `pagination_walk` was failing on this CRASH — not on the pagination shape.

## What this PR fixes

### Fix 1: `signal_spec` accepts object form (the AAO crash)

`src/mcp/server.ts callGetSignals` now handles both shapes:
- `string` → use directly (legacy callers)
- `{ brief: "..." }` → extract `.brief` (v3 callers, AAO runner)
- Falls back to `args.brief` for older callers

The TypeScript cast `as string | undefined` was a lie — runtime value was an object. `toLowerCase()` etc. throws on objects → uncaught exception → MCP `-32603 Internal error`. Hand-rolled curl tests didn't catch it because I always sent the legacy string form.

### Fix 2: demo pagination read (the regression #177 introduced)

`src/demo/script/fragments/discover.ts` was reading `data.hasMore` from MCP. PR #177 moved that to `data.pagination.has_more`. The demo's catalog-load loop would have stopped after the first 5 signals instead of paginating through all 521. Now reads both shapes defensively:

```js
const hasMore = data.pagination?.has_more ?? data.hasMore;
```

Snapshot golden updated.

### NOT-A-BUG: `agent_activation` "still failing" per AAO

Live curl with your exact quoted runner payload (`destinations: [{type:"agent", agent_url:"https://wonderstruck...."}]`) returns `deployments[0].type: "agent"` cleanly on prod. AAO's evaluate_agent_quality almost certainly cached the prior verdict before #176 deployed; a fresh post-#178 run should overwrite it.

## Will this break the demo?

| Demo surface | Pre-#177/#178 | Post-#178 |
|---|---|---|
| Catalog load loop (`get_signals` → all 521 signals) | reads `data.hasMore` | reads `data.pagination?.has_more ?? data.hasMore` ✅ defensive |
| Activation flow (`activate_signal`) | reads `act.task_id` (still present) | unchanged ✅ |
| MCP Inspector display | renders raw JSON (visual only) | renders new shape (no functional break) ✅ |
| All REST endpoints (`/signals/search`, `/audience/*`, `/portfolio/*`, etc.) | flat shape | unchanged ✅ |

**Net: workshop demo unaffected after #178.**

## Validation (all green)

```
npx tsc --noEmit                 → 0 errors
python tmp-mining/trap_audit.py  → CLEAN (0 traps × 37 files)
npx vitest run                   → 441 passed / 0 failed / 12 skipped
npx wrangler deploy --dry-run    → bundle ok
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)