### PR TITLE
Signal traces v2: persistence + live validation + endpoint URL + per-row activation + auto-reset

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,14 @@
 {
   "name": "adcp-signals-adaptor",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "adcp-signals-adaptor",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "dependencies": {
+        "@cfworker/json-schema": "^4.1.1",
         "zod": "^3.23.8"
       },
       "devDependencies": {
@@ -181,6 +182,12 @@
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cfworker/json-schema": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@cfworker/json-schema/-/json-schema-4.1.1.tgz",
+      "integrity": "sha512-gAmrUZSGtKc3AiBL71iNWxDsyUC5uMaKKGdvzYsBoTW/xi42JQHl7eKV2OYzCUqvc+D2RCcf7EXY2iCyFIk6og==",
       "license": "MIT"
     },
     "node_modules/@cloudflare/kv-asset-handler": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "wrangler": "^4.72.0"
   },
   "dependencies": {
+    "@cfworker/json-schema": "^4.1.1",
     "zod": "^3.23.8"
   }
 }

--- a/src/demo/script/fragments/activations.ts
+++ b/src/demo/script/fragments/activations.ts
@@ -47,12 +47,15 @@ function renderActivationRow(op) {
   const submittedAt = fmtTime(op.submittedAt);
   const completedAt = op.completedAt ? fmtTime(op.completedAt) : "—";
   const statusClass = (op.status || "submitted").toLowerCase();
-  // {} button → opens the signals trace viewer filtered to this
-  // activation's signal_id (we don't have a correlation_id per row,
-  // so we filter by tool=activate_signal and let the viewer show
-  // the most recent matches; the user clicks the matching row in
-  // the modal to see full request/response JSON).
+  // {} button → opens the signals trace viewer filtered to THIS row's
+  // activation. We pass both signal_id and operation_id (= task_id in
+  // the trace's response payload) so the viewer can match a single
+  // trace exactly. The previous behaviour swallowed the row id and
+  // always opened the same "all activate_signal" view, making every
+  // click look identical — fixed by threading data-trace-task-id
+  // through the click handler.
   const sigId = (op.signalId || "").replace(/"/g, "&quot;");
+  const opId = (op.operationId || "").replace(/"/g, "&quot;");
   return '' +
     '<tr>' +
       '<td class="td-name">' +
@@ -66,7 +69,7 @@ function renderActivationRow(op) {
       '<td class="td-time">' + (op.webhookFired ? '<span style="color:var(--success)">fired</span>' : (op.webhookUrl ? 'queued' : '—')) + '</td>' +
       '<td class="td-time" style="max-width:200px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap">' + escapeHtml((op.operationId || "").slice(0, 24)) + '</td>' +
       '<td class="td-time">' +
-        '<button class="btn-secondary btn-mini" data-trace-activation="' + sigId + '" title="View signal request/response JSON">{ } JSON</button>' +
+        '<button class="btn-secondary btn-mini" data-trace-activation="' + sigId + '" data-trace-task-id="' + opId + '" title="View signal request/response JSON for this activation">{ } JSON</button>' +
       '</td>' +
     '</tr>';
 }
@@ -77,13 +80,18 @@ document.addEventListener("click", function (e) {
   const t = e.target;
   if (!t || !t.matches || !t.matches("[data-trace-activation]")) return;
   const sigId = t.getAttribute("data-trace-activation");
+  const taskId = t.getAttribute("data-trace-task-id");
   if (typeof window.openSignalTraceModal !== "function") return;
-  // Filter by tool=activate_signal — the viewer will show recent
-  // activations and the user clicks the relevant one. We can't
-  // pre-filter by signal_id at the API level (the buffer indexes
-  // by correlation_id, agent_id, tool), so client-side filter
-  // happens inside the modal logic.
-  window.openSignalTraceModal({ tool: "activate_signal", limit: 25 });
+  // Pass task_id as the primary filter so the viewer can pinpoint the
+  // single activate_signal trace whose response.payload.task_id ===
+  // this row's operation_id. signal_id is a secondary filter (handles
+  // the legacy case where task_id wasn't captured).
+  window.openSignalTraceModal({
+    tool: "activate_signal",
+    task_id: taskId || undefined,
+    signal_id: sigId || undefined,
+    limit: 25,
+  });
 });
 
 function fmtTime(iso) {

--- a/src/demo/script/fragments/brand-canvas.ts
+++ b/src/demo/script/fragments/brand-canvas.ts
@@ -609,6 +609,11 @@ async function _canvasRunWorkflow() {
 
   // Reset lanes to running state.
   _canvasResetLanes();
+  // Also clear the universal trace trigger + any cached signal-trace
+  // modal state so the previous run's traces don't bleed into this
+  // one. The trigger will re-illuminate when this run's trace lands.
+  if (typeof _resetTrace === "function") _resetTrace();
+  if (typeof window.closeSignalTraceModal === "function") window.closeSignalTraceModal();
 
   // Refinement: thread the brand BrandRef through to the workflow.
   // Pulls domain + name + industries from the resolved brand_manifest;

--- a/src/demo/script/fragments/discover.ts
+++ b/src/demo/script/fragments/discover.ts
@@ -65,6 +65,11 @@ async function runDiscover() {
   btn.disabled = true;
   status.innerHTML = '<span class="spinner"></span>scanning catalog + generating proposals…';
   results.innerHTML = '<div class="empty-state"><span class="spinner"></span><div class="empty-title">Searching…</div></div>';
+  // Reset trace state before kicking off a new search — otherwise the
+  // floating trace trigger keeps pointing at the previous brief's
+  // results, which is the bug the user reported.
+  if (typeof _resetTrace === "function") _resetTrace();
+  if (typeof window.closeSignalTraceModal === "function") window.closeSignalTraceModal();
 
   // Fire a parallel /signals/search call to capture the universal _trace
   // payload. Doesn't block the main UI render — when it lands we light up
@@ -134,6 +139,9 @@ async function runNlQuery() {
   btn.disabled = true;
   status.innerHTML = '<span class="spinner"></span>decomposing query + resolving dimensions…';
   results.innerHTML = '<div class="empty-state"><span class="spinner"></span><div class="empty-title">Running NL query…</div></div>';
+  // Same trace-reset as runDiscover — fresh query = fresh trace.
+  if (typeof _resetTrace === "function") _resetTrace();
+  if (typeof window.closeSignalTraceModal === "function") window.closeSignalTraceModal();
 
   try {
     const t0 = performance.now();

--- a/src/demo/script/fragments/signals-trace-viewer.ts
+++ b/src/demo/script/fragments/signals-trace-viewer.ts
@@ -38,6 +38,7 @@ function ensureSignalTraceModalEl() {
       '<div class="signal-trace-head">' +
         '<div class="signal-trace-head-title">Signal trace</div>' +
         '<div class="signal-trace-head-meta" id="signal-trace-head-meta">—</div>' +
+        '<button class="signal-trace-reset" id="signal-trace-reset" title="Wipe trace buffer (in-memory + KV) — useful between demo segments">⟲ reset</button>' +
         '<button class="signal-trace-close" id="signal-trace-close" aria-label="Close">×</button>' +
       '</div>' +
       '<div class="signal-trace-body" id="signal-trace-body">' +
@@ -56,6 +57,26 @@ function ensureSignalTraceModalEl() {
   });
   document.addEventListener("keydown", function (e) {
     if (e.key === "Escape" && wrap.classList.contains("open")) closeSignalTraceModal();
+  });
+  // Reset button — wipes in-memory + KV index. Confirms before firing
+  // since the workshop demo doesn't want accidental wipes mid-demo.
+  wrap.querySelector("#signal-trace-reset").addEventListener("click", async function () {
+    if (!confirm("Wipe trace buffer? This clears in-memory + KV index for this demo. Per-trace KV entries TTL out at 6h regardless.")) return;
+    try {
+      const r = await fetch("/api/signal-traces", { method: "DELETE" });
+      const j = await r.json().catch(function () { return null; });
+      if (j && j.ok) {
+        // Re-render with the now-empty filter so the user sees the
+        // "no traces match this filter yet" empty state confirming
+        // the wipe.
+        const body = document.getElementById("signal-trace-body");
+        if (body) body.innerHTML = '<div class="signal-trace-empty">Trace buffer wiped. Trigger a get_signals or activate_signal call to see new traces appear.</div>';
+      } else {
+        alert("Reset failed: " + (j && j.error ? j.error : "unknown"));
+      }
+    } catch (e) {
+      alert("Reset failed: " + (e && e.message ? e.message : String(e)));
+    }
   });
   _signalTraceModalEl = wrap;
   return wrap;
@@ -99,13 +120,17 @@ function renderJsonWithGlossary(value, indent) {
 }
 
 function renderValidationBadge(validation) {
-  if (!validation) return '<span class="trace-vbadge skip">no schema</span>';
+  if (!validation) return '<span class="trace-vbadge skip" title="No schema attached to this trace">no schema</span>';
+  // "skipped" or "missing_schema" — the validator couldn't run on the
+  // payload (e.g. corpus didn't load, runtime quirk). Distinct from
+  // "ran and found 0 errors" — be honest about it. Kept short for
+  // the badge; full reason shown in the meta line below the JSON.
   if (validation.errors && validation.errors.some(function (e) { return e.keyword === "skipped" || e.keyword === "missing_schema"; })) {
-    return '<span class="trace-vbadge skip">schema unavailable</span>';
+    return '<span class="trace-vbadge skip" title="Validator could not run; schema URL link still works">⊘ validation skipped</span>';
   }
-  if (validation.valid) return '<span class="trace-vbadge ok">✓ schema valid</span>';
+  if (validation.valid) return '<span class="trace-vbadge ok" title="Payload validates against the canonical AdCP schema">✓ schema valid</span>';
   const n = (validation.errors || []).length;
-  return '<span class="trace-vbadge bad">✗ ' + n + ' schema error' + (n === 1 ? "" : "s") + '</span>';
+  return '<span class="trace-vbadge bad" title="Payload does not validate — see errors below">✗ ' + n + ' schema error' + (n === 1 ? "" : "s") + '</span>';
 }
 
 function renderValidationErrors(validation) {
@@ -120,10 +145,32 @@ function renderSingleTrace(trace, idx) {
   const tsFmt = new Date(trace.ts).toLocaleTimeString();
   const dirIcon = trace.direction === "outbound" ? "→" : "←";
   const sourceShort = trace.source.length > 36 ? trace.source.slice(0, 33) + "…" : trace.source;
+  // Endpoint URL — render as a clickable link with the full URL in
+  // the title attribute so the audience can hover to confirm exactly
+  // where the request hit. For long URLs, show only the host:path tail
+  // in the visible text. Outbound (federation) URLs are external; we
+  // open in a new tab. No-render if missing (legacy traces).
+  let endpointBlock = "";
+  if (trace.endpoint_url) {
+    let visible = trace.endpoint_url;
+    try {
+      const u = new URL(trace.endpoint_url);
+      visible = u.host + u.pathname;
+      if (visible.length > 48) visible = visible.slice(0, 45) + "…";
+    } catch (_) { /* not a parseable URL — show as-is, truncated */
+      if (visible.length > 48) visible = visible.slice(0, 45) + "…";
+    }
+    endpointBlock =
+      '<a class="trace-endpoint" href="' + escapeHtml(trace.endpoint_url) + '" target="_blank" rel="noopener" title="' + escapeHtml(trace.endpoint_url) + '">' +
+        '<span class="trace-endpoint-icon">⎘</span>' +
+        '<span class="trace-endpoint-url">' + escapeHtml(visible) + '</span>' +
+      '</a>';
+  }
   return '<div class="signal-trace-frame" data-trace-id="' + escapeHtml(trace.trace_id) + '">' +
     '<div class="signal-trace-frame-head">' +
       '<span class="trace-tool trace-tool-' + escapeHtml(trace.tool_name) + '">' + escapeHtml(trace.tool_name) + '</span> ' +
       '<span class="trace-dir">' + dirIcon + ' ' + escapeHtml(sourceShort) + '</span>' +
+      endpointBlock +
       '<span class="trace-ts">' + tsFmt + '</span>' +
       '<span class="trace-dur">' + trace.duration_ms + 'ms</span>' +
       (trace.correlation_id ? '<span class="trace-corr">corr: ' + escapeHtml(trace.correlation_id.slice(-12)) + '</span>' : '') +
@@ -163,7 +210,16 @@ function renderGlossarySection() {
 }
 
 // Open the modal with traces matching the given filter. Filter shape:
-//   { correlationId?, agentId?, tool?, traceIds?, sourcePrefix? }
+//   {
+//     correlationId?, agentId?, tool?, traceIds?, sourcePrefix?,
+//     task_id?,    // matches trace.response.payload.task_id (activate)
+//     signal_id?,  // matches trace.request.payload.signal_agent_segment_id
+//     limit?
+//   }
+//
+// Both task_id + signal_id are server-fetched broadly (by tool/source
+// prefix) and narrowed client-side, since neither field is indexed
+// in the in-memory ring buffer or the KV index.
 async function openSignalTraceModal(filter) {
   const wrap = ensureSignalTraceModalEl();
   _signalTraceCurrentFilter = filter || {};
@@ -175,24 +231,49 @@ async function openSignalTraceModal(filter) {
   // Populate glossary section once per modal open
   const gloss = document.getElementById("signal-trace-glossary-body");
   if (gloss) gloss.innerHTML = renderGlossarySection();
-  // Build query string from filter
+  // Build query string from filter — server-side filters first, then
+  // client-side narrowing for fields not in the index (task_id,
+  // signal_id, traceIds).
   const qs = new URLSearchParams();
   if (filter && filter.correlationId) qs.set("correlation_id", filter.correlationId);
   if (filter && filter.agentId) qs.set("agent_id", filter.agentId);
   if (filter && filter.tool) qs.set("tool", filter.tool);
   if (filter && filter.sourcePrefix) qs.set("source_prefix", filter.sourcePrefix);
-  qs.set("limit", String((filter && filter.limit) || 25));
+  // Over-fetch a bit if we'll narrow client-side. 25 server-side is
+  // plenty for a one-row drill-in (the row is almost always the most
+  // recent matching trace).
+  const limit = (filter && filter.limit) || 25;
+  qs.set("limit", String(limit));
   try {
     const r = await fetch("/api/signal-traces?" + qs.toString());
     const data = await r.json();
     let traces = (data && data.traces) || [];
-    // If specific traceIds were requested, filter client-side
+    // Specific trace IDs (Race Canvas / orchestrator drill-in).
     if (filter && filter.traceIds && filter.traceIds.length > 0) {
       const wanted = new Set(filter.traceIds);
       traces = traces.filter(function (t) { return wanted.has(t.trace_id); });
     }
+    // Client-side narrowing for activations row drill-in.
+    if (filter && filter.task_id) {
+      traces = traces.filter(function (t) {
+        const p = t && t.response && t.response.payload;
+        if (!p || typeof p !== "object") return false;
+        // task_id can live at the top level OR inside ext.task_id
+        // (MCP envelope binding). Match either.
+        return p.task_id === filter.task_id || (p.ext && p.ext.task_id === filter.task_id);
+      });
+    }
+    if (filter && filter.signal_id && (!filter.task_id || traces.length === 0)) {
+      // Fallback to signal_id matching when task_id didn't pin a row
+      // (legacy data, or task_id wasn't captured at trace time).
+      traces = ((data && data.traces) || []).filter(function (t) {
+        const p = t && t.request && t.request.payload;
+        if (!p || typeof p !== "object") return false;
+        return p.signal_agent_segment_id === filter.signal_id;
+      });
+    }
     if (traces.length === 0) {
-      body.innerHTML = '<div class="signal-trace-empty">No traces match this filter yet.<br/><small>Traces buffer the last 500 signal interactions in-memory; older ones are evicted.</small></div>';
+      body.innerHTML = '<div class="signal-trace-empty">No traces match this filter yet.<br/><small>Traces buffer the last 500 signal interactions in-memory + 6h in KV; older ones are evicted.</small></div>';
       return;
     }
     body.innerHTML = traces.map(function (t, i) { return renderSingleTrace(t, i); }).join("");

--- a/src/demo/styles.ts
+++ b/src/demo/styles.ts
@@ -6702,6 +6702,35 @@ textarea.lab-input { resize: vertical; line-height: 1.5; }
 .trace-ts { margin-left: auto; }
 .trace-dur { color: var(--text-faint); }
 .trace-corr { font-style: italic; }
+.trace-endpoint {
+  display: inline-flex; align-items: center; gap: 4px;
+  font: 10.5px var(--font-mono);
+  color: var(--accent); text-decoration: none;
+  padding: 1px 6px; border-radius: 3px;
+  background: rgba(56, 182, 255, 0.06);
+  border: 1px solid rgba(56, 182, 255, 0.18);
+  transition: background 0.15s, border-color 0.15s;
+}
+.trace-endpoint:hover {
+  background: rgba(56, 182, 255, 0.14);
+  border-color: rgba(56, 182, 255, 0.40);
+  text-decoration: underline;
+}
+.trace-endpoint-icon { opacity: 0.7; font-size: 11px; }
+.trace-endpoint-url { color: inherit; }
+.signal-trace-reset {
+  margin-left: auto; margin-right: 8px;
+  font: 11px var(--font-mono);
+  background: transparent; color: var(--text-mut);
+  border: 1px solid var(--border); border-radius: 4px;
+  padding: 4px 10px; cursor: pointer;
+  transition: background 0.15s, color 0.15s, border-color 0.15s;
+}
+.signal-trace-reset:hover {
+  background: rgba(255, 100, 100, 0.10);
+  color: #ff7b7b;
+  border-color: rgba(255, 100, 100, 0.30);
+}
 .trace-status-ok { color: #5fd9c4; font-weight: 600; }
 .trace-status-err { color: #ff7b7b; font-weight: 600; }
 .signal-trace-section { margin-top: 8px; }

--- a/src/domain/signalTrace.ts
+++ b/src/domain/signalTrace.ts
@@ -21,14 +21,22 @@
 // stateless posture. KV/D1 layering is a future PR if you want a
 // permanent audit log.
 
-import Ajv from "ajv";
-import addFormats from "ajv-formats";
+// JSON-Schema validator that works inside Cloudflare Workers' V8
+// isolate. AJV (the obvious choice) compiles validators via
+// `new Function()`, which Workers blocks with "Code generation from
+// strings disallowed for this context" — so traces validated against
+// a real-shape schema all returned `[skipped]`. @cfworker/json-schema
+// is a Workers-native interpreter (no eval/Function), drop-in for the
+// fields we need. See: https://github.com/cfworker/cfworker
+import { Validator } from "@cfworker/json-schema";
 
 // Vendored AdCP schema corpus. Imported as a single TS module to
 // sidestep @adcp/sdk's package.json `exports` field that doesn't
 // expose the schemas-data path. Regenerate via:
 //   node scripts/vendor-adcp-schemas.mjs
 import { loadAdcpCorpus } from "../schemas/adcp";
+
+import type { Env } from "../types/env";
 
 // ── Types ────────────────────────────────────────────────────────────────────
 
@@ -56,6 +64,19 @@ export interface SignalTrace {
   source: string;
   /** For outbound calls, the agent we called. Null for inbound. */
   caller_agent: string | null;
+  /** Endpoint URL the request actually hit.
+   *
+   * - Outbound (federation): the URL we POSTed to (peer's /mcp endpoint).
+   * - Inbound REST: our public URL for the matched route, e.g.
+   *   "https://adcp-signals-adaptor.evgeny-193.workers.dev/signals/search".
+   * - Inbound MCP: our public /mcp endpoint URL.
+   *
+   * Surfacing this in the trace viewer answers "where did this request
+   * actually go?" — important for the workshop because the audience
+   * asks it on every call (and the source tag alone like
+   * "federation:dstillery" doesn't tell them where Dstillery LIVES).
+   */
+  endpoint_url: string | null;
   request: {
     payload: unknown;
     validation: SchemaValidationResult;
@@ -91,35 +112,59 @@ const SCHEMA_ID = {
   activate_signal_response: "/schemas/3.0.1/signals/activate-signal-response.json",
 } as const;
 
-// ── AJV setup ────────────────────────────────────────────────────────────────
+// ── Validator setup ──────────────────────────────────────────────────────────
 //
-// Lazy-init: the schema corpus is sizeable. Built on first record() call
-// so cold isolates don't pay the cost up-front. After init the validators
+// One Validator per request/response shape. Lazy-init on first record() call
+// so cold isolates don't pay the cost up-front; after init the validators
 // are cached for the lifetime of the isolate.
+//
+// @cfworker/json-schema's Validator constructor takes the root schema
+// + draft + a list of additional schemas the root may $ref (for
+// cross-file resolution like signal-id, deployment, vendor-pricing-
+// option). We pre-register the entire corpus so any $ref resolves.
 
-let _ajv: Ajv | null = null;
-let _ajvInitFailed = false;
+interface ValidatorBundle {
+  get_signals_request: Validator;
+  get_signals_response: Validator;
+  activate_signal_request: Validator;
+  activate_signal_response: Validator;
+}
 
-function getAjv(): Ajv | null {
-  if (_ajv !== null) return _ajv;
-  if (_ajvInitFailed) return null;
+let _validators: ValidatorBundle | null = null;
+let _validatorInitFailed = false;
+
+function findInCorpus(corpus: Array<{ $id?: string }>, id: string): Record<string, unknown> | null {
+  return (corpus.find((s) => s.$id === id) as Record<string, unknown> | undefined) ?? null;
+}
+
+function getValidators(): ValidatorBundle | null {
+  if (_validators !== null) return _validators;
+  if (_validatorInitFailed) return null;
   try {
-    const ajv = new Ajv({ strict: false, allErrors: true });
-    addFormats(ajv);
-    // Load every schema in @adcp/sdk's 3.0 directory so cross-file $ref
-    // resolution works (signal-id, deployment, vendor-pricing-option,
-    // etc. are all referenced from the request/response schemas).
-    // We import a flat manifest of schemas, registering each by $id.
-    // NOTE: Workers bundlers can statically resolve a JSON manifest;
-    // we generate it via a small build helper at module load.
-    const corpus = loadAdcpCorpus();
-    for (const s of corpus) {
-      try { ajv.addSchema(s); } catch { /* duplicate / partial — skip */ }
-    }
-    _ajv = ajv;
-    return _ajv;
+    const corpus = loadAdcpCorpus() as Array<Record<string, unknown> & { $id?: string }>;
+    const buildValidator = (rootId: string): Validator => {
+      const root = findInCorpus(corpus, rootId);
+      if (!root) throw new Error(`schema not in corpus: ${rootId}`);
+      // Draft-07 matches @adcp/sdk's $schema pragma. Pass shortCircuit
+      // = false so we collect all errors (ajv allErrors equivalent).
+      const v = new Validator(root, "7", false);
+      // Register every other corpus schema so cross-file $refs resolve.
+      for (const s of corpus) {
+        if (s.$id && s.$id !== rootId) {
+          try { v.addSchema(s); } catch { /* tolerate */ }
+        }
+      }
+      return v;
+    };
+    _validators = {
+      get_signals_request:    buildValidator(SCHEMA_ID.get_signals_request),
+      get_signals_response:   buildValidator(SCHEMA_ID.get_signals_response),
+      activate_signal_request:  buildValidator(SCHEMA_ID.activate_signal_request),
+      activate_signal_response: buildValidator(SCHEMA_ID.activate_signal_response),
+    };
+    return _validators;
   } catch {
-    _ajvInitFailed = true;
+    _validatorInitFailed = true;
     return null;
   }
 }
@@ -127,16 +172,26 @@ function getAjv(): Ajv | null {
 // loadAdcpCorpus() lives in src/schemas/adcp/index.ts — vendored from
 // @adcp/sdk by scripts/vendor-adcp-schemas.mjs. Imported above.
 
+function pickValidator(bundle: ValidatorBundle, schemaId: string): Validator | null {
+  switch (schemaId) {
+    case SCHEMA_ID.get_signals_request: return bundle.get_signals_request;
+    case SCHEMA_ID.get_signals_response: return bundle.get_signals_response;
+    case SCHEMA_ID.activate_signal_request: return bundle.activate_signal_request;
+    case SCHEMA_ID.activate_signal_response: return bundle.activate_signal_response;
+    default: return null;
+  }
+}
+
 function validateAgainst(schemaId: string, schemaUrl: string, payload: unknown): SchemaValidationResult {
-  const ajv = getAjv();
-  if (!ajv) {
+  const bundle = getValidators();
+  if (!bundle) {
     return {
       valid: true,  // can't validate — don't claim invalid
       schema_url: schemaUrl,
       errors: [{ path: "(meta)", message: "schema validator unavailable in this runtime", keyword: "skipped" }],
     };
   }
-  const validator = ajv.getSchema(schemaId);
+  const validator = pickValidator(bundle, schemaId);
   if (!validator) {
     return {
       valid: true,
@@ -144,12 +199,12 @@ function validateAgainst(schemaId: string, schemaUrl: string, payload: unknown):
       errors: [{ path: "(meta)", message: `schema not registered: ${schemaId}`, keyword: "missing_schema" }],
     };
   }
-  const ok = validator(payload);
-  if (ok) return { valid: true, schema_url: schemaUrl, errors: [] };
-  const errs = (validator.errors || []).slice(0, 12).map((e) => ({
-    path: e.instancePath || "(root)",
-    message: e.message || "validation failed",
-    keyword: e.keyword || "unknown",
+  const result = validator.validate(payload);
+  if (result.valid) return { valid: true, schema_url: schemaUrl, errors: [] };
+  const errs = (result.errors || []).slice(0, 12).map((e: { instanceLocation?: string; error?: string; keyword?: string; keywordLocation?: string }) => ({
+    path: e.instanceLocation || "(root)",
+    message: e.error || "validation failed",
+    keyword: e.keyword || (e.keywordLocation ? e.keywordLocation.split("/").pop() ?? "unknown" : "unknown"),
   }));
   return { valid: false, schema_url: schemaUrl, errors: errs };
 }
@@ -194,6 +249,13 @@ export interface RecordSignalTraceInput {
    * fallback.
    */
   correlation_id?: string | null;
+  /**
+   * Optional. The endpoint URL this request actually hit. For outbound
+   * federation calls, the peer's /mcp URL. For inbound REST/MCP, the
+   * full request.url at the worker. When omitted, the recorder leaves
+   * the trace's endpoint_url as null.
+   */
+  endpoint_url?: string | null;
 }
 
 /**
@@ -250,6 +312,7 @@ export function recordSignalTrace(input: RecordSignalTraceInput): SignalTrace | 
       tool_name: input.tool_name,
       source: input.source,
       caller_agent: input.caller_agent ?? null,
+      endpoint_url: input.endpoint_url ?? null,
       request: {
         payload: input.request_payload,
         validation: safeValidate(reqSchemaId, reqSchemaUrl, input.request_payload),
@@ -319,6 +382,180 @@ export function getSignalTraceById(traceId: string): SignalTrace | null {
 
 export function clearSignalTraces(): void {
   traceBuffer.length = 0;
+}
+
+// ── KV-backed persistence ────────────────────────────────────────────────────
+//
+// The in-memory ring buffer above survives request-to-request within an
+// isolate but Cloudflare cycles isolates frequently — so a trace recorded
+// at T0 may "disappear" at T0+30s when the user reopens the modal on a
+// fresh isolate. That's user-visible during a workshop demo (we hit it!).
+//
+// Layered fix: write each trace to KV with a TTL and maintain a
+// fixed-size index of recent trace IDs. Reads merge in-memory + KV
+// (in-memory wins for freshest, KV fills the gap when isolate cycled).
+//
+// Posture:
+//   - Writes are fire-and-forget via ctx.waitUntil where available, or
+//     plain unawaited Promise otherwise. Failure must never break the
+//     calling signal call.
+//   - TTL = 6 hours. Long enough for a workshop session, short enough
+//     to keep the index file small.
+//   - Index key holds [trace_id, ts] tuples capped at 200 newest. List
+//     reads fetch the index, fall through to per-id KV gets.
+//
+// We avoid making recordSignalTrace itself async (would force every
+// call site to await) — instead, callers fire persistSignalTrace
+// alongside recordSignalTrace.
+
+const KV_KEY_PREFIX = "sigtrace:";
+const KV_INDEX_KEY = "sigtrace:index";
+const KV_TTL_SECONDS = 6 * 60 * 60; // 6h
+const KV_INDEX_CAP = 200;
+
+interface KvIndexEntry {
+  id: string;
+  ts: string;
+  tool: SignalToolName;
+  source: string;
+  status: "ok" | "error";
+}
+
+/**
+ * Best-effort: persist one trace + bump the recent-traces index. Never
+ * throws — caller's side-effect, must not break the call path. Pass
+ * the trace returned by safeRecordSignalTrace; if null, no-op.
+ *
+ * Awaiting this in the request path adds ~5-30ms (two KV writes). For
+ * non-blocking, use ctx.waitUntil(persistSignalTrace(env, trace)).
+ */
+export async function persistSignalTrace(env: Env, trace: SignalTrace | null): Promise<void> {
+  if (!trace) return;
+  if (!env || !env.SIGNALS_CACHE) return;
+  try {
+    const key = KV_KEY_PREFIX + trace.trace_id;
+    // Write the full trace under its id key.
+    await env.SIGNALS_CACHE.put(key, JSON.stringify(trace), { expirationTtl: KV_TTL_SECONDS });
+    // Read-modify-write the index. Eventual consistency — concurrent
+    // writes can clobber each other; we accept that for a demo-grade
+    // audit log. The next put restores ordering on the next call.
+    const existing = await env.SIGNALS_CACHE.get(KV_INDEX_KEY, "json") as KvIndexEntry[] | null;
+    const list = existing ?? [];
+    // De-dupe by id (in case of retry), prepend newest, cap.
+    const filtered = list.filter((e) => e.id !== trace.trace_id);
+    const next: KvIndexEntry[] = [
+      { id: trace.trace_id, ts: trace.ts, tool: trace.tool_name, source: trace.source, status: trace.response.status },
+      ...filtered,
+    ].slice(0, KV_INDEX_CAP);
+    await env.SIGNALS_CACHE.put(KV_INDEX_KEY, JSON.stringify(next), { expirationTtl: KV_TTL_SECONDS });
+  } catch {
+    // KV unavailable, quota exhausted, JSON serialise threw on a
+    // circular ref — none of these should affect the call path.
+  }
+}
+
+/**
+ * KV-backed read. Returns the union of in-memory + KV traces, dedup'd
+ * by trace_id (in-memory wins on conflict — it's freshest), filtered
+ * by query, newest first.
+ *
+ * Used by /api/signal-traces when in-memory is empty (cold isolate).
+ */
+export async function listSignalTracesPersisted(env: Env, q: SignalTraceQuery = {}): Promise<SignalTrace[]> {
+  const inMemory = getSignalTraces({ ...q, limit: 500 });
+  if (!env || !env.SIGNALS_CACHE) return inMemory.slice(0, q.limit ?? 100);
+  let kvTraces: SignalTrace[] = [];
+  try {
+    const index = await env.SIGNALS_CACHE.get(KV_INDEX_KEY, "json") as KvIndexEntry[] | null;
+    if (!index || index.length === 0) {
+      return inMemory.slice(0, q.limit ?? 100);
+    }
+    // Pre-filter by index metadata (tool, source) before fetching the
+    // full payloads — saves KV reads on tool-specific queries.
+    const candidates = index.filter((e) => {
+      if (q.tool && e.tool !== q.tool) return false;
+      if (q.source_prefix && !e.source.startsWith(q.source_prefix)) return false;
+      return true;
+    });
+    // Fetch in parallel. Cap at 100 to keep KV-read fanout bounded.
+    const fetchN = Math.min(100, candidates.length);
+    const fetched = await Promise.all(
+      candidates.slice(0, fetchN).map((e) =>
+        env.SIGNALS_CACHE.get(KV_KEY_PREFIX + e.id, "json") as Promise<SignalTrace | null>
+      )
+    );
+    kvTraces = fetched.filter((t): t is SignalTrace => t !== null);
+  } catch {
+    // Fall back to in-memory only.
+  }
+  // Merge by trace_id, in-memory wins on conflict.
+  const seen = new Set(inMemory.map((t) => t.trace_id));
+  const merged = [...inMemory];
+  for (const t of kvTraces) {
+    if (!seen.has(t.trace_id)) {
+      merged.push(t);
+      seen.add(t.trace_id);
+    }
+  }
+  // Apply the post-fetch filter that index couldn't pre-filter
+  // (correlation_id, agent_id, since_ms — fields not in index).
+  const sinceMs = q.since_ms ?? 0;
+  const filtered = merged.filter((t) => {
+    if (q.tool && t.tool_name !== q.tool) return false;
+    if (q.source_prefix && !t.source.startsWith(q.source_prefix)) return false;
+    if (q.correlation_id && t.correlation_id !== q.correlation_id) return false;
+    if (q.agent_id && t.caller_agent !== q.agent_id) return false;
+    if (sinceMs > 0 && new Date(t.ts).getTime() < sinceMs) return false;
+    return true;
+  });
+  // Sort newest first.
+  filtered.sort((a, b) => new Date(b.ts).getTime() - new Date(a.ts).getTime());
+  return filtered.slice(0, Math.max(1, Math.min(500, q.limit ?? 100)));
+}
+
+/** KV-backed single-trace read. Falls back to in-memory if not in KV. */
+export async function getSignalTraceByIdPersisted(env: Env, traceId: string): Promise<SignalTrace | null> {
+  const inMem = getSignalTraceById(traceId);
+  if (inMem) return inMem;
+  if (!env || !env.SIGNALS_CACHE) return null;
+  try {
+    return (await env.SIGNALS_CACHE.get(KV_KEY_PREFIX + traceId, "json")) as SignalTrace | null;
+  } catch {
+    return null;
+  }
+}
+
+/** KV-backed snapshot. Reads index size + per-tool counts. */
+export async function snapshotSignalTracesPersisted(env: Env): Promise<{
+  total_buffered: number;
+  total_persisted: number;
+  earliest_ts: string | null;
+  latest_ts: string | null;
+  by_tool: Record<string, number>;
+  by_source: Record<string, number>;
+  schema_valid_pct: number;
+}> {
+  const inMem = snapshotSignalTraces();
+  if (!env || !env.SIGNALS_CACHE) {
+    return { ...inMem, total_persisted: 0 };
+  }
+  try {
+    const index = await env.SIGNALS_CACHE.get(KV_INDEX_KEY, "json") as KvIndexEntry[] | null;
+    if (!index) return { ...inMem, total_persisted: 0 };
+    const byTool: Record<string, number> = { ...inMem.by_tool };
+    const bySource: Record<string, number> = { ...inMem.by_source };
+    for (const e of index) {
+      byTool[e.tool] = (byTool[e.tool] || 0) + 0; // index just informs presence
+    }
+    return {
+      ...inMem,
+      total_persisted: index.length,
+      by_tool: byTool,
+      by_source: bySource,
+    };
+  } catch {
+    return { ...inMem, total_persisted: 0 };
+  }
 }
 
 export function snapshotSignalTraces(): {

--- a/src/federation/genericMcpClient.ts
+++ b/src/federation/genericMcpClient.ts
@@ -21,7 +21,8 @@
 // frequently; this is best-effort, we renew on every cold start.
 
 import { AGENT_REGISTRY } from "../domain/agentRegistry";
-import { safeRecordSignalTrace } from "../domain/signalTrace";
+import { safeRecordSignalTrace, persistSignalTrace } from "../domain/signalTrace";
+import type { Env } from "../types/env";
 
 const SESSION_TTL_MS = 9 * 60 * 1000;
 /** Sentinel used for agents that negotiate stateless MCP (no mcp-session-id header
@@ -302,7 +303,7 @@ type SelfToolHook = (url: string, name: string, args: Record<string, unknown>) =
 let SELF_TOOL_HOOK: SelfToolHook | null = null;
 export function installSelfToolHook(hook: SelfToolHook | null): void { SELF_TOOL_HOOK = hook; }
 
-export async function callAgentTool(url: string, name: string, args: Record<string, unknown>, opts?: { timeoutMs?: number }): Promise<ToolCallResult> {
+export async function callAgentTool(url: string, name: string, args: Record<string, unknown>, opts?: { timeoutMs?: number; env?: Env }): Promise<ToolCallResult> {
   const timeoutMs = opts?.timeoutMs ?? 20_000;
   const start = Date.now();
   // Sec-48b: if this is a call against our own URL, use the in-process hook
@@ -342,11 +343,15 @@ export async function callAgentTool(url: string, name: string, args: Record<stri
       // "federation:dstillery" instead of "federation:https://...".
       const match = AGENT_REGISTRY.find((a) => a.mcp_url && url.startsWith(a.mcp_url.replace(/\/$/, "")));
       const agentId = match?.id ?? null;
-      safeRecordSignalTrace({
+      const trace = safeRecordSignalTrace({
         tool_name: name as "get_signals" | "activate_signal",
         direction: "outbound",
         source: agentId ? "federation:" + agentId : "federation:" + url,
         caller_agent: agentId,
+        // The actual URL we POSTed to. This is the most useful piece
+        // of info for the trace viewer — the audience asks "where
+        // does Dstillery live?" on every call. Surface the answer.
+        endpoint_url: url,
         request_payload: args,
         response_payload: result.ok
           ? (result.structured_content ?? result.content ?? null)
@@ -355,6 +360,14 @@ export async function callAgentTool(url: string, name: string, args: Record<stri
         ...(result.error ? { response_error_message: result.error } : {}),
         duration_ms: result.latency_ms ?? (Date.now() - start),
       });
+      // Persist outbound traces too if the caller threaded an env
+      // (the orchestrator, brand canvas, race canvas pages do — they
+      // pass opts.env through to the federation client). Without env,
+      // outbound traces stay in-memory only (fine — they'll appear
+      // in the modal during the same isolate's lifetime).
+      if (opts && opts.env && trace) {
+        await persistSignalTrace(opts.env, trace);
+      }
     } catch { /* tracing must never break the call path */ }
   }
   return result;

--- a/src/index.ts
+++ b/src/index.ts
@@ -166,6 +166,7 @@ import {
 import {
     handleSignalTracesList,
     handleSignalTracesSnapshot,
+    handleSignalTracesClear,
     handleSignalTraceById,
 } from "./routes/signalTraceRoutes";
 import {
@@ -464,14 +465,20 @@ export default {
                 response = await handleEcosystemProbe();
 
             } else if (method === "GET" && path === "/api/signal-traces") {
-                response = handleSignalTracesList(request);
+                response = await handleSignalTracesList(request, env);
+
+            } else if (method === "DELETE" && path === "/api/signal-traces") {
+                // Demo "reset" — wipes in-memory + KV index. Public to
+                // match the rest of the demo's posture; not destructive
+                // beyond the demo's own buffer.
+                response = await handleSignalTracesClear(env);
 
             } else if (method === "GET" && path === "/api/signal-traces/snapshot") {
-                response = handleSignalTracesSnapshot();
+                response = await handleSignalTracesSnapshot(env);
 
             } else if (method === "GET" && path.startsWith("/api/signal-traces/")) {
                 const traceId = path.slice("/api/signal-traces/".length);
-                response = handleSignalTraceById(traceId);
+                response = await handleSignalTraceById(traceId, env);
 
             } else if (method === "GET" && path === "/health") {
                 response = jsonResponse({

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -28,7 +28,7 @@ import { getAllSignalsForCatalog } from "../domain/signalService";
 import { handleNLQuery } from "../domain/nlQueryHandler";
 import { handleConceptToolCall } from "../domain/conceptHandler";
 import { compactObj } from "../utils/objects";
-import { safeRecordSignalTrace } from "../domain/signalTrace";
+import { safeRecordSignalTrace, persistSignalTrace } from "../domain/signalTrace";
 import { record as recordToolLog, argKeysOf } from "./toolLog";
 import { logCall as d1LogCall, cleanup as d1Cleanup, shouldRunCleanup } from "../storage/toolLogRepo";
 
@@ -637,7 +637,8 @@ async function callGetSignals(
     const response = withMcpEnvelope({ status: "completed" }, cleanResponse);
 
     // Record the get_signals trace for observability across the demo.
-    safeRecordSignalTrace({
+    // Persist to KV so it survives isolate cycles.
+    const _trace_get = safeRecordSignalTrace({
         tool_name: "get_signals",
         direction: "inbound",
         source: "mcp_external",
@@ -646,6 +647,7 @@ async function callGetSignals(
         response_status: "ok",
         duration_ms: Date.now() - _t0_get_signals,
     });
+    await persistSignalTrace(env, _trace_get);
 
     return toolResult(JSON.stringify(response, null, 2), response);
 }
@@ -815,7 +817,7 @@ async function callActivateSignal(
             payload
         );
 
-        safeRecordSignalTrace({
+        const _trace_act_ok = safeRecordSignalTrace({
             tool_name: "activate_signal",
             direction: "inbound",
             source: "mcp_external",
@@ -824,6 +826,7 @@ async function callActivateSignal(
             response_status: "ok",
             duration_ms: Date.now() - _t0_activate,
         });
+        await persistSignalTrace(env, _trace_act_ok);
 
         return toolResult(JSON.stringify(specResponse, null, 2), specResponse);
     } catch (err) {
@@ -981,7 +984,7 @@ async function callActivateSignal(
                 syntheticPayload
             );
             logger.warn("activate_unknown_signal_synthetic", { signalId });
-            safeRecordSignalTrace({
+            const _trace_act_synth = safeRecordSignalTrace({
                 tool_name: "activate_signal",
                 direction: "inbound",
                 source: "mcp_external",
@@ -990,11 +993,12 @@ async function callActivateSignal(
                 response_status: "ok",
                 duration_ms: Date.now() - _t0_activate,
             });
+            await persistSignalTrace(env, _trace_act_synth);
             return toolResult(JSON.stringify(syntheticResponse, null, 2), syntheticResponse);
         }
         // Record the failure trace too — observability matters when
         // activation throws as much as when it succeeds.
-        safeRecordSignalTrace({
+        const _trace_act_err = safeRecordSignalTrace({
             tool_name: "activate_signal",
             direction: "inbound",
             source: "mcp_external",
@@ -1004,6 +1008,7 @@ async function callActivateSignal(
             response_error_message: String((err as Error).message ?? err),
             duration_ms: Date.now() - _t0_activate,
         });
+        await persistSignalTrace(env, _trace_act_err);
         throw err;
     }
 }

--- a/src/routes/activateSignal.ts
+++ b/src/routes/activateSignal.ts
@@ -7,7 +7,7 @@ import { validateActivateRequest } from "../utils/validation";
 import { jsonResponse, errorResponse, parseJsonBody } from "./shared";
 import { getDb } from "../storage/db";
 import type { Logger } from "../utils/logger";
-import { safeRecordSignalTrace } from "../domain/signalTrace";
+import { safeRecordSignalTrace, persistSignalTrace } from "../domain/signalTrace";
 
 export async function handleActivateSignal(
   request: Request,
@@ -29,28 +29,32 @@ export async function handleActivateSignal(
   try {
     const db = getDb(env);
     const result = await activateSignalService(db, env.SIGNALS_CACHE, body, logger);
-    safeRecordSignalTrace({
+    const _traceOk = safeRecordSignalTrace({
       tool_name: "activate_signal",
       direction: "inbound",
       source: "rest_demo",
+      endpoint_url: request.url,
       request_payload: body,
       response_payload: result,
       response_status: "ok",
       duration_ms: Date.now() - _t0,
     });
+    await persistSignalTrace(env, _traceOk);
     return jsonResponse(result, 202);
   } catch (err) {
     const errMsg = (err as Error).message ?? String(err);
-    safeRecordSignalTrace({
+    const _traceErr = safeRecordSignalTrace({
       tool_name: "activate_signal",
       direction: "inbound",
       source: "rest_demo",
+      endpoint_url: request.url,
       request_payload: body,
       response_payload: { error: errMsg },
       response_status: "error",
       response_error_message: errMsg,
       duration_ms: Date.now() - _t0,
     });
+    await persistSignalTrace(env, _traceErr);
     if (err instanceof NotFoundError) {
       return errorResponse("NOT_FOUND", err.message, 404);
     }

--- a/src/routes/searchSignals.ts
+++ b/src/routes/searchSignals.ts
@@ -8,7 +8,7 @@ import { jsonResponse, errorResponse, readJsonBody } from "./shared";
 import { compactObj } from "../utils/objects";
 import { getDb } from "../storage/db";
 import type { Logger } from "../utils/logger";
-import { safeRecordSignalTrace } from "../domain/signalTrace";
+import { safeRecordSignalTrace, persistSignalTrace } from "../domain/signalTrace";
 
 export async function handleSearchSignals(
   request: Request,
@@ -72,33 +72,38 @@ export async function handleSearchSignals(
     });
 
     // Record the REST trace alongside the MCP one. Keeps signal traces
-    // unified across both transport bindings.
-    // safeRecordSignalTrace contains its own try/catch + isolate kill
-    // switch — caller doesn't need to wrap. It returns null on any
-    // failure so we discard the result.
-    safeRecordSignalTrace({
+    // unified across both transport bindings. safeRecordSignalTrace
+    // contains its own try/catch + isolate kill switch. Persist the
+    // resulting trace to KV so it survives isolate cycles — the
+    // in-memory ring buffer dies with the isolate, which broke the
+    // workshop demo when users reopened the trace modal.
+    const _trace = safeRecordSignalTrace({
       tool_name: "get_signals",
       direction: "inbound",
       source: "rest_demo",
+      endpoint_url: request.url,
       request_payload: req,
       response_payload: result,
       response_status: "ok",
       duration_ms: Date.now() - _t0,
     });
+    await persistSignalTrace(env, _trace);
 
     return jsonResponse(result);
   } catch (err) {
     logger.error("search_signals_error", { error: String(err) });
-    safeRecordSignalTrace({
+    const _trace = safeRecordSignalTrace({
       tool_name: "get_signals",
       direction: "inbound",
       source: "rest_demo",
+      endpoint_url: request.url,
       request_payload: req,
       response_payload: { error: String(err) },
       response_status: "error",
       response_error_message: String(err),
       duration_ms: Date.now() - _t0,
     });
+    await persistSignalTrace(env, _trace);
     return errorResponse("INTERNAL_ERROR", "Signal search failed", 500);
   }
 }

--- a/src/routes/signalTraceRoutes.ts
+++ b/src/routes/signalTraceRoutes.ts
@@ -3,25 +3,28 @@
 // Retrieval API for the centralized signals-protocol trace store.
 // Read-only, public (matches the demo's posture).
 //
-//   GET /api/signal-traces                             — last 100 traces
-//   GET /api/signal-traces?tool=activate_signal        — filter by tool
-//   GET /api/signal-traces?correlation_id=…            — all frames in a ceremony
-//   GET /api/signal-traces?source_prefix=federation:   — outbound only
-//   GET /api/signal-traces?agent_id=dstillery          — outbound to one agent
-//   GET /api/signal-traces?since_ms=…&limit=N
-//   GET /api/signal-traces/snapshot                    — buffer summary stats
-//   GET /api/signal-traces/:trace_id                   — single trace by id
+//   GET    /api/signal-traces                             — last 100 traces (in-memory + KV merged)
+//   GET    /api/signal-traces?tool=activate_signal        — filter by tool
+//   GET    /api/signal-traces?correlation_id=…            — all frames in a ceremony
+//   GET    /api/signal-traces?source_prefix=federation:   — outbound only
+//   GET    /api/signal-traces?agent_id=dstillery          — outbound to one agent
+//   GET    /api/signal-traces?since_ms=…&limit=N
+//   GET    /api/signal-traces/snapshot                    — buffer summary stats
+//   GET    /api/signal-traces/:trace_id                   — single trace by id
+//   DELETE /api/signal-traces                             — wipe in-memory + KV (demo "reset")
 //
 // Demo surfaces (Recent Activations, Orchestrator, Race Canvas, Brand
 // Canvas, Federation) hit these endpoints to render their trace
 // inspectors via the shared viewer component.
 
 import {
-  getSignalTraces,
-  getSignalTraceById,
-  snapshotSignalTraces,
+  getSignalTraceByIdPersisted,
+  listSignalTracesPersisted,
+  snapshotSignalTracesPersisted,
+  clearSignalTraces,
   type SignalToolName,
 } from "../domain/signalTrace";
+import type { Env } from "../types/env";
 
 function jsonOk(payload: unknown): Response {
   return new Response(JSON.stringify(payload, null, 2), {
@@ -41,7 +44,7 @@ function jsonNotFound(message: string): Response {
   });
 }
 
-export function handleSignalTracesList(request: Request): Response {
+export async function handleSignalTracesList(request: Request, env: Env): Promise<Response> {
   const url = new URL(request.url);
   const sp = url.searchParams;
   const toolParam = sp.get("tool");
@@ -52,7 +55,11 @@ export function handleSignalTracesList(request: Request): Response {
   const sinceMs = parseInt(sp.get("since_ms") ?? "0", 10) || 0;
   const limit = Math.min(500, Math.max(1, parseInt(sp.get("limit") ?? "100", 10) || 100));
 
-  const traces = getSignalTraces({
+  // Read merges in-memory + KV. In-memory wins on conflict (freshest).
+  // KV provides cross-isolate continuity — without it the modal is
+  // empty when the user reopens it on a fresh isolate (the actual bug
+  // the workshop demo hit).
+  const traces = await listSignalTracesPersisted(env, {
     ...(tool ? { tool } : {}),
     ...(sourcePrefix ? { source_prefix: sourcePrefix } : {}),
     ...(correlationId ? { correlation_id: correlationId } : {}),
@@ -63,12 +70,35 @@ export function handleSignalTracesList(request: Request): Response {
   return jsonOk({ traces, count: traces.length });
 }
 
-export function handleSignalTracesSnapshot(): Response {
-  return jsonOk(snapshotSignalTraces());
+export async function handleSignalTracesSnapshot(env: Env): Promise<Response> {
+  return jsonOk(await snapshotSignalTracesPersisted(env));
 }
 
-export function handleSignalTraceById(traceId: string): Response {
-  const trace = getSignalTraceById(traceId);
+export async function handleSignalTraceById(traceId: string, env: Env): Promise<Response> {
+  const trace = await getSignalTraceByIdPersisted(env, traceId);
   if (!trace) return jsonNotFound(`trace not found: ${traceId}`);
   return jsonOk(trace);
+}
+
+/**
+ * Demo-only "reset" endpoint. Wipes the in-memory ring buffer for
+ * THIS isolate AND best-effort clears the KV index so subsequent
+ * reads start clean. Per-trace KV entries TTL out at 6h regardless
+ * — the index clear just hides them from the listing.
+ *
+ * Public on purpose (matches the rest of the demo's posture). Not
+ * destructive across isolates because in-memory clear only hits
+ * this one — but the KV index clear gives a "fresh start" effect
+ * to any reader.
+ */
+export async function handleSignalTracesClear(env: Env): Promise<Response> {
+  clearSignalTraces();
+  let kvCleared = false;
+  try {
+    if (env && env.SIGNALS_CACHE) {
+      await env.SIGNALS_CACHE.delete("sigtrace:index");
+      kvCleared = true;
+    }
+  } catch { /* best-effort */ }
+  return jsonOk({ ok: true, in_memory_cleared: true, kv_index_cleared: kvCleared });
 }

--- a/tests/__snapshots__/demo-render-snapshot.test.ts.snap
+++ b/tests/__snapshots__/demo-render-snapshot.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`handleDemo byte-equivalence > matches the committed golden hash (LF-normalized SHA-256 of body) 1`] = `
 {
-  "hash": "a206140a1fb5dfcc357658fde854e019da3908f1b6ec2329e8afbde1536d4873",
-  "length": 1132294,
+  "hash": "517b1894b9e44f6e054a2ddf090bb90691da45deddc74b3916182e33b5ad0ce0",
+  "length": 1139077,
 }
 `;


### PR DESCRIPTION
## Summary

Five problems from the workshop demo run, all addressed in one batch.

| # | Issue | Fix |
|---|---|---|
| 1 | Trace doesn't show WHERE the request actually went | New `endpoint_url` field — outbound captures peer URL, inbound REST captures worker URL. Rendered as a clickable link with full URL on hover. |
| a | Schema validation showed "skipped" on every trace | Swapped AJV (uses `new Function()` — blocked by Workers) for `@cfworker/json-schema` (Workers-native interpreter). Real ✓/✗ badges now. |
| b | Trace trigger doesn't refresh on new Canvas search | Brand Canvas + Discover now call `_resetTrace()` + `closeSignalTraceModal()` before each run. |
| c | Activations JSON button shows same trace for every row | Added `data-trace-task-id` per row, threaded into modal as `task_id` filter (matches `trace.response.payload.task_id` or `ext.task_id`). |
| KV | Traces disappear when isolate cycles | New `persistSignalTrace(env, trace)` writes to KV with 6h TTL + index. Read-side merges in-memory + KV. |
| Reset | (User asked) | New `⟲ reset` button on the modal + `DELETE /api/signal-traces` endpoint. |

## Workshop reliability

After this lands, the workshop demo can:
- Run a brief on Brand Canvas → see traces
- Wait 5 minutes (isolate cycles) → reopen modal → traces still there (from KV)
- Click any Activations row → see THAT activation's exact trace
- Click any trace's endpoint URL → opens the actual peer URL in a new tab
- Hit Reset between demo segments → clean slate

## Verification

- `npx tsc --noEmit`: no new errors in any touched file
- `npx vitest run -u`: 441 passing / 12 skipped (snapshot updated for the changed inline JS)
- `npx wrangler deploy --dry-run`: bundle 2.64 MB / 635 KB gzipped (smaller — dropped AJV)

## Test plan

- [ ] Merge + deploy
- [ ] Brand Canvas: run a brief → verify trace trigger appears → reopen modal after 5+ min → traces still present
- [ ] Activations: click 3 different rows' JSON buttons → each shows a different trace with correct task_id
- [ ] Discover: type a brief, run search → verify validation badges show ✓ schema valid (or ✗ N errors), NOT "skipped"
- [ ] Federation traces: any trace with `endpoint_url` → click the link → opens peer's `/mcp` URL in new tab
- [ ] Reset button: confirm prompt → fire DELETE → modal shows "Trace buffer wiped" empty state
- [ ] Run multiple searches on Discover → verify trace trigger refreshes (doesn't stick to first run)

## Deferred to follow-up

- **(d) Per-page scope** via threaded `correlation_id` / `workflow_id`. Lighter mitigation in this PR: trace-trigger reset on new search + per-row task_id filter on activations. Full page-scoping needs `workflow_id` propagation through `agentsEndpoints` + federation client.
- **Brand Canvas Trace Inspector per-agent JSON drill-in** (the matches rows inside the workflow run modal — clicking each agent should drill into that agent's trace). Separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)