### PR TITLE
Peer version chip: surface MCP initialize serverInfo in trace header

### DIFF
--- a/src/demo/script/fragments/signals-trace-viewer.ts
+++ b/src/demo/script/fragments/signals-trace-viewer.ts
@@ -250,11 +250,26 @@ function renderSingleTrace(trace, idx) {
         '<span class="trace-endpoint-url">' + escapeHtml(visible) + '</span>' +
       '</a>';
   }
+  // Peer version chip — pulled live from MCP initialize handshake.
+  // Surfacing this answers the workshop question "why 12 errors? what
+  // version is the peer?" without hardcoding "Dstillery is 2.x". When
+  // a peer migrates, the chip follows automatically.
+  let peerVersionChip = "";
+  if (trace.peer_server_info && (trace.peer_server_info.version || trace.peer_server_info.name)) {
+    const name = trace.peer_server_info.name || "";
+    const version = trace.peer_server_info.version || "";
+    const label = version ? "peer v" + version : "peer";
+    const fullTitle = (name ? name + " · " : "") + (version ? "version " + version : "version unknown") +
+      " (advertised by the peer in the MCP initialize handshake)";
+    peerVersionChip = '<span class="trace-peer-version" title="' + escapeHtml(fullTitle) + '">' +
+      escapeHtml(label) + '</span>';
+  }
   return '<div class="signal-trace-frame" data-trace-id="' + escapeHtml(trace.trace_id) + '">' +
     '<div class="signal-trace-frame-head">' +
       '<span class="trace-tool trace-tool-' + escapeHtml(trace.tool_name) + '">' + escapeHtml(trace.tool_name) + '</span> ' +
       '<span class="trace-dir">' + dirIcon + ' ' + escapeHtml(sourceShort) + '</span>' +
       endpointBlock +
+      peerVersionChip +
       '<span class="trace-ts">' + tsFmt + '</span>' +
       '<span class="trace-dur">' + trace.duration_ms + 'ms</span>' +
       (trace.correlation_id ? '<span class="trace-corr">corr: ' + escapeHtml(trace.correlation_id.slice(-12)) + '</span>' : '') +

--- a/src/demo/styles.ts
+++ b/src/demo/styles.ts
@@ -6718,6 +6718,23 @@ textarea.lab-input { resize: vertical; line-height: 1.5; }
 }
 .trace-endpoint-icon { opacity: 0.7; font-size: 11px; }
 .trace-endpoint-url { color: inherit; }
