### PR TITLE
PR B: /ecosystem clarity layer + cinema flythrough + matrix-rain (review in totality)

### DIFF
--- a/src/routes/ecosystemCanvas.ts
+++ b/src/routes/ecosystemCanvas.ts
@@ -84,6 +84,66 @@ export function renderEcosystemCanvas(demoKey: string): string {
   .meta-pill { padding: 5px 10px; background: rgba(0,0,0,0.4); border: 1px solid rgba(56, 182, 255, 0.16); border-radius: 12px; }
   .meta-pill b { color: var(--text); font-weight: 600; }
 
+  /* Phase banner — sits below the topbar, centered. The single most
+     important affordance: tells the viewer WHAT IS HAPPENING right now
+     ("PHASE 2 of 6 · governance check"). Updates in real time as cycle
+     events arrive over SSE. */
+  .phase-banner {
+    position: fixed; top: 64px; left: 50%;
+    transform: translateX(-50%);
+    z-index: 9;
+    pointer-events: none;
+    display: flex; align-items: center; gap: 12px;
+    padding: 8px 18px;
+    background: rgba(10, 14, 21, 0.92);
+    border: 1px solid var(--panel-border);
+    border-radius: 18px;
+    font: 12px ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+    letter-spacing: 0.06em; text-transform: uppercase;
+    color: var(--text-dim);
+    transition: border-color 0.25s, color 0.25s, background 0.25s;
+  }
+  .phase-banner.is-phase-signals     { border-color: var(--c-signals);     color: var(--c-signals); }
+  .phase-banner.is-phase-governance  { border-color: var(--c-governance);  color: var(--c-governance); }
+  .phase-banner.is-phase-sales       { border-color: var(--c-sales);       color: var(--c-sales); }
+  .phase-banner.is-phase-creative    { border-color: var(--c-creative);    color: var(--c-creative); }
+  .phase-banner.is-phase-buying      { border-color: var(--c-buying);      color: var(--c-buying); }
+  .phase-banner.is-phase-measurement { border-color: var(--c-measurement); color: var(--c-measurement); }
+  .phase-dot { width: 8px; height: 8px; border-radius: 50%; background: currentColor; box-shadow: 0 0 12px currentColor; animation: phase-pulse 1.4s ease-in-out infinite; }
+  @keyframes phase-pulse { 0%,100% { opacity: 0.4; } 50% { opacity: 1; } }
+  .phase-num { font-weight: 600; color: var(--text); }
+  .phase-meta { color: var(--text-dim); font-size: 10.5px; letter-spacing: 0.04em; text-transform: none; }
+
+  /* Agent name labels — DOM elements positioned every frame from
+     each node's projected screen coords. Always visible so viewers
+     can read who is firing without clicking. Lower opacity for back-
+     hemisphere agents (z behind camera) so the constellation reads
+     clearly even when crowded. */
+  #label-layer {
+    position: fixed; inset: 0; z-index: 6;
+    pointer-events: none;
+  }
+  .agent-label {
+    position: absolute;
+    transform: translate(-50%, -50%);
+    padding: 2px 7px;
+    background: rgba(10, 14, 21, 0.78);
+    border: 1px solid rgba(56, 182, 255, 0.15);
+    border-radius: 4px;
+    font: 10px ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+    color: var(--text-dim);
+    white-space: nowrap;
+    letter-spacing: 0.02em;
+    transition: opacity 0.18s ease, transform 0.12s ease, border-color 0.2s;
+    will-change: left, top, opacity;
+  }
+  .agent-label.firing {
+    color: var(--text);
+    border-color: var(--accent);
+    background: rgba(56, 182, 255, 0.12);
+    transform: translate(-50%, -50%) scale(1.08);
+  }
+
   .legend {
     position: fixed; bottom: 18px; left: 18px; z-index: 10;
     background: var(--panel); border: 1px solid var(--panel-border); border-radius: 8px;
@@ -124,13 +184,14 @@ export function renderEcosystemCanvas(demoKey: string): string {
   .trace-summary.review { color: #f59e0b; }
 
   .agent-panel {
-    position: fixed; bottom: 18px; right: 18px; z-index: 11;
-    width: 320px;
+    position: fixed; top: 78px; left: 18px; z-index: 11;
+    width: 340px;
     background: var(--panel); border: 1px solid var(--panel-border); border-radius: 10px;
     padding: 14px 16px;
     backdrop-filter: blur(8px);
     pointer-events: auto;
     display: none;
+    box-shadow: 0 12px 40px rgba(0,0,0,0.6);
   }
   .agent-panel.open { display: block; }
   .agent-panel-head { display: flex; align-items: flex-start; justify-content: space-between; gap: 12px; }
@@ -154,9 +215,88 @@ export function renderEcosystemCanvas(demoKey: string): string {
     background: var(--panel); border: 1px solid var(--panel-border); border-radius: 16px;
     padding: 6px 12px; font-size: 11px; cursor: pointer; color: var(--text-dim);
     pointer-events: auto;
+    font-family: inherit;
   }
   .audio-toggle:hover { color: var(--accent); border-color: var(--accent); }
   .audio-toggle.on { color: var(--accent); border-color: var(--accent); }
+
+  /* Hide-UI mode for clean recordings: dim every panel except the
+     constellation. Recovers on toggle-off. */
+  body.hide-ui .topbar,
+  body.hide-ui .legend,
+  body.hide-ui .trace-panel,
+  body.hide-ui .agent-panel,
+  body.hide-ui .home-link,
+  body.hide-ui .phase-banner,
+  body.hide-ui #label-layer,
+  body.hide-ui .audio-toggle:not(#hide-ui-toggle):not(#cinema-toggle) {
+    opacity: 0; pointer-events: none; transition: opacity 0.4s;
+  }
+  body.hide-ui #hide-ui-toggle,
+  body.hide-ui #cinema-toggle {
+    opacity: 0.45;
+  }
+  body.hide-ui #hide-ui-toggle:hover,
+  body.hide-ui #cinema-toggle:hover { opacity: 1; }
+
+  /* Matrix-rain modal: vertical scroll of raw JSON-RPC frames for one
+     agent. Phosphor-green retro aesthetic on top of the constellation. */
+  .matrix-modal {
+    position: fixed; inset: 0; z-index: 20;
+    display: none; align-items: stretch; justify-content: center;
+    background: rgba(0, 0, 0, 0.55);
+    backdrop-filter: blur(2px);
+  }
+  .matrix-modal.open { display: flex; }
+  .matrix-modal-head {
+    position: fixed; top: 16px; left: 50%; transform: translateX(-50%);
+    z-index: 22;
+    display: flex; align-items: center; gap: 12px;
+    padding: 8px 18px;
+    background: rgba(0, 0, 0, 0.85);
+    border: 1px solid #2eff6a; border-radius: 4px;
+    color: #2eff6a; font: 11px ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+    text-transform: uppercase; letter-spacing: 0.08em;
+  }
+  .matrix-modal-title { font-weight: 600; }
+  .matrix-modal-close {
+    background: transparent; border: 1px solid #2eff6a; color: #2eff6a;
+    width: 22px; height: 22px; line-height: 18px; padding: 0;
+    border-radius: 3px; cursor: pointer;
+    font-family: inherit; font-size: 14px;
+  }
+  .matrix-modal-close:hover { background: rgba(46, 255, 106, 0.15); }
+  .matrix-modal-foot {
+    position: fixed; bottom: 16px; left: 50%; transform: translateX(-50%);
+    z-index: 22;
+    color: #2eff6a; font: 10px ui-monospace, monospace;
+    opacity: 0.55; letter-spacing: 0.08em;
+  }
+  .matrix-rain {
+    flex: 1;
+    align-self: center;
+    width: min(720px, 80vw);
+    max-height: 80vh;
+    overflow: hidden;
+    padding: 60px 24px 60px;
+    color: #2eff6a;
+    font: 10.5px ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+    line-height: 1.45;
+    text-shadow: 0 0 6px rgba(46, 255, 106, 0.55);
+    position: relative;
+  }
+  .matrix-rain pre {
+    margin: 0 0 14px;
+    white-space: pre-wrap; word-break: break-all;
+    opacity: 0.0;
+    animation: matrix-fade-in 0.6s ease forwards;
+  }
+  .matrix-rain pre:nth-child(odd) { color: #2eff6a; }
+  .matrix-rain pre:nth-child(even) { color: #5eff8e; }
+  @keyframes matrix-fade-in {
+    0% { opacity: 0; transform: translateY(-8px); }
+    100% { opacity: 0.92; transform: translateY(0); }
+  }
 
   .home-link {
     position: fixed; top: 18px; right: 18px; z-index: 11;
@@ -176,6 +316,14 @@ export function renderEcosystemCanvas(demoKey: string): string {
 <body>
 <div id="stage"></div>
 <div class="hero-overlay"></div>
+<div id="label-layer"></div>
+
+<div class="phase-banner" id="phase-banner">
+  <span class="phase-dot" aria-hidden="true"></span>
+  <span class="phase-num" id="phase-num">PHASE —</span>
+  <span id="phase-title">awaiting first brief</span>
+  <span class="phase-meta" id="phase-meta"></span>
+</div>
 
 <div class="topbar">
   <div class="brand">
@@ -236,6 +384,20 @@ export function renderEcosystemCanvas(demoKey: string): string {
 </div>
 
 <button class="audio-toggle" id="audio-toggle">♪ audio off</button>
+<button class="audio-toggle" id="cinema-toggle" style="left: 350px;">▶ cinema</button>
+<button class="audio-toggle" id="hide-ui-toggle" style="left: 470px;">⌘ hide UI</button>
+
+<!-- Matrix-rain modal: full-height vertical column of raw JSON-RPC
+     frames for a single agent, rendered as scrolling text. Opens on
+     click; dismisses on ESC, click outside, or close button. -->
+<div class="matrix-modal" id="matrix-modal">
+  <div class="matrix-modal-head">
+    <span class="matrix-modal-title" id="matrix-modal-title">—</span>
+    <button class="matrix-modal-close" id="matrix-modal-close">×</button>
+  </div>
+  <div class="matrix-rain" id="matrix-rain"></div>
+  <div class="matrix-modal-foot">click outside to dismiss · last 24 frames per agent</div>
+</div>
 
 <script type="importmap">
 {
@@ -371,8 +533,35 @@ function spawnAgent(agent) {
   const tether = new THREE.Line(tetherGeo, tetherMat);
   scene.add(tether);
 
-  agentMeshes.set(agent.id, { mesh, halo, position: pos, agent, lift: 0.5 });
+  // Always-visible name label. DOM element positioned each frame
+  // by projecting the mesh's 3D position to screen coords. Adds the
+  // single missing readability affordance — viewers can see WHO is
+  // firing without clicking. Stage-prefix (LIVE/SIM) badge upfront so
+  // it's clear which agents are talking to real services.
+  const labelEl = document.createElement("div");
+  labelEl.className = "agent-label";
+  const stageBadge = agent.stage === "live" ? "● " : "○ ";
+  labelEl.textContent = stageBadge + agent.name;
+  labelEl.style.color = "#" + color.toString(16).padStart(6, "0");
+  labelEl.style.borderColor = "rgba(" + ((color >> 16) & 0xff) + "," + ((color >> 8) & 0xff) + "," + (color & 0xff) + ",0.35)";
+  document.getElementById("label-layer").appendChild(labelEl);
+
+  agentMeshes.set(agent.id, { mesh, halo, position: pos, agent, lift: 0.5, label: labelEl, firingTimeout: 0 });
   agents.set(agent.id, agent);
+}
+
+// Pulse an agent visually when it sends/receives a message — bigger
+// glow, a quick scale bump, label highlights. Scheduled with a
+// timeout so concurrent beams stack rather than overwriting each
+// other's decay. Helps viewers correlate beams to specific nodes.
+function flashAgentFiring(agentId) {
+  const m = agentMeshes.get(agentId);
+  if (!m) return;
+  m.firingTimeout = 22; // frames of enhanced emission
+  if (m.label) m.label.classList.add("firing");
+  // De-class the label after a short delay; the mesh emission decays
+  // in the animation loop via firingTimeout.
+  setTimeout(function () { if (m.label) m.label.classList.remove("firing"); }, 480);
 }
 
 // ── Message beams ────────────────────────────────────────────────────────
@@ -394,6 +583,11 @@ function spawnBeam(fromId, toId, colorHint) {
   const from = getPos(fromId);
   const to = getPos(toId);
   if (!from || !to) return;
+  // Pulse both endpoints so the viewer can SEE which agents are
+  // currently exchanging the message. The buyer (origin) is always
+  // an endpoint but doesn't have an agent record — skip it cleanly.
+  if (fromId !== BUYER_AGENT_ID) flashAgentFiring(fromId);
+  if (toId !== BUYER_AGENT_ID) flashAgentFiring(toId);
   const mid = from.clone().add(to).multiplyScalar(0.5);
   const dir = to.clone().sub(from).normalize();
   const perp = new THREE.Vector3().crossVectors(dir, new THREE.Vector3(0,1,0)).normalize();
@@ -518,6 +712,47 @@ function bootstrapAgents(list) {
   for (const agent of list) spawnAgent(agent);
 }
 
+// Phase banner state — derives the current phase from message kinds.
+// The orchestrator runs phases in fixed order; we just watch which kind
+// most recently arrived. Index in PHASE_ORDER drives the "PHASE n of 6"
+// counter so viewers can see how far through the ceremony we are.
+const phaseBanner = document.getElementById("phase-banner");
+const phaseNumEl = document.getElementById("phase-num");
+const phaseTitleEl = document.getElementById("phase-title");
+const phaseMetaEl = document.getElementById("phase-meta");
+const PHASE_ORDER = [
+  { kinds: ["signals_fanout", "signal_response"],     key: "signals",     title: "Signals discovery",   role_count: 5 },
+  { kinds: ["governance_check"],                      key: "governance",  title: "Governance check",    role_count: 3 },
+  { kinds: ["sales_fanout", "sales_response"],        key: "sales",       title: "Sales fan-out",       role_count: 10 },
+  { kinds: ["creative_match"],                        key: "creative",    title: "Creative match",      role_count: 3 },
+  { kinds: ["buying_bid"],                            key: "buying",      title: "Buying bids",         role_count: 5 },
+  { kinds: ["measurement_report"],                    key: "measurement", title: "Measurement reports", role_count: 3 },
+];
+let currentPhaseIdx = -1;
+function setPhaseFromKind(kind) {
+  if (!kind) return;
+  for (let i = 0; i < PHASE_ORDER.length; i++) {
+    if (PHASE_ORDER[i].kinds.indexOf(kind) >= 0) {
+      if (i === currentPhaseIdx) return;
+      currentPhaseIdx = i;
+      const ph = PHASE_ORDER[i];
+      phaseNumEl.textContent = "PHASE " + (i + 1) + " / 6";
+      phaseTitleEl.textContent = ph.title;
+      phaseMetaEl.textContent = "· " + ph.role_count + " agents";
+      // Swap accent class
+      phaseBanner.className = "phase-banner is-phase-" + ph.key;
+      return;
+    }
+  }
+}
+function setPhaseIdle(label) {
+  currentPhaseIdx = -1;
+  phaseBanner.className = "phase-banner";
+  phaseNumEl.textContent = "PHASE —";
+  phaseTitleEl.textContent = label;
+  phaseMetaEl.textContent = "";
+}
+
 const evtSource = new EventSource("/ecosystem/stream");
 evtSource.onmessage = function (msg) {
   let ev;
@@ -529,18 +764,28 @@ evtSource.onmessage = function (msg) {
       break;
     case "cycle_start":
       if (ev.brief) appendBrief(ev.brief);
+      setPhaseIdle("brief spawned · " + (ev.brief ? ev.brief.prompt : ""));
       break;
     case "cycle_end":
-      // Add a separator card so the next brief reads as a new ceremony
+      setPhaseIdle("cycle complete · awaiting next brief");
       break;
     case "ecosystem_state":
       if (ev.state) updateState(ev.state);
       break;
     case "trace":
       if (ev.trace) appendTrace(ev.trace);
+      if (ev.trace && ev.trace.kind) setPhaseFromKind(ev.trace.kind);
+      // Stash trace into per-agent log for matrix-rain replay
+      if (ev.trace && ev.trace.agent_id) recordAgentFrame(ev.trace.agent_id, ev.trace);
       break;
     case "message":
-      if (ev.message) spawnBeam(ev.message.from_agent_id, ev.message.to_agent_id, ev.message.color_hint);
+      if (ev.message) {
+        spawnBeam(ev.message.from_agent_id, ev.message.to_agent_id, ev.message.color_hint);
+        setPhaseFromKind(ev.message.kind);
+        // Both endpoints get the message in their log
+        if (ev.message.from_agent_id && ev.message.from_agent_id !== BUYER_AGENT_ID) recordAgentFrame(ev.message.from_agent_id, ev.message);
+        if (ev.message.to_agent_id && ev.message.to_agent_id !== BUYER_AGENT_ID) recordAgentFrame(ev.message.to_agent_id, ev.message);
+      }
       break;
     case "lift_update":
       if (ev.lift) {
@@ -558,6 +803,81 @@ evtSource.onmessage = function (msg) {
 evtSource.onerror = function () {
   brandSub.textContent = "stream interrupted — reconnecting…";
 };
+
+// ── Per-agent frame log (drives matrix-rain) ─────────────────────────────
+//
+// Every message + trace whose subject is agent X gets pushed into X's
+// circular buffer (max 24 frames). Click handler reads the buffer to
+// render the matrix-rain stream. The shape is intentionally close to
+// the wire format — looks like real JSON-RPC traffic when displayed.
+const FRAME_LOG_MAX = 24;
+const agentFrames = new Map();
+function recordAgentFrame(agentId, payload) {
+  let buf = agentFrames.get(agentId);
+  if (!buf) { buf = []; agentFrames.set(agentId, buf); }
+  // Synthesize a JSON-RPC-shaped envelope so the matrix-rain reads
+  // like real protocol traffic. Includes ts, agent_id, payload kind.
+  const frame = {
+    ts: new Date().toISOString(),
+    agent_id: agentId,
+    kind: payload.kind || "?",
+    payload: payload.summary || payload.color_hint || payload,
+  };
+  if (payload.detail) frame.detail = payload.detail;
+  buf.push(frame);
+  if (buf.length > FRAME_LOG_MAX) buf.shift();
+}
+
+// ── Matrix-rain modal ────────────────────────────────────────────────────
+const matrixModal = document.getElementById("matrix-modal");
+const matrixRain = document.getElementById("matrix-rain");
+const matrixTitle = document.getElementById("matrix-modal-title");
+const matrixClose = document.getElementById("matrix-modal-close");
+let matrixTimer = null;
+let matrixAgentId = null;
+
+function openMatrix(agentId) {
+  matrixAgentId = agentId;
+  const agent = agents.get(agentId);
+  matrixTitle.textContent = agent ? (agent.name + " · raw frames") : agentId;
+  matrixRain.innerHTML = "";
+  matrixModal.classList.add("open");
+  refreshMatrix();
+  if (matrixTimer) clearInterval(matrixTimer);
+  matrixTimer = setInterval(refreshMatrix, 700);
+}
+function refreshMatrix() {
+  if (!matrixAgentId) return;
+  const buf = agentFrames.get(matrixAgentId) || [];
+  // Keep the existing children (already animated in) — only append
+  // new ones. We tag each <pre> with its frame timestamp so we can
+  // dedupe.
+  const existing = new Set(Array.from(matrixRain.children).map(function (c) { return c.dataset.ts; }));
+  for (const f of buf) {
+    if (existing.has(f.ts)) continue;
+    const pre = document.createElement("pre");
+    pre.dataset.ts = f.ts;
+    const json = JSON.stringify(f, null, 2);
+    pre.textContent = json;
+    matrixRain.appendChild(pre);
+  }
+  // Scroll to keep the latest visible
+  matrixRain.scrollTop = matrixRain.scrollHeight;
+  // Trim DOM nodes to the buffer size
+  while (matrixRain.children.length > FRAME_LOG_MAX) {
+    matrixRain.removeChild(matrixRain.firstChild);
+  }
+}
+function closeMatrix() {
+  matrixModal.classList.remove("open");
+  if (matrixTimer) { clearInterval(matrixTimer); matrixTimer = null; }
+  matrixAgentId = null;
+}
+matrixClose.addEventListener("click", closeMatrix);
+matrixModal.addEventListener("click", function (e) { if (e.target === matrixModal) closeMatrix(); });
+document.addEventListener("keydown", function (e) {
+  if (e.key === "Escape" && matrixModal.classList.contains("open")) closeMatrix();
+});
 
 // ── Click-to-detail ─────────────────────────────────────────────────────
 const raycaster = new THREE.Raycaster();
@@ -585,6 +905,13 @@ function showAgent(agent) {
   agentPanel.classList.add("open");
 }
 
+// Click strategy:
+//   - Single click on agent → details panel (top-left)
+//   - Double click on agent → matrix-rain drop-in (full-screen frame stream)
+//   - Click outside → close any open panels
+let lastClickTime = 0;
+let lastClickAgentId = null;
+const DOUBLE_CLICK_MS = 320;
 renderer.domElement.addEventListener("click", function (e) {
   const rect = renderer.domElement.getBoundingClientRect();
   mouse.x = ((e.clientX - rect.left) / rect.width) * 2 - 1;
@@ -595,10 +922,101 @@ renderer.domElement.addEventListener("click", function (e) {
   if (hits.length > 0) {
     const id = hits[0].object.userData.agentId;
     const agent = agents.get(id);
-    if (agent) showAgent(agent);
+    if (!agent) return;
+    const now = performance.now();
+    if (lastClickAgentId === id && (now - lastClickTime) < DOUBLE_CLICK_MS) {
+      openMatrix(id);
+      lastClickTime = 0;
+      lastClickAgentId = null;
+    } else {
+      showAgent(agent);
+      lastClickTime = now;
+      lastClickAgentId = id;
+    }
   } else {
     agentPanel.classList.remove("open");
   }
+});
+
+// ── Cinema mode (programmatic camera flythrough for screen recording) ──
+//
+// Linear interpolation between waypoints over a timed schedule. Disables
+// OrbitControls' auto-rotate while running so the viewer doesn't fight
+// the keyframe pose. Pressing the button again exits cinema and hands
+// control back to OrbitControls' default auto-rotate.
+//
+// Total duration: 60s. Optimized for a single-take screen recording.
+
+const cinemaToggle = document.getElementById("cinema-toggle");
+let cinemaOn = false;
+let cinemaStart = 0;
+
+const CINEMA_KEYFRAMES = [
+  // [t_seconds, camera position (x,y,z), look-at target (x,y,z)]
+  { t:  0, pos: [ 0,  6, 38], look: [ 0,  0,  0] },  // Wide opener
+  { t:  8, pos: [22,  4, 30], look: [ 0,  0,  0] },  // Pan to signals ring
+  { t: 16, pos: [12, -8, 22], look: [ 0,  0,  0] },  // Dive under, looking up at sales ring
+  { t: 24, pos: [-18, 10, 24], look: [ 0,  0,  0] },  // Swing left + up
+  { t: 32, pos: [ 0,  18, 22], look: [ 0, -2,  0] },  // Top-down looking at buyer + governance ring
+  { t: 40, pos: [-22, -2, 28], look: [ 0,  0,  0] },  // Side angle, full constellation
+  { t: 48, pos: [ 6,  4, 44], look: [ 0,  0,  0] },  // Pull back wide
+  { t: 56, pos: [ 0,  6, 38], look: [ 0,  0,  0] },  // Return to opener
+  { t: 60, pos: [ 0,  6, 38], look: [ 0,  0,  0] },  // Hold on opener
+];
+
+function lerp(a, b, t) { return a + (b - a) * t; }
+function lerp3(a, b, t) { return [lerp(a[0], b[0], t), lerp(a[1], b[1], t), lerp(a[2], b[2], t)]; }
+
+function cinemaTick() {
+  if (!cinemaOn) return;
+  const elapsed = (performance.now() - cinemaStart) / 1000;
+  if (elapsed >= 60) {
+    // Loop back to start for continuous recordable footage
+    cinemaStart = performance.now();
+    return;
+  }
+  // Find the segment we're in
+  let segA = CINEMA_KEYFRAMES[0];
+  let segB = CINEMA_KEYFRAMES[1];
+  for (let i = 0; i < CINEMA_KEYFRAMES.length - 1; i++) {
+    if (elapsed >= CINEMA_KEYFRAMES[i].t && elapsed < CINEMA_KEYFRAMES[i + 1].t) {
+      segA = CINEMA_KEYFRAMES[i];
+      segB = CINEMA_KEYFRAMES[i + 1];
+      break;
+    }
+  }
+  const segT = (elapsed - segA.t) / (segB.t - segA.t);
+  // Smoothstep for cinematic ease-in/out
+  const eased = segT * segT * (3 - 2 * segT);
+  const pos = lerp3(segA.pos, segB.pos, eased);
+  const look = lerp3(segA.look, segB.look, eased);
+  camera.position.set(pos[0], pos[1], pos[2]);
+  controls.target.set(look[0], look[1], look[2]);
+  // Don't call controls.update() here — it would re-apply auto-rotate.
+  // Instead, just set the camera matrix directly.
+  camera.lookAt(look[0], look[1], look[2]);
+}
+
+cinemaToggle.addEventListener("click", function () {
+  cinemaOn = !cinemaOn;
+  cinemaToggle.textContent = cinemaOn ? "■ stop" : "▶ cinema";
+  cinemaToggle.classList.toggle("on", cinemaOn);
+  if (cinemaOn) {
+    cinemaStart = performance.now();
+    controls.autoRotate = false;
+    controls.enabled = false;
+  } else {
+    controls.autoRotate = true;
+    controls.enabled = true;
+  }
+});
+
+// ── Hide-UI mode (clean recordings) ─────────────────────────────────────
+const hideUIToggle = document.getElementById("hide-ui-toggle");
+hideUIToggle.addEventListener("click", function () {
+  document.body.classList.toggle("hide-ui");
+  hideUIToggle.classList.toggle("on", document.body.classList.contains("hide-ui"));
+  hideUIToggle.textContent = document.body.classList.contains("hide-ui") ? "⌘ show UI" : "⌘ hide UI";
 });
 
 // ── Audio (Web Audio API) ────────────────────────────────────────────────
@@ -673,7 +1091,11 @@ function audioLiftBlip(lift) {
 // ── Animation loop ───────────────────────────────────────────────────────
 function animate() {
   requestAnimationFrame(animate);
-  controls.update();
+  if (cinemaOn) {
+    cinemaTick();
+  } else {
+    controls.update();
+  }
 
   // Buyer pulse
   const t = performance.now() * 0.001;
@@ -699,7 +1121,13 @@ function animate() {
     b.pulseMat.opacity = Math.max(0, b.life);
   }
 
-  // Lift halos
+  // Lift halos + label projection + firing pulse
+  // Reusable temp vector so we don't allocate one per agent per frame.
+  const __projTmp = new THREE.Vector3();
+  const halfW = window.innerWidth / 2;
+  const halfH = window.innerHeight / 2;
+  const camWorldDir = new THREE.Vector3();
+  camera.getWorldDirection(camWorldDir);
   for (const [agentId, m] of agentMeshes) {
     const decay = liftHaloDecay.get(agentId);
     if (decay) {
@@ -712,8 +1140,36 @@ function animate() {
       if (m.halo.material.opacity < 0) m.halo.material.opacity = 0;
     }
     m.halo.lookAt(camera.position);
-    // Gentle pulse on agent emissive
-    m.mesh.material.emissiveIntensity = (m.agent.stage === "live" ? 0.55 : 0.30) + 0.12 * Math.sin(t * 2 + m.position.x);
+
+    // Mesh emissive: base + sine-wave pulse + firing-pulse boost
+    let emiBase = (m.agent.stage === "live" ? 0.55 : 0.30) + 0.12 * Math.sin(t * 2 + m.position.x);
+    if (m.firingTimeout > 0) {
+      // Strong glow that decays over ~22 frames (~0.36s @ 60fps)
+      emiBase += 0.7 * (m.firingTimeout / 22);
+      m.firingTimeout -= 1;
+    }
+    m.mesh.material.emissiveIntensity = emiBase;
+
+    // Project the agent's world position to screen coords for its
+    // DOM label. Skip when agent is behind the camera (dot product
+    // with camera forward direction is negative) — keeps labels from
+    // crowding when they'd be unreadable anyway.
+    if (m.label) {
+      __projTmp.copy(m.position);
+      const toAgent = __projTmp.clone().sub(camera.position);
+      const facing = toAgent.dot(camWorldDir);
+      if (facing > 0) {
+        __projTmp.copy(m.position).project(camera);
+        const x = __projTmp.x * halfW + halfW;
+        const y = -__projTmp.y * halfH + halfH;
+        // Offset below the node a bit so it doesn't overlap the mesh
+        m.label.style.left = x + "px";
+        m.label.style.top = (y + 18) + "px";
+        m.label.style.opacity = String(Math.min(1, 0.55 + facing * 0.6));
+      } else {
+        m.label.style.opacity = "0";
+      }
+    }
   }
 
   renderer.render(scene, camera);


### PR DESCRIPTION
## Summary

Comprehensive polish for `/ecosystem` per direct prod-walkthrough feedback:

> "hard to see what is passed and how its actually working — just signal/neurons firing... also click hover not looking good, maybe top-left window?"

This PR addresses both. **+466 LOC, single file (ecosystemCanvas.ts).** Bundled as one review-in-totality changeset rather than incremental ships.

## Three layers

### Clarity (the "what's actually happening" fix)

| What | How |
|---|---|
| **Phase banner** at top-center | Color-coded current-phase indicator. "PHASE 2/6 · Governance check · 3 agents". Switches color per phase. Single most important new affordance. |
| **Always-visible agent labels** | DOM overlay projected from 3D coords each frame. ● live / ○ sim badge + agent name in role color. Hides for back-of-sphere agents. |
| **Firing highlights** | When a beam fires, both endpoints pulse: emissive boost + label highlights. Correlates beams to specific nodes. |
| **Agent details panel: top-left** | Was bottom-right competing with trace panel; now top-left where the eye lands. Added drop shadow for elevation. |

### Cinema (the "recordable" fix)

| What | How |
|---|---|
| **Cinema button** ▶ | 60-second programmatic flythrough, 9 keyframes, smoothstep easing. Loops continuously. |
| **Hide-UI button** ⌘ | Single-click fades all panels for clean recordings; toggle restores them. |

### Audit (the "expert lane" addition)

| What | How |
|---|---|
| **Matrix-rain drop-in** | Double-click any agent → full-screen phosphor-green stream of its raw JSON-RPC-shaped frames (last 24 captured live from SSE). ESC / click-outside / × to dismiss. |

## Click strategy

- **Single click** on agent → details panel (top-left)
- **Double click** on agent → matrix-rain (full-screen)
- **Click empty space** → close any open panel

## Recording recipe (60s video)

```
1. Open /ecosystem
2. Wait ~3s for first cycle to settle
3. (Optional) ♪ audio on
4. ⌘ hide UI    — panels fade
5. ▶ cinema     — flythrough begins
6. Press record, capture exactly 60s
7. Cinema loops, so any 60s slice works — re-record at will
```

## Deferred (intentionally)

- **Live MCP probe** — real-world latency on Adzymic/Claire/Dstillery (1–3s, some need session handshakes) would slow cycles and hurt the recording aesthetic. Better as an opt-in toggle in a follow-up.
- **Biz-trace tree fold-out** — flat per-brief list is readable enough; tree view is polish.
- **/ecosystem/replay endpoint** — cinema mode + continuous loop cover the recording use case.

## Test plan

- [x] `npx vitest run` — 441/441 passing
- [x] `python tmp-mining/trap_audit.py` — clean (38 files, 0 traps)
- [x] `npx wrangler deploy --dry-run` — clean
- [x] `npx tsc --noEmit -p .` — no errors
- [ ] After deploy: open /ecosystem, click ▶ cinema → verify 60s loop without controls fighting back
- [ ] After deploy: open /ecosystem, double-click an agent → matrix-rain modal opens with frames
- [ ] After deploy: ⌘ hide UI → constellation visible only

🤖 Generated with [Claude Code](https://claude.com/claude-code)