### PR TITLE
URGENT: Server reads pagination.max_results + Activations Poll button

### DIFF
--- a/src/demo/script/fragments/activations.ts
+++ b/src/demo/script/fragments/activations.ts
@@ -69,6 +69,7 @@ function renderActivationRow(op) {
       '<td class="td-time">' + (op.webhookFired ? '<span style="color:var(--success)">fired</span>' : (op.webhookUrl ? 'queued' : '—')) + '</td>' +
       '<td class="td-time" style="max-width:200px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap">' + escapeHtml((op.operationId || "").slice(0, 24)) + '</td>' +
       '<td class="td-time">' +
+        '<button class="btn-secondary btn-mini" data-poll-task-id="' + opId + '" data-poll-row-id="' + opId + '" title="Fire get_operation_status against this task. Records a trace under tool=get_operation_status — useful to demo the poll-loop story (the spec\\'s signed-receipt audit trail).">🔍 Poll</button> ' +
         '<button class="btn-secondary btn-mini" data-trace-activation="' + sigId + '" data-trace-task-id="' + opId + '" title="View signal request/response JSON for this activation">{ } JSON</button>' +
       '</td>' +
     '</tr>';
@@ -92,6 +93,41 @@ document.addEventListener("click", function (e) {
     signal_id: sigId || undefined,
     limit: 25,
   });
+});
+
+// Wire the 🔍 Poll button — fires get_operation_status via callTool so
+// the request goes through /mcp and produces a trace the audience can
+// inspect. Without this, the only path that produces get_operation_status
+// traces is the Detail-Panel activation poll loop (detail-panel.ts), which
+// requires a fresh Activate click in the current session. The Poll button
+// lets the workshop replay the receipt-audit story on any existing row.
+document.addEventListener("click", async function (e) {
+  const t = e.target;
+  if (!t || !t.matches || !t.matches("[data-poll-task-id]")) return;
+  const taskId = t.getAttribute("data-poll-task-id");
+  if (!taskId) return;
+  const orig = t.textContent;
+  t.disabled = true;
+  t.textContent = "🔍 polling…";
+  try {
+    const result = await callTool("get_operation_status", { task_id: taskId });
+    const newStatus = (result && (result.status || (result.ext && result.ext.status))) || "unknown";
+    t.textContent = "🔍 " + newStatus;
+    // Re-color the button briefly to show what came back
+    t.classList.add("poll-flash");
+    setTimeout(function () {
+      t.textContent = orig;
+      t.classList.remove("poll-flash");
+      t.disabled = false;
+    }, 2400);
+    // Trigger a row refresh so the status pill matches what the poll
+    // returned (the in-memory activation may be stale until next /operations).
+    if (typeof loadActivations === "function") loadActivations();
+  } catch (err) {
+    t.textContent = "🔍 ✗";
+    setTimeout(function () { t.textContent = orig; t.disabled = false; }, 2400);
+    if (typeof showToast === "function") showToast("Poll failed: " + (err && err.message ? err.message : err), true);
+  }
 });
 
 function fmtTime(iso) {

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -500,6 +500,17 @@ async function callGetSignals(
         // Use `!= null` (matches both null and undefined) instead of truthy
         // checks so a literal 0 isn't silently replaced by the default.
         //
+        // AdCP 3.0.1 deprecated top-level `max_results` in favor of
+        // `pagination.max_results`. Per the spec: "When both fields are
+        // present, agents MUST honor pagination.max_results." So we read
+        // pagination.max_results FIRST, then fall back to the deprecated
+        // top-level forms in priority order. Without this, a 3.0.x-shaped
+        // client (which we ship — bootstrap.ts:_getSignalsArgs nests
+        // max_results inside pagination per the deprecation) fell back to
+        // the default 5 because the server only checked the legacy
+        // top-level paths. That collapsed the Catalog tab from 512 to 54
+        // signals (10-page safety-break × 5/page + scraps).
+        //
         // Sec-24b: global default of 5 (was 20 with a probe-shape carve-out
         // to 3). Rich DTS + UCP payloads make 20-row responses >200 KB —
         // breaking the security_baseline runner's 64 KB probe ceiling and
@@ -507,7 +518,13 @@ async function callGetSignals(
         // ~50 KB, leaves headroom, and `hasMore` + `totalCount` in the
         // response make pagination discoverable. Callers who want the
         // bigger page still pass `max_results` explicitly.
-        limit: numArg(args["max_results"], numArg(args["limit"], 5)),
+        limit: numArg(
+            pagination?.["max_results"],          // 3.0.x canonical (preferred)
+            numArg(
+                args["max_results"],              // 3.0.x deprecated top-level
+                numArg(args["limit"], 5)          // legacy alias
+            )
+        ),
         // Sec-31w-cursor: callers can paginate via either explicit
         // pagination.offset (legacy) OR pagination.cursor (v3 / what we
         // emit when has_more=true). Cursor format is "offset:<int>".

--- a/tests/__snapshots__/demo-render-snapshot.test.ts.snap
+++ b/tests/__snapshots__/demo-render-snapshot.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`handleDemo byte-equivalence > matches the committed golden hash (LF-normalized SHA-256 of body) 1`] = `
 {
-  "hash": "97c806876dcc019d65094c42774da27238f1ceef9629a71254989e5b85fd89df",
-  "length": 1171448,
+  "hash": "30bc2bc8439c6258c4fe703117302abb88c9d10b3713fa34db640dc0496a9a80",
+  "length": 1173440,
 }
 `;


### PR DESCRIPTION
## Two workshop blockers

### 1. Catalog still showed 54 signals (not 33, not 512)

PR #228 fixed the wildcard normalization. That moved 33→54. The remaining gap was a separate bug: \`callGetSignals\` (server.ts:510) reads \`max_results\` from TOP-LEVEL args, but our 3.0.x-conformant client (bootstrap.ts \`_getSignalsArgs\` after PR #224) nests \`max_results\` inside \`pagination\` per the 3.0.1 deprecation. Server saw none, fell back to default **5**. loadCatalog's 10-page safety cap × 5/page ≈ 54.

Per AdCP 3.0.1 spec: *\"When both fields are present, agents MUST honor pagination.max_results.\"*

**Fix**: Three-tier lookup — \`pagination.max_results\` (canonical) → \`args.max_results\` (deprecated) → \`args.limit\` (legacy) → 5 (default).

### 2. Activations modal had no \`get_operation_status\` traces

The Activations tab polls REST \`/operations?limit=100\` every 10s — a list endpoint, NOT an MCP \`get_operation_status\` call. The only place \`get_operation_status\` fires is \`detail-panel.ts:693\` (post-Activate poll). So if you hadn't activated via Detail Panel in this session, the modal correctly showed nothing.

**Fix**: Added a 🔍 Poll button per activations row. Click → fires \`callTool(\"get_operation_status\", {task_id})\` → goes through /mcp → \`callGetOperation\` records trace → button label updates with the returned status. Audience can demo the receipt-audit story on stage by clicking Poll on any existing activation.

## Test plan

- [x] \`npx vitest run\` — **453 passed, 12 skipped, 0 failed**
- [x] Demo-render snapshot regenerated
- [x] \`npx tsc --noEmit\` clean
- [ ] **After deploy: Catalog tab shows full ~512 signals**
- [ ] After deploy: Activations row → 🔍 Poll button → status updates → trace appears in modal under tool=get_operation_status
- [ ] After deploy: Click \`{ } Signal traces\` chip on Activations tab → see both activate_signal AND get_operation_status traces interleaved