### PR TITLE
AAO #179: schema-grounded payload purity + correct pagination shape

### DIFF
--- a/src/demo/script/fragments/detail-panel.ts
+++ b/src/demo/script/fragments/detail-panel.ts
@@ -659,7 +659,16 @@ async function activateFromDetail(sig) {
       signal_agent_segment_id: sid,
       deliver_to: { deployments: [{ type: "platform", platform: "mock_dsp" }], countries: ["US"] },
     });
-    const taskId = act.task_id;
+    // Sec-31w-final: AdCP v3 spec moves task_id off the activate-signal
+    // response payload (envelope-level per protocol-envelope.json).
+    // MCP server now emits it inside ext for clients that need to poll.
+    // Read both shapes for backward-compat: top-level first, then ext.
+    const taskId = act.task_id ?? act.ext?.task_id;
+    if (!taskId) {
+      status.className = "activation-status success";
+      status.textContent = "✓ activated (sync, no task to poll)";
+      return;
+    }
     status.innerHTML = '<span class="spinner"></span> polling task ' + taskId.slice(0, 14) + '…';
 
     let finalState = null;

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -536,49 +536,60 @@ async function callGetSignals(
         result.hasMore = false;
     }
 
-    // Sec-31z: AAO `pagination_walk` envelope cleanup.
+    // Sec-31w-final: pagination shape grounded in authoritative schema.
     //
-    // searchSignalsService returns a response with these top-level
-    // fields aimed at REST callers + the demo trace inspector:
-    //   message, context_id, signals, count, totalCount, offset,
-    //   hasMore, _trace
+    // /schemas/source/core/pagination-response.json (HEAD) defines:
+    //   {
+    //     "has_more":   boolean   (REQUIRED),
+    //     "cursor":     string    (optional, only when has_more=true),
+    //     "total_count": integer  (optional)
+    //   }
+    //   "additionalProperties": false
     //
-    // AAO's get_signals_pagination_integrity check expects a v3-style
-    // envelope: pagination structured under a single sub-object, no
-    // legacy v2 flat fields, and no debugging _trace at top level.
+    // The strict additionalProperties:false means ANY extra field
+    // (page_size, offset, next_offset, etc.) FAILS schema validation
+    // under AJV strict mode. PR #177's pagination block included
+    // page_size/offset/next_offset — those were guesses, not
+    // schema-compliant. Reverted here to the literal three-field shape.
     //
-    // This block normalises the MCP-returned shape ONLY (REST
-    // /signals/search keeps its existing flat shape so other clients
-    // that depend on it don't break):
-    //   - strip _trace (UI-only debugging field)
-    //   - strip count, totalCount, offset, hasMore from top level
-    //   - emit pagination: { total_count, page_size, offset, has_more,
-    //                        next_offset? } as a single sub-object
-    const pageSize = (req as { limit: number }).limit;
+    // We don't emit `cursor` because we're not actually cursor-paginated
+    // — our pagination is offset-based on the search result set. Buyers
+    // who need a "next page" pass max_results + offset on the next
+    // request. cursor: undefined is permitted by the schema (optional
+    // field).
     const pageOffset = (req as { offset: number }).offset;
     const totalCount = (result as { totalCount: number }).totalCount;
     const hasMore = pageOffset + result.signals.length < totalCount;
     const paginationBlock = {
-        total_count: totalCount,
-        page_size: pageSize,
-        offset: pageOffset,
         has_more: hasMore,
-        ...(hasMore ? { next_offset: pageOffset + result.signals.length } : {}),
+        total_count: totalCount,
     };
 
     // Echo back the request's context block. Signals storyboard validates
     // `context.correlation_id` round-trips. Per /schemas/core/context.json,
-    // context is opaque — copy through unchanged. Same pattern as
-    // get_adcp_capabilities.
+    // context is opaque — copy through unchanged.
     const ctx = args["context"];
 
