### PR TITLE
URGENT: Restore catalog list-all (workshop-blocker)

### DIFF
--- a/src/domain/signalService.ts
+++ b/src/domain/signalService.ts
@@ -47,8 +47,26 @@ export async function searchSignalsService(
   const limit = Math.min(req.limit ?? DEFAULT_LIMIT, MAX_LIMIT);
   const offset = req.offset ?? 0;
 
+  // Normalize the brief field. AdCP 3.0.x's get_signals request schema
+  // requires anyOf(signal_spec, signal_ids), so callers doing a
+  // "list-everything" catalog walk pass a wildcard signal_spec ("*"
+  // or empty string) to satisfy validation. Treat those as no-brief
+  // here so we hit the catalog page-walk path (offset-honored, no
+  // re-ranking) instead of the relevance-rank path (which would
+  // keyword-match against the literal "*" and return ~33 of 512
+  // signals — the regression that broke the Catalog tab).
+  //
+  // We don't reassign req.brief because SearchSignalsRequest types it as
+  // a non-optional string under exactOptionalPropertyTypes; instead we
+  // derive a local `brief` value and use it in every downstream check.
+  const normalizedBrief = (typeof req.brief === "string"
+    && req.brief.trim() !== ""
+    && req.brief.trim() !== "*")
+    ? req.brief
+    : undefined;
+
   // When a brief is present, fetch a larger window so we can re-rank by relevance
-  const fetchLimit = req.brief ? Math.min(200, MAX_LIMIT * 4) : limit;
+  const fetchLimit = normalizedBrief ? Math.min(200, MAX_LIMIT * 4) : limit;
 
   const tDb0 = Date.now();
   const { signals, totalCount } = await searchSignals(db, {
@@ -61,14 +79,14 @@ export async function searchSignalsService(
       activationSupported: req.activationSupported,
     }),
     limit: fetchLimit,
-    offset: req.brief ? 0 : offset,  // always fetch from top when re-ranking
+    offset: normalizedBrief ? 0 : offset,  // always fetch from top when re-ranking
   });
   performance.db_read = Date.now() - tDb0;
   traceSteps.push({
     id: "fetch",
     label: "Fetch candidates from D1",
     duration_ms: performance.db_read,
-    note: req.brief
+    note: normalizedBrief
       ? "Wide window (up to 200) so we can re-rank by relevance after."
       : `Catalog window of ${fetchLimit} starting at offset ${offset}.`,
     details: [
@@ -86,14 +104,14 @@ export async function searchSignalsService(
   // If brief/signal_spec present, re-rank catalog results by relevance to brief
   // Fetch broader window, score, sort, then slice to limit
   const tRank0 = Date.now();
-  const ranked = req.brief ? rankByRelevance(signals, req.brief).slice(0, limit) : signals;
+  const ranked = normalizedBrief ? rankByRelevance(signals, normalizedBrief).slice(0, limit) : signals;
   performance.rank = Date.now() - tRank0;
 
-  if (req.brief) {
+  if (normalizedBrief) {
     // Build a detailed trace step for the keyword scoring pass. We re-run
     // the scorer here so the panel has access to the per-signal scores +
     // matched keywords that the production scorer doesn't normally surface.
-    const traceData = explainKeywordRanking(signals, req.brief, limit);
+    const traceData = explainKeywordRanking(signals, normalizedBrief, limit);
     traceSteps.push({
       id: "keyword_score",
       label: "Score by keyword match (current implementation)",
@@ -142,8 +160,8 @@ export async function searchSignalsService(
   // proposal in KV (not D1) so activate_signal can promote it lazily on
   // demand — see src/storage/proposalCache.ts for rationale.
   let proposals: CustomSignalProposal[] | undefined;
-  if (req.brief) {
-    const generated = generateProposalsFromBrief(req.brief);
+  if (normalizedBrief) {
+    const generated = generateProposalsFromBrief(normalizedBrief);
     if (generated.length > 0) {
       const now = new Date().toISOString();
       await Promise.all(
@@ -155,15 +173,15 @@ export async function searchSignalsService(
     }
   }
 
-  const filterDesc = req.brief
-    ? `matching brief "${req.brief.slice(0, 50)}"`
+  const filterDesc = normalizedBrief
+    ? `matching brief "${normalizedBrief.slice(0, 50)}"`
     : req.query
     ? `matching "${req.query}"`
     : req.categoryType
     ? `in category "${req.categoryType}"`
     : "from catalog";
 
-  if (req.brief && proposals && proposals.length > 0) {
+  if (normalizedBrief && proposals && proposals.length > 0) {
     traceSteps.push({
       id: "proposal",
       label: "Custom proposal generation",
@@ -180,8 +198,8 @@ export async function searchSignalsService(
   performance.other = Math.max(0, performance.total - (performance.db_read ?? 0) - (performance.rank ?? 0));
 
   const trace: TraceData = {
-    operation: req.brief ? "Discover query · brief mode" : "Discover query · catalog mode",
-    input: req.brief ?? req.query ?? "(no input)",
+    operation: normalizedBrief ? "Discover query · brief mode" : "Discover query · catalog mode",
+    input: normalizedBrief ?? req.query ?? "(no input)",
     duration_ms: performance.total,
     steps: traceSteps,
     performance,

--- a/tests/catalog-wildcard-listall.test.ts
+++ b/tests/catalog-wildcard-listall.test.ts
@@ -1,0 +1,168 @@
+// tests/catalog-wildcard-listall.test.ts
+//
+// Pin the catalog regression: signal_spec="*" must NOT keyword-match
+// against the literal "*", which collapsed the catalog from 512 to ~33
+// signals on the Catalog tab. AdCP 3.0.x's get-signals-request schema
+// requires anyOf(signal_spec, signal_ids), so the demo client passes
+// a wildcard signal_spec ("*") to satisfy validation when it wants
+// "list everything." The server must interpret that wildcard as
+// no-brief and hit the catalog page-walk path.
+//
+// These tests stub the storage layer with a known signal corpus and
+// confirm the wildcard hits the broad list-all path (no re-ranking,
+// offset honored) rather than the relevance-rank path.
+
+import { describe, it, expect, vi } from "vitest";
+import { searchSignalsService } from "../src/domain/signalService";
+
+// Build a fake D1 binding that returns a fixed-size catalog. We only
+// need the searchSignals storage call's contract; everything else
+// (proposal cache, ranker) operates on the returned list.
+function makeFakeDb(catalogSize: number) {
+  // Generate `catalogSize` synthetic catalog rows. Production
+  // searchSignals returns ranked-by-D1 ordering; we don't care about
+  // order here, only count + that the storage filter doesn't strip
+  // the wildcard.
+  const allSignals = Array.from({ length: catalogSize }, (_, i) => ({
+    signal_id: `sig_test_${i}`,
+    name: `Test Signal ${i}`,
+    description: `synthetic test signal #${i} for catalog count regression`,
+    signal_type: "marketplace",
+    category_type: "demographic",
+    generation_mode: "deterministic",
+    estimated_audience_size: 1_000_000 + i,
+    coverage_percentage: 50,
+    pricing_options: [],
+    deployments: [{ type: "platform", platform: "mock_dsp", is_live: true }],
+    data_provider: "test",
+    taxonomy_system: "test",
+    sensitivity_categories: [],
+  }));
+
+  let lastQueryParam: string | undefined = undefined;
+
+  return {
+    db: {
+      prepare(_sql: string) {
+        let bound: unknown[] = [];
+        return {
+          bind(...args: unknown[]) { bound = args; return this; },
+          async first<T>() { return null as unknown as T; },
+          async all<T>() {
+            // Production uses bound parameters; the storage shim doesn't
+            // route through them in this test. The fakeStorage path
+            // below intercepts at a higher level.
+            return { results: [] as T[] };
+          },
+          async run() { return { success: true, meta: {} } as unknown as D1Result; },
+        };
+      },
+    } as unknown as D1Database,
+    allSignals,
+    getLastQueryParam: () => lastQueryParam,
+    setLastQueryParam: (v: string | undefined) => { lastQueryParam = v; },
+  };
+}
+
+// Mock the storage layer so the real searchSignals doesn't try to
+// hit a non-existent D1. We capture the `query` param the service
+// passes through to confirm wildcard normalization happened
+// upstream.
+vi.mock("../src/storage/signalRepo", () => {
+  // Match CanonicalSignal shape (camelCase) per src/types/signal.ts
+  // — the mapper assumes signal.destinations is a string[] of platform
+  // ids, signal.signalId, signal.taxonomySystem etc.
+  const allSignals = Array.from({ length: 500 }, (_, i) => ({
+    signalId: `sig_test_${i}`,
+    name: `Test Signal ${i}`,
+    description: `synthetic test signal #${i} for catalog count regression`,
+    categoryType: "demographic" as const,
+    taxonomySystem: "test" as never,
+    sourceSystems: ["test"],
+    destinations: ["mock_dsp"],
+    activationSupported: true,
+    estimatedAudienceSize: 1_000_000 + i,
+    accessPolicy: "public" as never,
+    generationMode: "deterministic" as const,
+    status: "available" as never,
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
+  }));
+  return {
+    searchSignals: vi.fn(async (_db: unknown, opts: { limit?: number; offset?: number; query?: string }) => {
+      // Record the query the service passed through for assertions
+      (globalThis as Record<string, unknown>).__lastSearchSignalsQuery = opts.query;
+      const offset = opts.offset ?? 0;
+      const limit = opts.limit ?? 20;
+      // Storage doesn't keyword-filter unless `query` is set.
+      const slice = allSignals.slice(offset, offset + limit);
+      return { signals: slice, totalCount: allSignals.length };
+    }),
+    findSignalById: vi.fn(),
+  };
+});
+
+function makeFakeKv(): KVNamespace {
+  const store = new Map<string, string>();
+  return {
+    async get(k: string) { return store.get(k) ?? null; },
+    async put(k: string, v: string) { store.set(k, v); },
+    async delete(k: string) { store.delete(k); },
+    async list() { return { keys: [...store.keys()].map((name) => ({ name })), list_complete: true } as never; },
+    async getWithMetadata() { return { value: null, metadata: null } as never; },
+  } as unknown as KVNamespace;
+}
+
+describe("Catalog wildcard list-all regression", () => {
+  const fakeDb = {} as D1Database;
+  const fakeKv = makeFakeKv();
+
+  it('signal_spec="*" hits the catalog list-all path (no brief re-ranking)', async () => {
+    const r = await searchSignalsService(fakeDb, fakeKv, {
+      brief: "*",
+      limit: 100,
+      offset: 0,
+    });
+    // The service should return the full window (100 of 500), NOT a
+    // tiny re-ranked subset matching the literal "*".
+    expect(r.count).toBe(100);
+    expect(r.totalCount).toBe(500);
+    // No proposals — wildcard is not a brief, so generateProposalsFromBrief shouldn't run.
+    expect(r.proposals ?? []).toHaveLength(0);
+  });
+
+  it('empty signal_spec ("" / whitespace) is also normalized to list-all', async () => {
+    const r = await searchSignalsService(fakeDb, fakeKv, {
+      brief: "   ",
+      limit: 50,
+      offset: 0,
+    });
+    expect(r.count).toBe(50);
+    expect(r.totalCount).toBe(500);
+  });
+
+  it('cursor pagination walks all pages (offset honored when wildcard)', async () => {
+    const page1 = await searchSignalsService(fakeDb, fakeKv, { brief: "*", limit: 100, offset: 0 });
+    const page2 = await searchSignalsService(fakeDb, fakeKv, { brief: "*", limit: 100, offset: 100 });
+    const page3 = await searchSignalsService(fakeDb, fakeKv, { brief: "*", limit: 100, offset: 200 });
+    // Each page is a different slice of 100 — proves offset is being
+    // honored. (Without normalization, the service's req.brief check
+    // forced offset:0 always and re-ranked the same window each time.)
+    expect((page1.signals[0] as { signal_agent_segment_id?: string })?.signal_agent_segment_id).toBe("sig_test_0");
+    expect((page2.signals[0] as { signal_agent_segment_id?: string })?.signal_agent_segment_id).toBe("sig_test_100");
+    expect((page3.signals[0] as { signal_agent_segment_id?: string })?.signal_agent_segment_id).toBe("sig_test_200");
+  });
+
+  it('a real brief ("luxury cars") still triggers the relevance-rank path', async () => {
+    const r = await searchSignalsService(fakeDb, fakeKv, {
+      brief: "luxury cars",
+      limit: 10,
+      offset: 0,
+    });
+    // Real briefs return up to limit, sliced from a re-ranked window.
+    expect(r.count).toBeLessThanOrEqual(10);
+    // generateProposalsFromBrief runs on real briefs, so we MAY get
+    // proposals (depending on the brief). The point is the path is
+    // different from wildcard — service entered the brief branch.
+  });
+});


### PR DESCRIPTION
## Summary

**Workshop-blocking regression**: Catalog tab showed 33 signals instead of 512.

## Root cause

PR #223 changed \`loadCatalog\` to pass \`signal_spec: \"*\"\` so the request validates against AdCP 3.0.x's \`anyOf(signal_spec, signal_ids)\` requirement. But our \`searchSignalsService\` treats \`req.brief\` as a real keyword query when truthy — so the literal \`\"*\"\` hit the relevance-rank path and collapsed the catalog to whatever ranked >0 against that single character.

Cursor pagination was also broken on the same path: the brief-truthy check forced \`offset: 0\` every page, so the cursor walk emitted the same first-page-rerank repeatedly.

## Fix

At \`signalService\` entry, derive a \`normalizedBrief\` that's only populated when the brief is non-empty AND not a wildcard. Use it everywhere instead of \`req.brief\` — the offset gate, the re-ranking call, the proposal generation, trace metadata, filterDesc string.

Wildcard / empty / whitespace-only briefs now hit the catalog page-walk path (offset honored, no re-ranking, full totalCount).

The wire stays clean — clients keep sending \`signal_spec=\"*\"\` so trace recorder validates ✓ schema valid (anyOf satisfied). Server just stops over-interpreting.

## Test plan

\`tests/catalog-wildcard-listall.test.ts\` pins the regression with 4 cases:

- [x] \`signal_spec=\"*\"\` returns full 100/500 window (was: ~0)
- [x] whitespace-only brief normalizes to list-all
- [x] cursor pagination walks pages 0/100/200 (proves offset honored)
- [x] real brief still triggers relevance-rank path
- [x] \`npx vitest run\` — **453 passed (+4 new), 12 skipped, 0 failed**
- [ ] **After deploy: Catalog tab shows ~512 signals again**
- [ ] After deploy: Catalog tab → trace chip → multiple cursor-paged traces, each advancing offset