### PR TITLE
Federation page traces: record dstillerySearch + evgeny_signals fanout

### DIFF
--- a/src/federation/dstilleryClient.ts
+++ b/src/federation/dstilleryClient.ts
@@ -18,6 +18,9 @@
 //   - Session id expires after idle period (~10 min observed). Retry
 //     once on session error.
 
+import { safeRecordSignalTrace, persistSignalTrace } from "../domain/signalTrace";
+import type { Env } from "../types/env";
+
 export const DSTILLERY_MCP_URL = "https://adcp-signals-agent.dstillery.com/mcp";
 
 // Per-isolate session cache. Cloudflare recycles isolates frequently;
@@ -146,11 +149,24 @@ async function callGetSignalsOnce(
 export async function dstillerySearch(
   brief: string,
   maxResults: number = 10,
+  env?: Env,
 ): Promise<DstillerySearchResult> {
   const start = Date.now();
+  // Track the request payload separately so we can record it even when
+  // the network call throws. The trace recorder captures both successful
+  // and failed federation outbounds — same posture as callAgentTool's
+  // recorder in genericMcpClient.ts.
+  const requestPayload = { signal_spec: brief, max_results: maxResults };
   try {
     let session = await ensureSession();
-    if (!session) return { ok: false, signals: [], error: "session_init_failed", elapsed_ms: Date.now() - start };
+    if (!session) {
+      const failResult: DstillerySearchResult = {
+        ok: false, signals: [], error: "session_init_failed",
+        elapsed_ms: Date.now() - start,
+      };
+      await _recordDstilleryTrace(env, requestPayload, failResult);
+      return failResult;
+    }
 
     let r = await callGetSignalsOnce(session, brief, maxResults);
 
@@ -167,13 +183,56 @@ export async function dstillerySearch(
       elapsed_ms: Date.now() - start,
     };
     if (r.error) result.error = r.error;
+    await _recordDstilleryTrace(env, requestPayload, result, r);
     return result;
   } catch (e) {
-    return {
+    const errResult: DstillerySearchResult = {
       ok: false,
       signals: [],
       error: String((e as Error).message || e),
       elapsed_ms: Date.now() - start,
     };
+    await _recordDstilleryTrace(env, requestPayload, errResult);
+    return errResult;
   }
+}
+
+/**
+ * Helper: record + persist a Dstillery federation trace using the same
+ * shape as callAgentTool's recorder in genericMcpClient.ts. Without
+ * this, the Federation page's "Fan out" button produces results but
+ * the signal-trace modal stays empty for federation:dstillery — which
+ * is exactly the bug the user reported pre-workshop.
+ *
+ * Failures are silent — the trace is observability, not load-bearing.
+ */
+async function _recordDstilleryTrace(
+  env: Env | undefined,
+  requestPayload: Record<string, unknown>,
+  result: DstillerySearchResult,
+  rawCall?: { signals?: unknown[]; error?: string },
+): Promise<void> {
+  try {
+    // Build a response payload that mirrors what the wire actually
+    // returned. When the call succeeded, the structuredContent is
+    // { signals: [...] }. When it failed, surface the error string
+    // so the trace's response section shows context.
+    const responsePayload: Record<string, unknown> = result.ok
+      ? { signals: result.signals }
+      : { error: result.error ?? "unknown_error" };
+    const trace = safeRecordSignalTrace({
+      tool_name: "get_signals",
+      direction: "outbound",
+      source: "federation:dstillery",
+      caller_agent: "dstillery",
+      endpoint_url: DSTILLERY_MCP_URL,
+      request_payload: requestPayload,
+      response_payload: responsePayload,
+      response_status: result.ok ? "ok" : "error",
+      ...(result.error ? { response_error_message: result.error } : {}),
+      duration_ms: result.elapsed_ms,
+    });
+    if (env && trace) await persistSignalTrace(env, trace);
+    void rawCall;
+  } catch { /* observability never breaks the call path */ }
 }

--- a/src/federation/genericMcpClient.ts
+++ b/src/federation/genericMcpClient.ts
@@ -479,7 +479,7 @@ export async function callAgentToolWithCircuit(
   url: string,
   name: string,
   args: Record<string, unknown>,
-  opts?: { timeoutMs?: number; retries?: number },
+  opts?: { timeoutMs?: number; retries?: number; env?: Env },
 ): Promise<CircuitToolCallResult> {
   const circuit = getCircuit(url);
 
@@ -501,8 +501,14 @@ export async function callAgentToolWithCircuit(
   const maxRetries = Math.max(0, opts?.retries ?? RETRY_MAX_DEFAULT);
   let attempts = 0;
   let lastResult: ToolCallResult = { ok: false, error: "no_attempt", latency_ms: 0 };
+  // Pass through env so the underlying callAgentTool can persist
+  // outbound traces to KV. Without this, every DSP-side get_signals
+  // (handleDspCampaignSignalsLive) is silent.
+  const innerOpts: { timeoutMs?: number; env?: Env } = {};
+  if (opts?.timeoutMs) innerOpts.timeoutMs = opts.timeoutMs;
+  if (opts?.env) innerOpts.env = opts.env;
   while (attempts <= maxRetries) {
-    lastResult = await callAgentTool(url, name, args, opts?.timeoutMs ? { timeoutMs: opts.timeoutMs } : {});
+    lastResult = await callAgentTool(url, name, args, innerOpts);
     if (lastResult.ok) {
       onCircuitSuccess(url);
       return { ...lastResult, retries: attempts, circuit_state: "closed" };

--- a/src/routes/dspRoutes.ts
+++ b/src/routes/dspRoutes.ts
@@ -579,7 +579,7 @@ export async function handleDspCampaignSignalsLive(
       // pagination envelope intentionally NOT sent — see agentsEndpoints
       // comment about Pydantic-strict vendors rejecting unknown keywords.
       deliver_to: { deployments: [{ type: "platform", platform: "mock_dsp" }], countries: ["US"] },
-    }, { timeoutMs: 10_000 });
+    }, { timeoutMs: 10_000, env });
     const latency = Date.now() - start;
     interface SignalShape { signal_agent_segment_id?: string; id?: string; name?: string; coverage_percentage?: number; estimated_audience_size?: number }
     const sc = (r.structured_content as { signals?: SignalShape[] } | undefined) ?? {};

--- a/src/routes/federationEndpoints.ts
+++ b/src/routes/federationEndpoints.ts
@@ -11,6 +11,7 @@ import { jsonResponse, errorResponse } from "./shared";
 import { dstillerySearch, DSTILLERY_MCP_URL } from "../federation/dstilleryClient";
 import { searchSignalsService } from "../domain/signalService";
 import { getDb } from "../storage/db";
+import { safeRecordSignalTrace, persistSignalTrace } from "../domain/signalTrace";
 
 const SELF_URL = "https://adcp-signals-adaptor.evgeny-193.workers.dev";
 
@@ -133,24 +134,58 @@ export async function handleFederatedSearch(
   if (targetAgents.includes("evgeny_signals")) {
     tasks.push((async () => {
       const t0 = Date.now();
+      const reqPayload = { signal_spec: body.brief, max_results: maxPerAgent };
       try {
         const db = getDb(env);
         const r = await searchSignalsService(db, env.SIGNALS_CACHE, {
           brief: body.brief, limit: maxPerAgent, offset: 0,
         });
+        const elapsed = Date.now() - t0;
+        // Record federation:evgeny_signals trace so the modal shows
+        // BOTH peers (Evgeny + Dstillery) from a single fanout. The
+        // call is in-process (no network hop) but semantically the
+        // Federation page is treating us as one of N peers, so the
+        // trace is correct from the demo's POV.
+        const trace = safeRecordSignalTrace({
+          tool_name: "get_signals",
+          direction: "outbound",
+          source: "federation:evgeny_signals",
+          caller_agent: "evgeny_signals",
+          endpoint_url: new URL(request.url).origin + "/signals/search",
+          request_payload: reqPayload,
+          response_payload: { signals: r.signals },
+          response_status: "ok",
+          duration_ms: elapsed,
+        });
+        if (trace) await persistSignalTrace(env, trace);
         return {
           agent: "evgeny_signals",
           ok: true,
           signals: r.signals,
-          elapsed_ms: Date.now() - t0,
+          elapsed_ms: elapsed,
         };
       } catch (e) {
+        const elapsed = Date.now() - t0;
+        const errMsg = String((e as Error).message || e);
+        const trace = safeRecordSignalTrace({
+          tool_name: "get_signals",
+          direction: "outbound",
+          source: "federation:evgeny_signals",
+          caller_agent: "evgeny_signals",
+          endpoint_url: new URL(request.url).origin + "/signals/search",
+          request_payload: reqPayload,
+          response_payload: { error: errMsg },
+          response_status: "error",
+          response_error_message: errMsg,
+          duration_ms: elapsed,
+        });
+        if (trace) await persistSignalTrace(env, trace);
         return {
           agent: "evgeny_signals",
           ok: false,
           signals: [],
-          error: String((e as Error).message || e),
-          elapsed_ms: Date.now() - t0,
+          error: errMsg,
+          elapsed_ms: elapsed,
         };
       }
     })());
@@ -159,7 +194,12 @@ export async function handleFederatedSearch(
 
   if (targetAgents.includes("dstillery")) {
     tasks.push((async () => {
-      const r = await dstillerySearch(body.brief, maxPerAgent);
+      // Thread env so the dstilleryClient's internal trace recorder
+      // can persist outbound federation traces to KV. Without env they
+      // only land in the in-memory ring buffer and disappear on isolate
+      // cycle — which is the bug the user reported on the Federation
+      // page's "Fan out" button (modal showed empty after the run).
+      const r = await dstillerySearch(body.brief, maxPerAgent, env);
       return {
         agent: "dstillery",
         ok: r.ok,


### PR DESCRIPTION
## Summary — final audit + fix for ALL pages

User reported: Federation page "Fan out" produced results but trace modal showed OLD data. After auditing every signal-related call path in the codebase, found **THREE** missing instrumentation points (not just one). PR scope expanded.

## Audit results

| Surface | Path | Trace recording? |
|---|---|---|
| Discover tab | `/mcp` → `callGetSignals` | ✅ already recorded |
| Catalog tab | `/mcp` → `callGetSignals` | ✅ already recorded |
| Activations tab | `/mcp` `activate_signal` + `/signals/activate` | ✅ already recorded |
| Brand Canvas (workflow stream) | `/agents/workflow/run/stream` → `callAgentTool` | ✅ env-threaded in PR #218 |
| Multi-Agent Orchestrator | `/agents/orchestrate` → `callAgentTool` | ✅ env-threaded in PR #218 |
| Agentic chat | `/agentic/execute` → `callAgentTool` | ✅ env-threaded in PR #218 |
| **Federation page** | `/agents/federated-search` → `dstillerySearch` + `searchSignalsService` | ❌ **bypasses recorder entirely** — fixed in this PR |
| **DSP page (signals-live)** | `/dsp/campaigns/:id/signals-live` → `callAgentToolWithCircuit("get_signals")` | ❌ **circuit wrapper drops env** — fixed in this PR |
| Race Canvas | Embedded JS, separate page | (TBD — separate audit, not signal-recording surface) |
| Ecosystem / Vendor Health | probes only (`probeAgent`) | N/A — recorder skips non-signal tools |

## Fixes in this PR

### 1. `dstillerySearch` — added trace recording

`src/federation/dstilleryClient.ts` predates `genericMcpClient.ts` and was never instrumented. Now records:
- `source: "federation:dstillery"` · `caller_agent: "dstillery"` · `endpoint_url: DSTILLERY_MCP_URL`
- request/response payloads, status, error message
- New optional `env` param threads through to `persistSignalTrace`

### 2. `evgeny_signals` in-process fanout — added trace recording

`handleFederatedSearch`'s in-process branch hits `searchSignalsService` directly. Added a federation:evgeny_signals trace so the modal shows BOTH peers from each fanout.

### 3. `callAgentToolWithCircuit` — env threading + DSP page wiring

The circuit-breaker wrapper had `opts?: { timeoutMs?: number; retries?: number }` — no env. So even if a caller wanted persistence, the wrapper dropped it. Plus the `handleDspCampaignSignalsLive` callsite (DSP campaign signals-live page) wasn't passing env. Both fixed.

## Touched files

- `src/federation/dstilleryClient.ts` — added recorder + persist + optional env param
- `src/federation/genericMcpClient.ts` — `callAgentToolWithCircuit` accepts env, forwards to `callAgentTool`
- `src/routes/federationEndpoints.ts` — env threaded to `dstillerySearch`; evgeny_signals branch records its own trace
- `src/routes/dspRoutes.ts` — env threaded to `callAgentToolWithCircuit` from `handleDspCampaignSignalsLive`

## Verification

- ✅ `npx tsc --noEmit`: no new errors
- ✅ `npx vitest run`: 441 passing / 12 skipped
- ✅ Audit grep: every callsite for `get_signals` / `activate_signal` now has env in the opts (or is in-process and records via the helper)

## Test plan

- [ ] Merge + deploy
- [ ] Federation page → "Fan out" with brief X → modal shows TWO traces (evgeny + dstillery), both reflecting brief X
- [ ] DSP page → load any campaign's signals-live view → modal shows federation:dstillery (and evgeny_signals if applicable) for that campaign's audience_brief
- [ ] Wait 60s → reopen modal → traces still there (KV persistence)

## Why this matters for tomorrow

This was the actual gap. PRs 213/218 instrumented one federation client but didn't audit for siblings. The Federation page (the literal page named "Federation") was silent every time the user clicked "Fan out". Same for the DSP signals-live page. After this PR, EVERY signal-fanout surface in the demo records traces consistently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)