### PR TITLE
PR D+E+F: visual drama + cross-agent fit + cinema presets + keyboard shortcuts

### DIFF
--- a/src/domain/ecosystem.ts
+++ b/src/domain/ecosystem.ts
@@ -253,22 +253,65 @@ export function getAgentsByRole(role: AgentRole): EcosystemAgent[] {
 // ── Brief generator ──────────────────────────────────────────────────────────
 
 const BRIEF_PROMPTS: Array<{ prompt: string; weights: Brief["weights"] }> = [
+  // CTV-leaning
   { prompt: "Affluent CTV viewers 25-44, sports + drama affinity",
     weights: { audience: 0.7, ctv_bias: 0.9, b2b_bias: 0.0, audio_bias: 0.1 } },
-  { prompt: "Podcast listeners 35-54, automotive in-market",
-    weights: { audience: 0.6, ctv_bias: 0.1, b2b_bias: 0.0, audio_bias: 0.95 } },
-  { prompt: "B2B IT decision makers, mid-market SaaS",
-    weights: { audience: 0.5, ctv_bias: 0.0, b2b_bias: 0.95, audio_bias: 0.2 } },
-  { prompt: "New parents 0-12mo, household income > $80k",
-    weights: { audience: 0.85, ctv_bias: 0.5, b2b_bias: 0.0, audio_bias: 0.4 } },
   { prompt: "Cord-cutters 25-44, high streaming affinity, urban",
     weights: { audience: 0.7, ctv_bias: 0.85, b2b_bias: 0.05, audio_bias: 0.3 } },
+  { prompt: "CTV upper-funnel, premium content adjacency, brand-safe",
+    weights: { audience: 0.8, ctv_bias: 0.95, b2b_bias: 0.0, audio_bias: 0.05 } },
+  { prompt: "Live-event CTV viewers, sports + awards seasons",
+    weights: { audience: 0.7, ctv_bias: 0.92, b2b_bias: 0.0, audio_bias: 0.15 } },
+
+  // Audio-leaning
+  { prompt: "Podcast listeners 35-54, automotive in-market",
+    weights: { audience: 0.6, ctv_bias: 0.1, b2b_bias: 0.0, audio_bias: 0.95 } },
+  { prompt: "iHeartMedia audio + simulcast, affluent commuters",
+    weights: { audience: 0.6, ctv_bias: 0.2, b2b_bias: 0.05, audio_bias: 0.9 } },
+  { prompt: "Spoken-word podcast affinity, cooking + lifestyle",
+    weights: { audience: 0.55, ctv_bias: 0.05, b2b_bias: 0.0, audio_bias: 0.92 } },
+  { prompt: "Streaming radio drive-time, urban DMAs",
+    weights: { audience: 0.5, ctv_bias: 0.0, b2b_bias: 0.0, audio_bias: 0.98 } },
+
+  // B2B-leaning
+  { prompt: "B2B IT decision makers, mid-market SaaS",
+    weights: { audience: 0.5, ctv_bias: 0.0, b2b_bias: 0.95, audio_bias: 0.2 } },
+  { prompt: "Account-based: Fortune 500 marketing leadership",
+    weights: { audience: 0.4, ctv_bias: 0.1, b2b_bias: 0.98, audio_bias: 0.1 } },
+  { prompt: "Cybersecurity buying committee, enterprise",
+    weights: { audience: 0.45, ctv_bias: 0.05, b2b_bias: 0.93, audio_bias: 0.15 } },
+
+  // Lifestyle / demographic
+  { prompt: "New parents 0-12mo, household income > $80k",
+    weights: { audience: 0.85, ctv_bias: 0.5, b2b_bias: 0.0, audio_bias: 0.4 } },
   { prompt: "Luxury automotive intenders 45+, top DMAs",
     weights: { audience: 0.8, ctv_bias: 0.7, b2b_bias: 0.1, audio_bias: 0.5 } },
   { prompt: "Health-conscious affluent millennials, urban metros",
     weights: { audience: 0.75, ctv_bias: 0.5, b2b_bias: 0.0, audio_bias: 0.4 } },
+  { prompt: "Empty nesters 55+, premium travel intenders",
+    weights: { audience: 0.7, ctv_bias: 0.6, b2b_bias: 0.0, audio_bias: 0.5 } },
+  { prompt: "Gen Z gamers, console + PC, esports affinity",
+    weights: { audience: 0.7, ctv_bias: 0.5, b2b_bias: 0.0, audio_bias: 0.45 } },
+
+  // Seasonal / retail
   { prompt: "Holiday gift shoppers — Q4 retail, last-mile attribution",
     weights: { audience: 0.6, ctv_bias: 0.4, b2b_bias: 0.0, audio_bias: 0.5 } },
+  { prompt: "Back-to-school parents + students, mid-Aug surge",
+    weights: { audience: 0.65, ctv_bias: 0.4, b2b_bias: 0.0, audio_bias: 0.55 } },
+  { prompt: "Black Friday in-market deal hunters",
+    weights: { audience: 0.55, ctv_bias: 0.35, b2b_bias: 0.0, audio_bias: 0.6 } },
+
+  // Niche
+  { prompt: "DIY home renovators, project budget $5k+",
+    weights: { audience: 0.7, ctv_bias: 0.3, b2b_bias: 0.05, audio_bias: 0.6 } },
+  { prompt: "Sustainable lifestyle buyers, eco-credentials matter",
+    weights: { audience: 0.6, ctv_bias: 0.45, b2b_bias: 0.0, audio_bias: 0.55 } },
+  { prompt: "Pet owners — premium-food intenders, dogs + cats",
+    weights: { audience: 0.7, ctv_bias: 0.3, b2b_bias: 0.0, audio_bias: 0.6 } },
+  { prompt: "First-time home buyers 28-38, suburban migration",
+    weights: { audience: 0.75, ctv_bias: 0.55, b2b_bias: 0.05, audio_bias: 0.45 } },
+  { prompt: "Cookie-less ID-resolved CTV, UID2 + RampID coverage",
+    weights: { audience: 0.65, ctv_bias: 0.85, b2b_bias: 0.15, audio_bias: 0.1 } },
 ];
 
 let briefCounter = 0;
@@ -318,22 +361,73 @@ function syntheticDelay(agent: EcosystemAgent): Promise<void> {
   return new Promise((res) => setTimeout(res, base + jitter));
 }
 
+// Brief-fit score per agent: how well do this agent's specialties match
+// this brief's weight profile? Returns [0..1+]. Used to bias every
+// synthetic responder so agents look like they CARE about the brief
+// rather than randomly responding. Specialty keywords are mapped to
+// brief-weight dimensions; matches multiply the agent's response.
+//
+// e.g. mock_audio_signals (audio_ad_attention, podcast_listenership)
+// scores HIGH on a "podcast listeners" brief, LOW on a CTV brief.
+// Dstillery (behavioral_audiences, ttd_deployment) is balanced.
+const SPECIALTY_TO_DIMENSION: Record<string, keyof Brief["weights"]> = {
+  audio: "audio_bias",
+  audio_first: "audio_bias",
+  audio_ad_attention: "audio_bias",
+  podcast_listenership: "audio_bias",
+  podcast_buying: "audio_bias",
+  audio_attention: "audio_bias",
+  iheart_simulcast: "audio_bias",
+  ctv_premium: "ctv_bias",
+  ctv: "ctv_bias",
+  display_ctv_unified: "ctv_bias",
+  sports: "ctv_bias",
+  live_events: "ctv_bias",
+  b2b_account_based: "b2b_bias",
+  account_based: "b2b_bias",
+  technographic: "b2b_bias",
+  decision_maker_seniority: "b2b_bias",
+  linkedin_inventory: "b2b_bias",
+};
+
+function briefFitScore(agent: EcosystemAgent, brief: Brief): number {
+  const specs = agent.specialties || [];
+  if (specs.length === 0) return 0.6; // generic baseline
+  let score = 0.5; // baseline so no agent goes to zero
+  let matches = 0;
+  for (const spec of specs) {
+    const dim = SPECIALTY_TO_DIMENSION[spec];
+    if (!dim) continue;
+    const w = (brief.weights as Record<string, number>)[dim] ?? 0;
+    score += w * 0.35;
+    matches += 1;
+  }
+  // Universal-relevance specialties (cross-taxonomy etc.) get a small
+  // floor boost so generalist agents like evgeny_signals don't lose
+  // to specialists on every brief.
+  if (matches === 0 && specs.some((s) => s.includes("cross_taxonomy") || s.includes("ucp_") || s.includes("dts_"))) {
+    score += brief.weights.audience * 0.2;
+  }
+  return Math.min(1.4, score);
+}
+
 export async function syntheticSignalsResponse(agent: EcosystemAgent, brief: Brief): Promise<{
   signals: Array<{ name: string; coverage: number; cpm: number }>;
   agent_id: string;
+  fit: number;
 }> {
   await syntheticDelay(agent);
   if (Math.random() < (agent.personality?.failure_rate ?? 0)) throw new Error("simulated network error");
-  const baseCount = 3 + Math.floor(Math.random() * 5);
-  const audioBoost = brief.weights.audio_bias * 1.5;
-  const ctvBoost = brief.weights.ctv_bias * 1.3;
+  const fit = briefFitScore(agent, brief);
+  // Higher fit → more candidates returned + better coverage.
+  const baseCount = Math.max(1, Math.round(3 + fit * 3 + Math.random() * 2));
   const audienceBias = (agent.personality?.audience_size_bias ?? 0.5);
   const signals = Array.from({ length: baseCount }, (_, i) => ({
     name: `${agent.specialties?.[0] ?? "audience"}_seg_${i + 1}`,
-    coverage: Math.min(100, (15 + Math.random() * 40) * (1 + audienceBias)),
-    cpm: Math.max(0.5, (2 + Math.random() * 6) * (1 + audioBoost * 0.1 + ctvBoost * 0.1)),
+    coverage: Math.min(95, (15 + Math.random() * 40 + fit * 25) * (1 + audienceBias * 0.5)),
+    cpm: Math.max(0.5, (2 + Math.random() * 6) * (0.8 + fit * 0.5)),
   }));
-  return { signals, agent_id: agent.id };
+  return { signals, agent_id: agent.id, fit };
 }
 
 export async function syntheticGovernanceResponse(agent: EcosystemAgent, brief: Brief): Promise<{
@@ -352,19 +446,24 @@ export async function syntheticGovernanceResponse(agent: EcosystemAgent, brief: 
 export async function syntheticSalesResponse(agent: EcosystemAgent, brief: Brief): Promise<{
   products: Array<{ id: string; name: string; cpm: number; available_impressions: number }>;
   agent_id: string;
+  fit: number;
 }> {
   await syntheticDelay(agent);
   if (Math.random() < (agent.personality?.failure_rate ?? 0)) throw new Error("simulated sales agent error");
   const aggression = agent.personality?.bid_aggressiveness ?? 0.7;
-  const ctvFit = brief.weights.ctv_bias;
-  const productCount = 2 + Math.floor(Math.random() * 4);
+  const fit = briefFitScore(agent, brief);
+  // Sales agents whose specialty matches the brief return MORE products
+  // with better terms. Off-fit agents return a token 1-2 to show they
+  // tried; that's the "we handle the call but it's not our sweet spot"
+  // signal you'd see in real ecosystems.
+  const productCount = Math.max(1, Math.round(2 + fit * 3 + Math.random() * 1));
   const products = Array.from({ length: productCount }, (_, i) => ({
     id: `${agent.id}_prod_${i + 1}`,
     name: `${agent.specialties?.[0] ?? "premium"}_${i + 1}`,
-    cpm: 8 + Math.random() * 24 * (1 + ctvFit * 0.5),
-    available_impressions: Math.floor((5_000_000 + Math.random() * 30_000_000) * aggression),
+    cpm: (8 + Math.random() * 24) * (0.7 + fit * 0.4),
+    available_impressions: Math.floor((5_000_000 + Math.random() * 30_000_000) * aggression * (0.6 + fit * 0.6)),
   }));
-  return { products, agent_id: agent.id };
+  return { products, agent_id: agent.id, fit };
 }
 
 export async function syntheticCreativeResponse(agent: EcosystemAgent, brief: Brief): Promise<{
@@ -389,42 +488,80 @@ export async function syntheticBuyingBid(agent: EcosystemAgent, brief: Brief): P
   bid_cpm: number;
   budget_committed: number;
   agent_id: string;
+  fit: number;
 }> {
   await syntheticDelay(agent);
   if (Math.random() < (agent.personality?.failure_rate ?? 0)) throw new Error("buying agent timeout");
   const aggression = agent.personality?.bid_aggressiveness ?? 0.7;
-  const briefFit =
-    brief.weights.audio_bias * (agent.specialties?.includes("audio_first") ? 1.4 : 1) +
-    brief.weights.ctv_bias * (agent.specialties?.includes("display_ctv_unified") ? 1.3 : 1) +
-    brief.weights.b2b_bias * (agent.specialties?.includes("b2b_account_based") ? 1.6 : 1);
+  const fit = briefFitScore(agent, brief);
+  // Buying agents commit budget proportionally to brief fit. A b2b
+  // brief gets a $50k commitment from mock_dsp_gamma (b2b specialist)
+  // and a $5k token from mock_dsp_beta (audio specialist).
   return {
-    bid_cpm: 4 + Math.random() * 14 * aggression * briefFit,
-    budget_committed: Math.floor(brief.budget_usd * (0.15 + Math.random() * 0.5) * aggression),
+    bid_cpm: (4 + Math.random() * 14) * aggression * (0.7 + fit * 0.7),
+    budget_committed: Math.floor(brief.budget_usd * (0.10 + fit * 0.55) * aggression),
     agent_id: agent.id,
+    fit,
   };
 }
 
-export async function syntheticMeasurementReport(agent: EcosystemAgent, brief: Brief): Promise<{
-  lift: number;          // [0..1]
-  reach_pct: number;     // [0..100]
-  brand_safety: number;  // [0..1]
+export async function syntheticMeasurementReport(
+  agent: EcosystemAgent,
+  brief: Brief,
+  context?: {
+    avg_signal_fit?: number;
+    avg_sales_fit?: number;
+    avg_bid_cpm?: number;
+    total_budget_committed?: number;
+    bid_count?: number;
+  }
+): Promise<{
+  lift: number;
+  reach_pct: number;
+  brand_safety: number;
   agent_id: string;
+  fit_components?: { signal_fit: number; sales_fit: number; bid_efficiency: number; specialty_match: number };
 }> {
   await syntheticDelay(agent);
   if (Math.random() < (agent.personality?.failure_rate ?? 0)) throw new Error("measurement timeout");
-  // Lift correlates loosely with how well the brief matches an agent's
-  // specialty. This is what drives the feedback loop — measurement
-  // agents that find the brief "fit" their specialty report higher
-  // lift, which biases next-cycle brief generation.
-  const fitToAudio = brief.weights.audio_bias * (agent.id === "triton_attention_mock" ? 1.3 : 1.0);
-  const fitToCtv = brief.weights.ctv_bias * (agent.id === "nielsen_shape_mock" ? 1.2 : 1.0);
-  const baseLift = 0.35 + Math.random() * 0.5;
-  const lift = Math.min(0.99, baseLift * (1 + fitToAudio * 0.15 + fitToCtv * 0.1));
+  // Meaningful lift: weighted product of upstream-phase quality
+  // signals. This replaces the old random + per-agent-tweak pattern
+  // with a CV-style fit function so the feedback loop converges
+  // toward briefs that actually run well end-to-end.
+  //
+  //   signal_fit       = avg fit of signals agents that responded
+  //   sales_fit        = avg fit of sales agents that responded
+  //   bid_efficiency   = (sum bid_cpm / count) normalized — lower CPM at
+  //                      same coverage = more efficient
+  //   specialty_match  = does this measurement agent specialize in the
+  //                      brief's dominant axis?
+  const signalFit = context?.avg_signal_fit ?? 0.6;
+  const salesFit = context?.avg_sales_fit ?? 0.6;
+  const avgCpm = context?.avg_bid_cpm ?? 8;
+  // CPM efficiency: cap at 25 (very expensive) → 0; floor at 4 (cheap) → 1
+  const bidEfficiency = Math.max(0, Math.min(1, (25 - avgCpm) / 21));
+  // Specialty match: which axis does this measurement agent care about?
+  const dominant = brief.weights.audio_bias > brief.weights.ctv_bias && brief.weights.audio_bias > brief.weights.b2b_bias
+    ? "audio"
+    : brief.weights.ctv_bias > brief.weights.b2b_bias ? "ctv" : "b2b";
+  let specialtyMatch = 0.6;
+  if (agent.id === "triton_attention_mock" && dominant === "audio") specialtyMatch = 1.0;
+  else if (agent.id === "nielsen_shape_mock" && dominant === "ctv") specialtyMatch = 0.95;
+  else if (agent.id === "ias_shape_mock") specialtyMatch = 0.75; // generalist viewability + brand-safety
+  // Weighted geometric-ish mean. Falls toward 0.3 if any component is
+  // weak, toward 0.85 if all align. Random component adds ±0.08
+  // jitter — measurement noise.
+  const aligned = (signalFit * 0.30) + (salesFit * 0.25) + (bidEfficiency * 0.25) + (specialtyMatch * 0.20);
+  const jitter = (Math.random() - 0.5) * 0.16;
+  const lift = Math.max(0.15, Math.min(0.97, aligned + jitter));
+  // Reach scales with sales fit (more products = more reach)
+  const reachPct = Math.min(85, 12 + salesFit * 60 + Math.random() * 8);
   return {
     lift,
-    reach_pct: 8 + Math.random() * 60,
+    reach_pct: reachPct,
     brand_safety: 0.85 + Math.random() * 0.14,
     agent_id: agent.id,
+    fit_components: { signal_fit: signalFit, sales_fit: salesFit, bid_efficiency: bidEfficiency, specialty_match: specialtyMatch },
   };
 }
 
@@ -480,6 +617,15 @@ const BUYER_AGENT_ID = "__buyer_orchestrator";
 async function* runCycle(brief: Brief, _liftMap: Map<string, AgentLift>): AsyncGenerator<CycleEvent> {
   const t0 = Date.now();
 
+  // Accumulate quality signals across phases so measurement can do a
+  // real CV-fit-style lift score instead of randomly jittering.
+  const cycleContext = {
+    signal_fits: [] as number[],
+    sales_fits: [] as number[],
+    bid_cpms: [] as number[],
+    total_budget_committed: 0,
+  };
+
   yield {
     kind: "cycle_start",
     brief,
@@ -507,18 +653,19 @@ async function* runCycle(brief: Brief, _liftMap: Map<string, AgentLift>): AsyncG
   );
   for (const r of signalResponses) {
     if (r.status !== "fulfilled") continue;
-    const v = r.value as { agent: EcosystemAgent } & ({ response: { signals: Array<{ name: string; coverage: number; cpm: number }> } } | { error: string });
+    const v = r.value as { agent: EcosystemAgent } & ({ response: { signals: Array<{ name: string; coverage: number; cpm: number }>; fit?: number } } | { error: string });
     if ("error" in v) {
       yield { kind: "trace", trace: { id: nextTraceId(), kind: "signal_response", agent_id: v.agent.id, brief_id: brief.id, ts_ms: Date.now() - t0,
         summary: `${v.agent.name}: ERROR ${v.error}`, detail: { error: v.error } } };
       continue;
     }
+    if (typeof v.response.fit === "number") cycleContext.signal_fits.push(v.response.fit);
     yield { kind: "message", message: { id: nextTraceId(), brief_id: brief.id,
       from_agent_id: v.agent.id, to_agent_id: BUYER_AGENT_ID, kind: "signal_response", ts_ms: Date.now() - t0,
       color_hint: "signal" } };
     yield { kind: "trace", trace: { id: nextTraceId(), kind: "signal_response", agent_id: v.agent.id, brief_id: brief.id, ts_ms: Date.now() - t0,
-      summary: `${v.agent.name}: ${v.response.signals.length} signals, top coverage ${v.response.signals[0]?.coverage.toFixed(1)}%`,
-      detail: { signals: v.response.signals } } };
+      summary: `${v.agent.name}: ${v.response.signals.length} signals, top coverage ${v.response.signals[0]?.coverage.toFixed(1)}%${v.response.fit !== undefined ? ` · fit ${(v.response.fit * 100).toFixed(0)}%` : ""}`,
+      detail: { signals: v.response.signals, fit: v.response.fit } } };
   }
 
   // 2) Governance check (parallel across all governance agents — winner-take-all gate)
@@ -569,15 +716,16 @@ async function* runCycle(brief: Brief, _liftMap: Map<string, AgentLift>): AsyncG
   let productsEvaluated = 0;
   for (const r of salesResponses) {
     if (r.status !== "fulfilled") continue;
-    const v = r.value as { agent: EcosystemAgent } & ({ response: { products: Array<unknown> } } | { error: string });
+    const v = r.value as { agent: EcosystemAgent } & ({ response: { products: Array<unknown>; fit?: number } } | { error: string });
     if ("error" in v) continue;
     productsEvaluated += v.response.products.length;
+    if (typeof v.response.fit === "number") cycleContext.sales_fits.push(v.response.fit);
     yield { kind: "message", message: { id: nextTraceId(), brief_id: brief.id,
       from_agent_id: v.agent.id, to_agent_id: BUYER_AGENT_ID, kind: "sales_response", ts_ms: Date.now() - t0,
       color_hint: "product" } };
     yield { kind: "trace", trace: { id: nextTraceId(), kind: "sales_response", agent_id: v.agent.id, brief_id: brief.id, ts_ms: Date.now() - t0,
-      summary: `${v.agent.name}: ${v.response.products.length} products`,
-      detail: { products: v.response.products } } };
+      summary: `${v.agent.name}: ${v.response.products.length} products${v.response.fit !== undefined ? ` · fit ${(v.response.fit * 100).toFixed(0)}%` : ""}`,
+      detail: { products: v.response.products, fit: v.response.fit } } };
   }
 
   // 4) Creative match
@@ -617,14 +765,16 @@ async function* runCycle(brief: Brief, _liftMap: Map<string, AgentLift>): AsyncG
   let bidsReceived = 0;
   for (const r of bidResponses) {
     if (r.status !== "fulfilled") continue;
-    const v = r.value as { agent: EcosystemAgent } & ({ response: { bid_cpm: number; budget_committed: number } } | { error: string });
+    const v = r.value as { agent: EcosystemAgent } & ({ response: { bid_cpm: number; budget_committed: number; fit?: number } } | { error: string });
     if ("error" in v) continue;
     bidsReceived += 1;
+    cycleContext.bid_cpms.push(v.response.bid_cpm);
+    cycleContext.total_budget_committed += v.response.budget_committed;
     yield { kind: "message", message: { id: nextTraceId(), brief_id: brief.id,
       from_agent_id: v.agent.id, to_agent_id: BUYER_AGENT_ID, kind: "buying_bid", ts_ms: Date.now() - t0,
       color_hint: "bid" } };
     yield { kind: "trace", trace: { id: nextTraceId(), kind: "buying_bid", agent_id: v.agent.id, brief_id: brief.id, ts_ms: Date.now() - t0,
-      summary: `${v.agent.name}: $${v.response.bid_cpm.toFixed(2)} CPM, $${v.response.budget_committed.toLocaleString()} committed`,
+      summary: `${v.agent.name}: $${v.response.bid_cpm.toFixed(2)} CPM, $${v.response.budget_committed.toLocaleString()} committed${v.response.fit !== undefined ? ` · fit ${(v.response.fit * 100).toFixed(0)}%` : ""}`,
       detail: { bid: v.response } } };
   }
 
@@ -635,9 +785,25 @@ async function* runCycle(brief: Brief, _liftMap: Map<string, AgentLift>): AsyncG
       from_agent_id: BUYER_AGENT_ID, to_agent_id: a.id, kind: "measurement_report", ts_ms: Date.now() - t0,
       color_hint: "measurement" } };
   }
