### PR TITLE
HOTFIX #2: defensive recordSignalTrace at every call site

### DIFF
--- a/src/domain/signalTrace.ts
+++ b/src/domain/signalTrace.ts
@@ -160,6 +160,17 @@ const MAX_TRACES = 500;
 const traceBuffer: SignalTrace[] = [];
 let traceCounter = 0;
 
+// ── Isolate kill switch ──────────────────────────────────────────────────────
+//
+// If the recorder ever observes a thrown error path that escapes the inner
+// try/catch (shouldn't be possible after hotfix #209, but defense in depth
+// because PR #209 didn't actually unstick prod), we flip this and become a
+// no-op for the remainder of the isolate's lifetime. Cheaper than risking
+// a recurrence on every call.
+let _recorderDisabled = false;
+export function isRecorderDisabled(): boolean { return _recorderDisabled; }
+export function disableRecorderForIsolate(): void { _recorderDisabled = true; }
+
 function nextTraceId(): string {
   traceCounter += 1;
   return `st_${Date.now().toString(36)}_${traceCounter.toString(36)}`;
@@ -185,7 +196,31 @@ export interface RecordSignalTraceInput {
   correlation_id?: string | null;
 }
 
+/**
+ * Caller-safe wrapper. Use this from every call site instead of
+ * recordSignalTrace directly. If anything in the recorder throws —
+ * even something we haven't seen yet — we catch it here, flip the
+ * isolate kill switch so subsequent calls short-circuit, and return
+ * null. The calling code never sees the throw.
+ *
+ * This is the belt-and-suspenders to the inner try/catch in
+ * recordSignalTrace itself. Hotfix #209 wrapped the body but didn't
+ * stop /signals/search from 500ing in prod — defense in depth.
+ */
+export function safeRecordSignalTrace(input: RecordSignalTraceInput): SignalTrace | null {
+  if (_recorderDisabled) return null;
+  try {
+    return recordSignalTrace(input);
+  } catch {
+    _recorderDisabled = true;
+    return null;
+  }
+}
+
 export function recordSignalTrace(input: RecordSignalTraceInput): SignalTrace | null {
+  // Isolate kill switch — once we've seen one throw escape, we stop
+  // trying. This is the belt to hotfix #209's suspenders.
+  if (_recorderDisabled) return null;
   // Recording must NEVER throw — a failure in the trace path would
   // break the actual signal call, defeating the entire point of
   // observability. Wrap everything (id generation, AJV validation,

--- a/src/federation/genericMcpClient.ts
+++ b/src/federation/genericMcpClient.ts
@@ -21,7 +21,7 @@
 // frequently; this is best-effort, we renew on every cold start.
 
 import { AGENT_REGISTRY } from "../domain/agentRegistry";
-import { recordSignalTrace } from "../domain/signalTrace";
+import { safeRecordSignalTrace } from "../domain/signalTrace";
 
 const SESSION_TTL_MS = 9 * 60 * 1000;
 /** Sentinel used for agents that negotiate stateless MCP (no mcp-session-id header
@@ -342,7 +342,7 @@ export async function callAgentTool(url: string, name: string, args: Record<stri
       // "federation:dstillery" instead of "federation:https://...".
       const match = AGENT_REGISTRY.find((a) => a.mcp_url && url.startsWith(a.mcp_url.replace(/\/$/, "")));
       const agentId = match?.id ?? null;
-      recordSignalTrace({
+      safeRecordSignalTrace({
         tool_name: name as "get_signals" | "activate_signal",
         direction: "outbound",
         source: agentId ? "federation:" + agentId : "federation:" + url,

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -28,7 +28,7 @@ import { getAllSignalsForCatalog } from "../domain/signalService";
 import { handleNLQuery } from "../domain/nlQueryHandler";
 import { handleConceptToolCall } from "../domain/conceptHandler";
 import { compactObj } from "../utils/objects";
-import { recordSignalTrace } from "../domain/signalTrace";
+import { safeRecordSignalTrace } from "../domain/signalTrace";
 import { record as recordToolLog, argKeysOf } from "./toolLog";
 import { logCall as d1LogCall, cleanup as d1Cleanup, shouldRunCleanup } from "../storage/toolLogRepo";
 
@@ -637,7 +637,7 @@ async function callGetSignals(
     const response = withMcpEnvelope({ status: "completed" }, cleanResponse);
 
     // Record the get_signals trace for observability across the demo.
-    recordSignalTrace({
+    safeRecordSignalTrace({
         tool_name: "get_signals",
         direction: "inbound",
         source: "mcp_external",
@@ -815,7 +815,7 @@ async function callActivateSignal(
             payload
         );
 
-        recordSignalTrace({
+        safeRecordSignalTrace({
             tool_name: "activate_signal",
             direction: "inbound",
             source: "mcp_external",
@@ -981,7 +981,7 @@ async function callActivateSignal(
                 syntheticPayload
             );
             logger.warn("activate_unknown_signal_synthetic", { signalId });
-            recordSignalTrace({
+            safeRecordSignalTrace({
                 tool_name: "activate_signal",
                 direction: "inbound",
                 source: "mcp_external",
@@ -994,7 +994,7 @@ async function callActivateSignal(
         }
         // Record the failure trace too — observability matters when
         // activation throws as much as when it succeeds.
-        recordSignalTrace({
+        safeRecordSignalTrace({
             tool_name: "activate_signal",
             direction: "inbound",
             source: "mcp_external",

--- a/src/routes/activateSignal.ts
+++ b/src/routes/activateSignal.ts
@@ -7,7 +7,7 @@ import { validateActivateRequest } from "../utils/validation";
 import { jsonResponse, errorResponse, parseJsonBody } from "./shared";
 import { getDb } from "../storage/db";
 import type { Logger } from "../utils/logger";
-import { recordSignalTrace } from "../domain/signalTrace";
+import { safeRecordSignalTrace } from "../domain/signalTrace";
 
 export async function handleActivateSignal(
   request: Request,
@@ -29,7 +29,7 @@ export async function handleActivateSignal(
   try {
     const db = getDb(env);
     const result = await activateSignalService(db, env.SIGNALS_CACHE, body, logger);
-    recordSignalTrace({
+    safeRecordSignalTrace({
       tool_name: "activate_signal",
       direction: "inbound",
       source: "rest_demo",
@@ -41,7 +41,7 @@ export async function handleActivateSignal(
     return jsonResponse(result, 202);
   } catch (err) {
     const errMsg = (err as Error).message ?? String(err);
-    recordSignalTrace({
+    safeRecordSignalTrace({
       tool_name: "activate_signal",
       direction: "inbound",
       source: "rest_demo",

--- a/src/routes/searchSignals.ts
+++ b/src/routes/searchSignals.ts
@@ -8,7 +8,7 @@ import { jsonResponse, errorResponse, readJsonBody } from "./shared";
 import { compactObj } from "../utils/objects";
 import { getDb } from "../storage/db";
 import type { Logger } from "../utils/logger";
-import { recordSignalTrace } from "../domain/signalTrace";
+import { safeRecordSignalTrace } from "../domain/signalTrace";
 
 export async function handleSearchSignals(
   request: Request,
@@ -73,7 +73,10 @@ export async function handleSearchSignals(
 
     // Record the REST trace alongside the MCP one. Keeps signal traces
     // unified across both transport bindings.
-    recordSignalTrace({
+    // safeRecordSignalTrace contains its own try/catch + isolate kill
+    // switch — caller doesn't need to wrap. It returns null on any
+    // failure so we discard the result.
+    safeRecordSignalTrace({
       tool_name: "get_signals",
       direction: "inbound",
       source: "rest_demo",
@@ -86,7 +89,7 @@ export async function handleSearchSignals(
     return jsonResponse(result);
   } catch (err) {
     logger.error("search_signals_error", { error: String(err) });
-    recordSignalTrace({
+    safeRecordSignalTrace({
       tool_name: "get_signals",
       direction: "inbound",
       source: "rest_demo",


### PR DESCRIPTION
## Summary

- Hotfix #209 wrapped the `recordSignalTrace` body in try/catch but prod **still 500s** on `/signals/search` and MCP `get_signals`/`activate_signal` (user reported "Internal error" on the demo's Brief discovery page).
- Defense-in-depth: add a `safeRecordSignalTrace` wrapper + isolate kill switch and route every call site through it. If anything in the recorder ever throws, the kill switch flips and the recorder becomes a no-op for the rest of the isolate's lifetime.

## What changed

| File | Change |
| --- | --- |
| `src/domain/signalTrace.ts` | New `safeRecordSignalTrace` wrapper. New `_recorderDisabled` isolate-level kill switch. |
| `src/routes/searchSignals.ts` | `recordSignalTrace` → `safeRecordSignalTrace` (2 call sites) |
| `src/routes/activateSignal.ts` | `recordSignalTrace` → `safeRecordSignalTrace` (2 call sites) |
| `src/mcp/server.ts` | `recordSignalTrace` → `safeRecordSignalTrace` (4 call sites) |
| `src/federation/genericMcpClient.ts` | `recordSignalTrace` → `safeRecordSignalTrace` (1 call site) |

## Why a kill switch (not just try/catch at each call site)

Belt-and-suspenders. We've now seen one prod incident where wrapping the recorder body wasn't enough. Possible causes I haven't reproduced yet:
- AJV runtime quirk on Workers — `validator(payload)` on a deeply-nested response might throw asynchronously in a way our sync `try/catch` misses
- Schema corpus edge case — a $ref resolution that fails on first invocation but not on the trace endpoint's read path
- Buffer mutation under unusual GC pressure

The kill switch means **first call may lose its trace, all subsequent calls in the isolate short-circuit cleanly**. We can investigate root cause without prod being on fire.

## Verification

- `npx tsc --noEmit` — no new errors in any of the touched files
- `npx vitest run` — 441 passing / 12 skipped (no regressions)
- `npx wrangler deploy --dry-run` — bundle 2.87MB / 677KB gzipped

## Test plan

- [ ] Merge + deploy to prod
- [ ] Verify `/signals/search` returns 200 with results
- [ ] Verify MCP `tools/call` `get_signals` returns 200 with `result`
- [ ] Verify MCP `tools/call` `activate_signal` returns 200 with `task_id`
- [ ] Verify `/api/signal-traces` continues to return 200 (buffer may be 0 if recorder disabled in that isolate)
- [ ] Demo Brief discovery: type a brief, see catalog matches + AI proposals (no "Internal error")

## Follow-up (separate PR)

Once prod is restored, investigate the underlying recorder failure path — add structured logging on the kill-switch flip event so the next isolate-lifetime that hits it surfaces a diagnostic in the Cloudflare tail logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)