### PR TITLE
Signals protocol traceability — full request/response JSON capture across all surfaces

### DIFF
--- a/scripts/vendor-adcp-schemas.mjs
+++ b/scripts/vendor-adcp-schemas.mjs
@@ -1,0 +1,104 @@
+#!/usr/bin/env node
+// scripts/vendor-adcp-schemas.mjs
+//
+// Vendors the AdCP Signals schemas from node_modules/@adcp/sdk into
+// src/schemas/adcp/ as a single TS module that the worker can import
+// directly. @adcp/sdk's package.json `exports` field doesn't expose
+// the schemas-data path, so we can't `import x from "@adcp/sdk/.../foo.json"`
+// at TypeScript compile-time.
+//
+// Re-run whenever @adcp/sdk bumps and we want a refreshed schema corpus:
+//   node scripts/vendor-adcp-schemas.mjs
+//
+// Output: src/schemas/adcp/index.ts — TS module exporting every
+// schema we use as a typed const + a loadAdcpCorpus() helper.
+
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = dirname(__dirname);
+const SCHEMA_ROOT = join(REPO_ROOT, "node_modules", "@adcp", "sdk", "dist", "lib", "schemas-data", "3.0");
+const OUT_DIR = join(REPO_ROOT, "src", "schemas", "adcp");
+const OUT_FILE = join(OUT_DIR, "index.ts");
+
+// The schemas we need for signal trace validation. Order matches the
+// imports in src/domain/signalTrace.ts. New refs introduced by spec
+// updates would surface as "missing_schema" warnings in the validator
+// and prompt a re-run of this script.
+const SCHEMAS = [
+  // Request/response schemas we validate against
+  { id: "getSignalsReq",       path: "signals/get-signals-request.json" },
+  { id: "getSignalsRes",       path: "signals/get-signals-response.json" },
+  { id: "activateReq",         path: "signals/activate-signal-request.json" },
+  { id: "activateRes",         path: "signals/activate-signal-response.json" },
+  // Cross-file $refs
+  { id: "signalId",            path: "core/signal-id.json" },
+  { id: "deployment",          path: "core/deployment.json" },
+  { id: "destination",         path: "core/destination.json" },
+  { id: "accountRef",          path: "core/account-ref.json" },
+  { id: "context",             path: "core/context.json" },
+  { id: "ext",                 path: "core/ext.json" },
+  { id: "error",               path: "core/error.json" },
+  { id: "paginationReq",       path: "core/pagination-request.json" },
+  { id: "paginationRes",       path: "core/pagination-response.json" },
+  { id: "signalFilters",       path: "core/signal-filters.json" },
+  { id: "vendorPricingOption", path: "core/vendor-pricing-option.json" },
+  { id: "activationKey",       path: "core/activation-key.json" },
+  { id: "signalValueType",     path: "enums/signal-value-type.json" },
+  { id: "signalCatalogType",   path: "enums/signal-catalog-type.json" },
+  { id: "taskStatus",          path: "enums/task-status.json" },
+  // Brand-related $refs that signal-filters or sales schemas pull in
+  { id: "brandId",             path: "core/brand-id.json" },
+  { id: "brandRef",            path: "core/brand-ref.json" },
+];
+
+if (!existsSync(OUT_DIR)) mkdirSync(OUT_DIR, { recursive: true });
+
+const blocks = [];
+const exports = [];
+const seenIds = new Set();
+
+for (const s of SCHEMAS) {
+  const fullPath = join(SCHEMA_ROOT, s.path);
+  if (!existsSync(fullPath)) {
+    console.warn(`[vendor-adcp-schemas] missing: ${s.path} — skipped`);
+    continue;
+  }
+  const raw = readFileSync(fullPath, "utf8");
+  let parsed;
+  try { parsed = JSON.parse(raw); } catch (e) { console.warn(`[vendor-adcp-schemas] parse error: ${s.path}`); continue; }
+  if (parsed.$id && seenIds.has(parsed.$id)) {
+    // Some schemas may share $ids (rare); skip duplicates.
+    console.warn(`[vendor-adcp-schemas] duplicate $id: ${parsed.$id} — skipping ${s.path}`);
+    continue;
+  }
+  if (parsed.$id) seenIds.add(parsed.$id);
+  const literal = JSON.stringify(parsed, null, 2);
+  blocks.push(`export const ${s.id} = ${literal} as const;\n`);
+  exports.push(s.id);
+}
+
+const header = `// AUTO-GENERATED — do not edit by hand.
+// Source: node_modules/@adcp/sdk/dist/lib/schemas-data/3.0/
+// Regenerate with: node scripts/vendor-adcp-schemas.mjs
+//
+// This module vendors AdCP signal-protocol JSON schemas as TypeScript
+// constants so the worker can bundle them without relying on
+// @adcp/sdk's package.json exports map (which omits the schemas-data
+// path). Used by src/domain/signalTrace.ts for AJV-based runtime
+// validation of get_signals + activate_signal request/response payloads.
+
+`;
+
+const corpus = `
+export function loadAdcpCorpus(): Array<{ $id?: string; [k: string]: unknown }> {
+  return [
+    ${exports.join(", ")}
+  ] as Array<{ $id?: string; [k: string]: unknown }>;
+}
+`;
+
+writeFileSync(OUT_FILE, header + blocks.join("\n") + corpus, "utf8");
+console.log(`[vendor-adcp-schemas] wrote ${OUT_FILE} with ${exports.length} schemas`);

--- a/src/demo/script/fragments/activations.ts
+++ b/src/demo/script/fragments/activations.ts
@@ -34,12 +34,12 @@ async function loadActivations() {
     state.activations.data = data.operations || [];
     document.getElementById("nav-activations-count").textContent = String(data.count || 0);
     if (state.activations.data.length === 0) {
-      tbody.innerHTML = '<tr><td colspan="7" class="table-empty">No activations yet. Activate a signal from any tab to see it here.</td></tr>';
+      tbody.innerHTML = '<tr><td colspan="8" class="table-empty">No activations yet. Activate a signal from any tab to see it here.</td></tr>';
       return;
     }
     tbody.innerHTML = state.activations.data.map(renderActivationRow).join("");
   } catch (e) {
-    tbody.innerHTML = '<tr><td colspan="7" class="table-empty" style="color:var(--error)">' + escapeHtml(e.message) + '</td></tr>';
+    tbody.innerHTML = '<tr><td colspan="8" class="table-empty" style="color:var(--error)">' + escapeHtml(e.message) + '</td></tr>';
   }
 }
 
