### PR TITLE
Tier 1 trace coverage: extension tools + chip wiring + Race Canvas parity

### DIFF
--- a/src/demo/script/fragments/detail-panel.ts
+++ b/src/demo/script/fragments/detail-panel.ts
@@ -30,7 +30,8 @@ export const detailPanelJs = `function openDetail(sig) {
   // exact request/response on the wire.
   document.getElementById("detail-name").innerHTML =
     escapeHtml(sig.name || "(unnamed)") +
-    ' <button class="mcp-inspect-btn" id="detail-mcp-inspect" title="Inspect MCP exchange">{…}</button>';
+    ' <button class="mcp-inspect-btn" id="detail-mcp-inspect" title="Inspect MCP exchange">{…}</button>' +
+    ' <button class="mcp-inspect-btn" id="detail-signal-traces" title="View raw get_signals request/response JSON for the lookup that hydrated this panel — uses signal_ids (the discriminated SignalId form) so the trace shows the lookup path vs the brief-mode discovery path.">{ }</button>';
 
   const body = document.getElementById("detail-body");
   body.innerHTML = '' +

--- a/src/demo/script/fragments/signals-trace-viewer.ts
+++ b/src/demo/script/fragments/signals-trace-viewer.ts
@@ -121,6 +121,13 @@ function renderJsonWithGlossary(value, indent) {
 
 function renderValidationBadge(validation) {
   if (!validation) return '<span class="trace-vbadge skip" title="No schema attached to this trace">no schema</span>';
+  // "extension" — tool isn't standardized in the published AdCP spec
+  // yet, so we record the trace but skip validation. Distinct badge so
+  // the audience doesn't read this as a runtime failure. The schema
+  // URL banner still renders (pointing at the spec proposal / issue).
+  if (validation.errors && validation.errors.some(function (e) { return e.keyword === "extension"; })) {
+    return '<span class="trace-vbadge ext" title="Recorded for audit. Tool not yet standardized in published AdCP spec — schema link goes to the proposal.">⚙ extension</span>';
+  }
   // "skipped" or "missing_schema" — the validator couldn't run on the
   // payload (e.g. corpus didn't load, runtime quirk). Distinct from
   // "ran and found 0 errors" — be honest about it. Kept short for
@@ -352,6 +359,9 @@ async function openSignalTraceModal(filter) {
   const qs = new URLSearchParams();
   if (filter && filter.correlationId) qs.set("correlation_id", filter.correlationId);
   if (filter && filter.agentId) qs.set("agent_id", filter.agentId);
+  // Single-tool filter: pushed to server. Multi-tool (tools: [...]):
+  // we fetch unfiltered and narrow client-side below since the index
+  // backing /api/signal-traces only takes one tool name at a time.
   if (filter && filter.tool) qs.set("tool", filter.tool);
   if (filter && filter.sourcePrefix) qs.set("source_prefix", filter.sourcePrefix);
   // Over-fetch a bit if we'll narrow client-side. 25 server-side is
@@ -363,6 +373,12 @@ async function openSignalTraceModal(filter) {
     const r = await fetch("/api/signal-traces?" + qs.toString());
     const data = await r.json();
     let traces = (data && data.traces) || [];
+    // Multi-tool filter (tools: ["a", "b"]) — narrow client-side since
+    // the server index keys on a single tool name.
+    if (filter && Array.isArray(filter.tools) && filter.tools.length > 0) {
+      const want = new Set(filter.tools);
+      traces = traces.filter(function (t) { return want.has(t.tool_name); });
+    }
     // Specific trace IDs (Race Canvas / orchestrator drill-in).
     if (filter && filter.traceIds && filter.traceIds.length > 0) {
       const wanted = new Set(filter.traceIds);
@@ -415,6 +431,7 @@ function describeFilter(f) {
   if (!f) return "all recent";
   const parts = [];
   if (f.tool) parts.push("tool=" + f.tool);
+  if (Array.isArray(f.tools) && f.tools.length > 0) parts.push("tool ∈ {" + f.tools.join(", ") + "}");
   if (f.correlationId) parts.push("corr=" + f.correlationId.slice(-12));
   if (f.agentId) parts.push("agent=" + f.agentId);
   if (f.sourcePrefix) parts.push("src⊃ " + f.sourcePrefix);
@@ -438,9 +455,35 @@ document.addEventListener("click", function (e) {
   }
   // Discover tab: the brief sends a get_signals to OUR /mcp (mcp_external
   // direction is inbound from the demo's POV — the demo browser is
-  // calling our worker). Filter by tool to keep the modal scoped.
+  // calling our worker). Filter by tool to keep the modal scoped. The
+  // Discover NL Query mode dispatches query_signals_nl too — open with
+  // a multi-tool filter so the audience sees both the Brief mode
+  // (get_signals) and NL Query mode (query_signals_nl) traces in one
+  // pane and can compare the algorithmic surfaces side by side.
   if (t.closest("#discover-signal-traces")) {
+    return openSignalTraceModal({ tools: ["get_signals", "query_signals_nl"], limit: 25 });
+  }
+  // Catalog tab: the page-walk fires get_signals with a wildcard spec
+  // and pagination cursors. Showing the trace exposes the cursor
+  // mechanics — multiple traces with chained pagination.cursor values
+  // — which is the cleanest pagination story we can tell.
+  if (t.closest("#catalog-signal-traces")) {
     return openSignalTraceModal({ tool: "get_signals", limit: 25 });
+  }
+  // Detail Panel: the row drill-in fires get_signals with signal_ids
+  // (the discriminated SignalId form), so the trace shows the lookup
+  // path vs the spec/discovery path. Useful contrast for audience
+  // questions about "what does signal_id ACTUALLY look like".
+  if (t.closest("#detail-signal-traces")) {
+    return openSignalTraceModal({ tool: "get_signals", limit: 10 });
+  }
+  // Activations tab: the demo polls activate_signal then chains
+  // get_operation_status calls until the underlying task flips to
+  // completed. Wire the chip so the audience can audit the poll
+  // sequence (each iteration is its own trace with the same task_id
+  // in the request payload).
+  if (t.closest("#activation-signal-traces")) {
+    return openSignalTraceModal({ tools: ["activate_signal", "get_operation_status"], limit: 25 });
   }
 });
 `;

