### PR TITLE
Validation error UX: promote schema URL + humanize messages + add legend (workshop polish)

### DIFF
--- a/src/demo/script/fragments/signals-trace-viewer.ts
+++ b/src/demo/script/fragments/signals-trace-viewer.ts
@@ -133,12 +133,96 @@ function renderValidationBadge(validation) {
   return '<span class="trace-vbadge bad" title="Payload does not validate — see errors below">✗ ' + n + ' schema error' + (n === 1 ? "" : "s") + '</span>';
 }
 
+// Promoted schema URL banner — shown above the errors block (not a
+// tiny ↗ icon hidden in the section head). Surfacing the canonical
+// schema URL prominently is the answer to the workshop question
+// "what schema are we comparing against?". Click-through opens the
+// raw schema in a new tab so the audience can see the contract.
+function renderSchemaBanner(validation) {
+  if (!validation || !validation.schema_url) return "";
+  // Compact display — show the trailing path segments (e.g.
+  // "v3/signals/get-signals-response.json"). Full URL is in the
+  // href + title attribute for click-through and hover.
+  let visible = validation.schema_url;
+  try {
+    const u = new URL(validation.schema_url);
+    visible = u.host + u.pathname;
+  } catch (_) { /* not a parseable URL — keep raw */ }
+  if (visible.length > 64) visible = "…" + visible.slice(-62);
+  return '<div class="trace-schema-banner">' +
+    '<span class="trace-schema-banner-label">validating against</span>' +
+    '<a class="trace-schema-banner-link" href="' + escapeHtml(validation.schema_url) +
+    '" target="_blank" rel="noopener" title="' + escapeHtml(validation.schema_url) + '">' +
+    escapeHtml(visible) + ' ↗</a>' +
+  '</div>';
+}
+
+// Friendly translations for the dense JSON-Schema vocabulary that
+// surfaces in validator errors. The audience shouldn't need to learn
+// JSON-Pointer + JSON-Schema keywords on the spot to read a trace.
+function _humanizeErrorMessage(msg) {
+  if (!msg) return "(no detail)";
+  // "Instance does not have required property "X"" -> "missing required \"X\""
+  const reqMatch = msg.match(/^Instance does not have required property "([^"]+)"\.?$/);
+  if (reqMatch) return 'missing required "' + reqMatch[1] + '"';
+  // "Property "X" does not match schema." -> "\"X\" doesn't match expected shape"
+  const propMatch = msg.match(/^Property "([^"]+)" does not match schema\.?$/);
+  if (propMatch) return '"' + propMatch[1] + '" doesn\\'t match expected shape';
+  // "Items did not match schema." -> "array items don't match expected shape"
+  if (/^Items did not match schema\.?$/.test(msg)) return "array items don\\'t match expected shape";
+  // "Instance does not match exactly one subschema (0 matches)." -> "doesn't match any of the expected variants"
+  if (/^Instance does not match exactly one subschema/.test(msg)) return "doesn\\'t match any of the expected variants (oneOf)";
+  // "A subschema had errors." -> swallow — it's just bookkeeping
+  if (/^A subschema had errors\.?$/.test(msg)) return "(see nested errors below)";
+  return msg;
+}
+
+function _humanizeKeyword(k) {
+  switch (k) {
+    case "required":   return "missing required field";
+    case "oneOf":      return "no schema variant matched";
+    case "properties": return "wrong shape for a property";
+    case "items":      return "wrong shape for an array item";
+    case "$ref":       return "referenced subschema failed";
+    case "type":       return "wrong type";
+    case "enum":       return "value not in enum";
+    case "pattern":    return "string didn\\'t match pattern";
+    case "additionalProperties": return "unknown property";
+    default:           return k || "unknown";
+  }
+}
+
 function renderValidationErrors(validation) {
   if (!validation || !validation.errors || validation.errors.length === 0) return "";
-  return '<div class="trace-verrors">' +
-    validation.errors.map(function (e) {
-      return '<div class="trace-verr"><code>' + escapeHtml(e.path || "(root)") + '</code> · ' + escapeHtml(e.message) + ' <span class="trace-verr-kw">[' + escapeHtml(e.keyword) + ']</span></div>';
-    }).join("") + '</div>';
+  // Per-error rows now show a humanized message + the keyword as a
+  // tooltip-explained chip. Keep the raw path as <code> so workshop
+  // attendees can map it to the JSON pretty-print below.
+  const rows = validation.errors.map(function (e) {
+    const human = _humanizeErrorMessage(e.message);
+    const kwHuman = _humanizeKeyword(e.keyword);
+    return '<div class="trace-verr">' +
+      '<code class="trace-verr-path">' + escapeHtml(e.path || "(root)") + '</code>' +
+      '<span class="trace-verr-msg">' + escapeHtml(human) + '</span>' +
+      '<span class="trace-verr-kw" title="' + escapeHtml(kwHuman) + '">[' + escapeHtml(e.keyword) + ']</span>' +
+      '</div>';
+  }).join("");
+  // Collapsed legend explains the JSON-Pointer + keyword vocabulary in
+  // one click. Defaults to closed so the trace stays scannable; first-
+  // time viewers click to expand. Workshop demo: open it once at the
+  // top of Block 2 so the audience knows what they're reading.
+  const legend = '<details class="trace-verr-legend">' +
+    '<summary>How to read these errors</summary>' +
+    '<div class="trace-verr-legend-body">' +
+      '<div><strong>Path</strong> (e.g. <code>#/signals/0</code>): JSON-Pointer into the payload below. ' +
+        '<code>#</code> is the root, <code>#/signals</code> is the <code>signals</code> array, ' +
+        '<code>#/signals/0</code> is its first item.</div>' +
+      '<div><strong>Keyword</strong> (e.g. <code>[required]</code>, <code>[oneOf]</code>): which JSON-Schema rule the validator applied. ' +
+        'Hover the keyword chip for a plain-English meaning.</div>' +
+      '<div><strong>Schema link</strong> above the errors: opens the canonical AdCP schema we validated against. ' +
+        'Click through to see exactly what shape was expected.</div>' +
+    '</div>' +
+  '</details>';
+  return '<div class="trace-verrors">' + legend + rows + '</div>';
 }
 
 function renderSingleTrace(trace, idx) {
@@ -180,9 +264,9 @@ function renderSingleTrace(trace, idx) {
       '<div class="signal-trace-section-head">' +
         '<span class="signal-trace-section-label">REQUEST</span>' +
         renderValidationBadge(trace.request.validation) +
-        '<a class="signal-trace-schemalink" href="' + escapeHtml(trace.request.validation.schema_url) + '" target="_blank" rel="noopener">schema ↗</a>' +
         '<button class="signal-trace-copy" data-copy-target="req-' + idx + '">copy</button>' +
       '</div>' +
+      renderSchemaBanner(trace.request.validation) +
       renderValidationErrors(trace.request.validation) +
       '<pre class="signal-trace-json" id="req-' + idx + '">' + renderJsonWithGlossary(trace.request.payload) + '</pre>' +
     '</div>' +
@@ -190,9 +274,9 @@ function renderSingleTrace(trace, idx) {
       '<div class="signal-trace-section-head">' +
         '<span class="signal-trace-section-label">RESPONSE</span>' +
         renderValidationBadge(trace.response.validation) +
-        '<a class="signal-trace-schemalink" href="' + escapeHtml(trace.response.validation.schema_url) + '" target="_blank" rel="noopener">schema ↗</a>' +
         '<button class="signal-trace-copy" data-copy-target="res-' + idx + '">copy</button>' +
       '</div>' +
+      renderSchemaBanner(trace.response.validation) +
       renderValidationErrors(trace.response.validation) +
       (trace.response.error_message ? '<div class="signal-trace-errmsg">' + escapeHtml(trace.response.error_message) + '</div>' : '') +
       '<pre class="signal-trace-json" id="res-' + idx + '">' + renderJsonWithGlossary(trace.response.payload) + '</pre>' +

--- a/src/demo/styles.ts
+++ b/src/demo/styles.ts
@@ -6763,9 +6763,69 @@ textarea.lab-input { resize: vertical; line-height: 1.5; }
   padding: 6px 10px; margin-bottom: 8px;
   font: 10.5px var(--font-mono); color: var(--text-dim);
 }
-.trace-verr { padding: 1px 0; }
-.trace-verr code { color: var(--accent); }
-.trace-verr-kw { color: var(--text-faint); }
+.trace-verr {
+  display: flex; align-items: baseline; gap: 8px;
+  padding: 2px 0; line-height: 1.55;
+}
+.trace-verr-path {
+  flex-shrink: 0;
+  background: rgba(255, 123, 123, 0.14);
+  color: #ffd7c8;
+  padding: 0 5px; border-radius: 2px;
+}
+.trace-verr-msg { color: #ffbfa3; }
+.trace-verr-kw {
+  margin-left: auto;
+  color: var(--text-faint);
+  cursor: help;
+  white-space: nowrap;
+}
+/* Schema-URL banner — promotes the "what we validated against" answer
+   from a tiny ↗ link to a proper labeled banner. Sits between the
+   validation badge and the errors block. */
+.trace-schema-banner {
+  display: flex; align-items: baseline; gap: 8px;
+  padding: 4px 10px; margin-bottom: 6px;
+  font: 10.5px var(--font-mono);
+  background: rgba(56, 182, 255, 0.05);
+  border-left: 2px solid rgba(56, 182, 255, 0.40);
+  border-radius: 0 3px 3px 0;
+  color: var(--text-mut);
+}
+.trace-schema-banner-label {
+  font-size: 9.5px; letter-spacing: 0.08em;
+  text-transform: uppercase; color: var(--text-faint);
+}
+.trace-schema-banner-link {
+  color: var(--accent); text-decoration: none;
+  word-break: break-all;
+}
+.trace-schema-banner-link:hover { text-decoration: underline; }
+/* "How to read these errors" expandable legend */
+.trace-verr-legend {
+  margin-bottom: 6px; padding-bottom: 4px;
+  border-bottom: 1px dashed rgba(255, 100, 100, 0.20);
+  font: 10.5px var(--font-mono); color: var(--text-mut);
+}
+.trace-verr-legend > summary {
+  cursor: pointer;
+  color: var(--text-dim);
+  padding: 2px 0;
+  user-select: none;
+}
+.trace-verr-legend > summary:hover { color: var(--accent); }
+.trace-verr-legend-body {
+  padding: 6px 0 4px 16px;
+  display: flex; flex-direction: column; gap: 4px;
+  line-height: 1.55;
+}
+.trace-verr-legend-body code {
+  background: rgba(56, 182, 255, 0.10);
+  color: var(--accent);
+  padding: 0 4px; border-radius: 2px;
+  font-size: 10.5px;
+}
+.trace-verr-legend-body strong { color: var(--text); }
 .signal-trace-errmsg {
   background: rgba(255, 100, 100, 0.10); color: #ff9090;
   padding: 8px 12px; border-radius: 3px; margin-bottom: 8px;

--- a/src/routes/raceCanvas.ts
+++ b/src/routes/raceCanvas.ts
@@ -1572,23 +1572,77 @@ function renderRaceCanvas(demoKey: string): string {
   function escapeHtml(s) { return String(s == null ? "" : s).replace(/[&<>\\"']/g, function (c) { return ({"&":"&amp;","<":"&lt;",">":"&gt;","\\"":"&quot;","'":"&#39;"})[c]; }); }
 
   // ── Signal traces overlay ────────────────────────────────────────────
+  // Friendly translations matching the main signals-trace-viewer so
+  // Race Canvas + the rest of the demo speak the same vocabulary.
+  function _raceHumanizeErr(msg) {
+    if (!msg) return "(no detail)";
+    var m1 = msg.match(/^Instance does not have required property "([^"]+)"\\.?$/);
+    if (m1) return 'missing required "' + m1[1] + '"';
+    var m2 = msg.match(/^Property "([^"]+)" does not match schema\\.?$/);
+    if (m2) return '"' + m2[1] + '" doesn\\'t match expected shape';
+    if (/^Items did not match schema\\.?$/.test(msg)) return "array items don\\'t match expected shape";
+    if (/^Instance does not match exactly one subschema/.test(msg)) return "doesn\\'t match any of the expected variants (oneOf)";
+    if (/^A subschema had errors\\.?$/.test(msg)) return "(see nested errors below)";
+    return msg;
+  }
+  function _raceRenderErrorList(validation) {
+    if (!validation || !validation.errors || validation.errors.length === 0) return "";
+    var rows = validation.errors.map(function (e) {
+      var human = _raceHumanizeErr(e.message);
+      return '<div style="font-size:10.5px;line-height:1.55;padding:2px 0;color:#ffbfa3">' +
+        '<code style="background:rgba(255,123,123,0.14);color:#ffd7c8;padding:0 4px;border-radius:2px">' + escapeHtml(e.path || "(root)") + '</code> ' +
+        escapeHtml(human) +
+        ' <span style="color:#ff9b6b;opacity:0.7">[' + escapeHtml(e.keyword) + ']</span>' +
+      '</div>';
+    }).join("");
+    var legend = '<details style="margin:6px 0;font-size:10.5px;color:#9aa6b3">' +
+      '<summary style="cursor:pointer">How to read these errors</summary>' +
+      '<div style="padding:6px 0 6px 12px;line-height:1.55">' +
+        '<div><strong>Path</strong> (e.g. <code>#/signals/0</code>): JSON-Pointer into the payload below. <code>#</code> is the root.</div>' +
+        '<div><strong>Keyword</strong> (e.g. <code>[required]</code>, <code>[oneOf]</code>): which JSON-Schema rule the validator applied.</div>' +
+        '<div><strong>Schema link</strong> above: opens the canonical AdCP schema we validated against.</div>' +
+      '</div>' +
+    '</details>';
+    return legend + rows;
+  }
   function _raceRenderSignalTrace(t, idx) {
     var dirIcon = t.direction === "outbound" ? "→" : "←";
     var sourceShort = t.source.length > 36 ? t.source.slice(0, 33) + "…" : t.source;
     var statusColor = t.response.status === "ok" ? "#5fd9c4" : "#ff7b7b";
     var reqValid = t.request.validation && t.request.validation.valid;
     var resValid = t.response.validation && t.response.validation.valid;
-    function badge(ok) { return ok ? '<span style="color:#5fd9c4">✓ schema</span>' : '<span style="color:#ff9b6b">✗ schema</span>'; }
+    var reqErrCount = (t.request.validation && t.request.validation.errors || []).length;
+    var resErrCount = (t.response.validation && t.response.validation.errors || []).length;
+    function badge(ok, errCount) {
+      if (ok) return '<span style="color:#5fd9c4">✓ schema</span>';
+      return '<span style="color:#ff9b6b">✗ ' + errCount + ' err</span>';
+    }
+    // Endpoint URL (outbound only) — clickable, matches the main viewer.
+    var endpointBlock = "";
+    if (t.endpoint_url) {
+      var visible = t.endpoint_url;
+      try {
+        var u = new URL(t.endpoint_url);
+        visible = u.host + u.pathname;
+        if (visible.length > 48) visible = visible.slice(0, 45) + "…";
+      } catch (_) { if (visible.length > 48) visible = visible.slice(0, 45) + "…"; }
+      endpointBlock = ' · <a href="' + escapeHtml(t.endpoint_url) + '" target="_blank" rel="noopener" title="' + escapeHtml(t.endpoint_url) + '" style="color:#38b6ff;font-size:10.5px;text-decoration:none">⎘ ' + escapeHtml(visible) + '</a>';
+    }
     return '<details style="margin-bottom:10px;padding:8px 12px;background:rgba(255,255,255,0.04);border-radius:4px">' +
       '<summary style="cursor:pointer;font-size:12px;line-height:1.7">' +
         '<strong>' + escapeHtml(t.tool_name) + '</strong> · ' + dirIcon + ' ' + escapeHtml(sourceShort) +
+        endpointBlock +
         ' · <span style="color:' + statusColor + '">' + escapeHtml(t.response.status) + '</span>' +
         ' · ' + t.duration_ms + 'ms · ' + new Date(t.ts).toLocaleTimeString() +
-        ' · ' + badge(reqValid) + ' req · ' + badge(resValid) + ' res' +
+        ' · ' + badge(reqValid, reqErrCount) + ' req · ' + badge(resValid, resErrCount) + ' res' +
       '</summary>' +
-      '<div style="margin-top:8px"><strong style="font-size:10px;letter-spacing:0.1em">REQUEST</strong> · <a href="' + escapeHtml(t.request.validation.schema_url) + '" target="_blank" style="color:#38b6ff;font-size:10px">schema↗</a></div>' +
+      '<div style="margin-top:8px"><strong style="font-size:10px;letter-spacing:0.1em">REQUEST</strong>' +
+        ' · validating against <a href="' + escapeHtml(t.request.validation.schema_url) + '" target="_blank" style="color:#38b6ff;font-size:10px">' + escapeHtml(t.request.validation.schema_url.split("/").slice(-2).join("/")) + ' ↗</a></div>' +
+      _raceRenderErrorList(t.request.validation) +
       '<pre style="background:rgba(0,0,0,0.4);padding:8px;border-radius:3px;max-height:240px;overflow:auto;font-size:10.5px;white-space:pre-wrap;word-break:break-all">' + escapeHtml(JSON.stringify(t.request.payload, null, 2)) + '</pre>' +
-      '<div><strong style="font-size:10px;letter-spacing:0.1em">RESPONSE</strong> · <a href="' + escapeHtml(t.response.validation.schema_url) + '" target="_blank" style="color:#38b6ff;font-size:10px">schema↗</a></div>' +
+      '<div><strong style="font-size:10px;letter-spacing:0.1em">RESPONSE</strong>' +
+        ' · validating against <a href="' + escapeHtml(t.response.validation.schema_url) + '" target="_blank" style="color:#38b6ff;font-size:10px">' + escapeHtml(t.response.validation.schema_url.split("/").slice(-2).join("/")) + ' ↗</a></div>' +
+      _raceRenderErrorList(t.response.validation) +
       '<pre style="background:rgba(0,0,0,0.4);padding:8px;border-radius:3px;max-height:240px;overflow:auto;font-size:10.5px;white-space:pre-wrap;word-break:break-all">' + escapeHtml(JSON.stringify(t.response.payload, null, 2)) + '</pre>' +
     '</details>';
   }

--- a/tests/__snapshots__/demo-render-snapshot.test.ts.snap
+++ b/tests/__snapshots__/demo-render-snapshot.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`handleDemo byte-equivalence > matches the committed golden hash (LF-normalized SHA-256 of body) 1`] = `
 {
-  "hash": "517b1894b9e44f6e054a2ddf090bb90691da45deddc74b3916182e33b5ad0ce0",
-  "length": 1139077,
+  "hash": "45d0b3c6417225dae655260cfa97e5ee71abb2ae2a370a5392025f7fb51940e0",
+  "length": 1145401,
 }
 `;