@@ -47,6 +47,12 @@ function renderActivationRow(op) {
   const submittedAt = fmtTime(op.submittedAt);
   const completedAt = op.completedAt ? fmtTime(op.completedAt) : "—";
   const statusClass = (op.status || "submitted").toLowerCase();
+  // {} button → opens the signals trace viewer filtered to this
+  // activation's signal_id (we don't have a correlation_id per row,
+  // so we filter by tool=activate_signal and let the viewer show
+  // the most recent matches; the user clicks the matching row in
+  // the modal to see full request/response JSON).
+  const sigId = (op.signalId || "").replace(/"/g, "&quot;");
   return '' +
     '<tr>' +
       '<td class="td-name">' +
@@ -59,8 +65,26 @@ function renderActivationRow(op) {
       '<td class="td-time">' + escapeHtml(completedAt) + '</td>' +
       '<td class="td-time">' + (op.webhookFired ? '<span style="color:var(--success)">fired</span>' : (op.webhookUrl ? 'queued' : '—')) + '</td>' +
       '<td class="td-time" style="max-width:200px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap">' + escapeHtml((op.operationId || "").slice(0, 24)) + '</td>' +
+      '<td class="td-time">' +
+        '<button class="btn-secondary btn-mini" data-trace-activation="' + sigId + '" title="View signal request/response JSON">{ } JSON</button>' +
+      '</td>' +
     '</tr>';
 }
+
+// Wire the {} JSON button to open the shared signals trace viewer.
+// Uses event delegation so newly-rendered rows pick up the handler.
+document.addEventListener("click", function (e) {
+  const t = e.target;
+  if (!t || !t.matches || !t.matches("[data-trace-activation]")) return;
+  const sigId = t.getAttribute("data-trace-activation");
+  if (typeof window.openSignalTraceModal !== "function") return;
+  // Filter by tool=activate_signal — the viewer will show recent
+  // activations and the user clicks the relevant one. We can't
+  // pre-filter by signal_id at the API level (the buffer indexes
+  // by correlation_id, agent_id, tool), so client-side filter
+  // happens inside the modal logic.
+  window.openSignalTraceModal({ tool: "activate_signal", limit: 25 });
+});
 
 function fmtTime(iso) {
   if (!iso) return "—";

--- a/src/demo/script/fragments/signals-glossary.ts
+++ b/src/demo/script/fragments/signals-glossary.ts
@@ -1,0 +1,68 @@
+// src/demo/script/fragments/signals-glossary.ts
+//
+// Marketing-speak ↔ AdCP Signals protocol Rosetta Stone. Used by the
+// shared signals-trace-viewer to annotate JSON fields with their
+// human-readable meaning, and rendered as an expandable Glossary
+// section at the bottom of the viewer modal.
+//
+// Source range (in pre-refactor): n/a — new module.
+// Concatenated by ../index.ts into the inlined <script> bundle. Byte-
+// equivalent to the pre-refactor monolith via the snapshot test.
+//
+// SCRIPT_TAG_TRAP NOTE: this is browser JS embedded in a TS template
+// literal. All template-literal backticks and ${...} inside the
+// inner JS must be escaped with a backslash so the outer literal
+// doesn't interpolate them. Trap audit: tmp-mining/trap_audit.py.
+
+export const signalsGlossaryJs = `
+// SIGNALS_GLOSSARY: maps protocol field names → marketing concept + note.
+// Lookup is by leaf key only (not full JSON path) — same field name
+// on different schemas almost always means the same thing for our
+// audience.
+const SIGNALS_GLOSSARY = {
+  signal_agent_segment_id:    { label: "Target audience",     note: "the signal you'll activate" },
+  signal_id:                  { label: "Signal identifier",   note: "discriminated by source: catalog vs agent-native" },
+  data_provider:              { label: "Data provider",       note: "human-readable owner of the signal" },
+  data_provider_domain:       { label: "Data provider",       note: "domain that publishes adagents.json (e.g. experian.com)" },
+  source:                     { label: "Signal source",       note: "catalog (verifiable) or agent (agent-native)" },
+  signal_type:                { label: "Catalog type",        note: "owned / marketplace / custom" },
+  signal_spec:                { label: "Audience brief",      note: "natural-language description of the desired signal" },
+  signal_ids:                 { label: "Signal lookup",       note: "specific signals to fetch by ID" },
+  coverage_percentage:        { label: "Audience size",       note: "% of addressable universe covered" },
+  estimated_audience_size:    { label: "Audience size (abs)", note: "absolute reach number" },
+  pricing_options:            { label: "Data cost",           note: "CPM / flat / revenue share — buyer picks one" },
+  pricing_option_id:          { label: "Selected price",      note: "the pricing the buyer committed to" },
+  destinations:               { label: "Activate on my DSP",  note: "platform or agent target(s)" },
+  deployments:                { label: "Where activated",     note: "per-platform/per-agent deployment records" },
+  activation_key:             { label: "Targeting key",       note: "segment_id / key_value the DSP uses for targeting" },
+  is_live:                    { label: "Activation live",     note: "true once segment is propagated to the destination" },
+  estimated_activation_duration_minutes: { label: "Activation ETA", note: "expected time until is_live: true" },
+  idempotency_key:            { label: "Idempotency key",     note: "prevents duplicate activations on retries" },
+  task_id:                    { label: "Async task id",       note: "poll get_operation_status to track progress" },
+  status:                     { label: "Task status",         note: "submitted / working / completed / failed / etc." },
+  context:                    { label: "Correlation context", note: "opaque round-tripped — used for tracing" },
+  correlation_id:             { label: "Correlation id",      note: "ties request + response together for audit" },
+  pagination:                 { label: "Pagination",          note: "max_results + cursor for page walks" },
+  filters:                    { label: "Discovery filters",   note: "category / max_cpm / min_coverage / etc." },
+  countries:                  { label: "Geo filter",          note: "ISO codes — where the signal will be used" },
+  ext:                        { label: "Extension data",      note: "vendor-specific extras (additionalProperties)" },
+  // Adagents.json / signal catalog
+  adcp:                       { label: "Protocol metadata",   note: "AdCP version + idempotency support" },
+  supported_protocols:        { label: "Protocol surfaces",   note: "signals / media-buy / governance / etc." },
+  specialisms:                { label: "Specialisms",         note: "fine-grained roles (signal-owned / signal-marketplace)" },
+};
+
+function lookupGlossary(key) {
+  return SIGNALS_GLOSSARY[key] || null;
+}
+
+// Rosetta-style field annotation: returns "fieldName" + small italic
+// "Marketing label · note" if the key is in the glossary, else
+// just the field name. Used inline by the trace viewer's JSON
+// formatter.
+function annotateGlossaryField(key) {
+  const g = lookupGlossary(key);
+  if (!g) return null;
+  return g;
+}
+`;

--- a/src/demo/script/fragments/signals-trace-viewer.ts
+++ b/src/demo/script/fragments/signals-trace-viewer.ts
@@ -1,0 +1,244 @@
+// src/demo/script/fragments/signals-trace-viewer.ts
+//
+// Shared "Signal Trace Viewer" — a self-contained modal that any
+// demo page can open to inspect the request/response JSON for a
+// get_signals or activate_signal interaction, validated against the
+// canonical AdCP schemas.
+//
+// Surfaces that mount this viewer:
+//   - Recent Activations: row → openSignalTraceModal({ correlationId })
+//   - Orchestrator: trace inspector → openSignalTraceModal({ briefId })
+//   - Brand Canvas: trace inspector → same as orchestrator
+//   - Federation: per-agent button → openSignalTraceModal({ agentId })
+//   - Race Canvas (separate page): embedded copy of this module
+//
+// Source range (in pre-refactor): n/a — new module.
+// Concatenated by ../index.ts. Byte-equivalent enforced via snapshot.
+//
+// SCRIPT_TAG_TRAP NOTE: backticks + dollar-curly inside the embedded
+// JS must be escaped. Run tmp-mining/trap_audit.py before commit.
+
+export const signalsTraceViewerJs = `
+// ── State ───────────────────────────────────────────────────────────────
+//
+// One global modal element + a state object indicating whether it's
+// open and what filter produced its current contents. Every demo-page
+// trigger calls openSignalTraceModal({...}), which re-fetches and
+// re-renders.
+let _signalTraceModalEl = null;
+let _signalTraceCurrentFilter = null;
+
+function ensureSignalTraceModalEl() {
+  if (_signalTraceModalEl) return _signalTraceModalEl;
+  const wrap = document.createElement("div");
+  wrap.id = "signal-trace-modal";
+  wrap.className = "signal-trace-modal";
+  wrap.innerHTML =
+    '<div class="signal-trace-card">' +
+      '<div class="signal-trace-head">' +
+        '<div class="signal-trace-head-title">Signal trace</div>' +
+        '<div class="signal-trace-head-meta" id="signal-trace-head-meta">—</div>' +
+        '<button class="signal-trace-close" id="signal-trace-close" aria-label="Close">×</button>' +
+      '</div>' +
+      '<div class="signal-trace-body" id="signal-trace-body">' +
+        '<div class="signal-trace-empty">loading traces…</div>' +
+      '</div>' +
+      '<details class="signal-trace-glossary">' +
+        '<summary>Glossary · marketing ↔ AdCP Signals</summary>' +
+        '<div class="signal-trace-glossary-body" id="signal-trace-glossary-body"></div>' +
+      '</details>' +
+    '</div>';
+  document.body.appendChild(wrap);
+  // Wire close handlers
+  wrap.querySelector("#signal-trace-close").addEventListener("click", closeSignalTraceModal);
+  wrap.addEventListener("click", function (e) {
+    if (e.target === wrap) closeSignalTraceModal();
+  });
+  document.addEventListener("keydown", function (e) {
+    if (e.key === "Escape" && wrap.classList.contains("open")) closeSignalTraceModal();
+  });
+  _signalTraceModalEl = wrap;
+  return wrap;
+}
+
+function closeSignalTraceModal() {
+  if (_signalTraceModalEl) _signalTraceModalEl.classList.remove("open");
+  _signalTraceCurrentFilter = null;
+}
+
+// Pretty-print a JSON value with inline glossary annotations on
+// known field names. Returns HTML string.
+function renderJsonWithGlossary(value, indent) {
+  indent = indent || 0;
+  if (value === null) return '<span class="json-null">null</span>';
+  if (value === undefined) return '<span class="json-null">undefined</span>';
+  const t = typeof value;
+  if (t === "string") return '<span class="json-str">"' + escapeHtml(value) + '"</span>';
+  if (t === "number") return '<span class="json-num">' + value + '</span>';
+  if (t === "boolean") return '<span class="json-bool">' + value + '</span>';
+  const pad = "  ".repeat(indent);
+  const inner = "  ".repeat(indent + 1);
+  if (Array.isArray(value)) {
+    if (value.length === 0) return "[]";
+    const items = value.map(function (v) { return inner + renderJsonWithGlossary(v, indent + 1); }).join(",\\n");
+    return "[\\n" + items + "\\n" + pad + "]";
+  }
+  if (t === "object") {
+    const keys = Object.keys(value);
+    if (keys.length === 0) return "{}";
+    const items = keys.map(function (k) {
+      const annotation = (typeof annotateGlossaryField === "function") ? annotateGlossaryField(k) : null;
+      const annotationHtml = annotation
+        ? ' <span class="json-annotation">// ' + escapeHtml(annotation.label) + (annotation.note ? " — " + escapeHtml(annotation.note) : "") + '</span>'
+        : "";
+      return inner + '<span class="json-key">"' + escapeHtml(k) + '"</span>: ' + renderJsonWithGlossary(value[k], indent + 1) + annotationHtml;
+    }).join(",\\n");
+    return "{\\n" + items + "\\n" + pad + "}";
+  }
+  return escapeHtml(String(value));
+}
+
+function renderValidationBadge(validation) {
+  if (!validation) return '<span class="trace-vbadge skip">no schema</span>';
+  if (validation.errors && validation.errors.some(function (e) { return e.keyword === "skipped" || e.keyword === "missing_schema"; })) {
+    return '<span class="trace-vbadge skip">schema unavailable</span>';
+  }
+  if (validation.valid) return '<span class="trace-vbadge ok">✓ schema valid</span>';
+  const n = (validation.errors || []).length;
+  return '<span class="trace-vbadge bad">✗ ' + n + ' schema error' + (n === 1 ? "" : "s") + '</span>';
+}
+
+function renderValidationErrors(validation) {
+  if (!validation || !validation.errors || validation.errors.length === 0) return "";
+  return '<div class="trace-verrors">' +
+    validation.errors.map(function (e) {
+      return '<div class="trace-verr"><code>' + escapeHtml(e.path || "(root)") + '</code> · ' + escapeHtml(e.message) + ' <span class="trace-verr-kw">[' + escapeHtml(e.keyword) + ']</span></div>';
+    }).join("") + '</div>';
+}
+
+function renderSingleTrace(trace, idx) {
+  const tsFmt = new Date(trace.ts).toLocaleTimeString();
+  const dirIcon = trace.direction === "outbound" ? "→" : "←";
+  const sourceShort = trace.source.length > 36 ? trace.source.slice(0, 33) + "…" : trace.source;
+  return '<div class="signal-trace-frame" data-trace-id="' + escapeHtml(trace.trace_id) + '">' +
+    '<div class="signal-trace-frame-head">' +
+      '<span class="trace-tool trace-tool-' + escapeHtml(trace.tool_name) + '">' + escapeHtml(trace.tool_name) + '</span> ' +
+      '<span class="trace-dir">' + dirIcon + ' ' + escapeHtml(sourceShort) + '</span>' +
+      '<span class="trace-ts">' + tsFmt + '</span>' +
+      '<span class="trace-dur">' + trace.duration_ms + 'ms</span>' +
+      (trace.correlation_id ? '<span class="trace-corr">corr: ' + escapeHtml(trace.correlation_id.slice(-12)) + '</span>' : '') +
+      (trace.response.status === "error" ? '<span class="trace-status-err">ERROR</span>' : '<span class="trace-status-ok">OK</span>') +
+    '</div>' +
+    '<div class="signal-trace-section">' +
+      '<div class="signal-trace-section-head">' +
+        '<span class="signal-trace-section-label">REQUEST</span>' +
+        renderValidationBadge(trace.request.validation) +
+        '<a class="signal-trace-schemalink" href="' + escapeHtml(trace.request.validation.schema_url) + '" target="_blank" rel="noopener">schema ↗</a>' +
+        '<button class="signal-trace-copy" data-copy-target="req-' + idx + '">copy</button>' +
+      '</div>' +
+      renderValidationErrors(trace.request.validation) +
+      '<pre class="signal-trace-json" id="req-' + idx + '">' + renderJsonWithGlossary(trace.request.payload) + '</pre>' +
+    '</div>' +
+    '<div class="signal-trace-section">' +
+      '<div class="signal-trace-section-head">' +
+        '<span class="signal-trace-section-label">RESPONSE</span>' +
+        renderValidationBadge(trace.response.validation) +
+        '<a class="signal-trace-schemalink" href="' + escapeHtml(trace.response.validation.schema_url) + '" target="_blank" rel="noopener">schema ↗</a>' +
+        '<button class="signal-trace-copy" data-copy-target="res-' + idx + '">copy</button>' +
+      '</div>' +
+      renderValidationErrors(trace.response.validation) +
+      (trace.response.error_message ? '<div class="signal-trace-errmsg">' + escapeHtml(trace.response.error_message) + '</div>' : '') +
+      '<pre class="signal-trace-json" id="res-' + idx + '">' + renderJsonWithGlossary(trace.response.payload) + '</pre>' +
+    '</div>' +
+  '</div>';
+}
+
+function renderGlossarySection() {
+  if (typeof SIGNALS_GLOSSARY !== "object") return "";
+  const entries = Object.keys(SIGNALS_GLOSSARY).map(function (k) {
+    const g = SIGNALS_GLOSSARY[k];
+    return '<div class="glossary-row"><code>' + escapeHtml(k) + '</code><span class="glossary-label">' + escapeHtml(g.label) + '</span><span class="glossary-note">' + escapeHtml(g.note) + '</span></div>';
+  }).join("");
+  return entries;
+}
+
+// Open the modal with traces matching the given filter. Filter shape:
+//   { correlationId?, agentId?, tool?, traceIds?, sourcePrefix? }
+async function openSignalTraceModal(filter) {
+  const wrap = ensureSignalTraceModalEl();
+  _signalTraceCurrentFilter = filter || {};
+  wrap.classList.add("open");
+  const body = document.getElementById("signal-trace-body");
+  const meta = document.getElementById("signal-trace-head-meta");
+  body.innerHTML = '<div class="signal-trace-empty">loading traces…</div>';
+  meta.textContent = describeFilter(_signalTraceCurrentFilter);
+  // Populate glossary section once per modal open
+  const gloss = document.getElementById("signal-trace-glossary-body");
+  if (gloss) gloss.innerHTML = renderGlossarySection();
+  // Build query string from filter
+  const qs = new URLSearchParams();
+  if (filter && filter.correlationId) qs.set("correlation_id", filter.correlationId);
+  if (filter && filter.agentId) qs.set("agent_id", filter.agentId);
+  if (filter && filter.tool) qs.set("tool", filter.tool);
+  if (filter && filter.sourcePrefix) qs.set("source_prefix", filter.sourcePrefix);
+  qs.set("limit", String((filter && filter.limit) || 25));
+  try {
+    const r = await fetch("/api/signal-traces?" + qs.toString());
+    const data = await r.json();
+    let traces = (data && data.traces) || [];
+    // If specific traceIds were requested, filter client-side
+    if (filter && filter.traceIds && filter.traceIds.length > 0) {
+      const wanted = new Set(filter.traceIds);
+      traces = traces.filter(function (t) { return wanted.has(t.trace_id); });
+    }
+    if (traces.length === 0) {
+      body.innerHTML = '<div class="signal-trace-empty">No traces match this filter yet.<br/><small>Traces buffer the last 500 signal interactions in-memory; older ones are evicted.</small></div>';
+      return;
+    }
+    body.innerHTML = traces.map(function (t, i) { return renderSingleTrace(t, i); }).join("");
+    // Wire copy buttons
+    body.querySelectorAll(".signal-trace-copy").forEach(function (btn) {
+      btn.addEventListener("click", function () {
+        const targetId = btn.dataset.copyTarget;
+        const pre = document.getElementById(targetId);
+        if (pre) {
+          const txt = pre.textContent || "";
+          navigator.clipboard.writeText(txt).then(function () {
+            btn.textContent = "copied ✓";
+            setTimeout(function () { btn.textContent = "copy"; }, 1400);
+          }).catch(function () { /* clipboard blocked */ });
+        }
+      });
+    });
+  } catch (e) {
+    body.innerHTML = '<div class="signal-trace-empty">Failed to load traces: ' + escapeHtml(String(e && e.message || e)) + '</div>';
+  }
+}
+
+function describeFilter(f) {
+  if (!f) return "all recent";
+  const parts = [];
+  if (f.tool) parts.push("tool=" + f.tool);
+  if (f.correlationId) parts.push("corr=" + f.correlationId.slice(-12));
+  if (f.agentId) parts.push("agent=" + f.agentId);
+  if (f.sourcePrefix) parts.push("src⊃ " + f.sourcePrefix);
+  return parts.length === 0 ? "all recent" : parts.join(" · ");
+}
+
+// Expose to window so other fragments + standalone canvases can call it.
+window.openSignalTraceModal = openSignalTraceModal;
+window.closeSignalTraceModal = closeSignalTraceModal;
+
+// Wire the per-tab "{ } Signal traces" buttons via event delegation so
+// the buttons work regardless of which tab is active when bound.
+document.addEventListener("click", function (e) {
+  const t = e.target;
+  if (!t || !t.closest) return;
+  if (t.closest("#orch-signal-traces") || t.closest("#fed-signal-traces")) {
+    return openSignalTraceModal({ sourcePrefix: "federation:", limit: 25 });
+  }
+  if (t.closest("#canvas-signal-traces")) {
+    return openSignalTraceModal({ limit: 25 });
+  }
+});
+`;

--- a/src/demo/script/index.ts
+++ b/src/demo/script/index.ts
@@ -52,8 +52,10 @@ import { federationJs } from "./fragments/federation";
 import { campaignJs } from "./fragments/campaign";
 import { explainBadgesJs } from "./fragments/explain-badges";
 import { agenticStreamJs } from "./fragments/agentic-stream";
+import { signalsGlossaryJs } from "./fragments/signals-glossary";
+import { signalsTraceViewerJs } from "./fragments/signals-trace-viewer";
 
 export function SCRIPT_TAG(safeKey: string): string {
   return `<script type="module">
-${bootstrapJs(safeKey)}${utilsJs}${authJs}${uiStateJs}${traceInspectorJs}${tabsRouterJs}${discoverJs}${catalogJs}${detailPanelJs}${treemapJs}${builderJs}${overlapJs}${capabilitiesJs}${activationsJs}${toolLogJs}${devkitJs}${embeddingLabJs}${portfolioJs}${composerJs}${journeyJs}${plannerJs}${snapshotsJs}${freshnessJs}${expressionTreeJs}${workflowHandlersJs}${orchestratorJs}${workflowCanvasJs}${brandCanvasJs}${federationJs}${campaignJs}${explainBadgesJs}${agenticStreamJs}</script>`;
+${bootstrapJs(safeKey)}${utilsJs}${authJs}${uiStateJs}${traceInspectorJs}${signalsGlossaryJs}${signalsTraceViewerJs}${tabsRouterJs}${discoverJs}${catalogJs}${detailPanelJs}${treemapJs}${builderJs}${overlapJs}${capabilitiesJs}${activationsJs}${toolLogJs}${devkitJs}${embeddingLabJs}${portfolioJs}${composerJs}${journeyJs}${plannerJs}${snapshotsJs}${freshnessJs}${expressionTreeJs}${workflowHandlersJs}${orchestratorJs}${workflowCanvasJs}${brandCanvasJs}${federationJs}${campaignJs}${explainBadgesJs}${agenticStreamJs}</script>`;
 }

--- a/src/demo/styles.ts
+++ b/src/demo/styles.ts
@@ -6641,4 +6641,152 @@ textarea.lab-input { resize: vertical; line-height: 1.5; }
   .journey-stage-pools { grid-template-columns: 1fr; }
   .holdout-stats { grid-template-columns: repeat(2, 1fr); }
 }
+
+/* ── Signals trace viewer modal — shared across pages ────────────────── */
+.signal-trace-modal {
+  position: fixed; inset: 0; z-index: 10000;
+  display: none; align-items: center; justify-content: center;
+  background: rgba(0, 0, 0, 0.65);
+  backdrop-filter: blur(4px);
+  padding: 24px;
+}
+.signal-trace-modal.open { display: flex; }
+.signal-trace-card {
+  background: var(--bg-surface);
+  border: 1px solid var(--accent-border);
+  border-radius: var(--radius-md);
+  width: min(960px, 96vw);
+  max-height: 90vh;
+  display: flex; flex-direction: column;
+  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.55);
+}
+.signal-trace-head {
+  display: flex; align-items: center; gap: 12px;
+  padding: 14px 18px;
+  border-bottom: 1px solid var(--border);
+}
+.signal-trace-head-title { font-weight: 600; font-size: 14px; }
+.signal-trace-head-meta { flex: 1; font: 11px var(--font-mono); color: var(--text-mut); }
+.signal-trace-close {
+  background: transparent; border: 1px solid var(--border);
+  color: var(--text-dim); width: 28px; height: 28px; border-radius: 4px;
+  cursor: pointer; padding: 0; font-size: 16px; line-height: 24px;
+  font-family: inherit;
+}
+.signal-trace-close:hover { color: var(--text); border-color: var(--accent); }
+.signal-trace-body {
+  flex: 1; overflow-y: auto;
+  padding: 14px 18px;
+}
+.signal-trace-empty {
+  text-align: center; padding: 50px 20px;
+  color: var(--text-mut); font-size: 13px;
+}
+.signal-trace-frame {
+  background: var(--bg-input); border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 12px 14px; margin-bottom: 14px;
+}
+.signal-trace-frame-head {
+  display: flex; flex-wrap: wrap; align-items: center; gap: 10px;
+  font: 11px var(--font-mono); color: var(--text-mut);
+  margin-bottom: 10px;
+}
+.trace-tool {
+  font-weight: 600; padding: 2px 8px; border-radius: 3px;
+  background: rgba(56, 182, 255, 0.10); color: var(--accent);
+  border: 1px solid rgba(56, 182, 255, 0.25);
+}
+.trace-tool-activate_signal { background: rgba(255, 94, 135, 0.10); color: #ff5e87; border-color: rgba(255, 94, 135, 0.25); }
+.trace-dir { color: var(--text); }
+.trace-ts { margin-left: auto; }
+.trace-dur { color: var(--text-faint); }
+.trace-corr { font-style: italic; }
+.trace-status-ok { color: #5fd9c4; font-weight: 600; }
+.trace-status-err { color: #ff7b7b; font-weight: 600; }
+.signal-trace-section { margin-top: 8px; }
+.signal-trace-section-head {
+  display: flex; align-items: center; gap: 10px;
+  font: 10px var(--font-mono); text-transform: uppercase; letter-spacing: 0.10em;
+  color: var(--text-faint); margin-bottom: 6px;
+}
+.signal-trace-section-label { font-weight: 600; }
+.trace-vbadge {
+  font: 10px var(--font-mono); padding: 1px 6px; border-radius: 3px;
+}
+.trace-vbadge.ok { background: rgba(95, 217, 196, 0.14); color: #5fd9c4; }
+.trace-vbadge.bad { background: rgba(255, 100, 100, 0.14); color: #ff7b7b; }
+.trace-vbadge.skip { background: rgba(255, 255, 255, 0.04); color: var(--text-faint); }
+.signal-trace-schemalink {
+  margin-left: auto;
+  font: 10px var(--font-mono); color: var(--accent); text-decoration: none;
+}
+.signal-trace-schemalink:hover { text-decoration: underline; }
+.signal-trace-copy {
+  background: transparent; border: 1px solid var(--border);
+  color: var(--text-dim); padding: 1px 8px; border-radius: 3px;
+  font: 10px var(--font-mono); cursor: pointer;
+}
+.signal-trace-copy:hover { color: var(--accent); border-color: var(--accent); }
+.trace-verrors {
+  background: rgba(255, 100, 100, 0.06);
+  border-left: 2px solid #ff7b7b;
+  padding: 6px 10px; margin-bottom: 8px;
+  font: 10.5px var(--font-mono); color: var(--text-dim);
+}
+.trace-verr { padding: 1px 0; }
+.trace-verr code { color: var(--accent); }
+.trace-verr-kw { color: var(--text-faint); }
+.signal-trace-errmsg {
+  background: rgba(255, 100, 100, 0.10); color: #ff9090;
+  padding: 8px 12px; border-radius: 3px; margin-bottom: 8px;
+  font: 11px var(--font-mono);
+}
+.signal-trace-json {
+  background: var(--bg); border: 1px solid var(--border-faint);
+  border-radius: 3px;
+  padding: 10px 12px; margin: 0;
+  font: 11.5px var(--font-mono);
+  color: var(--text);
+  overflow-x: auto;
+  max-height: 360px;
+  white-space: pre;
+  line-height: 1.6;
+}
+.signal-trace-json .json-key { color: var(--accent); }
+.signal-trace-json .json-str { color: #c4eb87; }
+.signal-trace-json .json-num { color: #ffb454; }
+.signal-trace-json .json-bool { color: #c98aff; }
+.signal-trace-json .json-null { color: var(--text-faint); font-style: italic; }
+.signal-trace-json .json-annotation {
+  color: var(--text-faint); font-style: italic;
+  font-size: 0.85em;
+}
+.signal-trace-glossary {
+  border-top: 1px solid var(--border);
+  padding: 12px 18px;
+  font: 11.5px var(--font-mono);
+  background: rgba(0,0,0,0.18);
+}
+.signal-trace-glossary summary {
+  cursor: pointer; color: var(--text-dim); font-weight: 500;
+  padding: 4px 0;
+}
+.signal-trace-glossary summary:hover { color: var(--accent); }
+.signal-trace-glossary-body {
+  margin-top: 10px;
+  display: grid;
+  grid-template-columns: minmax(180px, auto) minmax(140px, auto) 1fr;
+  gap: 4px 14px;
+  font-size: 11px;
+}
+.glossary-row {
+  display: contents;
+}
+.glossary-row code {
+  color: var(--accent);
+  font-family: var(--font-mono);
+}
+.glossary-row .glossary-label { color: var(--text); }
+.glossary-row .glossary-note { color: var(--text-mut); font-style: italic; }
 </style>`;

--- a/src/domain/signalTrace.ts
+++ b/src/domain/signalTrace.ts
@@ -1,0 +1,299 @@
+// src/domain/signalTrace.ts
+//
+// Centralized recorder for the AdCP Signals protocol handshake.
+//
+// Captures every get_signals + activate_signal interaction across:
+//   - inbound MCP tools/call (src/mcp/server.ts)
+//   - inbound REST /signals/* (src/routes/searchSignals.ts, activateSignal.ts)
+//   - outbound federation (src/federation/genericMcpClient.ts)
+//
+// Each trace records the full request + response payloads, validates
+// them against the canonical AdCP schemas (@adcp/sdk@3.0.1), and
+// keeps the result in an in-memory ring buffer (last 500 traces).
+//
+// Demo surfaces (Recent Activations, Orchestrator, Race Canvas,
+// Federation, Brand Canvas) read traces via GET /api/signal-traces
+// and render them through a shared viewer that explains each field
+// in marketing terms (the "Glossary" — see signals-glossary.ts).
+//
+// Storage posture: in-memory only. Survives request-to-request within
+// an isolate but not across deploys. Matches the rest of the demo's
+// stateless posture. KV/D1 layering is a future PR if you want a
+// permanent audit log.
+
+import Ajv from "ajv";
+import addFormats from "ajv-formats";
+
+// Vendored AdCP schema corpus. Imported as a single TS module to
+// sidestep @adcp/sdk's package.json `exports` field that doesn't
+// expose the schemas-data path. Regenerate via:
+//   node scripts/vendor-adcp-schemas.mjs
+import { loadAdcpCorpus } from "../schemas/adcp";
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+export type SignalToolName = "get_signals" | "activate_signal";
+export type TraceDirection = "inbound" | "outbound";
+
+export interface SchemaValidationResult {
+  valid: boolean;
+  schema_url: string;
+  errors: Array<{ path: string; message: string; keyword: string }>;
+}
+
+export interface SignalTrace {
+  trace_id: string;
+  correlation_id: string | null;
+  ts: string;
+  duration_ms: number;
+  direction: TraceDirection;
+  tool_name: SignalToolName;
+  /** Source of this trace:
+   *    "mcp_external"        — inbound MCP tools/call from a remote agent
+   *    "rest_demo"           — inbound REST call from the demo UI
+   *    "federation:<id>"     — outbound call to a peer agent (id = our agentRegistry id)
+   */
+  source: string;
+  /** For outbound calls, the agent we called. Null for inbound. */
+  caller_agent: string | null;
+  request: {
+    payload: unknown;
+    validation: SchemaValidationResult;
+  };
+  response: {
+    payload: unknown;
+    validation: SchemaValidationResult;
+    status: "ok" | "error";
+    /** When status === "error", this carries the human-readable error message. */
+    error_message?: string;
+  };
+}
+
+// ── Schema URLs (canonical AdCP) ─────────────────────────────────────────────
+//
+// Surfaced in each trace so consumers know what the payload SHOULD
+// match. Same canonical URLs the spec publishes; we run AJV against
+// the locally-installed @adcp/sdk schemas which mirror them.
+
+export const SCHEMA_URL = {
+  get_signals_request:    "https://adcontextprotocol.org/schemas/v3/signals/get-signals-request.json",
+  get_signals_response:   "https://adcontextprotocol.org/schemas/v3/signals/get-signals-response.json",
+  activate_signal_request:  "https://adcontextprotocol.org/schemas/v3/signals/activate-signal-request.json",
+  activate_signal_response: "https://adcontextprotocol.org/schemas/v3/signals/activate-signal-response.json",
+} as const;
+
+// Internal $id values @adcp/sdk uses to register schemas. We resolve
+// validators against these, then surface the public URL to consumers.
+const SCHEMA_ID = {
+  get_signals_request:      "/schemas/3.0.1/signals/get-signals-request.json",
+  get_signals_response:     "/schemas/3.0.1/signals/get-signals-response.json",
+  activate_signal_request:  "/schemas/3.0.1/signals/activate-signal-request.json",
+  activate_signal_response: "/schemas/3.0.1/signals/activate-signal-response.json",
+} as const;
+
+// ── AJV setup ────────────────────────────────────────────────────────────────
+//
+// Lazy-init: the schema corpus is sizeable. Built on first record() call
+// so cold isolates don't pay the cost up-front. After init the validators
+// are cached for the lifetime of the isolate.
+
+let _ajv: Ajv | null = null;
+let _ajvInitFailed = false;
+
+function getAjv(): Ajv | null {
+  if (_ajv !== null) return _ajv;
+  if (_ajvInitFailed) return null;
+  try {
+    const ajv = new Ajv({ strict: false, allErrors: true });
+    addFormats(ajv);
+    // Load every schema in @adcp/sdk's 3.0 directory so cross-file $ref
+    // resolution works (signal-id, deployment, vendor-pricing-option,
+    // etc. are all referenced from the request/response schemas).
+    // We import a flat manifest of schemas, registering each by $id.
+    // NOTE: Workers bundlers can statically resolve a JSON manifest;
+    // we generate it via a small build helper at module load.
+    const corpus = loadAdcpCorpus();
+    for (const s of corpus) {
+      try { ajv.addSchema(s); } catch { /* duplicate / partial — skip */ }
+    }
+    _ajv = ajv;
+    return _ajv;
+  } catch {
+    _ajvInitFailed = true;
+    return null;
+  }
+}
+
+// loadAdcpCorpus() lives in src/schemas/adcp/index.ts — vendored from
+// @adcp/sdk by scripts/vendor-adcp-schemas.mjs. Imported above.
+
+function validateAgainst(schemaId: string, schemaUrl: string, payload: unknown): SchemaValidationResult {
+  const ajv = getAjv();
+  if (!ajv) {
+    return {
+      valid: true,  // can't validate — don't claim invalid
+      schema_url: schemaUrl,
+      errors: [{ path: "(meta)", message: "schema validator unavailable in this runtime", keyword: "skipped" }],
+    };
+  }
+  const validator = ajv.getSchema(schemaId);
+  if (!validator) {
+    return {
+      valid: true,
+      schema_url: schemaUrl,
+      errors: [{ path: "(meta)", message: `schema not registered: ${schemaId}`, keyword: "missing_schema" }],
+    };
+  }
+  const ok = validator(payload);
+  if (ok) return { valid: true, schema_url: schemaUrl, errors: [] };
+  const errs = (validator.errors || []).slice(0, 12).map((e) => ({
+    path: e.instancePath || "(root)",
+    message: e.message || "validation failed",
+    keyword: e.keyword || "unknown",
+  }));
+  return { valid: false, schema_url: schemaUrl, errors: errs };
+}
+
+// ── Ring buffer ──────────────────────────────────────────────────────────────
+
+const MAX_TRACES = 500;
+const traceBuffer: SignalTrace[] = [];
+let traceCounter = 0;
+
+function nextTraceId(): string {
+  traceCounter += 1;
+  return `st_${Date.now().toString(36)}_${traceCounter.toString(36)}`;
+}
+
+// ── Public API ───────────────────────────────────────────────────────────────
+
+export interface RecordSignalTraceInput {
+  tool_name: SignalToolName;
+  direction: TraceDirection;
+  source: string;
+  caller_agent?: string | null;
+  request_payload: unknown;
+  response_payload: unknown;
+  response_status: "ok" | "error";
+  response_error_message?: string;
+  duration_ms: number;
+  /**
+   * If the request's context.correlation_id exists, pass it through.
+   * Otherwise we extract from request_payload at record-time as a
+   * fallback.
+   */
+  correlation_id?: string | null;
+}
+
+export function recordSignalTrace(input: RecordSignalTraceInput): SignalTrace {
+  const reqSchemaId = input.tool_name === "get_signals" ? SCHEMA_ID.get_signals_request : SCHEMA_ID.activate_signal_request;
+  const resSchemaId = input.tool_name === "get_signals" ? SCHEMA_ID.get_signals_response : SCHEMA_ID.activate_signal_response;
+  const reqSchemaUrl = input.tool_name === "get_signals" ? SCHEMA_URL.get_signals_request : SCHEMA_URL.activate_signal_request;
+  const resSchemaUrl = input.tool_name === "get_signals" ? SCHEMA_URL.get_signals_response : SCHEMA_URL.activate_signal_response;
+
+  let correlationId = input.correlation_id ?? null;
+  if (correlationId === null && typeof input.request_payload === "object" && input.request_payload !== null) {
+    const ctx = (input.request_payload as Record<string, unknown>)["context"];
+    if (ctx && typeof ctx === "object") {
+      const cid = (ctx as Record<string, unknown>)["correlation_id"];
+      if (typeof cid === "string") correlationId = cid;
+    }
+  }
+
+  const trace: SignalTrace = {
+    trace_id: nextTraceId(),
+    correlation_id: correlationId,
+    ts: new Date().toISOString(),
+    duration_ms: Math.max(0, input.duration_ms),
+    direction: input.direction,
+    tool_name: input.tool_name,
+    source: input.source,
+    caller_agent: input.caller_agent ?? null,
+    request: {
+      payload: input.request_payload,
+      validation: validateAgainst(reqSchemaId, reqSchemaUrl, input.request_payload),
+    },
+    response: {
+      payload: input.response_payload,
+      validation: validateAgainst(resSchemaId, resSchemaUrl, input.response_payload),
+      status: input.response_status,
+      ...(input.response_error_message ? { error_message: input.response_error_message } : {}),
+    },
+  };
+
+  traceBuffer.push(trace);
+  while (traceBuffer.length > MAX_TRACES) traceBuffer.shift();
+  return trace;
+}
+
+export interface SignalTraceQuery {
+  tool?: SignalToolName;
+  source_prefix?: string;       // e.g. "federation:" matches all outbound
+  correlation_id?: string;
+  agent_id?: string;            // for outbound, matches caller_agent
+  since_ms?: number;            // unix ms — only newer traces
+  limit?: number;               // max results, default 100
+}
+
+export function getSignalTraces(q: SignalTraceQuery = {}): SignalTrace[] {
+  const limit = Math.max(1, Math.min(500, q.limit ?? 100));
+  const sinceMs = q.since_ms ?? 0;
+  let out = traceBuffer.filter((t) => {
+    if (q.tool && t.tool_name !== q.tool) return false;
+    if (q.source_prefix && !t.source.startsWith(q.source_prefix)) return false;
+    if (q.correlation_id && t.correlation_id !== q.correlation_id) return false;
+    if (q.agent_id && t.caller_agent !== q.agent_id) return false;
+    if (sinceMs > 0 && new Date(t.ts).getTime() < sinceMs) return false;
+    return true;
+  });
+  // Most recent first
+  out = out.slice().reverse();
+  return out.slice(0, limit);
+}
+
+export function getSignalTraceById(traceId: string): SignalTrace | null {
+  return traceBuffer.find((t) => t.trace_id === traceId) ?? null;
+}
+
+export function clearSignalTraces(): void {
+  traceBuffer.length = 0;
+}
+
+export function snapshotSignalTraces(): {
+  total_buffered: number;
+  earliest_ts: string | null;
+  latest_ts: string | null;
+  by_tool: Record<string, number>;
+  by_source: Record<string, number>;
+  schema_valid_pct: number;
+} {
+  const total = traceBuffer.length;
+  if (total === 0) {
+    return { total_buffered: 0, earliest_ts: null, latest_ts: null, by_tool: {}, by_source: {}, schema_valid_pct: 0 };
+  }
+  const byTool: Record<string, number> = {};
+  const bySource: Record<string, number> = {};
+  let validCount = 0;
+  let validDenom = 0;
+  for (const t of traceBuffer) {
+    byTool[t.tool_name] = (byTool[t.tool_name] || 0) + 1;
+    bySource[t.source] = (bySource[t.source] || 0) + 1;
+    // Count req + res as separate validation samples; skip "skipped" markers
+    if (!t.request.validation.errors.some((e) => e.keyword === "skipped" || e.keyword === "missing_schema")) {
+      validDenom += 1;
+      if (t.request.validation.valid) validCount += 1;
+    }
+    if (!t.response.validation.errors.some((e) => e.keyword === "skipped" || e.keyword === "missing_schema")) {
+      validDenom += 1;
+      if (t.response.validation.valid) validCount += 1;
+    }
+  }
+  return {
+    total_buffered: total,
+    earliest_ts: traceBuffer[0]!.ts,
+    latest_ts: traceBuffer[traceBuffer.length - 1]!.ts,
+    by_tool: byTool,
+    by_source: bySource,
+    schema_valid_pct: validDenom > 0 ? Math.round((validCount / validDenom) * 1000) / 10 : 0,
+  };
+}

--- a/src/federation/genericMcpClient.ts
+++ b/src/federation/genericMcpClient.ts
@@ -20,6 +20,9 @@
 // Per-isolate session cache keyed by URL. Cloudflare recycles isolates
 // frequently; this is best-effort, we renew on every cold start.
 
+import { AGENT_REGISTRY } from "../domain/agentRegistry";
+import { recordSignalTrace } from "../domain/signalTrace";
+
 const SESSION_TTL_MS = 9 * 60 * 1000;
 /** Sentinel used for agents that negotiate stateless MCP (no mcp-session-id header
  * on initialize). Subsequent calls for these agents don't send the header. */
@@ -311,21 +314,50 @@ export async function callAgentTool(url: string, name: string, args: Record<stri
       catch (e) { return { ok: false, error: String((e as Error).message || e), latency_ms: Date.now() - start }; }
     }
   }
+  let result: ToolCallResult;
   try {
     let session = await ensureSession(url, { timeoutMs });
     if (!session) {
-      return { ok: false, error: "session_init_failed", latency_ms: Date.now() - start };
+      result = { ok: false, error: "session_init_failed", latency_ms: Date.now() - start };
+    } else {
+      let r = await callToolOnce(url, session, name, args, timeoutMs);
+      if (r.error && /session/i.test(r.error)) {
+        invalidateSession(url);
+        session = await ensureSession(url, { timeoutMs });
+        if (session) r = await callToolOnce(url, session, name, args, timeoutMs);
+      }
+      result = r;
     }
-    let r = await callToolOnce(url, session, name, args, timeoutMs);
-    if (r.error && /session/i.test(r.error)) {
-      invalidateSession(url);
-      session = await ensureSession(url, { timeoutMs });
-      if (session) r = await callToolOnce(url, session, name, args, timeoutMs);
-    }
-    return r;
   } catch (e) {
-    return { ok: false, error: String((e as Error).message || e), latency_ms: Date.now() - start };
+    result = { ok: false, error: String((e as Error).message || e), latency_ms: Date.now() - start };
   }
+  // Outbound-call trace for get_signals + activate_signal only — these
+  // are the AdCP signals-protocol surfaces the demo's trace inspector
+  // showcases. Other tools (get_products, list_creative_formats, etc.)
+  // are out-of-scope; they're already captured by the existing
+  // tool-log pipeline.
+  if (name === "get_signals" || name === "activate_signal") {
+    try {
+      // Reverse-lookup the agent from URL prefix to put a friendly
+      // "federation:dstillery" instead of "federation:https://...".
+      const match = AGENT_REGISTRY.find((a) => a.mcp_url && url.startsWith(a.mcp_url.replace(/\/$/, "")));
+      const agentId = match?.id ?? null;
+      recordSignalTrace({
+        tool_name: name as "get_signals" | "activate_signal",
+        direction: "outbound",
+        source: agentId ? "federation:" + agentId : "federation:" + url,
+        caller_agent: agentId,
+        request_payload: args,
+        response_payload: result.ok
+          ? (result.structured_content ?? result.content ?? null)
+          : { error: result.error ?? "unknown_error" },
+        response_status: result.ok ? "ok" : "error",
+        ...(result.error ? { response_error_message: result.error } : {}),
+        duration_ms: result.latency_ms ?? (Date.now() - start),
+      });
+    } catch { /* tracing must never break the call path */ }
+  }
+  return result;
 }
 
 // ── Wave 2: per-agent circuit breaker + retry wrapper ───────────────────────

--- a/src/index.ts
+++ b/src/index.ts
@@ -164,6 +164,11 @@ import {
     handleEcosystemProbe,
 } from "./routes/ecosystemRoutes";
 import {
+    handleSignalTracesList,
+    handleSignalTracesSnapshot,
+    handleSignalTraceById,
+} from "./routes/signalTraceRoutes";
+import {
   handleVendorHealthSnapshot,
   handleVendorHealthProbeOne,
 } from "./routes/vendorHealthRoutes";
@@ -357,6 +362,10 @@ export default {
             "/ecosystem/agents",
             "/ecosystem/state",
             "/ecosystem/probe",
+            // Signal protocol trace store — read-only, public (demo posture).
+            // Surfaces full request/response JSON for every get_signals +
+            // activate_signal interaction across MCP / REST / federation.
+            "/api/signal-traces",
             "/taxonomy/reverse",
             // Sec-43: audience composer + activation-planning analytics.
             // Read-only — same posture as /portfolio/* and /analytics/*.
@@ -453,6 +462,16 @@ export default {
 
             } else if (method === "GET" && path === "/ecosystem/probe") {
                 response = await handleEcosystemProbe();
+
+            } else if (method === "GET" && path === "/api/signal-traces") {
+                response = handleSignalTracesList(request);
+
+            } else if (method === "GET" && path === "/api/signal-traces/snapshot") {
+                response = handleSignalTracesSnapshot();
+
+            } else if (method === "GET" && path.startsWith("/api/signal-traces/")) {
+                const traceId = path.slice("/api/signal-traces/".length);
+                response = handleSignalTraceById(traceId);
 
             } else if (method === "GET" && path === "/health") {
                 response = jsonResponse({

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -28,6 +28,7 @@ import { getAllSignalsForCatalog } from "../domain/signalService";
 import { handleNLQuery } from "../domain/nlQueryHandler";
 import { handleConceptToolCall } from "../domain/conceptHandler";
 import { compactObj } from "../utils/objects";
+import { recordSignalTrace } from "../domain/signalTrace";
 import { record as recordToolLog, argKeysOf } from "./toolLog";
 import { logCall as d1LogCall, cleanup as d1Cleanup, shouldRunCleanup } from "../storage/toolLogRepo";
 
@@ -450,6 +451,7 @@ async function callGetSignals(
     args: Record<string, unknown>,
     env: Env
 ): Promise<unknown> {
+    const _t0_get_signals = Date.now();
     const filters = args["filters"] as Record<string, unknown> | undefined;
     const pagination = args["pagination"] as Record<string, unknown> | undefined;
 
@@ -634,6 +636,17 @@ async function callGetSignals(
     // structuredContent. Signals discovery is fully synchronous → completed.
     const response = withMcpEnvelope({ status: "completed" }, cleanResponse);
 
+    // Record the get_signals trace for observability across the demo.
+    recordSignalTrace({
+        tool_name: "get_signals",
+        direction: "inbound",
+        source: "mcp_external",
+        request_payload: args,
+        response_payload: response,
+        response_status: "ok",
+        duration_ms: Date.now() - _t0_get_signals,
+    });
+
     return toolResult(JSON.stringify(response, null, 2), response);
 }
 
@@ -642,6 +655,7 @@ async function callActivateSignal(
     env: Env,
     logger: Logger
 ): Promise<unknown> {
+    const _t0_activate = Date.now();
     // Accept three request shapes for the destinations payload:
     //   - args.destinations  (current AdCP signals storyboard / HEAD spec)
     //   - args.deliver_to    (legacy AdCP shape we shipped earlier)
@@ -801,6 +815,16 @@ async function callActivateSignal(
             payload
         );
 
+        recordSignalTrace({
+            tool_name: "activate_signal",
+            direction: "inbound",
+            source: "mcp_external",
+            request_payload: args,
+            response_payload: specResponse,
+            response_status: "ok",
+            duration_ms: Date.now() - _t0_activate,
+        });
+
         return toolResult(JSON.stringify(specResponse, null, 2), specResponse);
     } catch (err) {
         // Sec-31x: Storyboard-safe unknown-signal handling.
@@ -957,8 +981,29 @@ async function callActivateSignal(
                 syntheticPayload
             );
             logger.warn("activate_unknown_signal_synthetic", { signalId });
+            recordSignalTrace({
+                tool_name: "activate_signal",
+                direction: "inbound",
+                source: "mcp_external",
+                request_payload: args,
+                response_payload: syntheticResponse,
+                response_status: "ok",
+                duration_ms: Date.now() - _t0_activate,
+            });
             return toolResult(JSON.stringify(syntheticResponse, null, 2), syntheticResponse);
         }
+        // Record the failure trace too — observability matters when
+        // activation throws as much as when it succeeds.
+        recordSignalTrace({
+            tool_name: "activate_signal",
+            direction: "inbound",
+            source: "mcp_external",
+            request_payload: args,
+            response_payload: { error: String((err as Error).message ?? err) },
+            response_status: "error",
+            response_error_message: String((err as Error).message ?? err),
+            duration_ms: Date.now() - _t0_activate,
+        });
         throw err;
     }
 }

--- a/src/routes/activateSignal.ts
+++ b/src/routes/activateSignal.ts
@@ -7,6 +7,7 @@ import { validateActivateRequest } from "../utils/validation";
 import { jsonResponse, errorResponse, parseJsonBody } from "./shared";
 import { getDb } from "../storage/db";
 import type { Logger } from "../utils/logger";
+import { recordSignalTrace } from "../domain/signalTrace";
 
 export async function handleActivateSignal(
   request: Request,
@@ -24,11 +25,32 @@ export async function handleActivateSignal(
     return errorResponse(validation.error!.code, validation.error!.error, 400);
   }
 
+  const _t0 = Date.now();
   try {
     const db = getDb(env);
     const result = await activateSignalService(db, env.SIGNALS_CACHE, body, logger);
+    recordSignalTrace({
+      tool_name: "activate_signal",
+      direction: "inbound",
+      source: "rest_demo",
+      request_payload: body,
+      response_payload: result,
+      response_status: "ok",
+      duration_ms: Date.now() - _t0,
+    });
     return jsonResponse(result, 202);
   } catch (err) {
+    const errMsg = (err as Error).message ?? String(err);
+    recordSignalTrace({
+      tool_name: "activate_signal",
+      direction: "inbound",
+      source: "rest_demo",
+      request_payload: body,
+      response_payload: { error: errMsg },
+      response_status: "error",
+      response_error_message: errMsg,
+      duration_ms: Date.now() - _t0,
+    });
     if (err instanceof NotFoundError) {
       return errorResponse("NOT_FOUND", err.message, 404);
     }

--- a/src/routes/demo.ts
+++ b/src/routes/demo.ts
@@ -1469,6 +1469,11 @@ ${STYLES}
             </div>
             <p class="pane-subtitle">Cross-agent search across the AdCP Signals Discovery ecosystem. Live partner: Dstillery. More coming.</p>
           </div>
+          <div class="activations-controls">
+            <button class="btn-secondary" id="fed-signal-traces" title="View raw get_signals + activate_signal request/response JSON for every federated call">
+              <span class="mono">{ }</span><span>Signal traces</span>
+            </button>
+          </div>
         </div>
         <div class="lab-grid">
           <div class="lab-panel">
@@ -1519,6 +1524,9 @@ ${STYLES}
             <p class="pane-subtitle">Live view of every AdCP agent we know about. Probe each MCP endpoint in parallel to see who's up, what they expose, and how fast they respond. Fan out a signals brief to all live signals agents with one click, or compare tool surfaces side-by-side.</p>
           </div>
           <div class="activations-controls">
+            <button class="btn-secondary" id="orch-signal-traces" title="View raw get_signals + activate_signal request/response JSON for every federated call">
+              <span class="mono">{ }</span><span>Signal traces</span>
+            </button>
             <button class="btn-secondary" id="orch-refresh">
               <svg class="ico"><use href="#icon-chart"/></svg><span>Probe all</span>
             </button>
@@ -1603,6 +1611,11 @@ ${STYLES}
           <div>
             <h1 class="pane-title">Brand-Anchored Canvas <span class="pill pill-accent" style="margin-left:8px;font-size:10px">v2 phase 1</span></h1>
             <p class="pane-subtitle">Pick a real brand from the AdCP agentic-advertising registry. The brand's <code>brand.json</code> drives the orchestration: industries fan out to signals, colors+fonts+logos feed creative builds, governance category triggers human review for regulated industries.</p>
+          </div>
+          <div class="activations-controls">
+            <button class="btn-secondary" id="canvas-signal-traces" title="View raw get_signals + activate_signal request/response JSON">
+              <span class="mono">{ }</span><span>Signal traces</span>
+            </button>
           </div>
         </div>
 
@@ -2270,11 +2283,12 @@ ${STYLES}
                 <th>Submitted</th>
                 <th>Completed</th>
                 <th>Webhook</th>
-                <th></th>
+                <th>Operation ID</th>
+                <th>Trace</th>
               </tr>
             </thead>
             <tbody id="activations-tbody">
-              <tr><td colspan="7" class="table-empty"><span class="spinner"></span> loading activations…</td></tr>
+              <tr><td colspan="8" class="table-empty"><span class="spinner"></span> loading activations…</td></tr>
             </tbody>
           </table>
         </div>

--- a/src/routes/raceCanvas.ts
+++ b/src/routes/raceCanvas.ts
@@ -860,6 +860,7 @@ function renderRaceCanvas(demoKey: string): string {
 <div class="app">
   <header class="header">
     <a class="header-back" href="/">&larr; Back to Signals</a>
+    <button class="try-chip" id="race-signal-traces" style="margin-left:auto;border-color:var(--accent);color:var(--accent)">{ } Signal traces</button>
     <div class="header-title-block">
       <div class="header-title-row">
         <div class="header-title">Race <span class="accent">Canvas</span></div>
@@ -952,6 +953,18 @@ function renderRaceCanvas(demoKey: string): string {
       <div class="modal-section-title">Output</div>
       <pre id="modal-output"></pre>
     </div>
+  </div>
+</div>
+
+<!-- Race Canvas Signal traces overlay — slim version of the demo's
+     shared viewer, fetches /api/signal-traces and renders a list. -->
+<div class="modal-backdrop" id="signal-trace-backdrop" style="display:none">
+  <div class="modal" style="max-width:920px;width:96vw;max-height:88vh;overflow-y:auto">
+    <div class="modal-title">Signal traces · raw protocol JSON</div>
+    <div class="modal-sub" style="opacity:0.7">Get_signals + activate_signal request/response captures with schema validation. Refresh to pull latest.</div>
+    <button class="modal-close" id="signal-trace-modal-close">close</button>
+    <div style="margin-top:14px"><button class="try-chip" id="signal-trace-refresh">↻ refresh</button></div>
+    <div id="signal-trace-list" style="margin-top:12px;font:11.5px ui-monospace,Menlo,Consolas,monospace">loading…</div>
   </div>
 </div>
 
@@ -1557,6 +1570,55 @@ function renderRaceCanvas(demoKey: string): string {
     document.getElementById("race-trace-panel").classList.remove("is-open");
   });
   function escapeHtml(s) { return String(s == null ? "" : s).replace(/[&<>\\"']/g, function (c) { return ({"&":"&amp;","<":"&lt;",">":"&gt;","\\"":"&quot;","'":"&#39;"})[c]; }); }
+
+  // ── Signal traces overlay ────────────────────────────────────────────
+  function _raceRenderSignalTrace(t, idx) {
+    var dirIcon = t.direction === "outbound" ? "→" : "←";
+    var sourceShort = t.source.length > 36 ? t.source.slice(0, 33) + "…" : t.source;
+    var statusColor = t.response.status === "ok" ? "#5fd9c4" : "#ff7b7b";
+    var reqValid = t.request.validation && t.request.validation.valid;
+    var resValid = t.response.validation && t.response.validation.valid;
+    function badge(ok) { return ok ? '<span style="color:#5fd9c4">✓ schema</span>' : '<span style="color:#ff9b6b">✗ schema</span>'; }
+    return '<details style="margin-bottom:10px;padding:8px 12px;background:rgba(255,255,255,0.04);border-radius:4px">' +
+      '<summary style="cursor:pointer;font-size:12px;line-height:1.7">' +
+        '<strong>' + escapeHtml(t.tool_name) + '</strong> · ' + dirIcon + ' ' + escapeHtml(sourceShort) +
+        ' · <span style="color:' + statusColor + '">' + escapeHtml(t.response.status) + '</span>' +
+        ' · ' + t.duration_ms + 'ms · ' + new Date(t.ts).toLocaleTimeString() +
+        ' · ' + badge(reqValid) + ' req · ' + badge(resValid) + ' res' +
+      '</summary>' +
+      '<div style="margin-top:8px"><strong style="font-size:10px;letter-spacing:0.1em">REQUEST</strong> · <a href="' + escapeHtml(t.request.validation.schema_url) + '" target="_blank" style="color:#38b6ff;font-size:10px">schema↗</a></div>' +
+      '<pre style="background:rgba(0,0,0,0.4);padding:8px;border-radius:3px;max-height:240px;overflow:auto;font-size:10.5px;white-space:pre-wrap;word-break:break-all">' + escapeHtml(JSON.stringify(t.request.payload, null, 2)) + '</pre>' +
+      '<div><strong style="font-size:10px;letter-spacing:0.1em">RESPONSE</strong> · <a href="' + escapeHtml(t.response.validation.schema_url) + '" target="_blank" style="color:#38b6ff;font-size:10px">schema↗</a></div>' +
+      '<pre style="background:rgba(0,0,0,0.4);padding:8px;border-radius:3px;max-height:240px;overflow:auto;font-size:10.5px;white-space:pre-wrap;word-break:break-all">' + escapeHtml(JSON.stringify(t.response.payload, null, 2)) + '</pre>' +
+    '</details>';
+  }
+  async function _raceLoadSignalTraces() {
+    var listEl = document.getElementById("signal-trace-list");
+    listEl.textContent = "loading…";
+    try {
+      var r = await fetch("/api/signal-traces?limit=25");
+      var d = await r.json();
+      var traces = (d && d.traces) || [];
+      if (traces.length === 0) {
+        listEl.innerHTML = '<div style="opacity:0.7;padding:20px;text-align:center">No signal traces buffered yet. Run a race or trigger get_signals/activate_signal from any page.</div>';
+        return;
+      }
+      listEl.innerHTML = traces.map(_raceRenderSignalTrace).join("");
+    } catch (e) {
+      listEl.textContent = "Failed to load: " + (e && e.message || e);
+    }
+  }
+  document.getElementById("race-signal-traces").addEventListener("click", function () {
+    document.getElementById("signal-trace-backdrop").style.display = "flex";
+    _raceLoadSignalTraces();
+  });
+  document.getElementById("signal-trace-modal-close").addEventListener("click", function () {
+    document.getElementById("signal-trace-backdrop").style.display = "none";
+  });
+  document.getElementById("signal-trace-refresh").addEventListener("click", _raceLoadSignalTraces);
+  document.getElementById("signal-trace-backdrop").addEventListener("click", function (e) {
+    if (e.target === this) this.style.display = "none";
+  });
 })();
 </script>
 

--- a/src/routes/searchSignals.ts
+++ b/src/routes/searchSignals.ts
@@ -8,6 +8,7 @@ import { jsonResponse, errorResponse, readJsonBody } from "./shared";
 import { compactObj } from "../utils/objects";
 import { getDb } from "../storage/db";
 import type { Logger } from "../utils/logger";
+import { recordSignalTrace } from "../domain/signalTrace";
 
 export async function handleSearchSignals(
   request: Request,
@@ -58,6 +59,7 @@ export async function handleSearchSignals(
     );
   }
 
+  const _t0 = Date.now();
   try {
     const db = getDb(env);
     const result = await searchSignalsService(db, env.SIGNALS_CACHE, req);
@@ -69,9 +71,31 @@ export async function handleSearchSignals(
       total: result.totalCount,
     });
 
+    // Record the REST trace alongside the MCP one. Keeps signal traces
+    // unified across both transport bindings.
+    recordSignalTrace({
+      tool_name: "get_signals",
+      direction: "inbound",
+      source: "rest_demo",
+      request_payload: req,
+      response_payload: result,
+      response_status: "ok",
+      duration_ms: Date.now() - _t0,
+    });
+
     return jsonResponse(result);
   } catch (err) {
     logger.error("search_signals_error", { error: String(err) });
+    recordSignalTrace({
+      tool_name: "get_signals",
+      direction: "inbound",
+      source: "rest_demo",
+      request_payload: req,
+      response_payload: { error: String(err) },
+      response_status: "error",
+      response_error_message: String(err),
+      duration_ms: Date.now() - _t0,
+    });
     return errorResponse("INTERNAL_ERROR", "Signal search failed", 500);
   }
 }

--- a/src/routes/signalTraceRoutes.ts
+++ b/src/routes/signalTraceRoutes.ts
@@ -1,0 +1,74 @@
+// src/routes/signalTraceRoutes.ts
+//
+// Retrieval API for the centralized signals-protocol trace store.
+// Read-only, public (matches the demo's posture).
+//
+//   GET /api/signal-traces                             — last 100 traces
+//   GET /api/signal-traces?tool=activate_signal        — filter by tool
+//   GET /api/signal-traces?correlation_id=…            — all frames in a ceremony
+//   GET /api/signal-traces?source_prefix=federation:   — outbound only
+//   GET /api/signal-traces?agent_id=dstillery          — outbound to one agent
+//   GET /api/signal-traces?since_ms=…&limit=N
+//   GET /api/signal-traces/snapshot                    — buffer summary stats
+//   GET /api/signal-traces/:trace_id                   — single trace by id
+//
+// Demo surfaces (Recent Activations, Orchestrator, Race Canvas, Brand
+// Canvas, Federation) hit these endpoints to render their trace
+// inspectors via the shared viewer component.
+
+import {
+  getSignalTraces,
+  getSignalTraceById,
+  snapshotSignalTraces,
+  type SignalToolName,
+} from "../domain/signalTrace";
+
+function jsonOk(payload: unknown): Response {
+  return new Response(JSON.stringify(payload, null, 2), {
+    status: 200,
+    headers: {
+      "Content-Type": "application/json",
+      "Cache-Control": "no-store",
+      "Access-Control-Allow-Origin": "*",
+    },
+  });
+}
+
+function jsonNotFound(message: string): Response {
+  return new Response(JSON.stringify({ error: message }), {
+    status: 404,
+    headers: { "Content-Type": "application/json", "Cache-Control": "no-store" },
+  });
+}
+
+export function handleSignalTracesList(request: Request): Response {
+  const url = new URL(request.url);
+  const sp = url.searchParams;
+  const toolParam = sp.get("tool");
+  const tool: SignalToolName | undefined = toolParam === "get_signals" || toolParam === "activate_signal" ? toolParam : undefined;
+  const sourcePrefix = sp.get("source_prefix") ?? undefined;
+  const correlationId = sp.get("correlation_id") ?? undefined;
+  const agentId = sp.get("agent_id") ?? undefined;
+  const sinceMs = parseInt(sp.get("since_ms") ?? "0", 10) || 0;
+  const limit = Math.min(500, Math.max(1, parseInt(sp.get("limit") ?? "100", 10) || 100));
+
+  const traces = getSignalTraces({
+    ...(tool ? { tool } : {}),
+    ...(sourcePrefix ? { source_prefix: sourcePrefix } : {}),
+    ...(correlationId ? { correlation_id: correlationId } : {}),
+    ...(agentId ? { agent_id: agentId } : {}),
+    ...(sinceMs > 0 ? { since_ms: sinceMs } : {}),
+    limit,
+  });
+  return jsonOk({ traces, count: traces.length });
+}
+
+export function handleSignalTracesSnapshot(): Response {
+  return jsonOk(snapshotSignalTraces());
+}
+
+export function handleSignalTraceById(traceId: string): Response {
+  const trace = getSignalTraceById(traceId);
+  if (!trace) return jsonNotFound(`trace not found: ${traceId}`);
+  return jsonOk(trace);
+}

--- a/src/schemas/adcp/index.ts
+++ b/src/schemas/adcp/index.ts
@@ -1,0 +1,1063 @@
+// AUTO-GENERATED — do not edit by hand.
+// Source: node_modules/@adcp/sdk/dist/lib/schemas-data/3.0/
+// Regenerate with: node scripts/vendor-adcp-schemas.mjs
+//
+// This module vendors AdCP signal-protocol JSON schemas as TypeScript
+// constants so the worker can bundle them without relying on
+// @adcp/sdk's package.json exports map (which omits the schemas-data
+// path). Used by src/domain/signalTrace.ts for AJV-based runtime
+// validation of get_signals + activate_signal request/response payloads.
+
+export const getSignalsReq = {
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "/schemas/3.0.1/signals/get-signals-request.json",
+  "title": "Get Signals Request",
+  "description": "Request parameters for discovering and refining signals. Use signal_spec for natural language discovery, signal_ids for exact lookups, or both to refine previous results (signal_ids anchor the starting set, signal_spec guides adjustments).",
+  "type": "object",
+  "properties": {
+    "adcp_major_version": {
+      "type": "integer",
+      "description": "The AdCP major version the buyer's payloads conform to. Sellers validate against their supported major_versions and return VERSION_UNSUPPORTED if unsupported. When omitted, the seller assumes its highest supported version.",
+      "minimum": 1,
+      "maximum": 99
+    },
+    "account": {
+      "$ref": "/schemas/3.0.1/core/account-ref.json",
+      "description": "Account for this request. When provided, the signals agent returns per-account pricing options if configured."
+    },
+    "signal_spec": {
+      "type": "string",
+      "description": "Natural language description of the desired signals. When used alone, enables semantic discovery. When combined with signal_ids, provides context for the agent but signal_ids matches are returned first."
+    },
+    "signal_ids": {
+      "type": "array",
+      "description": "Specific signals to look up by data provider and ID. Returns exact matches from the data provider's catalog. When combined with signal_spec, these signals anchor the starting set and signal_spec guides adjustments.",
+      "items": {
+        "$ref": "/schemas/3.0.1/core/signal-id.json"
+      },
+      "minItems": 1
+    },
+    "destinations": {
+      "type": "array",
+      "description": "Filter signals to those activatable on specific agents/platforms. When omitted, returns all signals available on the current agent. If the authenticated caller matches one of these destinations, activation keys will be included in the response.",
+      "items": {
+        "$ref": "/schemas/3.0.1/core/destination.json"
+      },
+      "minItems": 1
+    },
+    "countries": {
+      "type": "array",
+      "description": "Countries where signals will be used (ISO 3166-1 alpha-2 codes). When omitted, no geographic filter is applied.",
+      "items": {
+        "type": "string",
+        "pattern": "^[A-Z]{2}$"
+      },
+      "minItems": 1
+    },
+    "filters": {
+      "$ref": "/schemas/3.0.1/core/signal-filters.json"
+    },
+    "max_results": {
+      "type": "integer",
+      "description": "DEPRECATED: Use pagination.max_results instead. When both fields are present, agents MUST honor pagination.max_results. When only this field is present without a pagination envelope, agents SHOULD treat it as the page size subject to a maximum of 100 results. This field will be removed in AdCP 4.0.",
+      "deprecated": true,
+      "minimum": 1
+    },
+    "pagination": {
+      "$ref": "/schemas/3.0.1/core/pagination-request.json",
+      "description": "Pagination parameters. Use pagination.max_results (max: 100, default: 50) and pagination.cursor for cursor-based page walks. When the deprecated top-level max_results field is also present, pagination.max_results takes precedence."
+    },
+    "context": {
+      "$ref": "/schemas/3.0.1/core/context.json"
+    },
+    "ext": {
+      "$ref": "/schemas/3.0.1/core/ext.json"
+    }
+  },
+  "anyOf": [
+    {
+      "required": [
+        "signal_spec"
+      ]
+    },
+    {
+      "required": [
+        "signal_ids"
+      ]
+    }
+  ],
+  "additionalProperties": true
+} as const;
+
+export const getSignalsRes = {
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "/schemas/3.0.1/signals/get-signals-response.json",
+  "title": "Get Signals Response",
+  "description": "Response payload for get_signals task",
+  "type": "object",
+  "properties": {
+    "signals": {
+      "type": "array",
+      "description": "Array of matching signals",
+      "items": {
+        "type": "object",
+        "properties": {
+          "signal_id": {
+            "$ref": "/schemas/3.0.1/core/signal-id.json",
+            "description": "Universal signal identifier referencing the data provider's catalog. Use this to verify authorization and look up signal definitions."
+          },
+          "signal_agent_segment_id": {
+            "type": "string",
+            "description": "Opaque identifier used for activation. This is the signals agent's internal segment ID.",
+            "x-entity": "signal_activation_id"
+          },
+          "name": {
+            "type": "string",
+            "description": "Human-readable signal name"
+          },
+          "description": {
+            "type": "string",
+            "description": "Detailed signal description"
+          },
+          "value_type": {
+            "$ref": "/schemas/3.0.1/enums/signal-value-type.json",
+            "description": "The data type of this signal's values (binary, categorical, numeric)"
+          },
+          "categories": {
+            "type": "array",
+            "description": "Valid values for categorical signals. Present when value_type is 'categorical'. Buyers must use one of these values in SignalTargeting.values.",
+            "items": {
+              "type": "string"
+            }
+          },
+          "range": {
+            "type": "object",
+            "description": "Valid range for numeric signals. Present when value_type is 'numeric'.",
+            "properties": {
+              "min": {
+                "type": "number",
+                "description": "Minimum value (inclusive)"
+              },
+              "max": {
+                "type": "number",
+                "description": "Maximum value (inclusive)"
+              }
+            },
+            "required": [
+              "min",
+              "max"
+            ],
+            "additionalProperties": false
+          },
+          "signal_type": {
+            "$ref": "/schemas/3.0.1/enums/signal-catalog-type.json",
+            "description": "Catalog type of signal (marketplace, custom, owned)"
+          },
+          "data_provider": {
+            "type": "string",
+            "description": "Human-readable name of the data provider"
+          },
+          "coverage_percentage": {
+            "type": "number",
+            "description": "Percentage of audience coverage",
+            "minimum": 0,
+            "maximum": 100
+          },
+          "deployments": {
+            "type": "array",
+            "description": "Array of deployment targets",
+            "items": {
+              "$ref": "/schemas/3.0.1/core/deployment.json"
+            }
+          },
+          "pricing_options": {
+            "type": "array",
+            "description": "Pricing options available for this signal. The buyer selects one and passes its pricing_option_id in report_usage for billing verification.",
+            "items": {
+              "$ref": "/schemas/3.0.1/core/vendor-pricing-option.json"
+            },
+            "minItems": 1
+          }
+        },
+        "required": [
+          "signal_id",
+          "signal_agent_segment_id",
+          "name",
+          "description",
+          "signal_type",
+          "data_provider",
+          "coverage_percentage",
+          "deployments",
+          "pricing_options"
+        ],
+        "additionalProperties": true
+      }
+    },
+    "errors": {
+      "type": "array",
+      "description": "Task-specific errors and warnings (e.g., signal discovery or pricing issues)",
+      "items": {
+        "$ref": "/schemas/3.0.1/core/error.json"
+      }
+    },
+    "pagination": {
+      "$ref": "/schemas/3.0.1/core/pagination-response.json"
+    },
+    "sandbox": {
+      "type": "boolean",
+      "description": "When true, this response contains simulated data from sandbox mode."
+    },
+    "context": {
+      "$ref": "/schemas/3.0.1/core/context.json"
+    },
+    "ext": {
+      "$ref": "/schemas/3.0.1/core/ext.json"
+    }
+  },
+  "required": [
+    "signals"
+  ],
+  "additionalProperties": true
+} as const;
+
+export const activateReq = {
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "/schemas/3.0.1/signals/activate-signal-request.json",
+  "title": "Activate Signal Request",
+  "description": "Request parameters for activating or deactivating a signal on deployment targets",
+  "x-mutates-state": true,
+  "type": "object",
+  "properties": {
+    "adcp_major_version": {
+      "type": "integer",
+      "description": "The AdCP major version the buyer's payloads conform to. Sellers validate against their supported major_versions and return VERSION_UNSUPPORTED if unsupported. When omitted, the seller assumes its highest supported version.",
+      "minimum": 1,
+      "maximum": 99
+    },
+    "action": {
+      "type": "string",
+      "enum": [
+        "activate",
+        "deactivate"
+      ],
+      "default": "activate",
+      "description": "Whether to activate or deactivate the signal. Deactivating removes the segment from downstream platforms, required when campaigns end to comply with data governance policies (GDPR, CCPA). Defaults to 'activate' when omitted."
+    },
+    "signal_agent_segment_id": {
+      "type": "string",
+      "description": "The universal identifier for the signal to activate",
+      "x-entity": "signal_activation_id"
+    },
+    "destinations": {
+      "type": "array",
+      "description": "Target destination(s) for activation. If the authenticated caller matches one of these destinations, activation keys will be included in the response.",
+      "items": {
+        "$ref": "/schemas/3.0.1/core/destination.json"
+      },
+      "minItems": 1
+    },
+    "pricing_option_id": {
+      "type": "string",
+      "description": "The pricing option selected from the signal's pricing_options in the get_signals response. Required when the signal has pricing options. Records the buyer's pricing commitment at activation time; pass this same value in report_usage for billing verification.",
+      "x-entity": "vendor_pricing_option"
+    },
+    "account": {
+      "$ref": "/schemas/3.0.1/core/account-ref.json",
+      "description": "Account for this activation. Associates with a commercial relationship established via sync_accounts."
+    },
+    "idempotency_key": {
+      "type": "string",
+      "description": "Client-generated unique key for this request. Prevents duplicate activations on retries. MUST be unique per (seller, request) pair to prevent cross-seller correlation. Use a fresh UUID v4 for each request.",
+      "minLength": 16,
+      "maxLength": 255,
+      "pattern": "^[A-Za-z0-9_.:-]{16,255}$"
+    },
+    "context": {
+      "$ref": "/schemas/3.0.1/core/context.json"
+    },
+    "ext": {
+      "$ref": "/schemas/3.0.1/core/ext.json"
+    }
+  },
+  "required": [
+    "idempotency_key",
+    "signal_agent_segment_id",
+    "destinations"
+  ],
+  "additionalProperties": true
+} as const;
+
+export const activateRes = {
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "/schemas/3.0.1/signals/activate-signal-response.json",
+  "title": "Activate Signal Response",
+  "description": "Response payload for activate_signal task. Returns either complete success data OR error information, never both. This enforces atomic operation semantics - the signal is either fully activated or not activated at all.",
+  "type": "object",
+  "oneOf": [
+    {
+      "title": "ActivateSignalSuccess",
+      "description": "Success response - signal activated successfully to one or more deployment targets",
+      "type": "object",
+      "properties": {
+        "deployments": {
+          "type": "array",
+          "description": "Array of deployment results for each deployment target",
+          "items": {
+            "$ref": "/schemas/3.0.1/core/deployment.json"
+          }
+        },
+        "sandbox": {
+          "type": "boolean",
+          "description": "When true, this response contains simulated data from sandbox mode."
+        },
+        "context": {
+          "$ref": "/schemas/3.0.1/core/context.json"
+        },
+        "ext": {
+          "$ref": "/schemas/3.0.1/core/ext.json"
+        }
+      },
+      "required": [
+        "deployments"
+      ],
+      "additionalProperties": true,
+      "not": {
+        "required": [
+          "errors"
+        ]
+      }
+    },
+    {
+      "title": "ActivateSignalError",
+      "description": "Error response - operation failed, signal not activated",
+      "type": "object",
+      "properties": {
+        "errors": {
+          "type": "array",
+          "description": "Array of errors explaining why activation failed (e.g., platform connectivity issues, signal definition problems, authentication failures)",
+          "items": {
+            "$ref": "/schemas/3.0.1/core/error.json"
+          },
+          "minItems": 1
+        },
+        "context": {
+          "$ref": "/schemas/3.0.1/core/context.json"
+        },
+        "ext": {
+          "$ref": "/schemas/3.0.1/core/ext.json"
+        }
+      },
+      "required": [
+        "errors"
+      ],
+      "additionalProperties": true,
+      "not": {
+        "anyOf": [
+          {
+            "required": [
+              "deployments"
+            ]
+          },
+          {
+            "required": [
+              "sandbox"
+            ]
+          }
+        ]
+      }
+    }
+  ]
+} as const;
+
+export const signalId = {
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "/schemas/3.0.1/core/signal-id.json",
+  "title": "Signal ID",
+  "description": "Universal signal identifier. Uses 'source' as discriminator: 'catalog' for signals from a data provider's published catalog (verifiable), 'agent' for agent-native signals (not externally verifiable).",
+  "x-entity": "signal",
+  "discriminator": {
+    "propertyName": "source"
+  },
+  "oneOf": [
+    {
+      "type": "object",
+      "description": "Catalog signal - references a signal from a data provider's published catalog. Buyers can verify authorization by checking the data provider's adagents.json.",
+      "properties": {
+        "source": {
+          "type": "string",
+          "const": "catalog",
+          "description": "Discriminator indicating this signal is from a data provider's published catalog"
+        },
+        "data_provider_domain": {
+          "type": "string",
+          "description": "Domain of the data provider that owns this signal (e.g., 'polk.com', 'experian.com'). The signal definition is published at this domain's /.well-known/adagents.json",
+          "pattern": "^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$"
+        },
+        "id": {
+          "type": "string",
+          "pattern": "^[a-zA-Z0-9_-]+$",
+          "description": "Signal identifier within the data provider's catalog (e.g., 'likely_tesla_buyers', 'income_100k_plus')"
+        }
+      },
+      "required": [
+        "source",
+        "data_provider_domain",
+        "id"
+      ],
+      "additionalProperties": true
+    },
+    {
+      "type": "object",
+      "description": "Agent signal - references a signal native to the signals agent. Not externally verifiable; buyer trusts the agent's claim about the signal.",
+      "properties": {
+        "source": {
+          "type": "string",
+          "const": "agent",
+          "description": "Discriminator indicating this signal is native to the agent (not from a data provider catalog)"
+        },
+        "agent_url": {
+          "type": "string",
+          "format": "uri",
+          "description": "URL of the signals agent that provides this signal (e.g., 'https://liveramp.com/.well-known/adcp/signals')"
+        },
+        "id": {
+          "type": "string",
+          "pattern": "^[a-zA-Z0-9_-]+$",
+          "description": "Signal identifier within the agent's signal set (e.g., 'custom_auto_intenders')"
+        }
+      },
+      "required": [
+        "source",
+        "agent_url",
+        "id"
+      ],
+      "additionalProperties": true
+    }
+  ]
+} as const;
+
+export const deployment = {
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "/schemas/3.0.1/core/deployment.json",
+  "title": "Deployment",
+  "description": "A signal deployment to a specific deployment target with activation status and key",
+  "oneOf": [
+    {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "platform",
+          "description": "Discriminator indicating this is a platform-based deployment"
+        },
+        "platform": {
+          "type": "string",
+          "description": "Platform identifier for DSPs"
+        },
+        "account": {
+          "type": "string",
+          "description": "Account identifier if applicable"
+        },
+        "is_live": {
+          "type": "boolean",
+          "description": "Whether signal is currently active on this deployment"
+        },
+        "activation_key": {
+          "$ref": "/schemas/3.0.1/core/activation-key.json",
+          "description": "The key to use for targeting. Only present if is_live=true AND requester has access to this deployment."
+        },
+        "estimated_activation_duration_minutes": {
+          "type": "number",
+          "description": "Estimated time to activate if not live, or to complete activation if in progress",
+          "minimum": 0
+        },
+        "deployed_at": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Timestamp when activation completed (if is_live=true)"
+        }
+      },
+      "required": [
+        "type",
+        "platform",
+        "is_live"
+      ],
+      "additionalProperties": true
+    },
+    {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "agent",
+          "description": "Discriminator indicating this is an agent URL-based deployment"
+        },
+        "agent_url": {
+          "type": "string",
+          "format": "uri",
+          "description": "URL identifying the deployment agent"
+        },
+        "account": {
+          "type": "string",
+          "description": "Account identifier if applicable"
+        },
+        "is_live": {
+          "type": "boolean",
+          "description": "Whether signal is currently active on this deployment"
+        },
+        "activation_key": {
+          "$ref": "/schemas/3.0.1/core/activation-key.json",
+          "description": "The key to use for targeting. Only present if is_live=true AND requester has access to this deployment."
+        },
+        "estimated_activation_duration_minutes": {
+          "type": "number",
+          "description": "Estimated time to activate if not live, or to complete activation if in progress",
+          "minimum": 0
+        },
+        "deployed_at": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Timestamp when activation completed (if is_live=true)"
+        }
+      },
+      "required": [
+        "type",
+        "agent_url",
+        "is_live"
+      ],
+      "additionalProperties": true
+    }
+  ]
+} as const;
+
+export const destination = {
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "/schemas/3.0.1/core/destination.json",
+  "title": "Destination",
+  "description": "A deployment target where signals can be activated (DSP, sales agent, etc.)",
+  "oneOf": [
+    {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "platform",
+          "description": "Discriminator indicating this is a platform-based deployment"
+        },
+        "platform": {
+          "type": "string",
+          "description": "Platform identifier for DSPs (e.g., 'the-trade-desk', 'amazon-dsp')"
+        },
+        "account": {
+          "type": "string",
+          "description": "Optional account identifier on the platform"
+        }
+      },
+      "required": [
+        "type",
+        "platform"
+      ],
+      "additionalProperties": true
+    },
+    {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "agent",
+          "description": "Discriminator indicating this is an agent URL-based deployment"
+        },
+        "agent_url": {
+          "type": "string",
+          "format": "uri",
+          "description": "URL identifying the deployment agent (for sales agents, etc.)"
+        },
+        "account": {
+          "type": "string",
+          "description": "Optional account identifier on the agent"
+        }
+      },
+      "required": [
+        "type",
+        "agent_url"
+      ],
+      "additionalProperties": true
+    }
+  ]
+} as const;
+
+export const accountRef = {
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "/schemas/3.0.1/core/account-ref.json",
+  "title": "Account Reference",
+  "description": "Reference to an account by seller-assigned ID or natural key. Use account_id for explicit accounts (require_operator_auth: true, discovered via list_accounts). Use the natural key (brand + operator) for implicit accounts (require_operator_auth: false, declared via sync_accounts). For sandbox: explicit accounts use account_id (pre-existing test account), implicit accounts use the natural key with sandbox: true.",
+  "type": "object",
+  "oneOf": [
+    {
+      "properties": {
+        "account_id": {
+          "type": "string",
+          "description": "Seller-assigned account identifier (from sync_accounts or list_accounts)",
+          "x-entity": "account"
+        }
+      },
+      "required": [
+        "account_id"
+      ],
+      "additionalProperties": false
+    },
+    {
+      "properties": {
+        "brand": {
+          "$ref": "/schemas/3.0.1/core/brand-ref.json",
+          "description": "Brand reference identifying the advertiser"
+        },
+        "operator": {
+          "type": "string",
+          "description": "Domain of the entity operating on the brand's behalf. When the brand operates directly, this is the brand's domain.",
+          "pattern": "^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$",
+          "x-entity": "operator"
+        },
+        "sandbox": {
+          "type": "boolean",
+          "description": "When true, references the sandbox account for this brand/operator pair. Defaults to false (production account).",
+          "default": false
+        }
+      },
+      "required": [
+        "brand",
+        "operator"
+      ],
+      "additionalProperties": false
+    }
+  ],
+  "examples": [
+    {
+      "account_id": "acc_acme_001"
+    },
+    {
+      "brand": {
+        "domain": "acme-corp.com"
+      },
+      "operator": "acme-corp.com"
+    },
+    {
+      "brand": {
+        "domain": "nova-brands.com",
+        "brand_id": "spark"
+      },
+      "operator": "pinnacle-media.com"
+    },
+    {
+      "brand": {
+        "domain": "acme-corp.com"
+      },
+      "operator": "acme-corp.com",
+      "sandbox": true
+    }
+  ]
+} as const;
+
+export const context = {
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "/schemas/3.0.1/core/context.json",
+  "title": "Context Object",
+  "description": "Opaque correlation data that is echoed unchanged in responses. Used for internal tracking, UI session IDs, trace IDs, and other caller-specific identifiers that don't affect protocol behavior. Context data is never parsed by AdCP agents - it's simply preserved and returned.",
+  "type": "object",
+  "additionalProperties": true
+} as const;
+
+export const ext = {
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "/schemas/3.0.1/core/ext.json",
+  "title": "Extension Object",
+  "description": "Extension object for platform-specific, vendor-namespaced parameters. Extensions are always optional and must be namespaced under a vendor/platform key (e.g., ext.gam, ext.roku). Used for custom capabilities, partner-specific configuration, and features being proposed for standardization.",
+  "type": "object",
+  "additionalProperties": true
+} as const;
+
+export const error = {
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "/schemas/3.0.1/core/error.json",
+  "title": "Error",
+  "description": "Standard error structure for task-specific errors and warnings",
+  "type": "object",
+  "properties": {
+    "code": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 64,
+      "description": "Error code for programmatic handling. Standard codes are defined in error-code.json and enable autonomous agent recovery. Sellers MAY use codes not in the standard vocabulary for platform-specific errors; agents MUST handle unknown codes gracefully by falling back to the recovery classification."
+    },
+    "message": {
+      "type": "string",
+      "description": "Human-readable error message"
+    },
+    "field": {
+      "type": "string",
+      "description": "Field path associated with the error (e.g., 'packages[0].targeting')"
+    },
+    "suggestion": {
+      "type": "string",
+      "description": "Suggested fix for the error"
+    },
+    "retry_after": {
+      "type": "number",
+      "description": "Seconds to wait before retrying the operation. Sellers MUST return values between 1 and 3600. Clients MUST clamp values outside this range.",
+      "minimum": 1,
+      "maximum": 3600
+    },
+    "details": {
+      "type": "object",
+      "description": "Additional task-specific error details",
+      "additionalProperties": true
+    },
+    "recovery": {
+      "type": "string",
+      "enum": [
+        "transient",
+        "correctable",
+        "terminal"
+      ],
+      "description": "Agent recovery classification. transient: retry after delay (rate limit, service unavailable, timeout). correctable: fix the request and resend (invalid field, budget too low, creative rejected). terminal: requires human action (account suspended, payment required, account not found)."
+    }
+  },
+  "required": [
+    "code",
+    "message"
+  ],
+  "additionalProperties": true
+} as const;
+
+export const paginationReq = {
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "/schemas/3.0.1/core/pagination-request.json",
+  "title": "Pagination Request",
+  "description": "Standard cursor-based pagination parameters for list operations",
+  "type": "object",
+  "properties": {
+    "max_results": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 100,
+      "default": 50,
+      "description": "Maximum number of items to return per page"
+    },
+    "cursor": {
+      "type": "string",
+      "description": "Opaque cursor from a previous response to fetch the next page"
+    }
+  },
+  "additionalProperties": false
+} as const;
+
+export const paginationRes = {
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "/schemas/3.0.1/core/pagination-response.json",
+  "title": "Pagination Response",
+  "description": "Standard cursor-based pagination metadata for list responses",
+  "type": "object",
+  "properties": {
+    "has_more": {
+      "type": "boolean",
+      "description": "Whether more results are available beyond this page"
+    },
+    "cursor": {
+      "type": "string",
+      "description": "Opaque cursor to pass in the next request to fetch the next page. Only present when has_more is true."
+    },
+    "total_count": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Total number of items matching the query across all pages. Optional because not all backends can efficiently compute this."
+    }
+  },
+  "required": [
+    "has_more"
+  ],
+  "additionalProperties": false
+} as const;
+
+export const signalFilters = {
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "/schemas/3.0.1/core/signal-filters.json",
+  "title": "Signal Filters",
+  "description": "Filters to refine signal discovery results",
+  "type": "object",
+  "properties": {
+    "catalog_types": {
+      "type": "array",
+      "description": "Filter by catalog type",
+      "items": {
+        "$ref": "/schemas/3.0.1/enums/signal-catalog-type.json"
+      },
+      "minItems": 1
+    },
+    "data_providers": {
+      "type": "array",
+      "description": "Filter by specific data providers",
+      "items": {
+        "type": "string"
+      },
+      "minItems": 1
+    },
+    "max_cpm": {
+      "type": "number",
+      "description": "Maximum CPM filter. Applies only to signals with model='cpm'.",
+      "minimum": 0
+    },
+    "max_percent": {
+      "type": "number",
+      "description": "Maximum percent-of-media rate filter. Signals where all percent_of_media pricing options exceed this value are excluded. Does not account for max_cpm caps.",
+      "minimum": 0,
+      "maximum": 100
+    },
+    "min_coverage_percentage": {
+      "type": "number",
+      "description": "Minimum coverage requirement",
+      "minimum": 0,
+      "maximum": 100
+    }
+  },
+  "additionalProperties": true
+} as const;
+
+export const vendorPricingOption = {
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "/schemas/3.0.1/core/vendor-pricing-option.json",
+  "title": "Vendor Pricing Option",
+  "description": "A pricing option offered by a vendor agent (signals, creative, governance). Combines pricing_option_id with the pricing model fields. Pass pricing_option_id in report_usage for billing verification. All vendor discovery responses return pricing_options as an array — vendors may offer multiple options (volume tiers, context-specific rates, different models per product line).",
+  "allOf": [
+    {
+      "type": "object",
+      "properties": {
+        "pricing_option_id": {
+          "type": "string",
+          "description": "Opaque identifier for this pricing option, unique within the vendor agent. Pass this in report_usage to identify which pricing option was applied.",
+          "x-entity": "vendor_pricing_option"
+        }
+      },
+      "required": [
+        "pricing_option_id"
+      ]
+    },
+    {
+      "$ref": "/schemas/3.0.1/core/signal-pricing.json"
+    }
+  ]
+} as const;
+
+export const activationKey = {
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "/schemas/3.0.1/core/activation-key.json",
+  "title": "Activation Key",
+  "description": "Universal identifier for using a signal on a destination platform. Can be either a segment ID or a key-value pair depending on the platform's targeting mechanism.",
+  "type": "object",
+  "oneOf": [
+    {
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "segment_id",
+          "description": "Segment ID based targeting"
+        },
+        "segment_id": {
+          "type": "string",
+          "description": "The platform-specific segment identifier to use in campaign targeting"
+        }
+      },
+      "required": [
+        "type",
+        "segment_id"
+      ],
+      "additionalProperties": true
+    },
+    {
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "key_value",
+          "description": "Key-value pair based targeting"
+        },
+        "key": {
+          "type": "string",
+          "description": "The targeting parameter key"
+        },
+        "value": {
+          "type": "string",
+          "description": "The targeting parameter value"
+        }
+      },
+      "required": [
+        "type",
+        "key",
+        "value"
+      ],
+      "additionalProperties": true
+    }
+  ]
+} as const;
+
+export const signalValueType = {
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "/schemas/3.0.1/enums/signal-value-type.json",
+  "title": "Signal Value Type",
+  "description": "The data type of a signal's values, determining how it can be targeted",
+  "type": "string",
+  "enum": [
+    "binary",
+    "categorical",
+    "numeric"
+  ],
+  "x-enum-descriptions": {
+    "binary": "Boolean signal - user either matches or doesn't (e.g., 'likely_tesla_buyers')",
+    "categorical": "Signal with discrete values from a defined set (e.g., 'vehicle_ownership' with values 'tesla', 'bmw', etc.)",
+    "numeric": "Signal with continuous numeric values within a range (e.g., 'purchase_propensity' from 0.0 to 1.0)"
+  }
+} as const;
+
+export const signalCatalogType = {
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "/schemas/3.0.1/enums/signal-catalog-type.json",
+  "title": "Signal Catalog Type",
+  "description": "Types of signal catalogs available for audience targeting",
+  "type": "string",
+  "enum": [
+    "marketplace",
+    "custom",
+    "owned"
+  ],
+  "enumDescriptions": {
+    "marketplace": "Resold third-party segments (provider authorization verifiable via the provider's adagents.json)",
+    "custom": "Agent-native segment built on demand from models, composites, or buyer inputs — not attributable to a standing upstream provider",
+    "owned": "First-party segments derived from data the signal agent directly owns (retailer purchase data, publisher behavioral data, telco data)"
+  }
+} as const;
+
+export const taskStatus = {
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "/schemas/3.0.1/enums/task-status.json",
+  "title": "Task Status",
+  "description": "Standardized task status values based on A2A TaskState enum. Indicates the current state of any AdCP operation.",
+  "type": "string",
+  "enum": [
+    "submitted",
+    "working",
+    "input-required",
+    "completed",
+    "canceled",
+    "failed",
+    "rejected",
+    "auth-required",
+    "unknown"
+  ],
+  "enumDescriptions": {
+    "submitted": "Task accepted and queued for long-running execution (hours to days). Client should poll with tasks/get or provide webhook_url at protocol level.",
+    "working": "Agent is actively processing the task, expect completion within 120 seconds",
+    "input-required": "Task is paused and waiting for input from the user (e.g., clarification, approval)",
+    "completed": "Task has been successfully completed",
+    "canceled": "Task was canceled by the user",
+    "failed": "Task failed due to an error during execution",
+    "rejected": "Task was rejected by the agent and was not started",
+    "auth-required": "Task requires authentication to proceed",
+    "unknown": "Task is in an unknown or indeterminate state"
+  }
+} as const;
+
+export const brandId = {
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "/schemas/3.0.1/core/brand-id.json",
+  "title": "Brand ID",
+  "description": "Identifier for a brand within a house portfolio. Must be lowercase alphanumeric with underscores only. The house chooses this identifier.",
+  "type": "string",
+  "pattern": "^[a-z0-9_]+$",
+  "x-entity": "advertiser_brand",
+  "examples": [
+    "tide",
+    "cheerios",
+    "air_jordan",
+    "nike",
+    "pampers"
+  ]
+} as const;
+
+export const brandRef = {
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "/schemas/3.0.1/core/brand-ref.json",
+  "title": "Brand Reference",
+  "description": "Reference to a brand by domain and optional brand_id. The domain hosts /.well-known/brand.json or is registered in the brand registry. For single-brand domains, brand_id can be omitted. For house-of-brands domains, brand_id identifies the specific brand.",
+  "type": "object",
+  "properties": {
+    "domain": {
+      "type": "string",
+      "description": "Domain where /.well-known/brand.json is hosted, or the brand's operating domain",
+      "pattern": "^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$"
+    },
+    "brand_id": {
+      "$ref": "/schemas/3.0.1/core/brand-id.json",
+      "description": "Brand identifier within the house portfolio. Optional for single-brand domains."
+    },
+    "industries": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "Inline override for the brand's industries. Useful when the caller cannot modify the brand's canonical brand.json but needs to declare industries for governance (e.g., Annex III vertical detection). brand.json remains the canonical source; when omitted here, governance agents SHOULD resolve from brand.json."
+    },
+    "data_subject_contestation": {
+      "type": "object",
+      "description": "Inline override for the brand's contestation contact point. Useful when the operator does not control brand.json but needs to discharge Art 22(3) for this plan. brand.json is canonical; when omitted, governance agents resolve brand → house → missing.",
+      "properties": {
+        "url": {
+          "type": "string",
+          "format": "uri",
+          "pattern": "^https://"
+        },
+        "email": {
+          "type": "string",
+          "format": "email"
+        },
+        "languages": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "anyOf": [
+        {
+          "required": [
+            "url"
+          ]
+        },
+        {
+          "required": [
+            "email"
+          ]
+        }
+      ],
+      "additionalProperties": false
+    }
+  },
+  "required": [
+    "domain"
+  ],
+  "additionalProperties": false,
+  "examples": [
+    {
+      "domain": "nova-brands.com",
+      "brand_id": "spark"
+    },
+    {
+      "domain": "nova-brands.com",
+      "brand_id": "glow"
+    },
+    {
+      "domain": "acme-corp.com"
+    }
+  ]
+} as const;
+
+export function loadAdcpCorpus(): Array<{ $id?: string; [k: string]: unknown }> {
+  return [
+    getSignalsReq, getSignalsRes, activateReq, activateRes, signalId, deployment, destination, accountRef, context, ext, error, paginationReq, paginationRes, signalFilters, vendorPricingOption, activationKey, signalValueType, signalCatalogType, taskStatus, brandId, brandRef
+  ] as Array<{ $id?: string; [k: string]: unknown }>;
+}

