### PR TITLE
Workshop prep: pre-flight runbook + script refresh + audit fix

### DIFF
--- a/docs/WORKSHOP_DEMO_SCRIPT.md
+++ b/docs/WORKSHOP_DEMO_SCRIPT.md
@@ -2,7 +2,18 @@
 
 **For:** "Mini Governance & Signals Workshop — AAO" · May 7, 2026 · 9–12 NYC · iHeartMedia (in-person + remote)
 **Live reference:** https://adcp-signals-adaptor.evgeny-193.workers.dev/ → **Orchestrator** tab
-**Companion:** [WORKSHOP_BLOCK1_EXHIBITS.md](./WORKSHOP_BLOCK1_EXHIBITS.md) — signal-definition card, boundary diagram, trust contract strawman.
+**Companions:**
+- [WORKSHOP_BLOCK1_EXHIBITS.md](./WORKSHOP_BLOCK1_EXHIBITS.md) — signal-definition card, boundary diagram, trust contract strawman.
+- [WORKSHOP_PRE_FLIGHT.md](./WORKSHOP_PRE_FLIGHT.md) — morning-of runbook, smoke commands, anticipated Q&A.
+
+**Status badge openers** (refresh on the morning of):
+
+| Lever | What | Live verification |
+|---|---|---|
+| **AAO Verified for Signals** | 21/21 core + 9/9 signals storyboards passing under AAO's `evaluate_agent_quality` runner. | Mention as credibility — "we passed AAO's compliance suite end to end." |
+| **AdCP 3.0.1 envelope binding** | MCP `structuredContent` carries `status` at top level (per `mcp-response-extraction.mdx` test vectors). Drove [adcp#3999](https://github.com/adcontextprotocol/adcp/issues/3999) ruling. | This is the resolution to gap #5 (was MCP-shape ambiguity); see §3 below. |
+| **Compliance suite** | `@adcp/client testAllScenarios` — **7/7** scenarios (signals_flow 9/9). | `npm run compliance` against prod. |
+| **Pre-demo audit** | 68/68 surface checks against prod (REST + MCP + LinkedIn + CORS + error paths). | `node scripts/pre-demo-audit.mjs`. |
 
 ---
 
@@ -15,7 +26,15 @@ Before opening the orchestrator:
 - **What we listen on:** measurement / attribution / lift (DV/IAS/Comscore/Nielsen own the floor), identity resolution (LiveRamp), attention measurement (Triton), IVT/fraud (Human/DV).
 - **What we volunteer to own** in the working committee: response-shape convention (gap #5) + brand-context primitive harmonization (gap #2). Both are concrete, scoped, and we can lead on a draft spec.
 
-Open the Orchestrator tab. Header chrome reads: **19 agents** in directory · **12 alive** · **~2s avg latency**. That's the credibility opener — we are speaking from interop reality, not slideware.
+Open the Orchestrator tab. Header chrome reads (live numbers — refresh on the morning of via `curl /agents/probe-all`): **~15 agents** in directory · **~11 alive** · **~2s avg latency**. That's the credibility opener — we are speaking from interop reality, not slideware.
+
+Currently-down vendors as of last smoke (2026-05-03) — useful to acknowledge live so the room sees us read the dashboard honestly:
+
+- `claire_scope3` — operation timeout
+- `setupad_gatavocom`, `setupad_wheelrandom` — HTTP 502 (vendor-side)
+- `mamamia` — HTTP 405 (probe method mismatch; not a real outage)
+
+The morning-of pre-flight (see [WORKSHOP_PRE_FLIGHT.md](./WORKSHOP_PRE_FLIGHT.md)) re-checks these so you walk in with the actual count.
 
 ---
 
@@ -66,7 +85,7 @@ Then surface the **6 implementation-observed gaps** (canonical, the workshop's g
 2. **Two distinct schema families for brand context.** Adzymic + Swivel use `brand_manifest: BrandManifest`. Claire + Content Ignite use top-level `brand: BrandReference` with `{domain, name}` — Claire's rejection cited the AdCP spec by URL. Not field-name drift; entirely different object contracts.
 3. **`packages[].buyer_ref`, `pricing_option_id`, scalar `budget`** — required by every known buying vendor's validator, NOT in the spec's required list. Implementation drift hardened.
 4. **`filters.format_ids` shape.** Spec wants `FormatId{agent_url, id}`; only `adzymic_apx` tolerates `string[]`. Five other agents reject Sec-48q's strings.
-5. **MCP response-shape optionality.** Celtra wraps JSON inside text blocks; most use `structuredContent`; Swivel embeds errors in a structured result. All three are spec-compliant. Naive extractors miss data.
+5. **MCP response-shape optionality.** Celtra wraps JSON inside text blocks; most use `structuredContent`; Swivel embeds errors in a structured result. All three were spec-compliant against the body schemas — the gap was at the *transport binding* level (where `status` lives in `structuredContent`). [adcp#3999](https://github.com/adcontextprotocol/adcp/issues/3999) ruled `status` must be at the top of `structuredContent` (per `mcp-response-extraction.mdx`); we shipped envelope binding accordingly. Naive extractors that only checked body schemas missed the binding requirement — that's the durable lesson.
 6. **Creative-agent surfaces beyond `list_creative_formats` are bespoke.** Celtra builds, Advertible previews. No shared creative-tool contract.
 
 Each maps to a Block 2 / Block 3 thread.
@@ -156,7 +175,7 @@ If the room wants a working committee with named deliverables, here's what I can
 
 | Deliverable | Scope | Target |
 |---|---|---|
-| **Signals tool-call response-shape convention** (gap #5) | Spec proposal: signals tools MUST emit results under a single canonical key in `structuredContent`; if using `content[].text`, must be parseable JSON without prefix wrapping. | Reviewable draft within 30 days of workshop |
+| **Signals tool-call response-shape convention** (gap #5) | Largely resolved upstream by [adcp#3999](https://github.com/adcontextprotocol/adcp/issues/3999) + bokelley's narrative-clarification PR [adcp#4005](https://github.com/adcontextprotocol/adcp/pulls/4005). Open follow-up: AdCP-side lint that gates `envelope_field_present` paths in `PATH_BEARING_CHECKS` (`code-reviewer` flagged this in #4005). I can drive that. | Reviewable draft within 30 days of workshop |
 | **Brand-context primitive harmonization** (gap #2) | Spec proposal: choose `brand_manifest: BrandManifest` OR `brand: BrandReference` as the single contract. Reference Adzymic + Claire shapes as priors. | Reviewable draft within 30 days |
 | **Live reference adaptor stays public** | `adcp-signals-adaptor` continues to host the orchestrator + interactive workflow as a working-committee testbed. PRs welcome. | Indefinite |
 

--- a/docs/WORKSHOP_PRE_FLIGHT.md
+++ b/docs/WORKSHOP_PRE_FLIGHT.md
@@ -1,0 +1,126 @@
+# Workshop Pre-Flight — Morning of May 7, 2026
+
+**Companion to:** [WORKSHOP_DEMO_SCRIPT.md](./WORKSHOP_DEMO_SCRIPT.md), [WORKSHOP_BLOCK1_EXHIBITS.md](./WORKSHOP_BLOCK1_EXHIBITS.md).
+
+This is the runbook for the morning of. Everything is copy-paste; nothing requires writing fresh code.
+
+---
+
+## T-90 minutes — environment check
+
+```bash
+# 1. Smoke the prod surface (68 checks)
+API_KEY=demo-key-adcp-signals-v1 node scripts/pre-demo-audit.mjs
+# Expected: TOTAL: 68 | PASS: 68 | FAIL: 0
+
+# 2. Run the @adcp/client compliance suite (7 scenarios)
+API_KEY=demo-key-adcp-signals-v1 npm run compliance
+# Expected: 7 passed, 0 failed out of 7 scenario(s)
+
+# 3. AdCP envelope + body schema validator (6 surfaces)
+node tmp-mining/validate_against_spec.mjs
+# Expected:
+#   Body schema:     6/6 passed
+#   MCP envelope:    6/6 passed
+#   Combined:        6/6 passed
+```
+
+If any fails: the worker rolled back, or a dependency drifted overnight. Fall back to the recorded screencast (see §"Fallbacks" below).
+
+---
+
+## T-60 minutes — visual smoke (the demo itself)
+
+Open https://adcp-signals-adaptor.evgeny-193.workers.dev/demo. Click through:
+
+| Tab | What to verify | Time-box |
+|---|---|---|
+| **Discover** | Type the brief `luxury travelers planning APAC trips` → click `get_signals`. ~10 results render. Click first row → detail panel opens with deployments + DTS labels. | 30s |
+| **Activations** | Hit "Demo activate" on the detail panel. Task moves submitted → working → completed in ~5s. Tab counter updates. | 30s |
+| **Orchestrator** | Header reads "**19 agents**, **12 alive**, **~2s avg latency**". This is the single most important headline number — if it reads anything else, federation probe failed (call out as known issue, don't lead with it). | 30s |
+| **Capabilities** | `adcp.major_versions` shows 2 + 3. `specialisms: ["signal-owned"]`. **`status: "completed"` at top of structuredContent** (post-adcp#3999). | 30s |
+| **Tool Log** | At least 5 recent calls visible. If empty, the Worker just cold-started — make a few calls in Discover first. | 15s |
+| **Embedding Lab** | 512-dim scatter renders. Hover shows signal names. (Skip if room is short on time — flagged "what I will NOT demo" in main script.) | optional |
+
+---
+
+## T-30 minutes — kill-switches ready
+
+Have these tabs/windows pre-opened so you can pivot mid-demo:
+
+1. **Demo URL** in browser, on Orchestrator tab — the credibility opener
+2. **Terminal #1** — `pre-demo-audit.mjs` output frozen (proof of state)
+3. **Terminal #2** — empty, ready for live curl (the §10 fallback in the main script)
+4. **GitHub PR list** — for the "we ship to spec" beat (#171–#184 arc visible)
+5. **AdCP issues #3999, #4005, #4009** — the upstream-driving evidence
+
+---
+
+## Anticipated Q&A — pre-loaded answers
+
+### "Are you AAO Verified?"
+**Yes.** AAO's `evaluate_agent_quality` runner: 21/21 core scenarios + 9/9 signals_flow steps, all silent. Drove and contributed to two upstream issues during the certification: [adcp#3999](https://github.com/adcontextprotocol/adcp/issues/3999) (envelope binding clarification — bokelley ruling) and [adcp#4009](https://github.com/adcontextprotocol/adcp/issues/4009) (storyboard runner bug, currently in triage).
+
+### "Why does your `agent_url` come back as `mock_dsp` on synthetic activations?"
+Cosmetic gotcha when `destinations` is absent (a malformed-request shape AAO's storyboard sends pending #4009). The fallback uses our `destination` default which is `"mock_dsp"`. The `type: "agent"` assertion is correct. We can fix the URL to be URL-shaped in a follow-up — flagged but not blocking.
+
+### "Doesn't passing AJV against the body schemas mean you're conformant?"
+**Necessary but not sufficient.** That was the lesson from the AAO arc. The body schemas (`get-signals-response.json`, `activate-signal-response.json`, etc.) describe only the *payload* portion. The MCP transport binding lives in `mcp-response-extraction.mdx` + `static/test-vectors/mcp-response-extraction.json` — neither is a JSON Schema. Naive validators miss `status` and the envelope-merge requirement. Our validator now checks both.
+
+### "How is this different from a standard DMP / signals catalog?"
+- **Standard DMP**: closed catalog, vendor-specific IDs, manual integration per consumer.
+- **AdCP**: agent-to-agent protocol over MCP/A2A/REST. Same agent serves any consumer that speaks the protocol. Cross-taxonomy mapping (`x_cross_taxonomy[]`) means the *same* signal is queryable in IAB, LiveRamp, TTD, AppNexus, Comscore, Nielsen, and 3 other namespaces from one call.
+
+### "Where does Triton's attention data fit?"
+Real-time / streaming axis — see Block 2 cross-cutting (§8). `get_signals` today is sync batch. Attention data probably needs its own primitive (subscribe? push notification?). Open question for the room — likely best for Triton + measurement vendors to lead.
+
+### "Brand suitability vs. signal — which side?"
+Probably a signal (it's a metadata attribute). But "don't run next to alcohol" is NOT — that's a governance directive carried alongside. See [Exhibit B](./WORKSHOP_BLOCK1_EXHIBITS.md#exhibit-b--what-signals-are-not-boundary-map).
+
+### "If I'm an iHeart audio buyer, what would I integrate?"
+- **Discovery**: `get_signals` with audio-specific brief ("podcast listeners 25-44 cooking content") → returns audio-eligible signals with deployments mapping to your audio DSPs.
+- **Activation**: `activate_signal` against the audio DSP destination → returns `task_id` + deployment record. Poll or webhook.
+- **Cross-pollination**: `x_cross_taxonomy[]` lets you reuse the same audience descriptor in CTV/display campaigns without rebuilding it. That's where iHeart audio + simulcast / CTV stories converge.
+- iHeartMedia is **measurement + identity heavy** in this room (see opening calibration). Lead on the trust contract (Exhibit C), not on tool count.
+
+### "What about TTD activation specifically?"
+`ttd_sandbox` is roadmap-stage in our destinations registry. We'd activate via `activate_signal` → segment CSV upload via TTD Partner API. Real OAuth not wired (stage: sandbox). For live demo, use `mock_dsp` which always succeeds in ~5s.
+
+### "Does this work for cookieless?"
+Yes — `id_resolution.cookieless_ready: true`, with `id_types_supported` covering UID2, ID5, RampID, Yahoo ConnectID, hashed_email, MAID iOS/Android, CTV device. See `/capabilities` `ext.id_resolution`.
+
+### "What's `_message` doing in your responses?"
+That's [AAO/Addie's runner display layer](https://github.com/adcontextprotocol/adcp/issues/3999), not us. Verified bytes: our `structuredContent` has `{status, deployments, context}` only. AAO's eval surface adds `_message` for human display. Codebase grep: 0 hits for `_message` in our source. Three-time confirmation across the AAO arc.
+
+---
+
+## Fallback if prod is down
+
+1. **Recorded screencast**: see `docs/workshop-evidence/` (run-through + key tab walks). Not yet recorded — TODO before May 6.
+2. **`curl-only fallback`**: see §10 of `WORKSHOP_DEMO_SCRIPT.md` — every flow has a one-line curl reproduction. Show the JSON, narrate as if the UI were rendering it.
+3. **Slide deck of the orchestrator screenshots**: `docs/workshop-evidence/` should contain frozen screenshots of headline tabs. TODO before May 6.
+
+---
+
+## Post-workshop hygiene
+
+- Share repo link in the chat: https://github.com/EvgenyAndroid/adcp-signals-adaptor
+- Reference the upstream issues: adcp#3999, #4005, #4009 (your fingerprint on the spec)
+- Offer the working-committee deliverables from §9 of the main script (gap #5 follow-up + brand-context harmonization)
+
+---
+
+## Pre-flight checklist (one-line summary)
+
+```
+□ pre-demo-audit.mjs — 68/68 PASS
+□ npm run compliance  — 7/7 PASS
+□ validate_against_spec.mjs — 6/6 + 6/6 PASS
+□ Demo URL loads, Orchestrator shows 12+ alive agents
+□ Discover → activates → completes (5s sanity loop)
+□ Tabs/windows pre-arranged for mid-demo pivots
+□ Q&A answers reviewed
+□ Fallback materials known to be where you expect them
+```
+
+If all 8 boxes check, you're shippable. Go run it.

--- a/scripts/pre-demo-audit.mjs
+++ b/scripts/pre-demo-audit.mjs
@@ -212,18 +212,32 @@ async function checkMcp() {
   log('mcp — tools/list 8 tools', tools.body.result?.tools?.length === 8);
   log('mcp — every tool has outputSchema', tools.body.result?.tools?.every(t => !!t.outputSchema));
 
-  const unauthCall = await fetchJson(`${BASE}/mcp`, {
+  // Sec-31v: get_adcp_capabilities is the ONE public tools/call carve-out
+  // (for AAO discovery probe). Other tools must still 401. Audit both
+  // sides of the carve-out so we catch regressions in either direction.
+  const publicCall = await fetchJson(`${BASE}/mcp`, {
     method: 'POST', headers: json,
     body: JSON.stringify({ jsonrpc: '2.0', id: 3, method: 'tools/call', params: { name: 'get_adcp_capabilities', arguments: {} } }),
   });
-  log('mcp — tools/call unauth returns -32001', unauthCall.body.error?.code === -32001);
+  log('mcp — tools/call get_adcp_capabilities unauth succeeds (Sec-31v public carve-out)',
+    !!publicCall.body.result?.structuredContent?.adcp);
+
+  const unauthCall = await fetchJson(`${BASE}/mcp`, {
+    method: 'POST', headers: json,
+    body: JSON.stringify({ jsonrpc: '2.0', id: 4, method: 'tools/call', params: { name: 'activate_signal', arguments: { signal_agent_segment_id: 'sig_drama_viewers', destinations: [{ type: 'platform', platform: 'mock_dsp' }] } } }),
+  });
+  log('mcp — tools/call (auth-gated tool) unauth returns -32001',
+    unauthCall.body.error?.code === -32001);
 
   const authedCall = await fetchJson(`${BASE}/mcp`, {
     method: 'POST', headers: { ...auth, ...json },
-    body: JSON.stringify({ jsonrpc: '2.0', id: 4, method: 'tools/call', params: { name: 'get_adcp_capabilities', arguments: {} } }),
+    body: JSON.stringify({ jsonrpc: '2.0', id: 5, method: 'tools/call', params: { name: 'get_adcp_capabilities', arguments: {} } }),
   });
   log('mcp — tools/call authed has structuredContent',
     !!authedCall.body.result?.structuredContent?.adcp);
+  // adcp#3999 envelope binding: status MUST be at top of structuredContent
+  log('mcp — structuredContent envelope status="completed" (adcp#3999)',
+    authedCall.body.result?.structuredContent?.status === 'completed');
 
   const similar = await fetchJson(`${BASE}/mcp`, {
     method: 'POST', headers: { ...auth, ...json },


### PR DESCRIPTION
## Summary

May 7 iHeartMedia workshop is 4 days out. This bundles three fixes/additions for the pre-flight phase.

## Changes

### `scripts/pre-demo-audit.mjs` — fix stale assertion

Audit was failing 1/66 because of a stale Sec-31v assumption. `get_adcp_capabilities` was carved out as a public tools/call (for AAO discovery probe) months ago — the audit was still expecting `-32001` on it.

Replaced with four assertions that audit both sides of the carve-out:
1. `tools/call get_adcp_capabilities` unauth → **succeeds** (Sec-31v public carve-out works)
2. `tools/call activate_signal` unauth → `-32001` (auth gate still works on auth-gated tools)
3. Authed `tools/call` returns `structuredContent.adcp`
4. `structuredContent.status === "completed"` (adcp#3999 envelope binding holds)

**Audit now: 68/68 PASS** (was 65/66 PASS + 1 stale FAIL).

### `docs/WORKSHOP_DEMO_SCRIPT.md` — post-AAO refresh

Existing 198-line script is solid. Surgical updates:

- **Header**: status badge openers (AAO Verified, 7/7 compliance, 68/68 audit, envelope binding shipped). The room is measurement/identity-heavy — these are the credibility levers, not feature counts.
- **Orchestrator headline numbers**: hard-coded "19 agents / 12 alive" is stale (currently 15/11). Added a "refresh on the morning of" note and a callout listing currently-down vendors (`claire_scope3`, `setupad_*`, `mamamia`) so the demo acknowledges them honestly rather than hiding them.
- **Gap #5**: clarify that adcp#3999 + bokelley's #4005 resolved the ambiguity at the binding level. New committee follow-up is the AdCP-side lint for `envelope_field_present` in `PATH_BEARING_CHECKS`.

### `docs/WORKSHOP_PRE_FLIGHT.md` — new morning-of runbook

- **T-90 environment check** (3 commands: `pre-demo-audit`, `npm run compliance`, `validate_against_spec.mjs`)
- **T-60 visual smoke** (6 tabs, 30s each)
- **T-30 kill-switches** (browser tabs, terminals, GitHub windows pre-staged)
- **Anticipated Q&A**: 9 pre-loaded answers covering AAO badge, body-schemas-vs-envelope, DMP comparison, Triton attention, brand suitability vs. signal, iHeart audio buyer integration, TTD activation, cookieless, and the `_message` non-issue.
- **Fallback if prod is down**
- **One-line pre-flight checklist** (8 boxes)

## Verification

| Check | Result |
|---|---|
| `pre-demo-audit.mjs` | 68/68 PASS |
| `npm run compliance` | 7/7 PASS |
| `validate_against_spec.mjs` | 6/6 + 6/6 (body + envelope) PASS |
| `/capabilities` | major_versions [2,3], specialisms [signal-owned], 6 destinations |
| `/signals/search?limit=100` | 521 total, 100% cross-taxonomy coverage, 13 CTV + 14 streaming/audio signals in first page |
| Demo HTML | 26 tab anchors all present, 1.07MB matches snapshot golden |
| `npx tsc --noEmit -p .` | no errors in `src/mcp/server.ts` |

## Caveat

Visual smoke (the actual UI walkthrough) was attempted via the Claude-in-Chrome extension but the extension wasn't reachable. Fell back to programmatic verification across all of the demo's data surfaces (REST endpoints, MCP tools, HTML structure, catalog coverage). That catches everything except pixels — recommend running the visual smoke yourself before May 7 using the T-60 checklist in `WORKSHOP_PRE_FLIGHT.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)