-    // Build the v3-clean response. Only message, context_id, signals,
-    // pagination, and (optionally) context survive; legacy fields are
-    // dropped. proposals (when present) is preserved as it's an AdCP-
-    // native field, not a v2 holdover.
+    // Sec-31w-final: get-signals-response payload per spec. Authoritative
+    // schema (/schemas/source/protocol/signals/get-signals-response.json):
+    //
+    //   required: [signals]
+    //   properties: signals, errors, pagination, sandbox, context, ext
+    //   additionalProperties: true
+    //
+    // Envelope-only fields (NOT in payload): context_id, task_id, status,
+    // message, timestamp, replayed, adcp_error. These belong on
+    // protocol-envelope.json (the MCP/A2A/REST layer wrapper) per its
+    // header text:
+    //   "Task response schemas should NOT include these fields — they
+    //    are protocol-level concerns."
+    //
+    // PR #177's normalisation kept message + context_id at top level as
+    // legacy holdovers; this finalisation removes them along with the
+    // demo-trace _trace and the v2 flat fields (count/totalCount/
+    // offset/hasMore). Result is a payload that is structurally
+    // schema-clean.
     const cleanResponse: Record<string, unknown> = {
-        message: (result as { message: string }).message,
-        context_id: (result as { context_id: string }).context_id,
         signals: result.signals,
         pagination: paginationBlock,
     };
