### PR TITLE
AAO: emit pagination.cursor when has_more=true

### DIFF
--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -496,7 +496,18 @@ async function callGetSignals(
         // response make pagination discoverable. Callers who want the
         // bigger page still pass `max_results` explicitly.
         limit: numArg(args["max_results"], numArg(args["limit"], 5)),
-        offset: numArg(pagination?.["offset"], numArg(args["offset"], 0)),
+        // Sec-31w-cursor: callers can paginate via either explicit
+        // pagination.offset (legacy) OR pagination.cursor (v3 / what we
+        // emit when has_more=true). Cursor format is "offset:<int>".
+        // Falls through to 0 if neither is set or cursor is malformed.
+        offset: (() => {
+            const c = pagination?.["cursor"];
+            if (typeof c === "string" && c.startsWith("offset:")) {
+                const n = parseInt(c.slice(7), 10);
+                if (!isNaN(n) && n >= 0) return n;
+            }
+            return numArg(pagination?.["offset"], numArg(args["offset"], 0));
+        })(),
     };
 
     const db = getDb(env);
@@ -560,10 +571,20 @@ async function callGetSignals(
     const pageOffset = (req as { offset: number }).offset;
     const totalCount = (result as { totalCount: number }).totalCount;
     const hasMore = pageOffset + result.signals.length < totalCount;
-    const paginationBlock = {
+    // Sec-31w-cursor: when has_more=true, emit an opaque cursor string.
+    // The pagination-response schema declares cursor as optional, but
+    // AAO's runner asserts that has_more=true REQUIRES cursor (so the
+    // caller knows how to fetch the next page). Cursor format is
+    // intentionally opaque per schema; we encode the next offset so
+    // round-tripping is straightforward but the caller doesn't need
+    // to parse it — pass it back in pagination.cursor on the next
+    // request and we resolve.
+    const nextOffset = pageOffset + result.signals.length;
+    const paginationBlock: Record<string, unknown> = {
         has_more: hasMore,
         total_count: totalCount,
     };
+    if (hasMore) paginationBlock["cursor"] = `offset:${nextOffset}`;
 
     // Echo back the request's context block. Signals storyboard validates
     // `context.correlation_id` round-trips. Per /schemas/core/context.json,


### PR DESCRIPTION
## TL;DR

One-field fix for AAO's `pagination_walk` runner check. PR #179 made the pagination block schema-clean (only `has_more` + `total_count`). AAO's runner applies an extra semantic assertion beyond the schema: `has_more: true` MUST come with `cursor`. This adds it.

## Fix

**Output side** (`callGetSignals` response):
```js
if (hasMore) paginationBlock["cursor"] = `offset:${nextOffset}`;
```

**Input side** (round-trip support):
```js
const c = pagination?.["cursor"];
if (typeof c === "string" && c.startsWith("offset:")) {
  const n = parseInt(c.slice(7), 10);
  if (!isNaN(n) && n >= 0) return n;
}
// fall back to pagination.offset / args.offset / 0
```

Cursor format is `"offset:<int>"` — intentionally opaque per the schema's "opaque cursor" description. Callers don't parse it; they just pass it back.

## Why this beyond the schema

`pagination-response.json` declares `cursor` as optional. AAO's runner asserts cursor is required when has_more=true. That's stricter than spec but reasonable: "you said there's more, how do I get there?" Cheap to satisfy.

## What this PR does NOT address

Two other AAO findings remain, both NOT reproducible against live prod:

| Finding | Status |
|---|---|
| `envelope_integrity_check` asserts `status` field on MCP envelope | **Filed as runner bug by AAO** — MCP transport doesn't have a `status` envelope field per spec; protocol-envelope.json is REST/A2A only |
| `agent_activation` returns `type: "platform"` + `_message` field | **Not reproducible.** Live curl shows `type: "agent"` cleanly post-#179. `_message` field has never appeared in any version of our code (zero hits across `src/` and `scripts/`). Wrangler deployments are atomic 100% splits — no half-deployed isolate state on Cloudflare Workers. AAO's `run_storyboard_step` is reading cached responses from before #179. |

## Validation (all green)

```
npx tsc --noEmit                 → 0 errors
python tmp-mining/trap_audit.py  → CLEAN (Trap1-5 × 37 files)
npx vitest run                   → 441 passed / 0 failed / 12 skipped
npx wrangler deploy --dry-run    → bundle ok
node tmp-mining/validate_against_spec.mjs → 6/6 passing against @adcp/sdk@3.0.1
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)