+  // Roll up cycle quality signals so measurement can score against
+  // actual upstream-phase outcomes — not random tilt against the brief
+  // weights. This is what makes the feedback loop meaningful.
+  const measurementContext = {
+    avg_signal_fit: cycleContext.signal_fits.length > 0
+      ? cycleContext.signal_fits.reduce((a, b) => a + b, 0) / cycleContext.signal_fits.length
+      : 0.6,
+    avg_sales_fit: cycleContext.sales_fits.length > 0
+      ? cycleContext.sales_fits.reduce((a, b) => a + b, 0) / cycleContext.sales_fits.length
+      : 0.6,
+    avg_bid_cpm: cycleContext.bid_cpms.length > 0
+      ? cycleContext.bid_cpms.reduce((a, b) => a + b, 0) / cycleContext.bid_cpms.length
+      : 8,
+    total_budget_committed: cycleContext.total_budget_committed,
+    bid_count: cycleContext.bid_cpms.length,
+  };
   const measurementResponses = await Promise.allSettled(
     measurementAgents.map(async (a) => {
-      try { return { agent: a, response: await syntheticMeasurementReport(a, brief) }; }
+      try { return { agent: a, response: await syntheticMeasurementReport(a, brief, measurementContext) }; }
       catch (e) { return { agent: a, error: String(e) }; }
     })
   );

