### PR TITLE
PR G: live MCP probe + stats overlay + halo dial-back + v1.1.0 version bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adcp-signals-adaptor",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "AdCP Signals Adaptor Agent - Evgeny Demo Provider for agentic advertising workflows",
   "private": true,
   "scripts": {

--- a/src/domain/ecosystem.ts
+++ b/src/domain/ecosystem.ts
@@ -829,6 +829,118 @@ async function* runCycle(brief: Brief, _liftMap: Map<string, AgentLift>): AsyncG
   };
 }
 
+// ── Live MCP probe ───────────────────────────────────────────────────────────
+//
+// Best-effort liveness check for agents that declare an mcp_url. Sends
+// a `tools/list` JSON-RPC frame with a 2.5s timeout, accepts any 2xx
+// response (any agent up enough to answer). Result cached per-agent;
+// re-probed on a rolling cadence so the visual reflects current state.
+//
+// Crucially: this never blocks a cycle. The probe runs in the
+// background; cycles continue with synthetic responses regardless.
+// What changes is the agent's visual stage indicator: "live ●" if the
+// last probe was 2xx within ~60s, "stale ●" if the last probe failed
+// or hasn't fired yet, "synthetic ○" for agents we never claimed
+// were live in the first place.
+
+export interface AgentLiveStatus {
+  /** ISO timestamp of the last probe attempt. */
+  last_probed_at: string | null;
+  /** Last probe outcome — "ok" | "timeout" | "http_<code>" | "error" | null. */
+  last_status: string | null;
+  /** Round-trip ms of last successful probe. */
+  last_latency_ms: number | null;
+  /** True iff the most recent probe within ~60s succeeded. */
+  is_live_now: boolean;
+}
+
+const PROBE_TIMEOUT_MS = 2500;
+const PROBE_STALE_AFTER_MS = 60_000;
+const liveStatusByAgent = new Map<string, AgentLiveStatus>();
+
+async function probeAgent(agent: EcosystemAgent): Promise<AgentLiveStatus> {
+  const status: AgentLiveStatus = {
+    last_probed_at: new Date().toISOString(),
+    last_status: null,
+    last_latency_ms: null,
+    is_live_now: false,
+  };
+  if (!agent.mcp_url) {
+    status.last_status = "no_url";
+    return status;
+  }
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), PROBE_TIMEOUT_MS);
+  const start = Date.now();
+  try {
+    const r = await fetch(agent.mcp_url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "Accept": "application/json, text/event-stream",
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/list",
+        params: {},
+      }),
+      signal: ctrl.signal,
+    });
+    status.last_latency_ms = Date.now() - start;
+    if (r.ok) {
+      status.last_status = "ok";
+      status.is_live_now = true;
+    } else {
+      status.last_status = "http_" + r.status;
+    }
+  } catch (err) {
+    status.last_latency_ms = Date.now() - start;
+    if ((err as Error).name === "AbortError") {
+      status.last_status = "timeout";
+    } else {
+      status.last_status = "error";
+    }
+  } finally {
+    clearTimeout(timer);
+  }
+  return status;
+}
+
+export async function probeAllLive(): Promise<{ probed: number; live: number }> {
+  const liveAgents = ECOSYSTEM_AGENTS.filter((a) => a.stage === "live");
+  let liveCount = 0;
+  await Promise.all(
+    liveAgents.map(async (agent) => {
+      try {
+        const status = await probeAgent(agent);
+        liveStatusByAgent.set(agent.id, status);
+        if (status.is_live_now) liveCount += 1;
+      } catch {
+        // Already wrapped inside probeAgent — defensive.
+      }
+    })
+  );
+  return { probed: liveAgents.length, live: liveCount };
+}
+
+export function getLiveStatusSnapshot(): Array<{ agent_id: string } & AgentLiveStatus> {
+  const now = Date.now();
+  const out: Array<{ agent_id: string } & AgentLiveStatus> = [];
+  for (const [agent_id, status] of liveStatusByAgent.entries()) {
+    // Auto-expire: if the last probe is older than the stale window,
+    // surface as not-live-now even if the probe succeeded back then.
+    const probedAt = status.last_probed_at ? new Date(status.last_probed_at).getTime() : 0;
+    const stale = now - probedAt > PROBE_STALE_AFTER_MS;
+    out.push({
+      agent_id,
+      ...status,
+      is_live_now: status.is_live_now && !stale,
+    });
+  }
+  return out;
+}
+
 // ── Singleton state ──────────────────────────────────────────────────────────
 
 class EcosystemState {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,15 @@
 // src/index.ts
 // Cloudflare Worker entrypoint for the AdCP Signals Adaptor Agent.
 
+// Worker version. Bumped on substantive feature releases. Surfaced
+// at /health alongside the AdCP protocol version. Mirrors
+// package.json's "version" field — keep in sync.
+const WORKER_VERSION = "1.1.0";
+// Build timestamp — frozen at module-eval time, so a fresh deploy
+// shows a fresh value at /health. Useful for verifying which build
+// is actually serving without checking commit hashes by hand.
+const BUILT_AT = new Date().toISOString();
+
 import type { Env } from "./types/env";
 import { handleGetCapabilities } from "./routes/capabilities";
 import { handleSearchSignals } from "./routes/searchSignals";
@@ -144,6 +153,7 @@ import {
     handleEcosystemAgents,
     handleEcosystemState,
     handleEcosystemStream,
+    handleEcosystemProbe,
 } from "./routes/ecosystemRoutes";
 import {
   handleVendorHealthSnapshot,
@@ -338,6 +348,7 @@ export default {
             "/ecosystem/stream",
             "/ecosystem/agents",
             "/ecosystem/state",
+            "/ecosystem/probe",
             "/taxonomy/reverse",
             // Sec-43: audience composer + activation-planning analytics.
             // Read-only — same posture as /portfolio/* and /analytics/*.
@@ -432,8 +443,17 @@ export default {
             } else if (method === "GET" && path === "/ecosystem/state") {
                 response = handleEcosystemState();
 
+            } else if (method === "GET" && path === "/ecosystem/probe") {
+                response = await handleEcosystemProbe();
+
             } else if (method === "GET" && path === "/health") {
-                response = jsonResponse({ status: "ok", version: "3.0" });
+                response = jsonResponse({
+                    status: "ok",
+                    version: "3.0",          // AdCP protocol version (kept for back-compat)
+                    adcp_version: "3.0",
+                    worker_version: WORKER_VERSION,
+                    built_at: BUILT_AT,
+                });
 
             } else if (method === "GET" && path.startsWith("/.well-known/oauth-protected-resource")) {
                 // RFC 9728: resource path is the suffix after the well-known

--- a/src/routes/ecosystemCanvas.ts
+++ b/src/routes/ecosystemCanvas.ts
@@ -519,6 +519,25 @@ export function renderEcosystemCanvas(demoKey: string): string {
   .cinema-btn:hover { color: var(--accent); border-color: var(--accent); }
   .cinema-btn.on { color: var(--accent); border-color: var(--accent); background: rgba(56, 182, 255, 0.08); }
 
+  /* Stats overlay — left-side rolling totals visible mid-cinema.
+     Sits below the legend, complements the topbar pills. Hides in
+     hide-UI mode like everything else. */
+  .stats-overlay {
+    position: fixed; bottom: 200px; left: 18px; z-index: 10;
+    background: var(--panel); border: 1px solid var(--panel-border); border-radius: 8px;
+    padding: 10px 14px; font: 11px ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+    backdrop-filter: blur(8px);
+    pointer-events: auto;
+    min-width: 188px;
+  }
+  .stats-title { font-size: 9.5px; text-transform: uppercase; letter-spacing: 0.12em; color: var(--text-faint); margin-bottom: 6px; }
+  .stat-row { display: flex; justify-content: space-between; padding: 3px 0; gap: 12px; }
+  .stat-row .k { color: var(--text-mut); }
+  .stat-row .v { color: var(--text); font-weight: 600; }
+  .stat-row .v.live  { color: #5fd9c4; }
+  .stat-row .v.stale { color: #ff9080; }
+  body.hide-ui .stats-overlay { opacity: 0; pointer-events: none; transition: opacity 0.4s; }
+
   /* Keyboard hint pill — small bottom-right ribbon listing the keys.
      Fades after 8s on first paint; reappears on '?' keypress. */
   .kbd-hint {
@@ -654,6 +673,15 @@ export function renderEcosystemCanvas(demoKey: string): string {
 </div>
 <button class="audio-toggle" id="hide-ui-toggle" style="left: 540px;">⌘ hide UI</button>
 
+<div class="stats-overlay" id="stats-overlay">
+  <div class="stats-title">Live ecosystem</div>
+  <div class="stat-row"><span class="k">Cycles</span><span class="v" id="stat-cycles">0</span></div>
+  <div class="stat-row"><span class="k">Avg lift</span><span class="v" id="stat-avg-lift">—</span></div>
+  <div class="stat-row"><span class="k">Top agent</span><span class="v" id="stat-top-agent">—</span></div>
+  <div class="stat-row"><span class="k">Live probe</span><span class="v live" id="stat-live-probe">—</span></div>
+  <div class="stat-row"><span class="k">Build</span><span class="v" id="stat-build">v—</span></div>
+</div>
+
 <div class="kbd-hint" id="kbd-hint">
   <kbd>1</kbd>/<kbd>2</kbd>/<kbd>3</kbd> cinema · <kbd>U</kbd> hide UI · <kbd>A</kbd> audio · <kbd>?</kbd> show keys
 </div>
@@ -734,9 +762,10 @@ const composer = new EffectComposer(renderer);
 composer.addPass(new RenderPass(scene, camera));
 const bloomPass = new UnrealBloomPass(
   new THREE.Vector2(window.innerWidth, window.innerHeight),
-  0.85,   // strength
-  0.6,    // radius
-  0.18    // threshold (only pixels brighter than this contribute)
+  0.55,   // strength (dialed down from 0.85 — was overloading halos)
+  0.55,   // radius
+  0.30    // threshold — only the brightest emissive contributes,
+          //              so non-firing nodes stay crisp
 );
 composer.addPass(bloomPass);
 composer.addPass(new OutputPass());
@@ -891,17 +920,20 @@ function flashAgentDramaScatter(agentId) {
 }
 
 // PR D — dramatic lift halo amplification.
-// Replaces the previous decay-from-0.8 with an outward-pulse-then-linger
-// curve: spike to 1.5x, then a longer 6s linger proportional to the lift
-// score. Higher lift = bigger pulse + longer tail. Reads as "this agent
-// reported strong lift" cinematically rather than as a brief blip.
+// PR G — dialed back: prior settings (peak 1.5, scale 2.0, slow decay)
+// drowned the constellation in glow when bloom amplified them and
+// multiple high-lift halos overlapped. Tuned conservatively now:
+//   peak intensity 0.35-0.70, capped well below 1.0
+//   pulseScaleMax 1.15-1.40 (was up to 2.0)
+//   decay 0.014-0.026/frame (faster — halos resolve in ~1s)
+// High-lift agents still announce themselves, but readability stays.
 function triggerLiftHalo(agentId, score) {
   liftHaloDecay.set(agentId, {
-    intensity: 0.7 + score * 0.8,   // peak proportional to lift
-    decayPerFrame: 0.006 + (1 - score) * 0.012, // higher lift decays slower
+    intensity: 0.35 + score * 0.35,
+    decayPerFrame: 0.014 + (1 - score) * 0.012,
     pulseScale: 1.0,
-    pulseGrowth: 0.012 + score * 0.018,
-    pulseScaleMax: 1.4 + score * 0.6,
+    pulseGrowth: 0.014 + score * 0.012,
+    pulseScaleMax: 1.15 + score * 0.25,
   });
 }
 
@@ -1027,6 +1059,39 @@ document.getElementById("trace-pause").addEventListener("click", function () {
   tracePaused = !tracePaused;
   this.textContent = tracePaused ? "resume" : "pause";
 });
+
+// ── Live probe status integration ───────────────────────────────────────
+// /ecosystem/stream emits live_probe events every ~45s with per-agent
+// liveness results from a real MCP tools/list ping. This updates the
+// agent's stage indicator on the constellation: live ● when the most
+// recent probe within the rolling window succeeded; degraded ● when
+// it failed or hasn't fired yet; synthetic ○ for agents that never
+// claimed a live URL. Updates the agent details panel on next click
+// so the stage line reflects the latest probe result.
+const liveProbeByAgent = new Map();
+function updateLiveProbeStatuses(statuses) {
+  for (const s of statuses) {
+    liveProbeByAgent.set(s.agent_id, s);
+    const m = agentMeshes.get(s.agent_id);
+    if (!m || !m.label) continue;
+    const agent = m.agent;
+    if (agent.stage !== "live") continue;
+    // Update the label badge: ● for live-confirmed, ◑ for degraded,
+    // ○ for never-claimed-live (handled at spawn).
+    const badge = s.is_live_now ? "● " : "◑ ";
+    m.label.textContent = badge + agent.name;
+    if (s.is_live_now) {
+      m.label.style.borderColor = "rgba(95, 217, 196, 0.45)"; // mint = healthy
+    } else {
+      m.label.style.borderColor = "rgba(255, 100, 100, 0.45)"; // dim red = degraded
+    }
+  }
+  // Update the live-probe stats line in the HUD
+  const live = statuses.filter(function (s) { return s.is_live_now; }).length;
+  const total = statuses.length;
+  const probeStat = document.getElementById("stat-live-probe");
+  if (probeStat) probeStat.textContent = live + " / " + total + " live";
+}
 
 // Brief banner — the prominent current-brief display.
 const briefBanner = document.getElementById("brief-banner");
@@ -1272,18 +1337,53 @@ function escapeHtml(s) {
   });
 }
 
+// Stats overlay refs
+const statCycles = document.getElementById("stat-cycles");
+const statAvgLift = document.getElementById("stat-avg-lift");
+const statTopAgent = document.getElementById("stat-top-agent");
+const statBuild = document.getElementById("stat-build");
+
+// Fetch build version from /health once on load. Provides a visible
+// deploy-traceability marker on the page, useful for confirming
+// "is this the latest build?" without DevTools.
+fetch("/health").then(function (r) { return r.json(); }).then(function (j) {
+  if (j && j.worker_version) statBuild.textContent = "v" + j.worker_version;
+}).catch(function () { /* network blip — leave default */ });
+
 function updateState(state) {
   if (!state) return;
-  if (state.cycle_count !== undefined) metaCycle.textContent = state.cycle_count;
+  if (state.cycle_count !== undefined) {
+    metaCycle.textContent = state.cycle_count;
+    statCycles.textContent = state.cycle_count;
+  }
   if (state.feedback) {
     metaAudio.textContent = state.feedback.audio_pull.toFixed(2);
     metaCtv.textContent = state.feedback.ctv_pull.toFixed(2);
     metaB2b.textContent = state.feedback.b2b_pull.toFixed(2);
   }
   if (state.lift_by_agent) {
+    let topAgent = null;
+    let topScore = -1;
+    let total = 0;
+    let count = 0;
     for (const x of state.lift_by_agent) {
       const m = agentMeshes.get(x.agent_id);
       if (m) m.lift = x.score;
+      total += x.score;
+      count += 1;
+      if (x.score > topScore) {
+        topScore = x.score;
+        topAgent = x;
+      }
+    }
+    if (count > 0) {
+      const avg = total / count;
+      statAvgLift.textContent = (avg * 100).toFixed(0) + "%";
+    }
+    if (topAgent) {
+      const a = agents.get(topAgent.agent_id);
+      const name = a ? a.name : topAgent.agent_id;
+      statTopAgent.textContent = name + " · " + (topScore * 100).toFixed(0) + "%";
     }
   }
 }
@@ -1385,6 +1485,9 @@ evtSource.onmessage = function (msg) {
           audioLiftBlip(ev.lift.score);
         }
       }
+      break;
+    case "live_probe":
+      if (Array.isArray(ev.statuses)) updateLiveProbeStatuses(ev.statuses);
       break;
   }
 };
@@ -1858,9 +1961,11 @@ function animate() {
         m.halo.material.color.setHex(baseColor);
       }
     } else {
-      // Persistent low-intensity halo proportional to long-term lift
-      m.halo.material.opacity = 0.05 + (m.lift - 0.4) * 0.4;
-      if (m.halo.material.opacity < 0) m.halo.material.opacity = 0;
+      // Persistent low-intensity halo proportional to long-term lift.
+      // PR G — clipped so even max-lift agents stay subtle (0.04..0.20)
+      // rather than the previous 0.05..0.29 that read as "always glowing"
+      // when bloom layered on top.
+      m.halo.material.opacity = Math.max(0, 0.04 + Math.max(0, m.lift - 0.5) * 0.32);
       m.halo.scale.set(1, 1, 1);
     }
     m.halo.lookAt(camera.position);

--- a/src/routes/ecosystemRoutes.ts
+++ b/src/routes/ecosystemRoutes.ts
@@ -14,7 +14,13 @@
 // feedback + lift across all viewers, so the system as a whole
 // "learns" from collective traffic.
 
-import { ECOSYSTEM, ECOSYSTEM_AGENTS, runOneCycle } from "../domain/ecosystem";
+import {
+    ECOSYSTEM,
+    ECOSYSTEM_AGENTS,
+    runOneCycle,
+    probeAllLive,
+    getLiveStatusSnapshot,
+} from "../domain/ecosystem";
 import { renderEcosystemCanvas } from "./ecosystemCanvas";
 
 export function handleEcosystemPage(env: { DEMO_API_KEY: string }): Response {
@@ -49,6 +55,20 @@ export function handleEcosystemState(): Response {
   });
 }
 
+export async function handleEcosystemProbe(): Promise<Response> {
+  // On-demand probe runner — fires fresh probes against every live agent
+  // and returns the snapshot. Useful for ad-hoc liveness inspection
+  // outside the SSE loop's rolling cadence.
+  const result = await probeAllLive();
+  return new Response(JSON.stringify({
+    ...result,
+    statuses: getLiveStatusSnapshot(),
+  }, null, 2), {
+    status: 200,
+    headers: { "Content-Type": "application/json", "Cache-Control": "no-store" },
+  });
+}
+
 // SSE stream — runs ceremonies back-to-back until the client disconnects.
 // Each event is a JSON object on a single `data:` line. Cycle boundaries
 // are surfaced as their own kinds so the client can clear visual state
@@ -69,6 +89,21 @@ export function handleEcosystemStream(): Response {
       // Initial frame: tell the client which agents exist so it can
       // pre-allocate the constellation before the first cycle starts.
       send({ kind: "bootstrap", agents: ECOSYSTEM_AGENTS, state: ECOSYSTEM.snapshot() });
+
+      // Kick off a background liveness probe loop. First wave fires
+      // immediately; subsequent waves every 45s. Each completion
+      // emits a `live_probe` event so the client repaints the agent
+      // stage indicators (live ●, stale ●, synthetic ○).
+      const probeLoop = async () => {
+        try {
+          await probeAllLive();
+          send({ kind: "live_probe", statuses: getLiveStatusSnapshot() });
+        } catch {
+          // Probe wave errored — ignore; next wave will retry.
+        }
+      };
+      probeLoop();
+      const probeInterval = setInterval(probeLoop, 45_000);
 
       // Heartbeat to keep CF Workers from idling the connection.
       const heartbeat = setInterval(() => {
@@ -95,6 +130,7 @@ export function handleEcosystemStream(): Response {
       } catch (err) {
         // Client disconnected or controller errored — clean up.
         clearInterval(heartbeat);
+        clearInterval(probeInterval);
         try { controller.close(); } catch { /* already closed */ }
         return;
       }


### PR DESCRIPTION
## Summary

Five-deliverable polish PR continuing after D+E+F merged. Includes a direct visual fix from prod walkthrough feedback ("much halo? too look at visuals").

## (1) Live MCP probe — closes the deferred credibility gap

Per-agent fetch against each `live` agent's `mcp_url` every 45s (2.5s timeout). SSE forwards a `live_probe` event; frontend repaints agent stage indicators in real time.

| Indicator | Meaning |
|---|---|
| `●` mint | Last probe succeeded within rolling 60s window |
| `◑` red | Last probe failed (degraded) |
| `○` dim | Synthetic agent (no URL ever claimed) |

New endpoint: `GET /ecosystem/probe` runs an on-demand wave + returns the snapshot.

This is what makes the demo's "live" badge actually mean something. Now there's real ground truth that Adzymic / Claire / Dstillery / Celtra / Advertible / etc. are answering MCP calls right now, not just listed as live in the registry.

## (2) Stats overlay HUD

Left-side panel above the legend:

```
LIVE ECOSYSTEM
Cycles       42
Avg lift     67%
Top agent    Triton-attention (mock) · 89%
Live probe   8 / 13 live
Build        v1.1.0
```

Hides in hide-UI mode. The "Build" line pulls from `/health` so you have visible deploy-traceability without DevTools.

## (3) Halo dial-back (the visual fix)

Prod walkthrough showed multiple high-lift halos overlapping + bloom amplifying = blurry constellation. Conservative tune:

| Param | Before | After |
|---|---|---|
| Halo peak intensity | 0.7 + score × 0.8 (max 1.5) | 0.35 + score × 0.35 (max 0.7) |
| Pulse scale max | 1.4 + score × 0.6 (max 2.0) | 1.15 + score × 0.25 (max 1.4) |
| Decay per frame | 0.006 - 0.018 | 0.014 - 0.026 (faster) |
| Persistent halo opacity | up to 0.29 | up to 0.20 |
| Bloom strength | 0.85 | 0.55 |
| Bloom threshold | 0.18 | 0.30 |

High-lift agents still announce themselves (just briefly); readability now intact.

## (4) Version bump

- `package.json`: 1.0.0 → **1.1.0** (minor — `/ecosystem` is the new feature surface)
- `/health` now returns `worker_version`, `built_at`, `adcp_version` alongside legacy `version: "3.0"`

## (5) New routes (all public)

```
GET /ecosystem/probe — on-demand live probe wave + status snapshot
```

## Test plan

- [x] `npx vitest run` — 441/441 passing
- [x] `python tmp-mining/trap_audit.py` — clean
- [x] `npx wrangler deploy --dry-run` — clean
- [x] `npx tsc --noEmit -p .` — no errors
- [ ] After deploy: hit `/health` → see worker_version: 1.1.0
- [ ] After deploy: hit `/ecosystem/probe` → see real probe results
- [ ] After deploy: open `/ecosystem` → wait 5s → live probe results paint agent labels (mint = live, red = degraded)
- [ ] After deploy: stats overlay populates after first cycle
- [ ] After deploy: halos no longer obscure agent names

## Deferred to PR H

- Money flow particles (gold particles flowing buyer↔agents on bid/measure)
- Audio harmonic build (per-phase chord progression)
- Supernova effect on cycle complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)