--- a/src/demo/styles.ts
+++ b/src/demo/styles.ts
@@ -6763,6 +6763,7 @@ textarea.lab-input { resize: vertical; line-height: 1.5; }
 .trace-vbadge.ok { background: rgba(95, 217, 196, 0.14); color: #5fd9c4; }
 .trace-vbadge.bad { background: rgba(255, 100, 100, 0.14); color: #ff7b7b; }
 .trace-vbadge.skip { background: rgba(255, 255, 255, 0.04); color: var(--text-faint); }
+.trace-vbadge.ext  { background: rgba(255, 196, 95, 0.14); color: #ffc45f; }
 .signal-trace-schemalink {
   margin-left: auto;
   font: 10px var(--font-mono); color: var(--accent); text-decoration: none;

--- a/src/domain/signalTrace.ts
+++ b/src/domain/signalTrace.ts
@@ -55,11 +55,33 @@ import type { Env } from "../types/env";
  * + SCHEMA_ID + getValidators() below.
  */
 export type AdcpToolName =
+  // Standardized in AdCP 3.0.x — schema-validated against the vendored corpus
   | "get_signals"
   | "activate_signal"
   | "list_creative_formats"
   | "get_products"
-  | "create_media_buy";
+  | "create_media_buy"
+  | "check_governance"
+  // Extension tools — implemented in our worker but not yet in the
+  // published AdCP spec. Recorded with an "extension" badge instead of
+  // ✓/✗ schema valid; lets the workshop trace inspector still show
+  // request/response JSON + correlation_id chains for these calls.
+  | "query_signals_nl"
+  | "get_operation_status";
+
+/**
+ * Tools that are recorded but not validated (extensions / not yet in the
+ * published spec). Surfaces an "extension" badge in the trace viewer
+ * instead of ✓/✗ schema valid.
+ */
+const EXTENSION_TOOLS: ReadonlySet<string> = new Set<string>([
+  "query_signals_nl",
+  "get_operation_status",
+]);
+
+export function isExtensionTool(toolName: string): boolean {
+  return EXTENSION_TOOLS.has(toolName);
+}
 
 /** Backward-compat alias — older imports referenced SignalToolName. */
 export type SignalToolName = AdcpToolName;
@@ -145,6 +167,16 @@ export const SCHEMA_URL = {
   get_products_response:    "https://adcontextprotocol.org/schemas/v3/media-buy/get-products-response.json",
   create_media_buy_request: "https://adcontextprotocol.org/schemas/v3/media-buy/create-media-buy-request.json",
   create_media_buy_response: "https://adcontextprotocol.org/schemas/v3/media-buy/create-media-buy-response.json",
+  // Governance domain
+  check_governance_request:  "https://adcontextprotocol.org/schemas/v3/governance/check-governance-request.json",
+  check_governance_response: "https://adcontextprotocol.org/schemas/v3/governance/check-governance-response.json",
+  // Extension tools — point at the AdCP issue tracker so the audience
+  // can see the spec proposal status. These DON'T go through the
+  // validator; the recorder marks them as "extension" instead.
+  query_signals_nl_request:  "https://github.com/adcontextprotocol/adcp/issues?q=query_signals_nl",
+  query_signals_nl_response: "https://github.com/adcontextprotocol/adcp/issues?q=query_signals_nl",
+  get_operation_status_request:  "https://adcontextprotocol.org/docs/reference/protocol-envelope#operation-status",
+  get_operation_status_response: "https://adcontextprotocol.org/docs/reference/protocol-envelope#operation-status",
 } as const;
 
 // Internal $id values the AdCP spec uses to register schemas. We resolve
@@ -169,6 +201,13 @@ const SCHEMA_ID = {
   get_products_response:    `/schemas/${ADCP_SPEC_VERSION}/media-buy/get-products-response.json`,
   create_media_buy_request: `/schemas/${ADCP_SPEC_VERSION}/media-buy/create-media-buy-request.json`,
   create_media_buy_response: `/schemas/${ADCP_SPEC_VERSION}/media-buy/create-media-buy-response.json`,
+  // Governance domain
+  check_governance_request:  `/schemas/${ADCP_SPEC_VERSION}/governance/check-governance-request.json`,
+  check_governance_response: `/schemas/${ADCP_SPEC_VERSION}/governance/check-governance-response.json`,
+  // NOTE: Extension tools (query_signals_nl, get_operation_status) have
+  // no canonical $id in the published spec corpus. They're intentionally
+  // absent here — the recorder routes them through the "extension" path
+  // (validator.ts:safeValidate handles the missing-schema case).
 } as const;
 
 // ── Validator setup ──────────────────────────────────────────────────────────
@@ -196,6 +235,9 @@ interface ValidatorBundle {
   get_products_response: Validator;
   create_media_buy_request: Validator;
   create_media_buy_response: Validator;
+  // Governance
+  check_governance_request: Validator;
+  check_governance_response: Validator;
 }
 
 let _validators: ValidatorBundle | null = null;
@@ -238,6 +280,9 @@ function getValidators(): ValidatorBundle | null {
       get_products_response:    buildValidator(SCHEMA_ID.get_products_response),
       create_media_buy_request: buildValidator(SCHEMA_ID.create_media_buy_request),
       create_media_buy_response: buildValidator(SCHEMA_ID.create_media_buy_response),
+      // Governance
+      check_governance_request:  buildValidator(SCHEMA_ID.check_governance_request),
+      check_governance_response: buildValidator(SCHEMA_ID.check_governance_response),
     };
     return _validators;
   } catch {
@@ -264,6 +309,9 @@ function pickValidator(bundle: ValidatorBundle, schemaId: string): Validator | n
     case SCHEMA_ID.get_products_response: return bundle.get_products_response;
     case SCHEMA_ID.create_media_buy_request: return bundle.create_media_buy_request;
     case SCHEMA_ID.create_media_buy_response: return bundle.create_media_buy_response;
+    // Governance
+    case SCHEMA_ID.check_governance_request: return bundle.check_governance_request;
+    case SCHEMA_ID.check_governance_response: return bundle.check_governance_response;
     default: return null;
   }
 }
@@ -390,6 +438,20 @@ export function recordSignalTrace(input: RecordSignalTraceInput): SignalTrace | 
     const reqSchemaUrl = SCHEMA_URL[`${input.tool_name}_request` as keyof typeof SCHEMA_URL];
     const resSchemaUrl = SCHEMA_URL[`${input.tool_name}_response` as keyof typeof SCHEMA_URL];
 
+    // Extension tools (query_signals_nl, get_operation_status) aren't
+    // standardized in the AdCP corpus yet — short-circuit validation to
+    // a clearly-labeled "extension" result so the trace viewer can
+    // render a distinct badge ("ext: not in spec") instead of "⊘
+    // validation skipped" (which connotes runtime failure). The audience
+    // gets to see request/response JSON for these calls without us
+    // implying they're spec-broken.
+    const reqValidation = isExtensionTool(input.tool_name)
+      ? extensionValidationResult(reqSchemaUrl, "request")
+      : safeValidate(reqSchemaId, reqSchemaUrl, input.request_payload);
+    const resValidation = isExtensionTool(input.tool_name)
+      ? extensionValidationResult(resSchemaUrl, "response")
+      : safeValidate(resSchemaId, resSchemaUrl, input.response_payload);
+
     let correlationId = input.correlation_id ?? null;
     if (correlationId === null && typeof input.request_payload === "object" && input.request_payload !== null) {
       const ctx = (input.request_payload as Record<string, unknown>)["context"];
@@ -412,11 +474,11 @@ export function recordSignalTrace(input: RecordSignalTraceInput): SignalTrace | 
       peer_server_info: input.peer_server_info ?? null,
       request: {
         payload: input.request_payload,
-        validation: safeValidate(reqSchemaId, reqSchemaUrl, input.request_payload),
+        validation: reqValidation,
       },
       response: {
         payload: input.response_payload,
-        validation: safeValidate(resSchemaId, resSchemaUrl, input.response_payload),
+        validation: resValidation,
         status: input.response_status,
         ...(input.response_error_message ? { error_message: input.response_error_message } : {}),
       },
@@ -446,6 +508,29 @@ function safeValidate(schemaId: string, schemaUrl: string, payload: unknown): Sc
       errors: [{ path: "(meta)", message: "validator threw: " + String((e as Error).message ?? e), keyword: "skipped" }],
     };
   }
+}
+
+/**
+ * Build the validation-result shell for an extension tool (one whose
+ * schema isn't in the published AdCP corpus). Surfaces a distinct
+ * `extension` keyword so the trace viewer can render an "ext: spec
+ * proposal" badge instead of "⊘ validation skipped" (which would
+ * imply runtime failure rather than intentional skip).
+ *
+ * The schema_url points at the spec issue / proposal so the workshop
+ * audience can click through to see where the standardization
+ * conversation lives.
+ */
+function extensionValidationResult(schemaUrl: string | undefined, leg: "request" | "response"): SchemaValidationResult {
+  return {
+    valid: true,  // we don't claim invalid for an unstandardized tool
+    schema_url: schemaUrl ?? "",
+    errors: [{
+      path: "(meta)",
+      message: `${leg} not standardized in AdCP yet — recorded for audit, schema link goes to the proposal`,
+      keyword: "extension",
+    }],
+  };
 }
 
 export interface SignalTraceQuery {

--- a/src/federation/genericMcpClient.ts
+++ b/src/federation/genericMcpClient.ts
@@ -355,6 +355,12 @@ export async function callAgentTool(url: string, name: string, args: Record<stri
     "get_signals", "activate_signal",                  // signals
     "list_creative_formats",                            // creative
     "get_products", "create_media_buy",                 // media-buy
+    "check_governance",                                 // governance
+    // Extension tools — the recorder marks these with an "extension"
+    // badge (no canonical schema yet). Useful when a peer agent
+    // advertises them so the workshop can contrast standardized vs
+    // proposed surfaces in the trace timeline.
+    "query_signals_nl", "get_operation_status",
   ]);
   if (TRACED_TOOLS.has(name)) {
     try {

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -1021,6 +1021,7 @@ async function callGetOperation(
     const taskId = (args["task_id"] ?? args["operationId"]) as string;
     if (!taskId) throw new McpToolError("task_id is required");
 
+    const _t0 = Date.now();
     try {
         const db = getDb(env);
         const result = await getOperationService(db, taskId, logger, env.WEBHOOK_SIGNING_SECRET);
@@ -1033,8 +1034,34 @@ async function callGetOperation(
             { status: "completed", task_id: taskId },
             result as unknown as Record<string, unknown>
         );
+        // Record the trace as an "extension" tool (no canonical AdCP
+        // schema for get_operation_status yet). The trace viewer renders
+        // the request/response JSON + the ext badge so the audience can
+        // audit each poll-cycle iteration during an activate_signal demo
+        // — the literal "signed receipts are observable" workshop story.
+        const _trace = safeRecordSignalTrace({
+            tool_name: "get_operation_status",
+            direction: "inbound",
+            source: "mcp_external",
+            request_payload: args,
+            response_payload: response,
+            response_status: "ok",
+            duration_ms: Date.now() - _t0,
+        });
+        await persistSignalTrace(env, _trace);
         return toolResult(JSON.stringify(response, null, 2), response);
     } catch (err) {
+        const _trace = safeRecordSignalTrace({
+            tool_name: "get_operation_status",
+            direction: "inbound",
+            source: "mcp_external",
+            request_payload: args,
+            response_payload: { errors: [{ message: String(err) }] },
+            response_status: "error",
+            response_error_message: String(err),
+            duration_ms: Date.now() - _t0,
+        });
+        await persistSignalTrace(env, _trace);
         if (err instanceof NotFoundError) throw new McpToolError(err.message);
         throw err;
     }
@@ -1125,6 +1152,7 @@ async function callQuerySignalsNl(
 
     const limit = numArg(args["limit"], 10);
 
+    const _t0 = Date.now();
     const db = getDb(env);
     const catalog = await getAllSignalsForCatalog(db);
     const res = await handleNLQuery({ query, limit }, catalog, env);
@@ -1134,12 +1162,32 @@ async function callQuerySignalsNl(
     // MCP transport binding (adcp#3999): when the NL response is a structured
     // object, flat-merge the envelope status. Plain-text responses skip the
     // envelope (no structuredContent emitted; envelope semantics don't apply).
+    let response: unknown;
     if (structured && typeof structured === "object" && !Array.isArray(structured)) {
-        const wrapped = withMcpEnvelope(
+        response = withMcpEnvelope(
             { status: "completed" },
             structured as Record<string, unknown>
         );
-        return toolResult(JSON.stringify(wrapped, null, 2), wrapped);
+    } else {
+        response = structured ?? text;
+    }
+    // Record the trace as an "extension" tool. NL Query is the most
+    // algorithmically rich path our worker exposes (boolean AST
+    // decomposition + multi-method dimension resolution); the workshop
+    // demos it on Discover and the audience needs to see the
+    // request/response JSON to trust the explainability.
+    const _trace = safeRecordSignalTrace({
+        tool_name: "query_signals_nl",
+        direction: "inbound",
+        source: "mcp_external",
+        request_payload: args,
+        response_payload: response,
+        response_status: "ok",
+        duration_ms: Date.now() - _t0,
+    });
+    await persistSignalTrace(env, _trace);
+    if (structured && typeof structured === "object" && !Array.isArray(structured)) {
+        return toolResult(JSON.stringify(response, null, 2), response);
     }
     return toolResult(text, structured);
 }

--- a/src/routes/demo.ts
+++ b/src/routes/demo.ts
@@ -471,6 +471,11 @@ ${STYLES}
               <span style="color:var(--text-mut)">Filter by <strong>vertical</strong> (data-provider grouping) and <strong>category type</strong> (AdCP 5-enum) — two independent axes.</span>
             </p>
           </div>
+          <div>
+            <button class="btn-secondary" id="catalog-signal-traces" title="View raw get_signals request/response JSON for the cursor-paged catalog walk. Each page-fetch is its own trace; the chained pagination.cursor values demonstrate AdCP 3.0.x cursor pagination end-to-end.">
+              <svg class="ico"><use href="#icon-braces"/></svg>{ } Signal traces
+            </button>
+          </div>
         </div>
 
         <div class="kpi-row">
@@ -2269,6 +2274,9 @@ ${STYLES}
             <p class="pane-subtitle">All activation jobs written to D1. Polls every 10s while this tab is visible so in-flight statuses auto-update.</p>
           </div>
           <div class="activations-controls">
+            <button class="btn-secondary" id="activation-signal-traces" title="View raw activate_signal + get_operation_status request/response JSON for every recent activation. Each row's poll loop (pending → working → completed) emits one trace per iteration so you can audit the receipt sequence.">
+              <svg class="ico"><use href="#icon-braces"/></svg>{ } Signal traces
+            </button>
             <button class="btn-secondary" id="refresh-activations">
               <svg class="ico"><use href="#icon-activations"/></svg>
               <span>Refresh</span>

--- a/src/routes/raceCanvas.ts
+++ b/src/routes/raceCanvas.ts
@@ -957,11 +957,16 @@ function renderRaceCanvas(demoKey: string): string {
 </div>
 
 <!-- Race Canvas Signal traces overlay — slim version of the demo's
-     shared viewer, fetches /api/signal-traces and renders a list. -->
+     shared viewer, fetches /api/signal-traces and renders a list.
+     Shares the rendering primitives (schema banner, peer version chip,
+     humanized errors, extension badge) with the main demo's
+     signals-trace-viewer.ts via _raceRender* helpers below — kept
+     inline because /race is a standalone HTML page that doesn't load
+     the full demo bundle. -->
 <div class="modal-backdrop" id="signal-trace-backdrop" style="display:none">
   <div class="modal" style="max-width:920px;width:96vw;max-height:88vh;overflow-y:auto">
     <div class="modal-title">Signal traces · raw protocol JSON</div>
-    <div class="modal-sub" style="opacity:0.7">Get_signals + activate_signal request/response captures with schema validation. Refresh to pull latest.</div>
+    <div class="modal-sub" style="opacity:0.7">Every recorded AdCP tool call (get_signals, activate_signal, query_signals_nl, get_operation_status, list_creative_formats, get_products, create_media_buy, check_governance) with schema validation against the vendored 3.0.6 corpus. Refresh to pull latest.</div>
     <button class="modal-close" id="signal-trace-modal-close">close</button>
     <div style="margin-top:14px"><button class="try-chip" id="signal-trace-refresh">↻ refresh</button></div>
     <div id="signal-trace-list" style="margin-top:12px;font:11.5px ui-monospace,Menlo,Consolas,monospace">loading…</div>
@@ -1622,9 +1627,17 @@ function renderRaceCanvas(demoKey: string): string {
     var statusColor = t.response.status === "ok" ? "#5fd9c4" : "#ff7b7b";
     var reqValid = t.request.validation && t.request.validation.valid;
     var resValid = t.response.validation && t.response.validation.valid;
-    var reqErrCount = (t.request.validation && t.request.validation.errors || []).length;
-    var resErrCount = (t.response.validation && t.response.validation.errors || []).length;
-    function badge(ok, errCount) {
+    var reqErrs = (t.request.validation && t.request.validation.errors) || [];
+    var resErrs = (t.response.validation && t.response.validation.errors) || [];
+    var reqErrCount = reqErrs.length;
+    var resErrCount = resErrs.length;
+    var reqIsExt = reqErrs.some(function (e) { return e.keyword === "extension"; });
+    var resIsExt = resErrs.some(function (e) { return e.keyword === "extension"; });
+    var reqIsSkip = reqErrs.some(function (e) { return e.keyword === "skipped" || e.keyword === "missing_schema"; });
+    var resIsSkip = resErrs.some(function (e) { return e.keyword === "skipped" || e.keyword === "missing_schema"; });
+    function badge(ok, errCount, isExt, isSkip) {
+      if (isExt) return '<span style="color:#ffc45f" title="Tool not yet standardized in published AdCP spec — recorded for audit, schema link goes to the proposal.">⚙ ext</span>';
+      if (isSkip) return '<span style="color:#9aa6b3" title="Validator could not run; schema URL link still works">⊘ skip</span>';
       if (ok) return '<span style="color:#5fd9c4">✓ schema</span>';
       return '<span style="color:#ff9b6b">✗ ' + errCount + ' err</span>';
     }
@@ -1656,7 +1669,7 @@ function renderRaceCanvas(demoKey: string): string {
         peerVerBlock +
         ' · <span style="color:' + statusColor + '">' + escapeHtml(t.response.status) + '</span>' +
         ' · ' + t.duration_ms + 'ms · ' + new Date(t.ts).toLocaleTimeString() +
-        ' · ' + badge(reqValid, reqErrCount) + ' req · ' + badge(resValid, resErrCount) + ' res' +
+        ' · ' + badge(reqValid, reqErrCount, reqIsExt, reqIsSkip) + ' req · ' + badge(resValid, resErrCount, resIsExt, resIsSkip) + ' res' +
       '</summary>' +
       '<div style="margin-top:8px"><strong style="font-size:10px;letter-spacing:0.1em">REQUEST</strong>' +
         ' · validating against <a href="' + escapeHtml(t.request.validation.schema_url) + '" target="_blank" style="color:#38b6ff;font-size:10px">' + escapeHtml(t.request.validation.schema_url.split("/").slice(-2).join("/")) + ' ↗</a></div>' +

--- a/tests/__snapshots__/demo-render-snapshot.test.ts.snap
+++ b/tests/__snapshots__/demo-render-snapshot.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`handleDemo byte-equivalence > matches the committed golden hash (LF-normalized SHA-256 of body) 1`] = `
 {
-  "hash": "6d48fe92d8f8e988f6f124eac69cd3d49312de401589bb0389b50eb268e18e41",
-  "length": 1153000,
+  "hash": "483125e5964ed9958b7662a8795d2f8913ecf9edc284e514826dcc2d9166f408",
+  "length": 1156915,
 }
 `;


### PR DESCRIPTION
## Summary

Closes the five gaps from the pre-workshop trace audit. After this PR, every demo path produces an inspectable trace.

### 1. Recorder: 3 new tools

| Tool | Treatment | Why |
|---|---|---|
| \`check_governance\` | Schema-validated against \`/schemas/3.0.6/governance/check-governance-{request,response}.json\` | Already standardized |
| \`query_signals_nl\` | Recorded, **extension badge** | Demoed live on Discover NL Query mode |
| \`get_operation_status\` | Recorded, **extension badge** | The activation poll loop |

New \`extensionValidationResult()\` helper emits \`keyword: \"extension\"\` so the viewer renders \`⚙ extension\` instead of the misleading \`⊘ validation skipped\`.

### 2. Recorder callsites in \`src/mcp/server.ts\`

\`callQuerySignalsNl\` + \`callGetOperation\` now record traces on success + error paths.

### 3. Federation gate

\`TRACED_TOOLS\` in \`genericMcpClient.ts\` widened to include all three new tools.

### 4. UI chips

- **Catalog** tab: \`{ } Signal traces\` button (cursor-paged walk)
- **Detail Panel**: \`{ }\` chip next to MCP-inspect (signal_ids lookup path)
- **Activations** tab: \`{ } Signal traces\` multi-tool filter (activate_signal + get_operation_status)
- **Discover** chip expanded to multi-tool (get_signals + query_signals_nl)

### 5. Race Canvas inline viewer

Recognizes extension + skipped validation states with distinct badges.

## Test plan

- [x] \`npx vitest run\` — **449 passed, 12 skipped, 0 failed**
- [x] Demo-render snapshot regenerated
- [x] \`npx tsc --noEmit\` clean