--- a/src/routes/ecosystemCanvas.ts
+++ b/src/routes/ecosystemCanvas.ts
@@ -481,11 +481,67 @@ export function renderEcosystemCanvas(demoKey: string): string {
     position: fixed; inset: 0; pointer-events: none; z-index: 5;
     background: radial-gradient(circle at 50% 50%, transparent, rgba(0,0,0,0.45));
   }
+
+  /* Governance-deny flash — full-screen red pulse signaling cycle abort.
+     Triggered programmatically by JS by toggling .firing class. Used
+     for cinematic drama: the room sees the protocol "fail loud". */
+  .deny-flash {
+    position: fixed; inset: 0; pointer-events: none; z-index: 8;
+    background: radial-gradient(circle at 50% 50%, rgba(255, 70, 70, 0.55), rgba(120, 20, 20, 0.0));
+    opacity: 0;
+    mix-blend-mode: screen;
+  }
+  .deny-flash.firing {
+    animation: deny-pulse 1.4s ease-out;
+  }
+  @keyframes deny-pulse {
+    0%   { opacity: 0;   transform: scale(0.92); }
+    18%  { opacity: 0.85; transform: scale(1.02); }
+    52%  { opacity: 0.40; transform: scale(1.05); }
+    100% { opacity: 0;   transform: scale(1.10); }
+  }
+
+  /* Cinema preset cluster — three buttons sharing space with the audio
+     toggle. Hidden in hide-UI mode along with the rest. */
+  .cinema-cluster {
+    position: fixed; bottom: 18px; left: 350px; z-index: 11;
+    display: flex; gap: 6px;
+    pointer-events: auto;
+  }
+  body.hide-ui .cinema-cluster { opacity: 0; pointer-events: none; transition: opacity 0.4s; }
+  body.hide-ui .cinema-cluster.armed { opacity: 0.45; }
+  body.hide-ui .cinema-cluster:hover { opacity: 1; }
+  .cinema-btn {
+    background: var(--panel); border: 1px solid var(--panel-border); border-radius: 16px;
+    padding: 6px 12px; font-size: 11px; cursor: pointer; color: var(--text-dim);
+    font-family: inherit;
+  }
+  .cinema-btn:hover { color: var(--accent); border-color: var(--accent); }
+  .cinema-btn.on { color: var(--accent); border-color: var(--accent); background: rgba(56, 182, 255, 0.08); }
+
+  /* Keyboard hint pill — small bottom-right ribbon listing the keys.
+     Fades after 8s on first paint; reappears on '?' keypress. */
+  .kbd-hint {
+    position: fixed; bottom: 18px; right: 18px; z-index: 11;
+    background: var(--panel); border: 1px solid var(--panel-border); border-radius: 6px;
+    padding: 6px 10px;
+    font: 10.5px ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+    color: var(--text-dim);
+    pointer-events: none;
+    transition: opacity 0.6s;
+  }
+  .kbd-hint.fade-out { opacity: 0; }
+  .kbd-hint kbd {
+    background: rgba(255, 255, 255, 0.08); border: 1px solid rgba(255, 255, 255, 0.12);
+    padding: 1px 5px; border-radius: 3px; margin: 0 1px;
+    font-family: inherit; color: var(--text);
+  }
 </style>
 </head>
 <body>
 <div id="stage"></div>
 <div class="hero-overlay"></div>