--- a/tests/__snapshots__/demo-render-snapshot.test.ts.snap
+++ b/tests/__snapshots__/demo-render-snapshot.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`handleDemo byte-equivalence > matches the committed golden hash (LF-normalized SHA-256 of body) 1`] = `
 {
-  "hash": "9216fb1dedbbacdad7a35be23b4fd8a81f68da5393e8a1b060c4adb042379229",
-  "length": 1109470,
+  "hash": "a206140a1fb5dfcc357658fde854e019da3908f1b6ec2329e8afbde1536d4873",
+  "length": 1132294,
 }
 `;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
     "target": "ES2022",
     "module": "ES2022",
     "moduleResolution": "bundler",
+    "resolveJsonModule": true,
     "lib": ["ES2022"],
     "types": ["@cloudflare/workers-types"],
     "strict": true,


### PR DESCRIPTION
Captures every \`get_signals\` + \`activate_signal\` interaction across **MCP, REST, and federation**. Each frame is validated against the canonical AdCP schemas (https://adcontextprotocol.org/schemas/v3/signals/...) and surfaced in a shared trace viewer mounted on 5 demo surfaces.

+2,261 LOC / -16 across 18 files.

## What gets captured

| Field | Notes |
|---|---|
| Full request payload | unfiltered JSON-RPC params |
| Full response payload | unfiltered JSON-RPC result OR error envelope |
| Schema validation result | AJV against the canonical schema; errors recorded |
| Schema URL | canonical \`https://adcontextprotocol.org/schemas/v3/signals/...\` URL |
| Direction | \`inbound\` (someone called us) / \`outbound\` (we called a peer) |
| Source | \`mcp_external\` / \`rest_demo\` / \`federation:<agent_id>\` |
| Correlation id | echoed from \`request.context.correlation_id\` |
| Latency | duration_ms |
| Status | \`ok\` / \`error\` |

In-memory ring buffer (last 500). Survives request-to-request, evicted at deploy.

## Hook points (4 entry surfaces)

- \`src/mcp/server.ts\` — \`callGetSignals\` + \`callActivateSignal\` (happy + synthetic + error paths)
- \`src/routes/searchSignals.ts\` — REST \`POST /signals/search\`
- \`src/routes/activateSignal.ts\` — REST \`POST /signals/activate\`
- \`src/federation/genericMcpClient.ts\` — outbound \`callAgentTool\` (orchestrator → external agents)

Outbound traces show **what we sent to Dstillery** and **what they returned**.

## Retrieval API (public)

\`\`\`
GET /api/signal-traces                       last 100, newest first
GET /api/signal-traces?tool=activate_signal  filter by tool
GET /api/signal-traces?correlation_id=...    all frames in a ceremony
GET /api/signal-traces?source_prefix=fed:    outbound only
GET /api/signal-traces?agent_id=dstillery    outbound to one agent
GET /api/signal-traces/snapshot              buffer summary stats
GET /api/signal-traces/:trace_id             single trace by id
\`\`\`

## Frontend — shared viewer

| File | Purpose |
|---|---|
| \`signals-glossary.ts\` | Rosetta Stone: 25 protocol fields ↔ marketing concepts |
| \`signals-trace-viewer.ts\` | Modal with syntax-highlighted JSON, inline glossary annotations, schema validation badges, schema URL links, copy-to-clipboard |
| \`styles.ts\` (~150 LOC added) | Modal CSS |

The Rosetta Stone you specified:

| Marketing | AdCP field |
|---|---|
| Target audience | \`signal_agent_segment_id\` |
| Segment taxonomy | Signal catalog (adagents.json) |
| Data provider | \`data_provider_domain\` |
| Activate on my DSP | \`destinations\` |
| Audience size | \`coverage_percentage\` |
| Data cost | \`pricing_options\` |

…plus 19 more (idempotency_key, deployments, activation_key, etc.).

## Mount points (all 5 surfaces)

| Surface | Trigger | Filter |
|---|---|---|
| **Recent Activations** | Per-row \`{ } JSON\` button | tool=activate_signal |
| **Orchestrator** | Header \`{ } Signal traces\` button | source_prefix=federation: |
| **Federation** | Header \`{ } Signal traces\` button | source_prefix=federation: |
| **Brand Canvas** | Header \`{ } Signal traces\` button | last 25 |
| **Race Canvas** (separate page) | Header chip → inline viewer | last 25 |

## Schema corpus (vendored from @adcp/sdk@3.0.1)

21 schemas: 4 signals request/response + 17 cross-file \$refs (signal-id, deployment, destination, account-ref, context, ext, error, pagination, signal-filters, vendor-pricing-option, activation-key, brand-id, brand-ref, value-type / catalog-type / task-status enums).

Vendored via \`scripts/vendor-adcp-schemas.mjs\` because @adcp/sdk's package.json \`exports\` field omits \`schemas-data\` paths. Re-run on SDK bumps.

## Test plan

- [x] \`npx vitest run\` — 441/441 passing (snapshot updated)
- [x] \`python tmp-mining/trap_audit.py\` — clean (40 files, 0 traps)
- [x] \`npx wrangler deploy --dry-run\` — clean (2.87 MiB / 677 KiB gzip)
- [x] \`npx tsc --noEmit -p .\` — no errors
- [ ] After deploy: \`/api/signal-traces\` returns \`{traces: [], count: 0}\` until a signal call fires
- [ ] After deploy: hit \`/signals/search\` → trace appears in buffer
- [ ] After deploy: open Recent Activations → click \`{ } JSON\` → modal opens with JSON + schema badges
- [ ] After deploy: open Orchestrator/Federation/Brand Canvas → click \`{ } Signal traces\` → modal opens
- [ ] After deploy: Race Canvas → click \`{ } Signal traces\` → inline viewer opens

## Deferred (explicit non-goals)

- Persistent KV/D1 storage (in-memory only)
- Aggregate analytics ("Dstillery: 92% schema validation success rate")
- Replay-from-trace (synthetic responses derived from real captures)
- Per-trace export (CSV/JSON download)
- Signal detail panel field annotations (only viewer has Rosetta today)

🤖 Generated with [Claude Code](https://claude.com/claude-code)