### PR DESCRIPTION
## Summary

The trace viewer's `✗ N schema errors` block was correct but dense — answers "what schema?" via a tiny `↗` icon and "what does the error mean?" via raw JSON-Schema vocabulary. In a workshop, that's 30 seconds of explanation before the demo lands.

Three surgical UX changes, same data, much easier to read at speed:

| Was | Now |
|---|---|
| Tiny `schema ↗` link tucked in section head | **Full banner**: `validating against ↗ adcontextprotocol.org/schemas/v3/signals/get-signals-response.json` |
| `Instance does not have required property "signal_id"` | `missing required "signal_id"` |
| No legend — viewer must know JSON-Pointer + JSON-Schema vocab | **Collapsed `▶ How to read these errors`** with 3-line legend |

## Applied across all 6 trace surfaces

- `src/demo/script/fragments/signals-trace-viewer.ts` — shared modal used by Activations, Discover, Brand Canvas, Multi-Agent Orchestrator, Federation
- `src/routes/raceCanvas.ts` — Race Canvas's separate embedded copy (was the most bare — gained error list + legend + endpoint URL block)

## Workshop value

This is the difference between "the validator caught 12 errors" and "the validator caught 12 errors against `/schemas/v3/signals/get-signals-response.json`, click the link to see exactly what was expected, here's what each error means in plain English." Same trace, faster comprehension, fewer questions.

## Verification

- ✅ `npx tsc --noEmit`: no new errors
- ✅ `npx vitest run -u`: 441 passing / 12 skipped (snapshot updated for changed inline JS + CSS)
- ✅ `npx wrangler deploy --dry-run`: 2.66 MB / 640 KB gzipped (+22 KB from new helpers/CSS)

## Test plan

- [ ] Merge + deploy
- [ ] Open Federation page → click `{ } Signal traces` → expand a trace
- [ ] Verify each section now shows `validating against ↗ <full schema path>`
- [ ] Verify error rows read in plain English ("missing required X" not "Instance does not have required property X")
- [ ] Click `▶ How to read these errors` — verify 3-line legend explains paths, keywords, and the schema link
- [ ] Spot-check Race Canvas → trace overlay → verify same UX

🤖 Generated with [Claude Code](https://claude.com/claude-code)