### PR TITLE
adcp-watch: track AAO registry (agenticadvertising.org)

### DIFF
--- a/.github/adcp-watch-config.json
+++ b/.github/adcp-watch-config.json
@@ -30,5 +30,14 @@
       "kind": "issue",
       "context": "Filed 2026-05-03. Runner bug: signal_owned/activate_on_agent storyboard step omits required `destinations` and `idempotency_key` per /schemas/3.0.1/signals/activate-signal-request.json. Schema-conformant agents have no signal of intent (agent vs platform). Workshop-insurance defensive heuristic shipped in this repo (correlation_id parsing in src/mcp/server.ts:callActivateSignal — search 'REMOVE WHEN adcp#4009 ships'). When the storyboard fix ships and Addie's evaluator confirms badge issuance, REVERT the heuristic — restore the simpler 2-stage destinationType precedence."
     }
+  ],
+  "external_registries": [
+    {
+      "name": "agenticadvertising_org",
+      "url": "https://agenticadvertising.org/api/registry/agents?capabilities=true",
+      "agent_id_field": "url",
+      "agent_summary_fields": ["name", "type"],
+      "context": "AAO official agent registry (https://agenticadvertising.org/registry/). Fires when agents are added, removed, or rename. Identity = agent URL (stable across renames; surfaces show the new name in the diff). Primary value: catch new ecosystem entrants without manual checks. As of 2026-05-04 the registry has 21 entries; we federate with ~6 of them via /agents/registry — when new agents appear we may want to add them to our local directory."
+    }
   ]
 }

--- a/scripts/adcp-watch.mjs
+++ b/scripts/adcp-watch.mjs
@@ -213,6 +213,54 @@ async function buildNewState() {
     }
   }
 
+  // 3c-bis. External agent registries (e.g. agenticadvertising.org).
+  // Identity for diff = config.agent_id_field (default "url"). Stored as
+  // a stable, sorted dict keyed on identity → summary fields, so the
+  // generic walker reports "agent X added/removed" cleanly. Network
+  // errors store as { error } so the watcher's silence-on-no-change
+  // semantics still fire on transient failures.
+  if (Array.isArray(config.external_registries) && config.external_registries.length > 0) {
+    newState.external_registries = {};
+    for (const reg of config.external_registries) {
+      const idField = reg.agent_id_field || "url";
+      const summaryFields = Array.isArray(reg.agent_summary_fields)
+        ? reg.agent_summary_fields
+        : ["name"];
+      try {
+        const r = await fetch(reg.url, { headers: { "Accept": "application/json" } });
+        if (!r.ok) {
+          newState.external_registries[reg.name] = {
+            error: `HTTP ${r.status} ${r.statusText}`,
+          };
+          continue;
+        }
+        const j = await r.json();
+        // Accept both top-level array and { agents } / { data } / { results }.
+        const list = Array.isArray(j) ? j : (j.agents || j.data || j.results || []);
+        const agents = {};
+        for (const a of list) {
+          const id = a?.[idField];
+          if (typeof id !== "string" || id.length === 0) continue;
+          // Pick stable summary fields. Skip absent ones rather than
+          // emitting null — keeps the diff focused on real changes.
+          const summary = {};
+          for (const f of summaryFields) {
+            if (a[f] !== undefined && a[f] !== null) summary[f] = a[f];
+          }
+          agents[id] = summary;
+        }
+        newState.external_registries[reg.name] = {
+          count: Object.keys(agents).length,
+          agents,
+        };
+      } catch (e) {
+        newState.external_registries[reg.name] = {
+          error: String(e?.message ?? e),
+        };
+      }
+    }
+  }
+
   // 3d. Live compliance run
   if (process.env.API_KEY) {
     try {


### PR DESCRIPTION
## Summary

Adds the AAO official agent registry (https://agenticadvertising.org/registry/) to our daily watcher cron. Get notified when agents are added, removed, or renamed in the upstream ecosystem.

## Why now

| Source | Agent count |
|---|---|
| AAO registry (https://agenticadvertising.org/api/registry/agents) | **21** |
| Our local `/agents/registry` | **6** |

15 agents in the upstream registry that we don't federate with locally. Without this watcher, we'd find out about new entrants only by manually visiting the registry page. This wires the daily silent-on-no-change cron to surface them automatically.

## Generic shape (not just AAO)

Added a top-level `external_registries[]` array to `.github/adcp-watch-config.json`. Each entry is:

```json
{
  "name": "<stable state-key>",
  "url":  "<JSON endpoint>",
  "agent_id_field": "url",
  "agent_summary_fields": ["name", "type"],
  "context": "<human-readable note>"
}
```

Other registries can be added by appending — no code changes.

## Local dry-run

```
node scripts/adcp-watch.mjs --dry
```

Confirms:
- `external_registries.agenticadvertising_org.count: 21`
- All 21 agents indexed by URL with `name` + `type` summaries
- Diff machinery surfaces the registry as `(new)` on first run; subsequent runs are silent unless something moves

## What you'll see

**On first workflow run after merge** — one larger comment in the watcher tracking issue with the full 21-agent baseline as `_(new)_ → {...}`. This is expected onboarding noise.

**On subsequent runs** — silent unless an agent is added/removed/renamed. When that fires, the diff is targeted (only the affected URL row).

## Test plan

- [x] Local `node scripts/adcp-watch.mjs --dry` — registry captured correctly
- [x] Network failure path tested mentally (try/catch → `{ error }` in state, no false-positive diffs)
- [ ] After merge: first scheduled run posts the 21-agent baseline
- [ ] Future delta: when AAO adds a new agent, comment fires automatically

## Backlog (not in this PR)

The 15-agent gap between AAO's registry and ours is a separate question. We can:
1. Pull more upstream agents into our local `/agents/registry` (federation work)
2. Or leave the gap and use the watcher just for awareness

Defer until after May 7 workshop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)