@@ -690,20 +701,39 @@ async function callActivateSignal(
             ? { context: ctx as Record<string, unknown> }
             : {};
 
-        // Sec-31z: AAO v3_envelope_integrity — top-level `status` is
-        // the v2 holdover Addie flagged. v3 conveys success via the
-        // presence of valid deployments + message; status was always
-        // a duplicate signal. Removed from both success + synthetic
-        // paths. task_id is preserved (no schema-authoritative reason
-        // to rename it; will revisit if envelope_integrity surfaces it
-        // as a new finding).
-        const specResponse = {
-            task_id: result.task_id,
-            signal_agent_segment_id: signalId,
+        // Sec-31w-final: activate-signal-response payload per spec.
+        // Authoritative schema (/schemas/source/signals/activate-signal-
+        // response.json) is a oneOf {success, error}:
+        //   success: required [deployments]
+        //            optional sandbox, context, ext
+        //            additionalProperties: true
+        //
+        // Envelope-only fields (per protocol-envelope.json header):
+        //   "Task response schemas should NOT include these fields"
+        //   → context_id, task_id, status, message, timestamp,
+        //     replayed, adcp_error
+        //
+        // Stripped from this payload: task_id, status (was already gone),
+        //   message, context_id, pricing_option_id, signal_agent_segment_id,
+        //   webhook_url at top level. None are in the activate-signal-
+        //   response schema's properties; while additionalProperties:true
+        //   permits them, they pollute the protocol-vs-payload boundary
+        //   that the AAO envelope_integrity check enforces.
+        //
+        // BUT: our demo's poll loop reads task_id off the response to
+        // call get_operation_status. To keep the demo working without
+        // re-polluting the payload, the task_id rides inside `ext`
+        // (which IS in the payload schema's properties). Demo reads
+        // `act.task_id ?? act.ext?.task_id` — backward-compat aware.
+        const specResponse: Record<string, unknown> = {
             deployments: responseDeployments,
-            ...(webhookUrl ? { webhook_url: webhookUrl } : {}),
-            ...(pricingOptionId ? { pricing_option_id: pricingOptionId } : {}),
             ...contextEcho,
+            ext: {
+                task_id: result.task_id,
+                ...(webhookUrl ? { webhook_url: webhookUrl } : {}),
+                ...(pricingOptionId ? { pricing_option_id: pricingOptionId } : {}),
+                signal_agent_segment_id: signalId,
+            },
         };
 
         return toolResult(JSON.stringify(specResponse, null, 2), specResponse);
@@ -822,25 +852,17 @@ async function callActivateSignal(
                 });
             const responseDeployments = [leadDeployment, ...trailingDeployments];
             const ctx = args["context"];
-            const correlationId = (ctx && typeof ctx === "object" && !Array.isArray(ctx)
-                ? (ctx as Record<string, unknown>)["correlation_id"]
-                : undefined) as string | undefined;
             const contextEcho = ctx && typeof ctx === "object" && !Array.isArray(ctx)
                 ? { context: ctx as Record<string, unknown> }
                 : {};
-            const syntheticResponse = {
-                // v3 envelope: message + context_id + deployments are
-                // the protocol-meaningful fields. status removed (v2
-                // holdover per Addie's envelope_integrity check).
-                // task_id preserved (no schema-authoritative reason to
-                // rename yet; envelope_integrity will surface it if so).
-                message: "Signal activated (synthetic response for unknown segment ID)",
-                context_id: correlationId ?? `ctx_synthetic_${Date.now()}_${signalId}`.slice(0, 64),
-                task_id: `task_synthetic_${Date.now()}_${signalId}`.slice(0, 64),
-                signal_agent_segment_id: signalId,
+            // Sec-31w-final: synthetic response also payload-pure per
+            // activate-signal-response schema. correlationId tracking
+            // (was used for the now-removed context_id field) is
+            // dropped; the request's context block — which carries the
+            // storyboard's correlation_id — already echoes back
+            // unchanged via contextEcho.
+            const syntheticResponse: Record<string, unknown> = {
                 deployments: responseDeployments,
-                ...(webhookUrl ? { webhook_url: webhookUrl } : {}),
-                ...(pricingOptionId ? { pricing_option_id: pricingOptionId } : {}),
                 ...contextEcho,
             };
             logger.warn("activate_unknown_signal_synthetic", { signalId });

--- a/tests/__snapshots__/demo-render-snapshot.test.ts.snap
+++ b/tests/__snapshots__/demo-render-snapshot.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`handleDemo byte-equivalence > matches the committed golden hash (LF-normalized SHA-256 of body) 1`] = `
 {
-  "hash": "099ecb9dec6606601d548c9a4b2e9502ec1bf3f20d272f54c8737be379b8c68a",
-  "length": 1095409,
+  "hash": "b136c33ca57419946a2bdcd1f03518d50843bfda8b2fcd3e533ccf637b0e5759",
+  "length": 1095875,
 }
 `;

--- a/tmp-mining/trap_audit.py
+++ b/tmp-mining/trap_audit.py
@@ -251,6 +251,36 @@ def main() -> int:
     print(f"Auditing {len(targets)} files for SCRIPT_TAG escape traps...")
     print()
 
+    # Sec-31w-final: Trap-5 — ODD number of unescaped backticks in
+    # source. The region-based audit above can be fooled by a backtick
+    # in a comment INSIDE the template literal, because that backtick
+    # closes the outer literal early and the audit then treats
+    # everything after as "outside the region." When that happens, the
+    # file has an odd backtick count overall (well-formed template
+    # literals always come in matched pairs).
+    #
+    # Cheap-and-correct check: count unescaped backticks in each file.
+    # An odd count is unconditionally a syntax bug — TypeScript will
+    # fail to compile, but the audit runs faster than tsc and surfaces
+    # the location in the same report.
+    odd_backtick_files: list[tuple[str, int]] = []
+    for path in targets:
+        text = path.read_text(encoding="utf-8")
+        count = 0
+        i = 0
+        while i < len(text):
+            if text[i] == BACKTICK:
+                bs = 0
+                k = i - 1
+                while k >= 0 and text[k] == BS:
+                    bs += 1
+                    k -= 1
+                if bs % 2 == 0:
+                    count += 1
+            i += 1
+        if count % 2 != 0:
+            odd_backtick_files.append((path.relative_to(REPO_ROOT).as_posix(), count))
+
     for path in targets:
         rel = path.relative_to(REPO_ROOT).as_posix()
         traps_apo, traps_esc, traps_regex, traps_bt = audit_file(path)
@@ -282,6 +312,14 @@ def main() -> int:
         total_bt += len(traps_bt)
 
     print(f"Totals  Trap1={total_apo}  Trap2={total_esc}  Trap3={total_regex}  Trap4={total_bt}")
+    if odd_backtick_files:
+        any_findings = True
+        print()
+        print("Trap 5 — ODD unescaped backtick count (unmatched template literal):")
+        for rel, count in odd_backtick_files:
+            print(f"  {rel}: {count} unescaped backticks")
+        print("  (One often hides in a comment inside the template literal — search")
+        print("   for ` and replace with single quotes or backslash-escape: \\`)")
     if any_findings:
         print()
         print("REMEDIATION:")


### PR DESCRIPTION
## Why this PR is different from #171-#178

**Stopped the reactive-fix cycle.** Pulled the authoritative AdCP HEAD schemas directly from `adcontextprotocol/adcp@HEAD` and audited our wire surface against them line-by-line. Every change in this PR cites a specific schema file.

PRs #171-#178 chased Addie's prose theories. Some were right, some were guesses, some were hallucinations (I have a memory note that the AAO chat "has historically hallucinated diagnoses"). This PR doesn't trust theories — only schemas.

## Three real gaps (with citations)

### Gap 1: pagination shape

**Schema:** `/schemas/source/core/pagination-response.json`

```json
required:                ["has_more"]
properties:              has_more, cursor, total_count
additionalProperties:    false   ← strict gate
```

PR #177 emitted `page_size`, `offset`, `next_offset` alongside the three permitted fields. AJV strict rejects them. Fixed: shape is now exactly `{has_more, total_count}`.

### Gap 2: payload vs envelope confusion

**Schema:** `/schemas/source/core/protocol-envelope.json` — literal header text:

> "This envelope is added by the protocol layer (MCP, A2A, REST) and wraps the task-specific response payload. **Task response schemas should NOT include these fields — they are protocol-level concerns.**"

Envelope-only fields: `context_id, task_id, status, message, timestamp, replayed, adcp_error`

We've been emitting them all INSIDE the payload. Stripped:

| Tool | Stripped from payload | Kept in payload |
|---|---|---|
| `activate_signal` | `task_id, status, message, context_id, pricing_option_id, signal_agent_segment_id, webhook_url` | `deployments, context, ext` |
| `get_signals` | `message, context_id, _trace, count, totalCount, offset, hasMore` | `signals, pagination, context, proposals` |

### Gap 3: task_id under ext (demo back-compat)

The demo's `detail-panel.ts` polls `get_operation_status` with `act.task_id`. After Gap 2's strip, that field is gone. Solution: emit `task_id` inside `ext` (which IS in the payload schema's properties):

```js
response.ext = { task_id, signal_agent_segment_id, pricing_option_id?, webhook_url? }
```

Demo updated to `act.task_id ?? act.ext?.task_id` (backward-compat).

## Bonus: Trap-5 added to trap_audit.py

While building this fix I introduced an unescaped backtick in a JSDoc comment inside the inlined-JS template literal — that closed the outer literal early. tsc caught it; the region-based audit did not (the accidental close was treated as a legit boundary).

**Trap-5**: count unescaped backticks per file. Odd count is unconditionally a bug (well-formed template literals come in matched pairs). Surfaces the file + count.

## Validation (all green)

```
npx tsc --noEmit                 → 0 errors
python tmp-mining/trap_audit.py  → CLEAN (Trap1-5 × 37 files)
npx vitest run                   → 441 passed / 0 failed / 12 skipped
npx wrangler deploy --dry-run    → bundle ok
```

Snapshot golden hash updated for the demo's `detail-panel.ts` edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)