### PR TITLE
Federation outbound traces: thread env so KV persistence kicks in

### DIFF
--- a/src/routes/agenticRoutes.ts
+++ b/src/routes/agenticRoutes.ts
@@ -169,7 +169,7 @@ export async function handleAgenticExecute(request: Request, env: Env, logger: L
             // on get_signals (rejected by Dstillery). See agenticArgsSanitizer.
             const args = sanitizeArgsForVendor(step.tool, rawArgs, plan.brief);
             const start = Date.now();
-            const r = await callAgentTool(a.mcp_url!, step.tool, args, { timeoutMs: 12_000 });
+            const r = await callAgentTool(a.mcp_url!, step.tool, args, { timeoutMs: 12_000, env });
             return { agent_id: a.id, agent_name: a.name, vendor: a.vendor, ok: r.ok, latency_ms: Date.now() - start, error: r.error, structured_content: r.structured_content, content: r.content };
           }));
 

--- a/src/routes/agentsEndpoints.ts
+++ b/src/routes/agentsEndpoints.ts
@@ -264,7 +264,7 @@ export async function handleAgentsOrchestrate(request: Request, env: Env, logger
     const res = await callAgentTool(a.mcp_url!, tool, {
       signal_spec: body.brief,
       max_results: maxResults,
-    }, { timeoutMs });
+    }, { timeoutMs, env });
     const structured = res.structured_content as { signals?: unknown[] } | undefined;
     const signals = structured?.signals ?? [];
     const out: OrchestratePerAgent = {
@@ -574,6 +574,7 @@ async function runSignalsStage(
   brief: string,
   maxResults: number,
   timeoutMs: number,
+  env?: Env,
 ): Promise<SignalsStageAgent[]> {
   return Promise.all(agents.map(async (a): Promise<SignalsStageAgent> => {
     const res = await callAgentTool(
@@ -583,7 +584,10 @@ async function runSignalsStage(
       // on why we dropped the `pagination` envelope (Pydantic-strict
       // vendors like Dstillery reject the unknown keyword).
       { signal_spec: brief, max_results: maxResults },
-      { timeoutMs },
+      // Thread env so federation outbound traces persist to KV — without
+      // this, the signal-trace modal shows empty for "src⊃ federation:"
+      // every time the isolate cycles.
+      env ? { timeoutMs, env } : { timeoutMs },
     );
     const signals = extractMcpToolArray<SignalLite>(res.structured_content, res.content, ["signals"])
       .map((s) => ({ source_agent: a.id, ...s }));
@@ -742,7 +746,7 @@ export async function handleWorkflowRun(request: Request, env: Env, logger: Logg
 
   // Stage 1 + Stage 2 in parallel (independent).
   const [signalsResults, creativeResults] = await Promise.all([
-    runSignalsStage(signalsAgents, body.brief, maxSignals, timeoutMs),
+    runSignalsStage(signalsAgents, body.brief, maxSignals, timeoutMs, env),
     creativeAgents.length > 0 ? runCreativeStage(creativeAgents, creativeFilter, timeoutMs) : Promise.resolve([]),
   ]);
 
@@ -952,7 +956,10 @@ export async function handleWorkflowRunStream(request: Request, env: Env, logger
             "get_signals",
             // Top-level max_results only (see handleAgentsOrchestrate comment).
             { signal_spec: body.brief, max_results: maxSignals },
-            { timeoutMs },
+            // Thread env so federation outbound traces land in KV — without
+            // this they only live in-memory and disappear on isolate cycle,
+            // which is the bug the demo's Federation page hit.
+            { timeoutMs, env },
           );
           const signals = extractMcpToolArray<SignalLite>(res.structured_content, res.content, ["signals"])
             .map((s) => ({ source_agent: a.id, ...s }));


### PR DESCRIPTION
## Summary

Federation page's `src⊃ federation:` modal was empty even after running federation calls. Root cause: PR #213 added env-threaded KV persistence to the federation client, but **every caller of `callAgentTool` dropped `env` from opts** — so outbound federation traces only lived in the in-memory ring buffer and died on every isolate cycle (deploys, idle GC, etc.).

## Fix

Thread `env` through every `callAgentTool` callsite that triggers the recorder (`get_signals` + `activate_signal`):

| File | Site | Change |
|---|---|---|
| `src/routes/agentsEndpoints.ts` | `handleAgentsOrchestrate` | `{ timeoutMs }` → `{ timeoutMs, env }` |
| `src/routes/agentsEndpoints.ts` | `runSignalsStage` | added `env?: Env` param + threaded through |
| `src/routes/agentsEndpoints.ts` | `handleWorkflowRunStream` (streaming fanout) | `{ timeoutMs }` → `{ timeoutMs, env }` |
| `src/routes/agenticRoutes.ts` | `handleAgenticExecute` (LLM-dispatched tools) | `{ timeoutMs: 12_000 }` → `{ timeoutMs: 12_000, env }` |

Other `callAgentTool` callsites (`list_creative_formats`, `get_products`, `create_media_buy`) don't trigger the recorder so don't need `env` — left untouched.

## Why this matters for the workshop

The Dstillery 12-error trace (the demo's centerpiece per workshop prompt PR #215) is an outbound federation trace. Without `env` threaded, that trace disappears on every isolate cycle. User opens the Federation page mid-workshop → modal is empty → live demo dies. After this PR lands, federation traces persist to KV with 6h TTL.

## Verification

- ✅ `npx tsc --noEmit`: no new errors
- ✅ `npx vitest run`: 441 passing / 12 skipped

## Test plan

- [ ] Merge + deploy
- [ ] Run any brief on Brand Canvas (workflow stream → signals fanout to federation)
- [ ] Wait for the run to complete
- [ ] Force a fresh isolate (or just wait 60s) to simulate cycle
- [ ] Open Federation page → `{ } Signal traces` button → modal should now show federation traces from previous runs (loaded from KV, not in-memory)

🤖 Generated with [Claude Code](https://claude.com/claude-code)