### PR TITLE
Sidebar: collapse/expand-all toggle + 2 new themes (paper, forest)

### DIFF
--- a/src/demo/script/fragments/ui-state.ts
+++ b/src/demo/script/fragments/ui-state.ts
@@ -64,6 +64,10 @@ function _applySidebarGroupState() {
     const parentGroup = activeItem.closest(".nav-group");
     if (parentGroup) parentGroup.classList.add("has-active");
   }
+  // Refresh the master collapse-all label/icon to reflect the new
+  // post-paint state. The function may be undefined on the very first
+  // call (defined later in the file), so guard it.
+  if (typeof _refreshCollapseAllUi === "function") _refreshCollapseAllUi();
 }
 // Wire group-header clicks to toggle + persist.
 document.querySelectorAll("[data-group-toggle]").forEach((header) => {
@@ -75,19 +79,62 @@ document.querySelectorAll("[data-group-toggle]").forEach((header) => {
     const state = _readSidebarState();
     state[id] = group.classList.contains("is-collapsed");
     _writeSidebarState(state);
+    _refreshCollapseAllUi();
   });
 });
+
+// Collapse-all / expand-all master toggle. Two states:
+//   - is-all-collapsed: every non-active group is collapsed → next click expands all
+//   - default:           at least one non-active group is expanded → next click collapses all
+//
+// "Active" group is force-expanded by _applySidebarGroupState regardless,
+// so "collapse all" really means "collapse everything except active". We
+// only inspect non-active groups when deciding which state we're in.
+function _everyNonActiveGroupCollapsed() {
+  const groups = Array.from(document.querySelectorAll(".nav-group"));
+  const nonActive = groups.filter(function(g) { return !g.classList.contains("has-active"); });
+  if (nonActive.length === 0) return true;
+  return nonActive.every(function(g) { return g.classList.contains("is-collapsed"); });
+}
+function _refreshCollapseAllUi() {
+  const btn = document.querySelector("[data-nav-collapse-all]");
+  if (!btn) return;
+  const allCollapsed = _everyNonActiveGroupCollapsed();
+  btn.classList.toggle("is-all-collapsed", allCollapsed);
+  const label = btn.querySelector(".nav-collapse-all-label");
+  if (label) label.textContent = allCollapsed ? "Expand all" : "Collapse all";
+}
+document.querySelectorAll("[data-nav-collapse-all]").forEach(function(btn) {
+  btn.addEventListener("click", function() {
+    const allCollapsed = _everyNonActiveGroupCollapsed();
+    // If all are collapsed → expand all (write false to every group's state).
+    // If any expanded → collapse all (write true to every group's state).
+    // The active group's force-expand happens later in _applySidebarGroupState
+    // regardless, so writing true universally is safe.
+    const nextCollapsedValue = !allCollapsed;
+    const state = _readSidebarState();
+    document.querySelectorAll(".nav-group").forEach(function(g) {
+      const id = g.dataset.groupId;
+      if (id) state[id] = nextCollapsedValue;
+    });
+    _writeSidebarState(state);
+    _applySidebarGroupState();
+    _refreshCollapseAllUi();
+  });
+});
+
 // Apply initial state on first paint.
 _applySidebarGroupState();
+_refreshCollapseAllUi();
 
 //────────────────────────────────────────────────────────────────────────
-// Theme switcher (Midnight / Daylight / Solar)
+// Theme switcher (Midnight / Daylight / Solar / Paper / Forest)
 // Sets data-theme on <html>; CSS in :root[data-theme="..."] picks up
-// the palette. Persists to localStorage under "ui-theme". Three themes
-// today; add more by adding a CSS block + a swatch button.
+// the palette. Persists to localStorage under "ui-theme". Add more by
+// adding a CSS block + a swatch button + an entry here.
 //────────────────────────────────────────────────────────────────────────
 const THEME_KEY = "ui-theme";
