### PR TITLE
HOTFIX: signal trace recorder must never throw — restores /signals/search

### DIFF
--- a/src/domain/signalTrace.ts
+++ b/src/domain/signalTrace.ts
@@ -185,45 +185,72 @@ export interface RecordSignalTraceInput {
   correlation_id?: string | null;
 }
 
-export function recordSignalTrace(input: RecordSignalTraceInput): SignalTrace {
-  const reqSchemaId = input.tool_name === "get_signals" ? SCHEMA_ID.get_signals_request : SCHEMA_ID.activate_signal_request;
-  const resSchemaId = input.tool_name === "get_signals" ? SCHEMA_ID.get_signals_response : SCHEMA_ID.activate_signal_response;
-  const reqSchemaUrl = input.tool_name === "get_signals" ? SCHEMA_URL.get_signals_request : SCHEMA_URL.activate_signal_request;
-  const resSchemaUrl = input.tool_name === "get_signals" ? SCHEMA_URL.get_signals_response : SCHEMA_URL.activate_signal_response;
+export function recordSignalTrace(input: RecordSignalTraceInput): SignalTrace | null {
+  // Recording must NEVER throw — a failure in the trace path would
+  // break the actual signal call, defeating the entire point of
+  // observability. Wrap everything (id generation, AJV validation,
+  // buffer mutation) in a top-level try/catch and silently no-op on
+  // any error.
+  try {
+    const reqSchemaId = input.tool_name === "get_signals" ? SCHEMA_ID.get_signals_request : SCHEMA_ID.activate_signal_request;
+    const resSchemaId = input.tool_name === "get_signals" ? SCHEMA_ID.get_signals_response : SCHEMA_ID.activate_signal_response;
+    const reqSchemaUrl = input.tool_name === "get_signals" ? SCHEMA_URL.get_signals_request : SCHEMA_URL.activate_signal_request;
+    const resSchemaUrl = input.tool_name === "get_signals" ? SCHEMA_URL.get_signals_response : SCHEMA_URL.activate_signal_response;
 
-  let correlationId = input.correlation_id ?? null;
-  if (correlationId === null && typeof input.request_payload === "object" && input.request_payload !== null) {
-    const ctx = (input.request_payload as Record<string, unknown>)["context"];
-    if (ctx && typeof ctx === "object") {
-      const cid = (ctx as Record<string, unknown>)["correlation_id"];
-      if (typeof cid === "string") correlationId = cid;
+    let correlationId = input.correlation_id ?? null;
+    if (correlationId === null && typeof input.request_payload === "object" && input.request_payload !== null) {
+      const ctx = (input.request_payload as Record<string, unknown>)["context"];
+      if (ctx && typeof ctx === "object") {
+        const cid = (ctx as Record<string, unknown>)["correlation_id"];
+        if (typeof cid === "string") correlationId = cid;
+      }
     }
+
+    const trace: SignalTrace = {
+      trace_id: nextTraceId(),
+      correlation_id: correlationId,
+      ts: new Date().toISOString(),
+      duration_ms: Math.max(0, input.duration_ms),
+      direction: input.direction,
+      tool_name: input.tool_name,
+      source: input.source,
+      caller_agent: input.caller_agent ?? null,
+      request: {
+        payload: input.request_payload,
+        validation: safeValidate(reqSchemaId, reqSchemaUrl, input.request_payload),
+      },
+      response: {
+        payload: input.response_payload,
+        validation: safeValidate(resSchemaId, resSchemaUrl, input.response_payload),
+        status: input.response_status,
+        ...(input.response_error_message ? { error_message: input.response_error_message } : {}),
+      },
+    };
+
+    traceBuffer.push(trace);
+    while (traceBuffer.length > MAX_TRACES) traceBuffer.shift();
+    return trace;
+  } catch {
+    // AJV setup failed, schema registry threw, ring buffer mutation
+    // glitched — whatever it is, we don't surface it. Trace is lost
+    // for this call; the underlying signal call proceeds unaffected.
+    return null;
   }
+}
 
-  const trace: SignalTrace = {
-    trace_id: nextTraceId(),
-    correlation_id: correlationId,
-    ts: new Date().toISOString(),
-    duration_ms: Math.max(0, input.duration_ms),
-    direction: input.direction,
-    tool_name: input.tool_name,
-    source: input.source,
-    caller_agent: input.caller_agent ?? null,
-    request: {
-      payload: input.request_payload,
-      validation: validateAgainst(reqSchemaId, reqSchemaUrl, input.request_payload),
-    },
-    response: {
-      payload: input.response_payload,
-      validation: validateAgainst(resSchemaId, resSchemaUrl, input.response_payload),
-      status: input.response_status,
-      ...(input.response_error_message ? { error_message: input.response_error_message } : {}),
-    },
-  };
-
-  traceBuffer.push(trace);
-  while (traceBuffer.length > MAX_TRACES) traceBuffer.shift();
-  return trace;
+// Defensive wrapper around validateAgainst — even if the validator
+// throws (Workers + AJV have historically had compat quirks), we
+// return a benign "skipped" result instead of crashing record path.
+function safeValidate(schemaId: string, schemaUrl: string, payload: unknown): SchemaValidationResult {
+  try {
+    return validateAgainst(schemaId, schemaUrl, payload);
+  } catch (e) {
+    return {
+      valid: true,
+      schema_url: schemaUrl,
+      errors: [{ path: "(meta)", message: "validator threw: " + String((e as Error).message ?? e), keyword: "skipped" }],
+    };
+  }
 }
 
 export interface SignalTraceQuery {


### PR DESCRIPTION
## Restore prod

PR #208 deployed and immediately broke \`/signals/search\` (\"Internal error\" in both REST and MCP paths). Root cause: \`recordSignalTrace\` was throwing somewhere on the AJV path — likely a Workers + AJV runtime quirk — and the call sites in MCP/REST/federation didn't catch it.

## Fix

**Top-level try/catch around the entire \`recordSignalTrace\` body.** Any failure — id generation, AJV validation, schema lookup, ring buffer mutation — now silently no-ops and returns \`null\` instead of crashing the calling code. Trace is lost for that one call; the underlying signal call proceeds unaffected.

Plus a \`safeValidate\` wrapper around \`validateAgainst\` — compiled AJV validators can throw on edge cases (recursive refs, unsupported keywords), so we wrap each invocation and return a benign \`{ valid: true, errors: [skipped] }\` if anything goes wrong.

## Validation guarantee

The recorder is now the equivalent of a structured logger: **best-effort, side-channel, MUST not affect the call path.** This is the correct posture for any observability layer — should have been there from PR #208.

## Test plan

- [x] \`npx vitest run\` — 441/441 passing
- [ ] After deploy: \`/signals/search\` returns 200 with results
- [ ] After deploy: MCP \`tools/call get_signals\` returns success
- [ ] After deploy: \`/api/signal-traces\` populates with traces (best-effort; may be empty if AJV is fully broken on Workers, but signals path works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)