### PR TITLE
/ecosystem pacing: stagger fanouts + slower cycles ('battlefield' fix)

### DIFF
--- a/src/domain/ecosystem.ts
+++ b/src/domain/ecosystem.ts
@@ -355,10 +355,27 @@ export function generateBrief(feedbackBias?: { audio_pull?: number; ctv_pull?: n
 // When the orchestrator's live-call attempt times out or errors, it
 // falls back to these.
 
+// Visual pacing: synthetic latency multiplier. Real-time agent
+// orchestration would happen in the 100-400ms range per phase, but
+// for visual clarity we stretch by 1.5x so each phase reads as a
+// distinct beat. The constellation otherwise looks like a battlefield —
+// all 10 sales-fanout responses landing in one frame.
+const PACING_MULTIPLIER = 1.5;
+
 function syntheticDelay(agent: EcosystemAgent): Promise<void> {
-  const base = agent.personality?.base_latency_ms ?? 150;
+  const base = (agent.personality?.base_latency_ms ?? 150) * PACING_MULTIPLIER;
   const jitter = Math.random() * base * 0.4;
   return new Promise((res) => setTimeout(res, base + jitter));
+}
+
+// Stagger between message yields inside a fanout. Currently the
+// orchestrator yields N message events for N agents in a tight for
+// loop — they hit the canvas effectively simultaneously. A small
+// inter-yield pause makes the beams sweep across the constellation
+// like a wave instead of arriving as one wall.
+const FANOUT_STAGGER_MS = 70;
+function fanoutPause(): Promise<void> {
+  return new Promise((res) => setTimeout(res, FANOUT_STAGGER_MS));
 }
 
 // Brief-fit score per agent: how well do this agent's specialties match
@@ -644,6 +661,7 @@ async function* runCycle(brief: Brief, _liftMap: Map<string, AgentLift>): AsyncG
     yield { kind: "message", message: { id: nextTraceId(), brief_id: brief.id,
       from_agent_id: BUYER_AGENT_ID, to_agent_id: a.id, kind: "signals_fanout", ts_ms: Date.now() - t0,
       color_hint: "discovery" } };
+    await fanoutPause();
   }
   const signalResponses = await Promise.allSettled(
     signalsAgents.map(async (a) => {
@@ -674,6 +692,7 @@ async function* runCycle(brief: Brief, _liftMap: Map<string, AgentLift>): AsyncG
     yield { kind: "message", message: { id: nextTraceId(), brief_id: brief.id,
       from_agent_id: BUYER_AGENT_ID, to_agent_id: a.id, kind: "governance_check", ts_ms: Date.now() - t0,
       color_hint: "policy" } };
+    await fanoutPause();
   }
   const govResponses = await Promise.allSettled(
     govAgents.map(async (a) => {
@@ -700,12 +719,15 @@ async function* runCycle(brief: Brief, _liftMap: Map<string, AgentLift>): AsyncG
     return;
   }
 
-  // 3) Sales fan-out
+  // 3) Sales fan-out — biggest fanout (10 agents). The stagger
+  // matters most here; without it the screen reads as a wall of
+  // beams arriving in one frame.
   const salesAgents = getAgentsByRole("sales");
   for (const a of salesAgents) {
     yield { kind: "message", message: { id: nextTraceId(), brief_id: brief.id,
       from_agent_id: BUYER_AGENT_ID, to_agent_id: a.id, kind: "sales_fanout", ts_ms: Date.now() - t0,
       color_hint: "discovery" } };
+    await fanoutPause();
   }
   const salesResponses = await Promise.allSettled(
     salesAgents.map(async (a) => {
@@ -734,6 +756,7 @@ async function* runCycle(brief: Brief, _liftMap: Map<string, AgentLift>): AsyncG
     yield { kind: "message", message: { id: nextTraceId(), brief_id: brief.id,
       from_agent_id: BUYER_AGENT_ID, to_agent_id: a.id, kind: "creative_match", ts_ms: Date.now() - t0,
       color_hint: "creative" } };
+    await fanoutPause();
   }
   await Promise.allSettled(
     creativeAgents.map(async (a) => {
@@ -747,6 +770,7 @@ async function* runCycle(brief: Brief, _liftMap: Map<string, AgentLift>): AsyncG
     yield { kind: "message", message: { id: nextTraceId(), brief_id: brief.id,
       from_agent_id: a.id, to_agent_id: BUYER_AGENT_ID, kind: "creative_match", ts_ms: Date.now() - t0,
       color_hint: "creative" } };
+    await fanoutPause();
   }
 
   // 5) Buying bids
@@ -755,6 +779,7 @@ async function* runCycle(brief: Brief, _liftMap: Map<string, AgentLift>): AsyncG
     yield { kind: "message", message: { id: nextTraceId(), brief_id: brief.id,
       from_agent_id: BUYER_AGENT_ID, to_agent_id: a.id, kind: "buying_bid", ts_ms: Date.now() - t0,
       color_hint: "bid" } };
+    await fanoutPause();
   }
   const bidResponses = await Promise.allSettled(
     buyingAgents.map(async (a) => {
@@ -784,6 +809,7 @@ async function* runCycle(brief: Brief, _liftMap: Map<string, AgentLift>): AsyncG
     yield { kind: "message", message: { id: nextTraceId(), brief_id: brief.id,
       from_agent_id: BUYER_AGENT_ID, to_agent_id: a.id, kind: "measurement_report", ts_ms: Date.now() - t0,
       color_hint: "measurement" } };
+    await fanoutPause();
   }
   // Roll up cycle quality signals so measurement can score against
   // actual upstream-phase outcomes — not random tilt against the brief

--- a/src/routes/ecosystemRoutes.ts
+++ b/src/routes/ecosystemRoutes.ts
@@ -123,9 +123,11 @@ export function handleEcosystemStream(): Response {
             await new Promise((r) => setTimeout(r, 4));
           }
           send({ kind: "ecosystem_state", state: ECOSYSTEM.snapshot() });
-          // Inter-cycle breath. Long enough for the constellation to settle,
-          // short enough that the screen-recorded loop stays "alive".
-          await new Promise((r) => setTimeout(r, 1200));
+          // Inter-cycle breath — bumped from 1.2s to 3s so viewers
+          // can read the supernova + brief banner without the next
+          // cycle stomping over them. Cinema mode loops over 60s, so
+          // a 3s pause still gives plenty of cycle activity in-frame.
+          await new Promise((r) => setTimeout(r, 3000));
         }
       } catch (err) {
         // Client disconnected or controller errored — clean up.


### PR DESCRIPTION
## Summary

Direct fix for "firing too fast — looks like a battlefield." Three pacing dials, all in the same direction.

## Changes

### 1. Stagger beams within fanouts (the biggest win)

Previously all N fanout beams in a phase yielded in tight succession — 10 sales-fanout beams hit the canvas in one frame. Adding 70ms between yields:

```ts
for (const a of salesAgents) {
  yield { ...messageEvent };
  await fanoutPause();   // 70ms
}
```

Beams now sweep across the constellation like a wave, not a wall. Applied to all 6 fanout loops + creative responses.

### 2. Stretch synthetic latencies 1.5×

```ts
const PACING_MULTIPLIER = 1.5;
const base = (agent.personality?.base_latency_ms ?? 150) * PACING_MULTIPLIER;
```

Each phase reads as a distinct beat. Response beams from phase N no longer blur into fanout beams of phase N+1.

### 3. Between-cycle breath 1.2s → 3s

After a cycle's supernova fires, we now pause 3 seconds. Supernova ring fully expands + dissipates, brief banner has time to be read, constellation has a clear "rest" beat.

Cinema 60s loop still catches 5-6 full cycles per minute (was 8-9). Still feels alive, just less frantic.

## Test plan

- [x] `npx vitest run` — 441/441 passing
- [x] `python tmp-mining/trap_audit.py` — clean
- [x] `npx tsc --noEmit -p .` — no errors
- [ ] After deploy: sales fanout shows visible left-to-right cascade
- [ ] After deploy: supernova has room to breathe before next brief
- [ ] Cinema mode still feels active

## What if still too slow?

I'd start by halving FANOUT_STAGGER_MS (70 → 35). If still too fast: bump it to 100. Both single-line tweaks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)