### PR TITLE
Keyboard shortcuts: cover all 26 tabs + sectioned cheat-sheet

### DIFF
--- a/src/demo/script/fragments/campaign.ts
+++ b/src/demo/script/fragments/campaign.ts
@@ -48,12 +48,27 @@ document.addEventListener("keydown", function (ev) {
   }
   if (_kbdPrefix === "g") {
     var map = {
+      // Original Sec-38 mapping
       d: "discover", c: "catalog", b: "builder", t: "treemap", o: "overlap",
       e: "embedding", k: "capabilities", v: "devkit", n: "destinations",
       l: "toollog", a: "activations",
       // Sec-41 new tabs. Bare f is reserved for detail-panel expand; the
       // g f prefix disambiguates.
       x: "lab", p: "portfolio", s: "seasonality", f: "federation",
+      // 2026-05-04 — fill in remaining tabs that lacked shortcuts.
+      // Mnemonics chosen to avoid collision with reserved letters above:
+      //   y → sYnonyms (concept registry is the vocab layer)
+      //   m → coMpose
+      //   r → Rule (expression is rule-AST)
+      //   j → Journey
+      //   q → Query / sQenario (planner is what-if)
+      //   h → History / Hash
+      //   w → Window (freshness window)
+      //   u → Unify agents (orchestrator)
+      //   1/2/3 → Workshop Canvases #1, #2, #3
+      y: "concepts", m: "composer", r: "expression", j: "journey",
+      q: "planner", h: "snapshots", w: "freshness", u: "orchestrator",
+      "1": "canvas", "2": "campaign", "3": "agentic",
     };
     var tab = map[ev.key.toLowerCase()];
     if (tab) { switchTab(tab); _kbdPrefix = null; if (_kbdPrefixTimer) clearTimeout(_kbdPrefixTimer); return; }

--- a/src/demo/styles.ts
+++ b/src/demo/styles.ts
@@ -3060,9 +3060,19 @@ svg.ico path, svg.ico circle, svg.ico rect, svg.ico line { vector-effect: non-sc
   background: var(--bg-surface); border: 1px solid var(--border);
   border-radius: var(--radius-md); padding: 20px 24px;
   min-width: 420px; max-width: 640px;
+  max-height: 80vh; overflow-y: auto;
   box-shadow: 0 20px 60px rgba(0,0,0,0.5);
 }
 .kbd-card h3 { margin: 0 0 14px 0; font-size: 15px; font-weight: 600; }
+.kbd-section-title {
+  font: 10px var(--font-mono);
+  text-transform: uppercase; letter-spacing: 0.10em;
+  color: var(--text-mut);
+  margin: 14px 0 4px;
+  padding-bottom: 4px;
+  border-bottom: 1px solid var(--border-faint);
+}
+.kbd-section-title:first-of-type { margin-top: 0; }
 .kbd-row {
   display: flex; justify-content: space-between; align-items: center;
   padding: 6px 0; border-bottom: 1px solid var(--border);

--- a/src/routes/demo.ts
+++ b/src/routes/demo.ts
@@ -2419,21 +2419,51 @@ ${STYLES}
 <div id="kbd-overlay" class="kbd-overlay" role="dialog" aria-modal="true" aria-label="Keyboard shortcuts">
   <div class="kbd-card">
     <h3>Keyboard shortcuts</h3>
+
+    <div class="kbd-section-title">Signals</div>
     <div class="kbd-row"><span>Open Discover</span><span class="kbd-keys"><span class="kbd-key">g</span><span class="kbd-key">d</span></span></div>
     <div class="kbd-row"><span>Open Catalog</span><span class="kbd-keys"><span class="kbd-key">g</span><span class="kbd-key">c</span></span></div>
-    <div class="kbd-row"><span>Open Builder</span><span class="kbd-keys"><span class="kbd-key">g</span><span class="kbd-key">b</span></span></div>
+    <div class="kbd-row"><span>Open Concepts</span><span class="kbd-keys"><span class="kbd-key">g</span><span class="kbd-key">y</span></span></div>
+
+    <div class="kbd-section-title">Analytics</div>
     <div class="kbd-row"><span>Open Treemap</span><span class="kbd-keys"><span class="kbd-key">g</span><span class="kbd-key">t</span></span></div>
     <div class="kbd-row"><span>Open Overlap</span><span class="kbd-keys"><span class="kbd-key">g</span><span class="kbd-key">o</span></span></div>
     <div class="kbd-row"><span>Open Embedding</span><span class="kbd-keys"><span class="kbd-key">g</span><span class="kbd-key">e</span></span></div>
+    <div class="kbd-row"><span>Open Embedding Lab</span><span class="kbd-keys"><span class="kbd-key">g</span><span class="kbd-key">x</span></span></div>
+    <div class="kbd-row"><span>Open Seasonality</span><span class="kbd-keys"><span class="kbd-key">g</span><span class="kbd-key">s</span></span></div>
+    <div class="kbd-row"><span>Open Freshness</span><span class="kbd-keys"><span class="kbd-key">g</span><span class="kbd-key">w</span></span></div>
+
+    <div class="kbd-section-title">Audience Composition</div>
+    <div class="kbd-row"><span>Open Builder</span><span class="kbd-keys"><span class="kbd-key">g</span><span class="kbd-key">b</span></span></div>
+    <div class="kbd-row"><span>Open Composer</span><span class="kbd-keys"><span class="kbd-key">g</span><span class="kbd-key">m</span></span></div>
+    <div class="kbd-row"><span>Open Expression</span><span class="kbd-keys"><span class="kbd-key">g</span><span class="kbd-key">r</span></span></div>
+    <div class="kbd-row"><span>Open Journey</span><span class="kbd-keys"><span class="kbd-key">g</span><span class="kbd-key">j</span></span></div>
+    <div class="kbd-row"><span>Open Portfolio</span><span class="kbd-keys"><span class="kbd-key">g</span><span class="kbd-key">p</span></span></div>
+    <div class="kbd-row"><span>Open Scenario (Planner)</span><span class="kbd-keys"><span class="kbd-key">g</span><span class="kbd-key">q</span></span></div>
+    <div class="kbd-row"><span>Open Snapshots</span><span class="kbd-keys"><span class="kbd-key">g</span><span class="kbd-key">h</span></span></div>
+
+    <div class="kbd-section-title">Workshop Canvases</div>
+    <div class="kbd-row"><span>Open Brand Canvas</span><span class="kbd-keys"><span class="kbd-key">g</span><span class="kbd-key">1</span></span></div>
+    <div class="kbd-row"><span>Open Campaign Canvas</span><span class="kbd-keys"><span class="kbd-key">g</span><span class="kbd-key">2</span></span></div>
+    <div class="kbd-row"><span>Open Agentic Canvas</span><span class="kbd-keys"><span class="kbd-key">g</span><span class="kbd-key">3</span></span></div>
+
+    <div class="kbd-section-title">Multi-Agent</div>
+    <div class="kbd-row"><span>Open Federation</span><span class="kbd-keys"><span class="kbd-key">g</span><span class="kbd-key">f</span></span></div>
+    <div class="kbd-row"><span>Open Orchestrator</span><span class="kbd-keys"><span class="kbd-key">g</span><span class="kbd-key">u</span></span></div>
+
+    <div class="kbd-section-title">Activations</div>
+    <div class="kbd-row"><span>Open Activations</span><span class="kbd-keys"><span class="kbd-key">g</span><span class="kbd-key">a</span></span></div>
+    <div class="kbd-row"><span>Open Destinations</span><span class="kbd-keys"><span class="kbd-key">g</span><span class="kbd-key">n</span></span></div>
+
+    <div class="kbd-section-title">Reference</div>
     <div class="kbd-row"><span>Open Capabilities</span><span class="kbd-keys"><span class="kbd-key">g</span><span class="kbd-key">k</span></span></div>
     <div class="kbd-row"><span>Open Dev kit</span><span class="kbd-keys"><span class="kbd-key">g</span><span class="kbd-key">v</span></span></div>
-    <div class="kbd-row"><span>Open Destinations</span><span class="kbd-keys"><span class="kbd-key">g</span><span class="kbd-key">n</span></span></div>
-    <div class="kbd-row"><span>Open Embedding Lab</span><span class="kbd-keys"><span class="kbd-key">g</span><span class="kbd-key">x</span></span></div>
-    <div class="kbd-row"><span>Open Portfolio</span><span class="kbd-keys"><span class="kbd-key">g</span><span class="kbd-key">p</span></span></div>
-    <div class="kbd-row"><span>Open Seasonality</span><span class="kbd-keys"><span class="kbd-key">g</span><span class="kbd-key">s</span></span></div>
-    <div class="kbd-row"><span>Open Federation</span><span class="kbd-keys"><span class="kbd-key">g</span><span class="kbd-key">f</span></span></div>
+    <div class="kbd-row"><span>Open Tool Log</span><span class="kbd-keys"><span class="kbd-key">g</span><span class="kbd-key">l</span></span></div>
+
+    <div class="kbd-section-title">Detail panel & UI</div>
+    <div class="kbd-row"><span>Toggle sidebar</span><span class="kbd-keys"><span class="kbd-key">Ctrl/Cmd</span><span class="kbd-key">B</span></span></div>
     <div class="kbd-row"><span>Expand / collapse detail panel</span><span class="kbd-keys"><span class="kbd-key">f</span></span></div>
-    <div class="kbd-row"><span>Close detail panel</span><span class="kbd-keys"><span class="kbd-key">Esc</span></span></div>
+    <div class="kbd-row"><span>Close detail panel / overlay</span><span class="kbd-keys"><span class="kbd-key">Esc</span></span></div>
     <div class="kbd-row"><span>Toggle this sheet</span><span class="kbd-keys"><span class="kbd-key">?</span></span></div>
   </div>
 </div>

--- a/tests/__snapshots__/demo-render-snapshot.test.ts.snap
+++ b/tests/__snapshots__/demo-render-snapshot.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`handleDemo byte-equivalence > matches the committed golden hash (LF-normalized SHA-256 of body) 1`] = `
 {
-  "hash": "e895eebe00b71214a78ff29de20e43bbe5306552fc0e95fdfc6edb6d1a39aaff",
-  "length": 1103366,
+  "hash": "c236c2c812edb618ba57da4d7ae8b7dd42bcfe53b2f8c0626c780e61f14d0958",
+  "length": 1106989,
 }
 `;


### PR DESCRIPTION
## Summary

Fill in the 11 tabs that had no keyboard shortcut + add the 2 that were wired in JS but missing from the cheat sheet. Reorganize the overlay into capability sections matching the sidebar groups.

## Coverage before / after

| | Before | After |
|---|---|---|
| Tabs with `g <key>` shortcut | 15 / 26 | **26 / 26** |
| Cheat sheet entries | 13 | **27** |

## New mappings

| Key | Tab | Mnemonic |
|---|---|---|
| `y` | Concepts | s**y**nonyms (vocab layer) |
| `m` | Composer | co**m**pose |
| `r` | Expression | **r**ule (expression AST) |
| `j` | Journey | **j**ourney |
| `q` | Planner (Scenario) | **q**uery / s**q**enario |
| `h` | Snapshots | **h**istory |
| `w` | Freshness | **w**indow |
| `u` | Orchestrator | **u**nify agents |
| `1` | Brand Canvas | Workshop Canvas #1 |
| `2` | Campaign Canvas | Workshop Canvas #2 |
| `3` | Agentic Canvas | Workshop Canvas #3 |

All chosen to avoid collision with existing 15 letters (d/c/b/t/o/e/k/v/n/l/a/x/p/s/f). Numeric 1/2/3 for the canvas trio because they're a natural sequence.

## Cheat-sheet overhaul

Reorganized into 7 sections that match the sidebar groups:

```
Signals          → Discover, Catalog, Concepts
Analytics        → Treemap, Overlap, Embedding, Embedding Lab, Seasonality, Freshness
Audience         → Builder, Composer, Expression, Journey, Portfolio, Scenario, Snapshots
Workshop Canvases → Brand, Campaign, Agentic
Multi-Agent      → Federation, Orchestrator
Activations      → Activations, Destinations
Reference        → Capabilities, Dev kit, Tool Log
Detail panel & UI → Ctrl/Cmd+B, f, Esc, ?
```

New `.kbd-section-title` style. Added `max-height: 80vh + overflow-y: auto` to the card so the longer list fits on smaller viewports. Surfaced Ctrl/Cmd+B (sidebar toggle) — was wired but undiscoverable.

## Test plan

- [x] `npx vitest run` — 441/441 passing (snapshot golden updated)
- [x] `python tmp-mining/trap_audit.py` — clean
- [x] All 11 missing tabs wired into the JS map
- [x] All 26 wired shortcuts present in the cheat sheet
- [ ] After merge + deploy: press `?` on prod to view; try `g 1`, `g j`, `g q`, etc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)