### PR TITLE
Demo sidebar: add /ecosystem link to Multi-Agent group

### DIFF
--- a/src/routes/demo.ts
+++ b/src/routes/demo.ts
@@ -289,6 +289,10 @@ ${STYLES}
             <svg class="ico"><use href="#icon-radar"/></svg><span>Vendor Health</span>
             <span class="nav-tag">new</span>
           </a>
+          <a class="nav-item" href="/ecosystem" target="_blank" rel="noopener">
+            <svg class="ico"><use href="#icon-bolt"/></svg><span>Ecosystem</span>
+            <span class="nav-tag">live</span>
+          </a>
         </div>
       </div>
 

--- a/tests/__snapshots__/demo-render-snapshot.test.ts.snap
+++ b/tests/__snapshots__/demo-render-snapshot.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`handleDemo byte-equivalence > matches the committed golden hash (LF-normalized SHA-256 of body) 1`] = `
 {
-  "hash": "d66bc56dc4539ab7ae7008fc4af44f36c59f361ae40f145a7f155a97614c464c",
-  "length": 1109247,
+  "hash": "9216fb1dedbbacdad7a35be23b4fd8a81f68da5393e8a1b060c4adb042379229",
+  "length": 1109470,
 }
 `;


### PR DESCRIPTION
## Summary

Wires the new \`/ecosystem\` constellation page into the demo's sidebar — until now the only way to reach it was typing the URL directly. Slotted into the **Multi-Agent** group as the third separate-page canvas alongside Race Canvas + Vendor Health.

## What changes

```
Multi-Agent
├── Federation              (in-tab)
├── Orchestrator            (in-tab)
├── Race Canvas             (separate page)
├── Vendor Health           (separate page)
└── Ecosystem               (separate page) ← NEW
```

- \`target="_blank"\` so the full-screen WebGL doesn't replace the demo's main UI
- Tag is **live** (not "new") to distinguish — only one streaming continuously from SSE
- Icon: \`#icon-bolt\` (matches the energy of the constellation)

## Test plan

- [x] \`npx vitest run\` — 441/441 passing (snapshot golden updated for the new link)
- [x] \`python tmp-mining/trap_audit.py\` — clean
- [ ] After deploy: open demo, expand Multi-Agent group → see "Ecosystem · live" entry → clicks open /ecosystem in new tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)