-const THEME_VALID = { midnight: 1, daylight: 1, solar: 1 };
+const THEME_VALID = { midnight: 1, daylight: 1, solar: 1, paper: 1, forest: 1 };
 
 function _readTheme() {
   try {

--- a/src/demo/styles.ts
+++ b/src/demo/styles.ts
@@ -135,6 +135,84 @@ export const STYLES = `<style>
   --cyan:        #6cd9d2;
 }
 
+/* Paper — pure-white, ultra-high-contrast variant of daylight. Built
+   for projector / boardroom visibility: no off-white tints, charcoal
+   text, navy accent. Borders are stronger than daylight so the surface
+   hierarchy is legible at a distance. */
+:root[data-theme="paper"] {
+  --bg-base:    #ffffff;
+  --bg-sidebar: #fafafa;
+  --bg-top:     #ffffff;
+  --bg-surface: #ffffff;
+  --bg-raised:  #f4f4f5;
+  --bg-input:   #ffffff;
+  --bg-hover:   #ececee;
+
+  --border:         #c0c4cc;
+  --border-faint:   #e2e4ea;
+  --border-strong:  #8b909c;
+  --border-focus:   #1c4faa;
+
+  --text:        #0a0a0a;
+  --text-bright: #000000;
+  --text-dim:    #34373f;
+  --text-mut:    #5a606e;
+  --text-dis:    #9aa0ac;
+
+  --accent:        #1c4faa;
+  --accent-hot:    #2a6bd1;
+  --accent-dim:    rgba(28, 79, 170, 0.10);
+  --accent-border: rgba(28, 79, 170, 0.40);
+
+  --success:     #06703f;
+  --success-dim: rgba(6, 112, 63, 0.10);
+  --warning:     #a85e00;
+  --warning-dim: rgba(168, 94, 0, 0.10);
+  --error:       #b81c1c;
+  --error-dim:   rgba(184, 28, 28, 0.10);
+  --violet:      #5325a8;
+  --cyan:        #00738a;
+}
+
+/* Forest — deep-green dark theme. Calmer than midnight (warmer
+   undertones), distinct from solar (green not amber). Pairs with a
+   pine-needle accent. Useful for long sessions where blue-light
+   reduction matters. */
+:root[data-theme="forest"] {
+  --bg-base:    #0d1411;
+  --bg-sidebar: #0a110d;
+  --bg-top:     #0f1612;
+  --bg-surface: #131c17;
+  --bg-raised:  #182320;
+  --bg-input:   #0c1310;
+  --bg-hover:   #1a2620;
+
+  --border:         #1f3028;
+  --border-faint:   #131e18;
+  --border-strong:  #2e4438;
+  --border-focus:   #4fa074;
+
+  --text:        #e6efe9;
+  --text-bright: #ffffff;
+  --text-dim:    #a8bdb1;
+  --text-mut:    #7a8e83;
+  --text-dis:    #4a5950;
+
+  --accent:        #4fa074;
+  --accent-hot:    #6fb88f;
+  --accent-dim:    rgba(79, 160, 116, 0.15);
+  --accent-border: rgba(79, 160, 116, 0.36);
+
+  --success:     #6fc78a;
+  --success-dim: rgba(111, 199, 138, 0.15);
+  --warning:     #d4a14a;
+  --warning-dim: rgba(212, 161, 74, 0.14);
+  --error:       #d96b6b;
+  --error-dim:   rgba(217, 107, 107, 0.14);
+  --violet:      #9a8bd9;
+  --cyan:        #5fb8c0;
+}
+
 /* Static layout + non-themed tokens */
 :root {
   --font-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
@@ -331,6 +409,39 @@ svg.ico path, svg.ico circle, svg.ico rect, svg.ico line { vector-effect: non-sc
      stronger affordance than a bg-tint alone, especially in light theme
    - has-active group: header icon goes full-opacity accent
 */
+/* Collapse-all toggle — sits above the first nav-group. Low visual
+   weight (no fill, mut text) so it doesn't compete with the group
+   headers themselves. The chevron rotates 180° in the .all-collapsed
+   state to mirror the next click's intent (expand). */
+.nav-collapse-all {
+  display: flex; align-items: center; gap: 8px;
+  width: 100%;
+  padding: 8px 12px;
+  margin: 4px 0 6px;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: var(--radius-md);
+  color: var(--text-mut);
+  font: 11px var(--font-mono);
+  text-transform: uppercase; letter-spacing: 0.08em;
+  cursor: pointer;
+  transition: background 0.12s, color 0.12s, border-color 0.12s;
+}
+.nav-collapse-all:hover {
+  background: var(--bg-hover);
+  color: var(--text-dim);
+  border-color: var(--border-faint);
+}
+.nav-collapse-all .ico {
+  width: 12px; height: 12px;
+  flex-shrink: 0;
+  transition: transform 0.18s ease;
+}
+.nav-collapse-all.is-all-collapsed .ico {
+  transform: rotate(-90deg);
+}
+.nav-collapse-all-label { flex: 1; text-align: left; }
+
 .nav-group {
   margin-bottom: 2px;
   padding-top: 2px;
@@ -463,6 +574,13 @@ svg.ico path, svg.ico circle, svg.ico rect, svg.ico line { vector-effect: non-sc
 .theme-swatch[data-theme-pick="solar"] {
   background: linear-gradient(135deg, #1c1810 0%, #ffaa3a 200%);
 }
+.theme-swatch[data-theme-pick="paper"] {
+  background: linear-gradient(135deg, #ffffff 0%, #c0c4cc 200%);
+  border-color: #b0b4bc;
+}
+.theme-swatch[data-theme-pick="forest"] {
+  background: linear-gradient(135deg, #0d1411 0%, #4fa074 200%);
+}
 
 .sidebar-footer {
   padding-top: 14px; border-top: 1px solid var(--border);
@@ -553,6 +671,7 @@ svg.ico path, svg.ico circle, svg.ico rect, svg.ico line { vector-effect: non-sc
 .app.is-sidebar-collapsed .nav-group-header,
 .app.is-sidebar-collapsed .nav-group-chevron,
 .app.is-sidebar-collapsed .nav-group-title,
+.app.is-sidebar-collapsed .nav-collapse-all,
 .app.is-sidebar-collapsed .sidebar-footer .kv,
 .app.is-sidebar-collapsed .sidebar-footer .theme-picker {
   display: none;
@@ -3702,7 +3821,7 @@ textarea.lab-input { resize: vertical; line-height: 1.5; }
   /* Narrow mode: collapse the group chrome and force all items visible
      as a flat icon list. Group headers + chevrons + titles disappear so
      the user gets a Linear-style icon-only nav. */
-  .nav-group-header, .nav-group-chevron, .nav-group-title { display: none; }
+  .nav-group-header, .nav-group-chevron, .nav-group-title, .nav-collapse-all { display: none; }
   .nav-group.is-collapsed .nav-group-items { display: flex !important; }
   .nav-group { margin-bottom: 0; }
   .sidebar-brand { justify-content: center; padding-bottom: 14px; }

--- a/src/routes/demo.ts
+++ b/src/routes/demo.ts
@@ -139,6 +139,20 @@ ${STYLES}
 
     <nav class="sidebar-nav">
 
+      <!-- Collapse-all / expand-all toggle. State semantics: if any group
+           is currently expanded, click → collapse all (except the
+           active-group force-expand). If all groups are collapsed, click
+           → expand all. The button mirrors that state in its label/icon
+           so users know what the next click will do. -->
+      <button class="nav-collapse-all" type="button" data-nav-collapse-all
+              title="Collapse / expand all groups"
+              aria-label="Toggle all sidebar groups">
+        <svg class="ico" viewBox="0 0 16 16" aria-hidden="true">
+          <path d="M4 6.5l4 3 4-3" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>
+        </svg>
+        <span class="nav-collapse-all-label">Collapse all</span>
+      </button>
+
       <!-- Group: Signals (sell-side discovery + browsing) -->
       <div class="nav-group" data-group-id="signals">
         <button class="nav-group-header" type="button" data-group-toggle>
@@ -336,6 +350,8 @@ ${STYLES}
         <button class="theme-swatch" data-theme-pick="midnight" title="Midnight (dark)" aria-label="Midnight theme"></button>
         <button class="theme-swatch" data-theme-pick="daylight" title="Daylight (light)" aria-label="Daylight theme"></button>
         <button class="theme-swatch" data-theme-pick="solar" title="Solar (warm)" aria-label="Solar theme"></button>
+        <button class="theme-swatch" data-theme-pick="paper" title="Paper (high-contrast white)" aria-label="Paper theme"></button>
+        <button class="theme-swatch" data-theme-pick="forest" title="Forest (deep green)" aria-label="Forest theme"></button>
       </div>
       <!-- Sign out: manual logout button + paired with 5-min idle auto-logout
            wired in src/demo/script/fragments/auth.ts. Both clear the

--- a/tests/__snapshots__/demo-render-snapshot.test.ts.snap
+++ b/tests/__snapshots__/demo-render-snapshot.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`handleDemo byte-equivalence > matches the committed golden hash (LF-normalized SHA-256 of body) 1`] = `
 {
-  "hash": "b136c33ca57419946a2bdcd1f03518d50843bfda8b2fcd3e533ccf637b0e5759",
-  "length": 1095875,
+  "hash": "1e36026a9d537a0b808b526ff15b43f1a77f86e89ad657cbbd2bc3de63453c59",
+  "length": 1102843,
 }
 `;


### PR DESCRIPTION
## Summary

Demo polish for May 7 workshop. Two requests:

1. **Collapse/expand-all toggle** for the sidebar groups
2. **Two new themes** — paper (high-contrast white) and forest (deep green)

## Collapse/expand-all toggle

Sits above the first nav-group. Mirrors the next-click intent:

| State | Label | Chevron |
|---|---|---|
| At least one non-active group expanded | "Collapse all" | down ▽ |
| All non-active groups collapsed | "Expand all" | left ◁ |

Click flips state for every group in localStorage. The existing `_applySidebarGroupState()` then runs and force-expands the active group regardless — so "collapse all" effectively means "collapse everything except the active one." Matches the implicit affordance: you never get stuck on a tab whose group is hidden.

Hidden in icons-only modes (`.app.is-sidebar-collapsed` + responsive narrow breakpoint).

## Two new themes

| Theme | Vibe | Use case |
|---|---|---|
| **paper** | Pure-white, charcoal text, navy accent, strong borders | Projector / boardroom — survives bad projector calibration |
| **forest** | Deep green dark, pine-needle accent | Long sessions where blue-light reduction matters; distinct from midnight (cool blue) and solar (warm amber) |

Both wired into:
- `styles.ts` — new `:root[data-theme="..."]` blocks + swatch gradients
- `demo.ts` — two new `.theme-swatch` buttons in the picker
- `ui-state.ts` — added to `THEME_VALID`

## Test plan

- [x] `npx vitest run` — 441/441 passing (snapshot golden updated, +6,968 bytes)
- [x] `python tmp-mining/trap_audit.py` — clean (0 traps)
- [x] `npx wrangler deploy --dry-run` — clean
- [x] `npx tsc --noEmit -p .` — no new errors
- [ ] After merge + deploy: visual smoke — verify themes render distinctly + collapse-all works

🤖 Generated with [Claude Code](https://claude.com/claude-code)