+/* Peer version chip — surfaces what the federated peer advertised in
+   its MCP initialize handshake (e.g. "peer v2.13.1"). Lives next to
+   the endpoint URL so the audience reads OUR_SCHEMA_URL vs PEER_VERSION
+   side-by-side and the version-drift story is self-evident.
+   Amber-toned to read as spec context, not error. */
+.trace-peer-version {
+  display: inline-flex; align-items: center;
+  font: 10.5px var(--font-mono);
+  color: #c8920b;
+  background: rgba(255, 203, 92, 0.18);
+  border: 1px solid rgba(255, 203, 92, 0.35);
+  padding: 1px 7px; border-radius: 3px;
+  font-weight: 600;
+  cursor: help;
+  transition: background 0.15s;
+}
+.trace-peer-version:hover { background: rgba(255, 203, 92, 0.30); }
 .signal-trace-reset {
   margin-left: auto; margin-right: 8px;
   font: 11px var(--font-mono);

--- a/src/domain/signalTrace.ts
+++ b/src/domain/signalTrace.ts
@@ -77,6 +77,19 @@ export interface SignalTrace {
    * "federation:dstillery" doesn't tell them where Dstillery LIVES).
    */
   endpoint_url: string | null;
+  /** Peer's advertised serverInfo from the MCP `initialize` handshake.
+   *
+   * Populated only for outbound federation calls — captured live from
+   * the peer's response to `initialize`, NEVER hardcoded. When the peer
+   * advertises e.g. `{ name: "dstillery_signals_agent", version: "2.13.1" }`
+   * the trace viewer can render that next to OUR schema URL ("validating
+   * against /schemas/v3/...") so the audience reads the spec-version
+   * mismatch directly from the data — no narration, no inference.
+   *
+   * Null for inbound traces (we ARE the server) and for any outbound
+   * call where the peer's handshake didn't include serverInfo.
+   */
+  peer_server_info: { name?: string; version?: string } | null;
   request: {
     payload: unknown;
     validation: SchemaValidationResult;
@@ -256,6 +269,13 @@ export interface RecordSignalTraceInput {
    * the trace's endpoint_url as null.
    */
   endpoint_url?: string | null;
+  /**
+   * Optional. Peer's serverInfo from the MCP `initialize` handshake
+   * (federation outbound only). Captured live — never hardcoded. Lets
+   * the trace viewer surface the peer's advertised version next to our
+   * schema URL so version-drift is self-evident.
+   */
+  peer_server_info?: { name?: string; version?: string } | null;
 }
 
 /**
@@ -313,6 +333,7 @@ export function recordSignalTrace(input: RecordSignalTraceInput): SignalTrace | 
       source: input.source,
       caller_agent: input.caller_agent ?? null,
       endpoint_url: input.endpoint_url ?? null,
+      peer_server_info: input.peer_server_info ?? null,
       request: {
         payload: input.request_payload,
         validation: safeValidate(reqSchemaId, reqSchemaUrl, input.request_payload),

--- a/src/federation/dstilleryClient.ts
+++ b/src/federation/dstilleryClient.ts
@@ -27,6 +27,11 @@ export const DSTILLERY_MCP_URL = "https://adcp-signals-agent.dstillery.com/mcp";
 // this is best-effort, we renew on every cold start.
 let _sessionId: string | null = null;
 let _sessionAtMs: number = 0;
+// Cache the peer's advertised serverInfo from the initialize handshake
+// so dstillerySearch can plumb it into the trace record (peer version
+// chip in the viewer). Pulled live from Dstillery's response — never
+// hardcoded.
+let _peerServerInfo: { name?: string; version?: string } | null = null;
 const SESSION_TTL_MS = 9 * 60 * 1000;
 
 function parseSSE(text: string): unknown | null {
@@ -59,8 +64,18 @@ async function initializeSession(): Promise<string | null> {
   if (!res.ok) return null;
   const sessionId = res.headers.get("mcp-session-id");
   if (!sessionId) return null;
-  // Read (and discard) the initialize response body so the stream closes
-  await res.text();
+  // Read the initialize response body and pull peer's serverInfo
+  // (e.g. { name: "dstillery_signals_agent", version: "2.13.1" }).
+  // Cached for trace plumbing — never hardcoded; reflects whatever
+  // Dstillery currently advertises. If the peer migrates to 3.0.1
+  // the chip will follow without code changes.
+  try {
+    const bodyText = await res.text();
+    const parsed = parseSSE(bodyText) as { result?: { serverInfo?: { name?: string; version?: string } } } | null;
+    if (parsed?.result?.serverInfo) {
+      _peerServerInfo = parsed.result.serverInfo;
+    }
+  } catch { /* non-critical — fall through with serverInfo unset */ }
   // Send initialized notification
   try {
     await fetch(DSTILLERY_MCP_URL, {
@@ -226,6 +241,11 @@ async function _recordDstilleryTrace(
       source: "federation:dstillery",
       caller_agent: "dstillery",
       endpoint_url: DSTILLERY_MCP_URL,
+      // Peer-advertised serverInfo from the live MCP handshake.
+      // Surfacing this lets the viewer show "v2.13.1" next to our
+      // "validating against /v3/..." banner — version drift is
+      // self-evident, no narration required.
+      peer_server_info: _peerServerInfo,
       request_payload: requestPayload,
       response_payload: responsePayload,
       response_status: result.ok ? "ok" : "error",

--- a/src/federation/genericMcpClient.ts
+++ b/src/federation/genericMcpClient.ts
@@ -28,7 +28,15 @@ const SESSION_TTL_MS = 9 * 60 * 1000;
 /** Sentinel used for agents that negotiate stateless MCP (no mcp-session-id header
  * on initialize). Subsequent calls for these agents don't send the header. */
 const STATELESS_SESSION = "__stateless__";
-const _sessions = new Map<string, { id: string; atMs: number }>();
+/** Per-URL session cache, also tracks the peer's advertised serverInfo
+ * from the initialize handshake so callAgentTool can plumb it into the
+ * trace record (peer version chip). Keep cached between calls — peer
+ * shouldn't change versions between session calls. */
+const _sessions = new Map<string, {
+  id: string;
+  atMs: number;
+  serverInfo?: { name?: string; version?: string };
+}>();
 
 /** Parse an SSE response body and return the last `data:` payload as JSON. */
 function parseSSELastData(text: string): unknown | null {
@@ -124,7 +132,11 @@ async function ensureSession(url: string, opts?: InitOptions): Promise<string | 
   if (cached && now - cached.atMs < SESSION_TTL_MS) return cached.id;
   const init = await initializeSession(url, opts);
   if (init.sessionId) {
-    _sessions.set(url, { id: init.sessionId, atMs: now });
+    const entry: { id: string; atMs: number; serverInfo?: { name?: string; version?: string } } = {
+      id: init.sessionId, atMs: now,
+    };
+    if (init.serverInfo) entry.serverInfo = init.serverInfo;
+    _sessions.set(url, entry);
   }
   return init.sessionId;
 }
@@ -343,6 +355,12 @@ export async function callAgentTool(url: string, name: string, args: Record<stri
       // "federation:dstillery" instead of "federation:https://...".
       const match = AGENT_REGISTRY.find((a) => a.mcp_url && url.startsWith(a.mcp_url.replace(/\/$/, "")));
       const agentId = match?.id ?? null;
+      // Read the peer's advertised serverInfo from the session cache
+      // (populated during ensureSession's `initialize` round-trip).
+      // This is LIVE — pulled from what the peer told us on connect,
+      // never hardcoded. Lets the viewer render the peer version chip.
+      const cached = _sessions.get(url);
+      const peerServerInfo = cached?.serverInfo ?? null;
       const trace = safeRecordSignalTrace({
         tool_name: name as "get_signals" | "activate_signal",
         direction: "outbound",
@@ -352,6 +370,7 @@ export async function callAgentTool(url: string, name: string, args: Record<stri
         // of info for the trace viewer — the audience asks "where
         // does Dstillery live?" on every call. Surface the answer.
         endpoint_url: url,
+        peer_server_info: peerServerInfo,
         request_payload: args,
         response_payload: result.ok
           ? (result.structured_content ?? result.content ?? null)

--- a/src/routes/raceCanvas.ts
+++ b/src/routes/raceCanvas.ts
@@ -1628,10 +1628,21 @@ function renderRaceCanvas(demoKey: string): string {
       } catch (_) { if (visible.length > 48) visible = visible.slice(0, 45) + "…"; }
       endpointBlock = ' · <a href="' + escapeHtml(t.endpoint_url) + '" target="_blank" rel="noopener" title="' + escapeHtml(t.endpoint_url) + '" style="color:#38b6ff;font-size:10.5px;text-decoration:none">⎘ ' + escapeHtml(visible) + '</a>';
     }
+    // Peer version chip — pulled live from MCP initialize.
+    var peerVerBlock = "";
+    if (t.peer_server_info && (t.peer_server_info.version || t.peer_server_info.name)) {
+      var pv = t.peer_server_info.version || "";
+      var pn = t.peer_server_info.name || "";
+      var pLabel = pv ? "peer v" + pv : "peer";
+      var pTitle = (pn ? pn + " · " : "") + (pv ? "version " + pv : "version unknown") +
+        " (advertised by the peer in the MCP initialize handshake)";
+      peerVerBlock = ' · <span style="color:#ffcb5c;font-size:10.5px;background:rgba(255,203,92,0.12);padding:1px 6px;border-radius:3px" title="' + escapeHtml(pTitle) + '">' + escapeHtml(pLabel) + '</span>';
+    }
     return '<details style="margin-bottom:10px;padding:8px 12px;background:rgba(255,255,255,0.04);border-radius:4px">' +
       '<summary style="cursor:pointer;font-size:12px;line-height:1.7">' +
         '<strong>' + escapeHtml(t.tool_name) + '</strong> · ' + dirIcon + ' ' + escapeHtml(sourceShort) +
         endpointBlock +
+        peerVerBlock +
         ' · <span style="color:' + statusColor + '">' + escapeHtml(t.response.status) + '</span>' +
         ' · ' + t.duration_ms + 'ms · ' + new Date(t.ts).toLocaleTimeString() +
         ' · ' + badge(reqValid, reqErrCount) + ' req · ' + badge(resValid, resErrCount) + ' res' +

--- a/tests/__snapshots__/demo-render-snapshot.test.ts.snap
+++ b/tests/__snapshots__/demo-render-snapshot.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`handleDemo byte-equivalence > matches the committed golden hash (LF-normalized SHA-256 of body) 1`] = `
 {
-  "hash": "bb9d20df77ba16e41a8ae34e6737e728cdafa22d1bf66184ef727d979645fdfd",
-  "length": 1146386,
+  "hash": "3de79381e443422061a0b19e309caedfc248404009b508f1257f1f6ee68d3531",
+  "length": 1147989,
 }
 `;


### PR DESCRIPTION
## Summary

User asked "where do we explain why 3 vs 2 compliance?" — the trace shows 12 errors but doesn't surface the version-drift narrative. User explicitly added: **"always check against live schema, don't hardcode."**

Right design: display the peer's advertised `serverInfo` (captured **live** from the MCP `initialize` handshake) next to our schema URL banner. The audience reads:
- **OUR schema**: `/schemas/v3/...` (banner already exists)
- **PEER's version**: `peer v2.13.1` (new chip in header)

…directly from the trace data — no narration, no inference, no hardcoded "Dstillery is on 2.x" detection. When peers migrate the chip follows automatically.

## What you'll see

```
get_signals → federation:dstillery   ⎘ adcp-signals-agent.dstillery.com/mcp   peer v2.13.1   992ms OK
```

The `peer v2.13.1` is amber-toned (spec context, not error). Hover for tooltip: *"dstillery_signals_agent · version 2.13.1 (advertised by the peer in the MCP initialize handshake)"*.

## Plumbing

| File | Change |
|---|---|
| `src/domain/signalTrace.ts` | New `peer_server_info` field on `SignalTrace` + `RecordSignalTraceInput` |
| `src/federation/genericMcpClient.ts` | Cache peer's `serverInfo` alongside session id (per-URL); read on every `callAgentTool`, pass to recorder |
| `src/federation/dstilleryClient.ts` | Parse `initialize` response body (was being discarded), extract `serverInfo`, cache in module-scope, pass to recorder |
| `src/demo/script/fragments/signals-trace-viewer.ts` | Render `peer v2.13.1` chip in trace header next to endpoint URL |
| `src/routes/raceCanvas.ts` | Same chip in Race Canvas's embedded viewer |
| `src/demo/styles.ts` | `.trace-peer-version` styling |

## Workshop impact

Before: Audience sees 12 errors. User verbalizes "Dstillery is on 2.x, we're 3.0.1, here's the delta."

After: Audience sees `peer v2.13.1` next to `/schemas/v3/...`. Conclusion lands without narration. User gets to use those 30 seconds for something else.

## Why "live, not hardcoded" matters

The chip pulls from the peer's actual `initialize` response. If Dstillery migrates to 3.0.1 tomorrow morning, the chip flips to v3.x.x and the schema errors disappear — no code change needed. Same primitive works for any future federation peer without per-peer detection logic.

## Verification

- ✅ `npx tsc --noEmit`: no new errors
- ✅ `npx vitest run -u`: 441 passing / 12 skipped (snapshot updated)

## Test plan

- [ ] Merge + deploy
- [ ] Federation page → "Fan out" any brief → modal opens
- [ ] Each `federation:dstillery` trace shows `peer v2.13.1` chip after the endpoint URL
- [ ] Hover the chip → tooltip explains it came from the MCP initialize handshake
- [ ] If multi-trace, every Dstillery trace shows the same version (it's the peer, not the call)

🤖 Generated with [Claude Code](https://claude.com/claude-code)