+<div class="deny-flash" id="deny-flash"></div>
 <div id="label-layer"></div>
 
 <div class="brief-banner hidden" id="brief-banner">
@@ -591,8 +647,16 @@ export function renderEcosystemCanvas(demoKey: string): string {
 </div>
 
 <button class="audio-toggle" id="audio-toggle">♪ audio off</button>
-<button class="audio-toggle" id="cinema-toggle" style="left: 350px;">▶ cinema</button>
-<button class="audio-toggle" id="hide-ui-toggle" style="left: 470px;">⌘ hide UI</button>
+<div class="cinema-cluster" id="cinema-cluster">
+  <button class="cinema-btn" data-cinema-preset="15">▶ 15s</button>
+  <button class="cinema-btn" data-cinema-preset="60">▶ 60s</button>
+  <button class="cinema-btn" data-cinema-preset="180">▶ 3min</button>
+</div>
+<button class="audio-toggle" id="hide-ui-toggle" style="left: 540px;">⌘ hide UI</button>
+
+<div class="kbd-hint" id="kbd-hint">
+  <kbd>1</kbd>/<kbd>2</kbd>/<kbd>3</kbd> cinema · <kbd>U</kbd> hide UI · <kbd>A</kbd> audio · <kbd>?</kbd> show keys
+</div>
 
 <!-- Matrix-rain modal: full-height vertical column of raw JSON-RPC
      frames for a single agent, rendered as scrolling text. Opens on
@@ -789,9 +853,56 @@ function flashAgentFiring(agentId) {
   if (!m) return;
   m.firingTimeout = 22; // frames of enhanced emission
   if (m.label) m.label.classList.add("firing");
-  // De-class the label after a short delay; the mesh emission decays
-  // in the animation loop via firingTimeout.
   setTimeout(function () { if (m.label) m.label.classList.remove("firing"); }, 480);
+}
+
+// PR D — drama beats:
+// (a) Full-screen red flash when governance denies the cycle. The flash
+//     lasts ~1.4s, peaks at 18%, and decays out. Re-arms on every deny
+//     (we cancel the previous animation's class-toggle by reflowing).
+// (b) Per-agent "scatter" — when this agent is the denying gov agent,
+//     spawn a visually distinct expanding red halo to anchor the drama
+//     to that specific node.
+const denyFlashEl = document.getElementById("deny-flash");
+function triggerDenyFlash() {
+  denyFlashEl.classList.remove("firing");
+  void denyFlashEl.offsetWidth; // force restart of the keyframe
+  denyFlashEl.classList.add("firing");
+}
+function flashAgentDramaScatter(agentId) {
+  const m = agentMeshes.get(agentId);
+  if (!m) return;
+  // Inject a bright red halo with steep decay, overrides the lift halo
+  // for a moment.
+  liftHaloDecay.set(agentId, { intensity: 1.4, decayPerFrame: 0.018, dramaColor: 0xff4646 });
+  // Bigger emissive boost than ordinary firing.
+  m.firingTimeout = 50;
+  if (m.label) {
+    m.label.style.color = "#ff7070";
+    m.label.style.borderColor = "rgba(255, 70, 70, 0.7)";
+    setTimeout(function () {
+      // Restore original styling
+      const role = m.agent.role;
+      const c = ROLE_COLORS[role] || 0xffffff;
+      m.label.style.color = "#" + c.toString(16).padStart(6, "0");
+      m.label.style.borderColor = "rgba(" + ((c >> 16) & 0xff) + "," + ((c >> 8) & 0xff) + "," + (c & 0xff) + ",0.35)";
+    }, 1400);
+  }
+}
+
+// PR D — dramatic lift halo amplification.
+// Replaces the previous decay-from-0.8 with an outward-pulse-then-linger
+// curve: spike to 1.5x, then a longer 6s linger proportional to the lift
+// score. Higher lift = bigger pulse + longer tail. Reads as "this agent
+// reported strong lift" cinematically rather than as a brief blip.
+function triggerLiftHalo(agentId, score) {
+  liftHaloDecay.set(agentId, {
+    intensity: 0.7 + score * 0.8,   // peak proportional to lift
+    decayPerFrame: 0.006 + (1 - score) * 0.012, // higher lift decays slower
+    pulseScale: 1.0,
+    pulseGrowth: 0.012 + score * 0.018,
+    pulseScaleMax: 1.4 + score * 0.6,
+  });
 }
 
 // ── Message beams ────────────────────────────────────────────────────────
@@ -809,6 +920,20 @@ function getPos(agentId) {
   return m ? m.position.clone() : null;
 }
 
+// Beam visual weight by message kind. Governance + measurement messages
+// are the heavy beats of the ceremony — render their pulses larger
+// + brighter. Discovery/product/creative are routine. This makes the
+// rhythm of the cycle readable from the visual alone.
+const BEAM_WEIGHT = {
+  policy:      { pulseSize: 0.30, lineOpacity: 0.85 },
+  measurement: { pulseSize: 0.32, lineOpacity: 0.85 },
+  bid:         { pulseSize: 0.26, lineOpacity: 0.75 },
+  signal:      { pulseSize: 0.20, lineOpacity: 0.65 },
+  product:     { pulseSize: 0.20, lineOpacity: 0.65 },
+  creative:    { pulseSize: 0.18, lineOpacity: 0.60 },
+  discovery:   { pulseSize: 0.18, lineOpacity: 0.55 },
+};
+
 function spawnBeam(fromId, toId, colorHint) {
   const from = getPos(fromId);
   const to = getPos(toId);
@@ -818,6 +943,7 @@ function spawnBeam(fromId, toId, colorHint) {
   // an endpoint but doesn't have an agent record — skip it cleanly.
   if (fromId !== BUYER_AGENT_ID) flashAgentFiring(fromId);
   if (toId !== BUYER_AGENT_ID) flashAgentFiring(toId);
+  const weight = BEAM_WEIGHT[colorHint] || { pulseSize: 0.18, lineOpacity: 0.55 };
   const mid = from.clone().add(to).multiplyScalar(0.5);
   const dir = to.clone().sub(from).normalize();
   const perp = new THREE.Vector3().crossVectors(dir, new THREE.Vector3(0,1,0)).normalize();
@@ -829,18 +955,41 @@ function spawnBeam(fromId, toId, colorHint) {
   const points = curve.getPoints(samples);
   const geo = new THREE.BufferGeometry().setFromPoints(points);
   const color = HINT_COLORS[colorHint] || 0x80a0ff;
-  const mat = new THREE.LineBasicMaterial({ color, transparent: true, opacity: 0.55 });
+  const mat = new THREE.LineBasicMaterial({ color, transparent: true, opacity: weight.lineOpacity });
   const line = new THREE.Line(geo, mat);
   scene.add(line);
 
-  // A pulse sprite that travels the curve
-  const pulseGeo = new THREE.SphereGeometry(0.18, 12, 12);
+  // A pulse sprite that travels the curve. Heavy-beat messages get
+  // a bigger sphere so governance + measurement read as the climax
+  // beats of the cycle.
+  const pulseGeo = new THREE.SphereGeometry(weight.pulseSize, 14, 14);
   const pulseMat = new THREE.MeshBasicMaterial({ color, transparent: true, opacity: 0.95 });
   const pulse = new THREE.Mesh(pulseGeo, pulseMat);
   pulse.position.copy(from);
   scene.add(pulse);
 
-  beams.push({ line, mat, pulse, pulseMat, curve, t: 0, life: 1.0, color });
+  // Motion-blur trail: a circular buffer of "ghost" pulse sprites that
+  // each frame inherit the lead pulse's previous position with decaying
+  // opacity. Cheap to render (just N small spheres), creates the comet
+  // look without per-frame texture compositing.
+  const TRAIL_LEN = 6;
+  const trail = [];
+  for (let i = 0; i < TRAIL_LEN; i++) {
+    const trailGeo = new THREE.SphereGeometry(weight.pulseSize * (1 - i * 0.10), 8, 8);
+    const trailMat = new THREE.MeshBasicMaterial({ color, transparent: true, opacity: 0.0 });
+    const tMesh = new THREE.Mesh(trailGeo, trailMat);
+    tMesh.position.copy(from);
+    scene.add(tMesh);
+    trail.push({ mesh: tMesh, mat: trailMat });
+  }
+
+  beams.push({
+    line, mat, pulse, pulseMat, curve, t: 0, life: 1.0, color,
+    weight, trail,
+    // Ring buffer of recent positions, used to seed the trail meshes
+    // each frame.
+    history: [],
+  });
 
   // Trim if too many
   while (beams.length > MAX_BEAMS) {
@@ -851,6 +1000,13 @@ function spawnBeam(fromId, toId, colorHint) {
       old.line.geometry.dispose();
       old.mat.dispose();
       old.pulseMat.dispose();
+      if (old.trail) {
+        for (const tr of old.trail) {
+          scene.remove(tr.mesh);
+          tr.mesh.geometry.dispose();
+          tr.mat.dispose();
+        }
+      }
     }
   }
 
@@ -1203,6 +1359,13 @@ evtSource.onmessage = function (msg) {
       if (ev.trace && ev.trace.kind) setPhaseFromKind(ev.trace.kind);
       // Stash trace into per-agent log for matrix-rain replay
       if (ev.trace && ev.trace.agent_id) recordAgentFrame(ev.trace.agent_id, ev.trace);
+      // Drama: governance deny → full-screen red flash + scatter the
+      // active agent's halo for cinematic effect.
+      if (ev.trace && ev.trace.kind === "governance_check"
+          && ev.trace.detail && ev.trace.detail.outcome === "deny") {
+        triggerDenyFlash();
+        if (ev.trace.agent_id) flashAgentDramaScatter(ev.trace.agent_id);
+      }
       break;
     case "message":
       if (ev.message) {
@@ -1218,8 +1381,7 @@ evtSource.onmessage = function (msg) {
         const m = agentMeshes.get(ev.lift.agent_id);
         if (m) {
           m.lift = ev.lift.score;
-          // Pulse the halo
-          liftHaloDecay.set(ev.lift.agent_id, { intensity: 0.8, decayPerFrame: 0.012 });
+          triggerLiftHalo(ev.lift.agent_id, ev.lift.score);
           audioLiftBlip(ev.lift.score);
         }
       }
@@ -1373,22 +1535,55 @@ renderer.domElement.addEventListener("click", function (e) {
 //
 // Total duration: 60s. Optimized for a single-take screen recording.
 
-const cinemaToggle = document.getElementById("cinema-toggle");
+const cinemaCluster = document.getElementById("cinema-cluster");
 let cinemaOn = false;
 let cinemaStart = 0;
+let cinemaDuration = 60;
+let cinemaActiveBtn = null;
 
-const CINEMA_KEYFRAMES = [
-  // [t_seconds, camera position (x,y,z), look-at target (x,y,z)]
-  { t:  0, pos: [ 0,  6, 38], look: [ 0,  0,  0] },  // Wide opener
-  { t:  8, pos: [22,  4, 30], look: [ 0,  0,  0] },  // Pan to signals ring
-  { t: 16, pos: [12, -8, 22], look: [ 0,  0,  0] },  // Dive under, looking up at sales ring
-  { t: 24, pos: [-18, 10, 24], look: [ 0,  0,  0] },  // Swing left + up
-  { t: 32, pos: [ 0,  18, 22], look: [ 0, -2,  0] },  // Top-down looking at buyer + governance ring
-  { t: 40, pos: [-22, -2, 28], look: [ 0,  0,  0] },  // Side angle, full constellation
-  { t: 48, pos: [ 6,  4, 44], look: [ 0,  0,  0] },  // Pull back wide
-  { t: 56, pos: [ 0,  6, 38], look: [ 0,  0,  0] },  // Return to opener
-  { t: 60, pos: [ 0,  6, 38], look: [ 0,  0,  0] },  // Hold on opener
-];
+// Three keyframe sets — one per preset duration. Each is normalized
+// over [0..1] internally so we can scale to any duration; here we
+// keep them duration-specific for hand-tuned beats.
+const CINEMA_PRESETS = {
+  // 15s Twitter clip — fast, four hero beats. Ends back at opener
+  // so the loop is seamless.
+  15: [
+    { t:  0, pos: [ 0,  6, 38], look: [ 0,  0,  0] },
+    { t:  4, pos: [18,  6, 28], look: [ 0,  0,  0] },
+    { t:  8, pos: [-12, 12, 24], look: [ 0,  0,  0] },
+    { t: 12, pos: [ 0,  4, 42], look: [ 0,  0,  0] },
+    { t: 15, pos: [ 0,  6, 38], look: [ 0,  0,  0] },
+  ],
+  // 60s default — current keyframes
+  60: [
+    { t:  0, pos: [ 0,  6, 38], look: [ 0,  0,  0] },
+    { t:  8, pos: [22,  4, 30], look: [ 0,  0,  0] },
+    { t: 16, pos: [12, -8, 22], look: [ 0,  0,  0] },
+    { t: 24, pos: [-18, 10, 24], look: [ 0,  0,  0] },
+    { t: 32, pos: [ 0,  18, 22], look: [ 0, -2,  0] },
+    { t: 40, pos: [-22, -2, 28], look: [ 0,  0,  0] },
+    { t: 48, pos: [ 6,  4, 44], look: [ 0,  0,  0] },
+    { t: 56, pos: [ 0,  6, 38], look: [ 0,  0,  0] },
+    { t: 60, pos: [ 0,  6, 38], look: [ 0,  0,  0] },
+  ],
+  // 180s explainer — slower, more rest at each pose, more nuanced
+  // angles. Designed for narration over the top.
+  180: [
+    { t:   0, pos: [ 0,  6, 38], look: [ 0,  0,  0] },
+    { t:  20, pos: [22,  4, 30], look: [ 0,  0,  0] },
+    { t:  35, pos: [22,  4, 22], look: [ 0,  0,  0] },
+    { t:  55, pos: [12, -8, 22], look: [ 0,  0,  0] },
+    { t:  75, pos: [-8,  -10, 22], look: [ 0,  0,  0] },
+    { t:  95, pos: [-22,   2, 24], look: [ 0,  0,  0] },
+    { t: 115, pos: [-18, 12, 22], look: [ 0,  0,  0] },
+    { t: 135, pos: [ 0,  20, 18], look: [ 0, -2,  0] },
+    { t: 155, pos: [ 14, 12, 28], look: [ 0,  0,  0] },
+    { t: 170, pos: [ 6,  4, 44], look: [ 0,  0,  0] },
+    { t: 180, pos: [ 0,  6, 38], look: [ 0,  0,  0] },
+  ],
+};
+
+let activeKeyframes = CINEMA_PRESETS["60"];
 
 function lerp(a, b, t) { return a + (b - a) * t; }
 function lerp3(a, b, t) { return [lerp(a[0], b[0], t), lerp(a[1], b[1], t), lerp(a[2], b[2], t)]; }
@@ -1396,45 +1591,67 @@ function lerp3(a, b, t) { return [lerp(a[0], b[0], t), lerp(a[1], b[1], t), lerp
 function cinemaTick() {
   if (!cinemaOn) return;
   const elapsed = (performance.now() - cinemaStart) / 1000;
-  if (elapsed >= 60) {
-    // Loop back to start for continuous recordable footage
+  if (elapsed >= cinemaDuration) {
     cinemaStart = performance.now();
     return;
   }
-  // Find the segment we're in
-  let segA = CINEMA_KEYFRAMES[0];
-  let segB = CINEMA_KEYFRAMES[1];
-  for (let i = 0; i < CINEMA_KEYFRAMES.length - 1; i++) {
-    if (elapsed >= CINEMA_KEYFRAMES[i].t && elapsed < CINEMA_KEYFRAMES[i + 1].t) {
-      segA = CINEMA_KEYFRAMES[i];
-      segB = CINEMA_KEYFRAMES[i + 1];
+  let segA = activeKeyframes[0];
+  let segB = activeKeyframes[1];
+  for (let i = 0; i < activeKeyframes.length - 1; i++) {
+    if (elapsed >= activeKeyframes[i].t && elapsed < activeKeyframes[i + 1].t) {
+      segA = activeKeyframes[i];
+      segB = activeKeyframes[i + 1];
       break;
     }
   }
   const segT = (elapsed - segA.t) / (segB.t - segA.t);
-  // Smoothstep for cinematic ease-in/out
   const eased = segT * segT * (3 - 2 * segT);
   const pos = lerp3(segA.pos, segB.pos, eased);
   const look = lerp3(segA.look, segB.look, eased);
   camera.position.set(pos[0], pos[1], pos[2]);
   controls.target.set(look[0], look[1], look[2]);
-  // Don't call controls.update() here — it would re-apply auto-rotate.
-  // Instead, just set the camera matrix directly.
   camera.lookAt(look[0], look[1], look[2]);
 }
 
-cinemaToggle.addEventListener("click", function () {
-  cinemaOn = !cinemaOn;
-  cinemaToggle.textContent = cinemaOn ? "■ stop" : "▶ cinema";
-  cinemaToggle.classList.toggle("on", cinemaOn);
-  if (cinemaOn) {
-    cinemaStart = performance.now();
-    controls.autoRotate = false;
-    controls.enabled = false;
-  } else {
-    controls.autoRotate = true;
-    controls.enabled = true;
-  }
+function startCinema(durationSec) {
+  cinemaOn = true;
+  cinemaDuration = durationSec;
+  activeKeyframes = CINEMA_PRESETS[String(durationSec)] || CINEMA_PRESETS["60"];
+  cinemaStart = performance.now();
+  controls.autoRotate = false;
+  controls.enabled = false;
+  cinemaCluster.classList.add("armed");
+  // Update button visual states
+  Array.from(cinemaCluster.querySelectorAll(".cinema-btn")).forEach(function (b) {
+    b.classList.toggle("on", String(b.dataset.cinemaPreset) === String(durationSec));
+    if (String(b.dataset.cinemaPreset) === String(durationSec)) {
+      b.textContent = "■ stop";
+      cinemaActiveBtn = b;
+    } else {
+      b.textContent = "▶ " + (b.dataset.cinemaPreset === "180" ? "3min" : b.dataset.cinemaPreset + "s");
+    }
+  });
+}
+function stopCinema() {
+  cinemaOn = false;
+  controls.autoRotate = true;
+  controls.enabled = true;
+  cinemaCluster.classList.remove("armed");
+  Array.from(cinemaCluster.querySelectorAll(".cinema-btn")).forEach(function (b) {
+    b.classList.remove("on");
+    b.textContent = "▶ " + (b.dataset.cinemaPreset === "180" ? "3min" : b.dataset.cinemaPreset + "s");
+  });
+  cinemaActiveBtn = null;
+}
+Array.from(cinemaCluster.querySelectorAll(".cinema-btn")).forEach(function (btn) {
+  btn.addEventListener("click", function () {
+    const preset = parseInt(btn.dataset.cinemaPreset, 10);
+    if (cinemaOn && cinemaActiveBtn === btn) {
+      stopCinema();
+    } else {
+      startCinema(preset);
+    }
+  });
 });
 
 // ── Hide-UI mode (clean recordings) ─────────────────────────────────────
@@ -1444,6 +1661,48 @@ hideUIToggle.addEventListener("click", function () {
   hideUIToggle.classList.toggle("on", document.body.classList.contains("hide-ui"));
   hideUIToggle.textContent = document.body.classList.contains("hide-ui") ? "⌘ show UI" : "⌘ hide UI";
 });
+
+// ── Keyboard shortcuts + URL params ─────────────────────────────────────
+//
+// Power-user controls. Press '?' to flash the hint pill again. URL
+// params drive auto-start so you can link to a pre-armed page (e.g.
+// /ecosystem?cinema=15&hide=1&audio=1 → ready-to-record).
+const kbdHint = document.getElementById("kbd-hint");
+function flashKbdHint() {
+  kbdHint.classList.remove("fade-out");
+  setTimeout(function () { kbdHint.classList.add("fade-out"); }, 8000);
+}
+flashKbdHint();
+
+document.addEventListener("keydown", function (e) {
+  // Ignore when typing in an input / contenteditable
+  const tag = e.target && e.target.tagName;
+  if (tag === "INPUT" || tag === "TEXTAREA" || (e.target && e.target.isContentEditable)) return;
+  if (e.metaKey || e.ctrlKey || e.altKey) return; // skip modifier-key combos
+
+  if (e.key === "1") { e.preventDefault(); cinemaOn ? stopCinema() : startCinema(15); }
+  else if (e.key === "2") { e.preventDefault(); cinemaOn ? stopCinema() : startCinema(60); }
+  else if (e.key === "3") { e.preventDefault(); cinemaOn ? stopCinema() : startCinema(180); }
+  else if (e.key === "u" || e.key === "U") { e.preventDefault(); hideUIToggle.click(); }
+  else if (e.key === "a" || e.key === "A") { e.preventDefault(); document.getElementById("audio-toggle").click(); }
+  else if (e.key === "?") { e.preventDefault(); flashKbdHint(); }
+});
+
+// URL params
+(function () {
+  const sp = new URLSearchParams(window.location.search);
+  const cinemaParam = sp.get("cinema");
+  const hideParam = sp.get("hide");
+  const audioParam = sp.get("audio");
+  if (hideParam === "1") document.body.classList.add("hide-ui");
+  // Audio + cinema need the page to settle first (audio context requires
+  // a user gesture; we trigger via a delayed click that browsers accept
+  // when initiated via a meta refresh-style URL action). Safari may block.
+  if (audioParam === "1") setTimeout(function () { document.getElementById("audio-toggle").click(); }, 1200);
+  if (cinemaParam === "15" || cinemaParam === "60" || cinemaParam === "180") {
+    setTimeout(function () { startCinema(parseInt(cinemaParam, 10)); }, 2200);
+  }
+})();
 
 // ── Audio (Web Audio API) ────────────────────────────────────────────────
 let audioOn = false;
@@ -1538,13 +1797,33 @@ function animate() {
       b.line.geometry.dispose();
       b.mat.dispose();
       b.pulseMat.dispose();
+      if (b.trail) {
+        for (const tr of b.trail) {
+          scene.remove(tr.mesh);
+          tr.mesh.geometry.dispose();
+          tr.mat.dispose();
+        }
+      }
       beams.splice(i, 1);
       continue;
     }
     const p = b.curve.getPointAt(Math.min(b.t, 0.999));
     b.pulse.position.copy(p);
-    b.mat.opacity = Math.max(0, b.life * 0.55);
+    b.mat.opacity = Math.max(0, b.life * (b.weight ? b.weight.lineOpacity : 0.55));
     b.pulseMat.opacity = Math.max(0, b.life);
+    // Push position into history; render trail meshes as receding ghosts
+    if (b.trail) {
+      b.history.unshift(p.clone());
+      if (b.history.length > b.trail.length) b.history.length = b.trail.length;
+      for (let j = 0; j < b.trail.length; j++) {
+        const histPos = b.history[j];
+        if (histPos) {
+          b.trail[j].mesh.position.copy(histPos);
+          // Each ghost fades faster than the last, scaled by overall life
+          b.trail[j].mat.opacity = Math.max(0, b.life * (1 - j / b.trail.length) * 0.7);
+        }
+      }
+    }
   }
 
   // Lift halos + label projection + firing pulse
@@ -1557,13 +1836,32 @@ function animate() {
   for (const [agentId, m] of agentMeshes) {
     const decay = liftHaloDecay.get(agentId);
     if (decay) {
-      m.halo.material.opacity = decay.intensity;
+      m.halo.material.opacity = Math.max(0, Math.min(1, decay.intensity));
       decay.intensity -= decay.decayPerFrame;
-      if (decay.intensity <= 0) liftHaloDecay.delete(agentId);
+      // Outward expansion of the halo ring while it pulses
+      if (decay.pulseScale !== undefined) {
+        decay.pulseScale += decay.pulseGrowth;
+        if (decay.pulseScale > decay.pulseScaleMax) decay.pulseScale = decay.pulseScaleMax;
+        m.halo.scale.set(decay.pulseScale, decay.pulseScale, 1);
+      }
+      // Drama color override (governance deny path)
+      if (decay.dramaColor !== undefined) {
+        m.halo.material.color.setHex(decay.dramaColor);
+      } else {
+        const baseColor = ROLE_COLORS[m.agent.role] || 0xffffff;
+        m.halo.material.color.setHex(baseColor);
+      }
+      if (decay.intensity <= 0) {
+        liftHaloDecay.delete(agentId);
+        m.halo.scale.set(1, 1, 1);
+        const baseColor = ROLE_COLORS[m.agent.role] || 0xffffff;
+        m.halo.material.color.setHex(baseColor);
+      }
     } else {
       // Persistent low-intensity halo proportional to long-term lift
       m.halo.material.opacity = 0.05 + (m.lift - 0.4) * 0.4;
       if (m.halo.material.opacity < 0) m.halo.material.opacity = 0;
+      m.halo.scale.set(1, 1, 1);
     }
     m.halo.lookAt(camera.position);
 


### PR DESCRIPTION
## Summary

Three layers shipped together per "move as ONE PR for D, E and F". ~750 LOC across `src/domain/ecosystem.ts` and `src/routes/ecosystemCanvas.ts`.

## D — Visual drama 🎬

| Beat | Before | After |
|---|---|---|
| **Governance deny** | trace line went red | full-screen radial red flash + per-agent red halo scatter; the cycle visibly aborts |
| **Beam thickness** | uniform 0.18 pulse | per-kind weight: governance + measurement render at 0.30-0.32 (heavy beats); routine messages stay at 0.18-0.20 |
| **Beam line opacity** | uniform 0.55 | weighted: heavy beats 0.85, routine 0.55-0.65 |
| **Pulse motion-blur** | crisp dot | 6-segment trail of fading ghost spheres → comet effect |
| **Lift halos** | fixed decay from 0.8 | score-proportional outward pulse + linger; high-lift = bright + lingering, low-lift = faint blip |

## E — Cross-agent correlation + meaningful lift 🧠

### Specialty-biased synthetics
`SPECIALTY_TO_DIMENSION` table maps each agent's declared specialties (audio, ctv, b2b, podcast_listenership, b2b_account_based, ...) to brief weight dimensions. `briefFitScore(agent, brief)` returns [0..1.4]:

```
mock_audio_signals + "Podcast listeners 35-54" brief → fit 1.30
  → returns 6 signals @ 60-90% coverage

mock_audio_signals + "B2B IT decision makers" brief → fit 0.50
  → returns 2 signals @ 20-40% coverage
```

Sales agents return more products on fit; buying agents commit bigger budgets on fit. Each response includes `fit` so trace summaries show `fit 87%` pills.

### Meaningful lift function

```
lift = 0.30 × signal_fit
     + 0.25 × sales_fit
     + 0.25 × bid_efficiency       // 1 - (avg_cpm / 25)
     + 0.20 × specialty_match      // measurement agent ↔ brief dominant axis
     + ±0.08 jitter
```

Replaces the old `random + per-agent tweak`. High lift now only fires when EVERYTHING aligned end-to-end. The feedback loop converges toward briefs that genuinely match the ecosystem, not toward briefs that randomly happened to roll high.

### Brief pool: 8 → 24

Grouped by lean: CTV (4), audio (4 — including iHeart + podcast specifics), b2b (3), lifestyle (5), seasonal (3), niche (5 incl. cookieless ID-resolved). Cycles stay fresh much longer.

## F — Cinema presets + keyboard shortcuts + URL params 🎥

### Three presets
- **▶ 15s** — Twitter clip pacing (4 hero beats)
- **▶ 60s** — default (9 keyframes)
- **▶ 3min** — explainer pacing (11 keyframes, narration-friendly rest at each pose)

Each preset has its own keyframe set. Active button glows; pressing the same button again stops.

### Keyboard shortcuts
| Key | Action |
|---|---|
| `1` `2` `3` | Start cinema 15s / 60s / 180s |
| `U` | Toggle hide-UI |
| `A` | Toggle audio |
| `?` | Re-flash the keyboard hint pill |

### URL params
| Param | Effect |
|---|---|
| `?cinema=15\|60\|180` | Auto-start cinema after 2.2s |
| `?hide=1` | Hide UI on load |
| `?audio=1` | Attempt audio enable (browser may require gesture) |

Compose freely: `/ecosystem?cinema=60&hide=1&audio=1` lands in recording mode.

## Test plan

- [x] `npx vitest run` — 441/441 passing
- [x] `python tmp-mining/trap_audit.py` — clean (38 files, 0 traps)
- [x] `npx wrangler deploy --dry-run` — clean
- [x] `npx tsc --noEmit -p .` — no errors
- [ ] After deploy: governance deny → red flash visible; cycle aborts cinematically
- [ ] Beam thickness varies between governance and signal beats
- [ ] Pulse trails leave visible comet-tails
- [ ] High-lift agents (mock_audio_signals on audio brief) get longer-lingering halos than low-lift
- [ ] Fit pills appear in trace summaries (`fit 87%`)
- [ ] Cinema 15/60/180 buttons all work + keyboard 1/2/3 mirrors them
- [ ] URL `/ecosystem?cinema=60&hide=1` lands in clean recording mode

## Recording recipes

### Twitter clip (15s)
`/ecosystem?cinema=15&hide=1` → press record → capture 15s → done.

### Standard demo (60s)
`/ecosystem` → wait 3s → `A` → `U` → `2` → record.

### Explainer (3min, narration)
`/ecosystem` → wait 3s → `A` → `U` → `3` → record + narrate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)