### PR TITLE
Publish /.well-known/adagents.json + Discovery probe for peers

### DIFF
--- a/src/demo/script/fragments/federation.ts
+++ b/src/demo/script/fragments/federation.ts
@@ -377,6 +377,101 @@ function fedCompareSelected() {
   host.scrollIntoView({ behavior: "smooth", block: "start" });
 }
 
+// ── Discovery probe panel ───────────────────────────────────────────────
+//
+// Workshop overdeliver: visible at top of Federation tab. Shows OUR
+// /.well-known/adagents.json + each peer's probe result side-by-side.
+// "We publish, peers don't, here's the gap" -- the discovery-anchor
+// coverage story in one click.
+async function _renderOurAdagents() {
+  var pre = document.getElementById("discovery-our-doc");
+  if (!pre) return;
+  try {
+    var r = await fetch("/.well-known/adagents.json");
+    var doc = await r.json();
+    pre.textContent = JSON.stringify(doc, null, 2);
+  } catch (e) {
+    pre.textContent = "Failed to fetch our adagents.json: " + (e && e.message ? e.message : e);
+  }
+}
+
+function _badgeForProbeStatus(status) {
+  var cls = "pill-mut", icon = "?";
+  if (status === "ok") { cls = "pill-success"; icon = "✓ valid"; }
+  else if (status === "schema_invalid") { cls = "pill-warn"; icon = "⚠ invalid shape"; }
+  else if (status === "not_found") { cls = "pill-mut"; icon = "404 no file"; }
+  else if (status === "http_error") { cls = "pill-warn"; icon = "HTTP error"; }
+  else if (status === "timeout") { cls = "pill-mut"; icon = "timeout"; }
+  else if (status === "network_error") { cls = "pill-mut"; icon = "network err"; }
+  return '<span class="pill ' + cls + '" style="font-size:10.5px">' + icon + '</span>';
+}
+
+async function _runDiscoveryProbe() {
+  var btn = document.getElementById("fed-discovery-probe");
+  var panel = document.getElementById("discovery-panel");
+  var resultsHost = document.getElementById("discovery-peer-results");
+  var countsEl = document.getElementById("discovery-peer-counts");
+  if (!panel || !resultsHost) return;
+  panel.style.display = "block";
+  if (btn) btn.disabled = true;
+  resultsHost.innerHTML = '<div class="empty-state"><span class="spinner"></span><div class="empty-title">Probing peer adagents.json files…</div></div>';
+  await _renderOurAdagents();
+  try {
+    var r = await fetch("/api/adagents-probe");
+    var data = await r.json();
+    var counts = data.counts || {};
+    if (countsEl) {
+      var parts = [];
+      if (counts.ok) parts.push(counts.ok + " published & valid");
+      if (counts.schema_invalid) parts.push(counts.schema_invalid + " published but invalid");
+      if (counts.not_found) parts.push(counts.not_found + " no file (404)");
+      if (counts.http_error || counts.timeout || counts.network_error) {
+        parts.push(((counts.http_error || 0) + (counts.timeout || 0) + (counts.network_error || 0)) + " unreachable");
+      }
+      countsEl.textContent = "· " + parts.join(" · ") + " (" + (data.probed_count || 0) + " peers)";
+    }
+    var rows = (data.results || []).map(function (p) {
+      var detail = "";
+      if (p.status === "ok" || p.status === "schema_invalid") {
+        var shapeJson = JSON.stringify(p.payload_preview || {}, null, 2);
+        if (shapeJson.length > 1500) shapeJson = shapeJson.slice(0, 1500) + "\\n… (truncated)";
+        detail = '<details style="margin-top:8px"><summary style="cursor:pointer;color:var(--text-mut);font-size:11px">show response</summary>' +
+          '<pre class="signal-trace-json" style="max-height:240px;margin-top:6px">' + escapeHtml(shapeJson) + '</pre>';
+        if (p.validation && p.validation.errors && p.validation.errors.length > 0) {
+          detail += '<div style="margin-top:6px;color:#ff9b6b;font-size:11px">' + p.validation.errors.length + ' schema error' + (p.validation.errors.length === 1 ? "" : "s") + ':</div>' +
+            '<ul style="margin:4px 0 0 20px;color:#ff9b6b;font-size:10.5px">' +
+            p.validation.errors.slice(0, 5).map(function (e) {
+              return '<li><code>' + escapeHtml(e.path || "(root)") + '</code> ' + escapeHtml(e.message || "") + '</li>';
+            }).join("") + '</ul>';
+        }
+        detail += '</details>';
+      } else if (p.error) {
+        detail = '<div style="margin-top:4px;color:var(--text-mut);font-size:10.5px">' + escapeHtml(p.error) + '</div>';
+      }
+      return '<div class="signal-trace-frame" style="padding:8px 12px">' +
+        '<div style="display:flex;align-items:baseline;gap:10px;flex-wrap:wrap">' +
+          '<strong style="font-size:12.5px">' + escapeHtml(p.agent_name || p.agent_id) + '</strong>' +
+          _badgeForProbeStatus(p.status) +
+          '<a href="' + escapeHtml(p.fetched_url) + '" target="_blank" rel="noopener" style="color:var(--accent);font-size:10.5px;text-decoration:none">' + escapeHtml(p.fetched_url) + ' ↗</a>' +
+          '<span style="color:var(--text-mut);font-size:10.5px;margin-left:auto">' + (p.duration_ms || 0) + 'ms</span>' +
+        '</div>' +
+        detail +
+      '</div>';
+    }).join("");
+    resultsHost.innerHTML = rows || '<div class="empty-state"><div class="empty-title">No peers in registry</div></div>';
+  } catch (e) {
+    resultsHost.innerHTML = '<div class="empty-state" style="color:var(--error)"><div class="empty-title">Probe failed: ' + escapeHtml(e && e.message ? e.message : String(e)) + '</div></div>';
+  } finally {
+    if (btn) btn.disabled = false;
+  }
+}
+
+document.addEventListener("click", function (e) {
+  var t = e.target;
+  if (!t || !t.closest) return;
+  if (t.closest("#fed-discovery-probe")) _runDiscoveryProbe();
+});
+
 // Sec-38 A7: keyboard shortcuts. Two-key "go to" prefix (g+x). Single
 // keys: ? toggles the cheat sheet, Esc closes overlays + detail panel.
 // Ignore shortcuts while typing in an input/textarea.

--- a/src/index.ts
+++ b/src/index.ts
@@ -144,6 +144,7 @@ import {
     handleAuthorizationServerMetadata,
     handleOAuthTokenStub,
 } from "./routes/wellKnown";
+import { handleAdAgents, handleAdagentsProbe } from "./routes/adagents";
 import { handleAdminReseed } from "./routes/adminReseed";
 import { handleAdminPurge } from "./routes/adminPurge";
 import { runScheduledPurge } from "./storage/scheduledPurge";
@@ -392,6 +393,13 @@ export default {
             // be reachable without auth so clients following the well-known
             // advertisement get the terminal error rather than 401.
             "/oauth/token",
+            // AdCP discovery anchor — public per the spec (a buyer agent
+            // doing /.well-known/adagents.json discovery wouldn't have a
+            // bearer token yet; that's the whole point of the file).
+            "/.well-known/adagents.json",
+            // Peer-probe endpoint — read-only summary of peer adagents
+            // discovery state. Same demo posture as /api/signal-traces.
+            "/api/adagents-probe",
         ];
         const isPublic = publicPaths.some((p) => path === p || path.startsWith(p + "/"));
 
@@ -488,6 +496,24 @@ export default {
                     worker_version: WORKER_VERSION,
                     built_at: builtAt(),
                 });
+
+            } else if (method === "GET" && path === "/.well-known/adagents.json") {
+                // AdCP discovery anchor — declares this worker as the
+                // authorized signals agent for the Demo Provider catalog.
+                // Public, cacheable, schema-validated against the
+                // vendored 3.0.6 adagents.json schema (see
+                // tests/adagents-self-publish.test.ts).
+                response = handleAdAgents(request, env);
+
+            } else if (method === "GET" && path === "/api/adagents-probe") {
+                // Probe every peer in the agent registry for their own
+                // /.well-known/adagents.json. Surfaces the discovery-anchor
+                // coverage gap visually — most peers (Dstillery is 2.x;
+                // Adzymic / Celtra / Claire / Swivel are sales agents not
+                // data providers) won't publish one, and the workshop
+                // demo can show "we publish, peers don't, here's why
+                // standardization matters."
+                response = await handleAdagentsProbe(request, env);
 
             } else if (method === "GET" && path.startsWith("/.well-known/oauth-protected-resource")) {
                 // RFC 9728: resource path is the suffix after the well-known

--- a/src/routes/adagents.ts
+++ b/src/routes/adagents.ts
@@ -1,0 +1,365 @@
+// src/routes/adagents.ts
+//
+// AdCP discovery anchor — /.well-known/adagents.json
+//
+// As a signals data provider, we publish this file to declare which
+// agents are authorized to resell our catalog. Per the AdCP 3.0.6
+// spec ($id: /schemas/3.0.6/adagents.json):
+//
+//   "Hosted at /.well-known/adagents.json on publisher domains (for
+//    properties) or data provider domains (for signals)."
+//
+// A buyer agent doing "find authorized signals agents for this
+// domain" would land on this file, read the `authorized_agents`
+// array, and discover which `agent_url` endpoints to call. Without
+// a published file we're invisible to that discovery flow.
+//
+// Validation: the served document is schema-validated at build via
+// tests/adagents-self-publish.test.ts against the vendored 3.0.6
+// schema. If we ever drift (new required field, etc.), the test
+// fails before deploy.
+//
+// Visibility: the demo footer (src/routes/demo.ts) carries a
+// "📡 adagents.json" link pointing here, and the Federation tab's
+// Discovery panel surfaces this document side-by-side with peer
+// probe results so the workshop audience sees what the protocol's
+// trust anchor looks like in practice.
+
+import type { Env } from "../types/env";
+import { Validator } from "@cfworker/json-schema";
+import { loadAdcpCorpus, ADCP_SPEC_VERSION } from "../schemas/adcp";
+
+export interface AdagentsDocument {
+  $schema: string;
+  contact: {
+    name: string;
+    email?: string;
+    domain?: string;
+    privacy_policy_url?: string;
+  };
+  authorized_agents: Array<{
+    url: string;
+    authorized_for: string;
+    authorization_type: "signal_tags";
+    signal_tags: string[];
+  }>;
+  signal_tags: Record<string, { name: string; description: string }>;
+  last_updated: string;
+}
+
+/**
+ * Build a 3.0.6-conformant adagents.json declaring our worker as the
+ * authorized signals agent for our own catalog. The agent URL is
+ * derived from the request origin so the document works on any deploy
+ * (production, preview, local) without rebuild.
+ */
+export function buildAdagentsDocument(request: Request): AdagentsDocument {
+  const url = new URL(request.url);
+  const origin = `${url.protocol}//${url.host}`;
+  return {
+    $schema: "https://adcontextprotocol.org/schemas/v3/adagents.json",
+    contact: {
+      name: "AdCP Signals Adaptor — Demo Provider (Evgeny)",
+      email: "Evgeny@gmail.com",
+      // Use hostname (not host) so the port doesn't sneak in; the
+      // schema's domain regex doesn't permit colons. Strip any
+      // trailing dot from FQDN-style hosts for the same reason.
+      domain: url.hostname.replace(/\.$/, ""),
+      privacy_policy_url: `${origin}/privacy`,
+    },
+    // Single authorized agent: ourselves. authorization_type = signal_tags
+    // with ["all"] grants the agent rights to all signals tagged "all" —
+    // and we tag every catalog signal "all" by convention. A multi-agent
+    // network (e.g. a federation reseller chain) would add more entries
+    // with narrower signal_tags scopes.
+    authorized_agents: [
+      {
+        url: `${origin}/mcp`,
+        authorized_for:
+          "AdCP signals data provider for the Demo Provider catalog (audience + outcome signals across 14 verticals)",
+        authorization_type: "signal_tags",
+        signal_tags: ["all"],
+      },
+    ],
+    signal_tags: {
+      all: {
+        name: "All catalog signals",
+        description:
+          "Every signal in the Demo Provider catalog, spanning Demographic / Interest / Purchase intent / Geo / Composite category types across 14 verticals. Includes both deterministic (rule-based) and dynamic (proposal-derived) signals.",
+      },
+    },
+    last_updated: new Date().toISOString(),
+  };
+}
+
+/**
+ * GET /.well-known/adagents.json
+ *
+ * Public, unauthenticated, cacheable for an hour. CORS open so a
+ * buyer agent fetching this from any origin (including a browser
+ * during workshop demos) gets a clean response.
+ */
+export function handleAdAgents(request: Request, _env: Env): Response {
+  const doc = buildAdagentsDocument(request);
+  return new Response(JSON.stringify(doc, null, 2), {
+    status: 200,
+    headers: {
+      "Content-Type": "application/json",
+      "Cache-Control": "public, max-age=3600",
+      "Access-Control-Allow-Origin": "*",
+      "X-AdCP-Spec-Version": ADCP_SPEC_VERSION,
+    },
+  });
+}
+
+// ── Validator (cached) ────────────────────────────────────────────────────
+//
+// Used by validateAdagentsDocument() below + the self-publish test.
+// Lazy-init to avoid paying schema-walk cost on cold isolates.
+
+let _adagentsValidator: Validator | null = null;
+function getAdagentsValidator(): Validator | null {
+  if (_adagentsValidator) return _adagentsValidator;
+  try {
+    const corpus = loadAdcpCorpus() as Array<Record<string, unknown> & { $id?: string }>;
+    const root = corpus.find((s) => s.$id === `/schemas/${ADCP_SPEC_VERSION}/adagents.json`);
+    if (!root) return null;
+    const v = new Validator(root, "7", false);
+    for (const s of corpus) {
+      if (s.$id && s.$id !== root.$id) {
+        try { v.addSchema(s); } catch { /* tolerate duplicates */ }
+      }
+    }
+    _adagentsValidator = v;
+    return v;
+  } catch {
+    return null;
+  }
+}
+
+export interface AdagentsValidationResult {
+  valid: boolean;
+  schema_url: string;
+  errors: Array<{ path: string; message: string; keyword: string }>;
+}
+
+export function validateAdagentsDocument(doc: unknown): AdagentsValidationResult {
+  const schemaUrl = `https://adcontextprotocol.org/schemas/v3/adagents.json`;
+  const validator = getAdagentsValidator();
+  if (!validator) {
+    return {
+      valid: true,
+      schema_url: schemaUrl,
+      errors: [{ path: "(meta)", message: "validator unavailable", keyword: "skipped" }],
+    };
+  }
+  const r = validator.validate(doc);
+  if (r.valid) return { valid: true, schema_url: schemaUrl, errors: [] };
+  return {
+    valid: false,
+    schema_url: schemaUrl,
+    errors: (r.errors || []).slice(0, 12).map((e: { instanceLocation?: string; error?: string; keyword?: string; keywordLocation?: string }) => ({
+      path: e.instanceLocation || "(root)",
+      message: e.error || "validation failed",
+      keyword: e.keyword || (e.keywordLocation ? e.keywordLocation.split("/").pop() ?? "unknown" : "unknown"),
+    })),
+  };
+}
+
+// ── Peer probe ────────────────────────────────────────────────────────────
+//
+// Workshop overdeliver: fetch each peer's /.well-known/adagents.json
+// and classify the result. Most won't publish one (Dstillery is 2.x;
+// Adzymic / Celtra / Claire / Swivel are sales agents not data
+// providers). The probe surfaces the discovery-anchor coverage gap
+// visually — "we publish, peers don't, here's the gap, here's why
+// AdCP standardization matters."
+//
+// Safety: 3-second timeout, 64KB cap, no redirect follow. We're
+// fetching from third-party domains so we don't want runaway responses
+// or being redirected to attacker-controlled URLs.
+
+const PROBE_TIMEOUT_MS = 3_000;
+const PROBE_MAX_BYTES = 65_536;
+
+export interface PeerProbeResult {
+  agent_id: string;
+  agent_name: string;
+  agent_mcp_url: string;
+  fetched_url: string;
+  status:
+    | "ok"               // 200 + valid schema
+    | "schema_invalid"   // 200 but doesn't validate
+    | "not_found"        // 404
+    | "http_error"       // non-200, non-404
+    | "timeout"
+    | "network_error";
+  http_status?: number;
+  duration_ms: number;
+  validation?: AdagentsValidationResult;
+  error?: string;
+  // Truncated payload for the UI render (full doc may be 50K+).
+  payload_preview?: unknown;
+}
+
+function deriveDomain(mcpUrl: string): string {
+  try {
+    const u = new URL(mcpUrl);
+    return `${u.protocol}//${u.host}`;
+  } catch {
+    return "";
+  }
+}
+
+export async function probePeerAdagents(
+  agent: { id: string; name: string; mcp_url: string },
+): Promise<PeerProbeResult> {
+  const t0 = Date.now();
+  const origin = deriveDomain(agent.mcp_url);
+  const fetched_url = `${origin}/.well-known/adagents.json`;
+  if (!origin) {
+    return {
+      agent_id: agent.id,
+      agent_name: agent.name,
+      agent_mcp_url: agent.mcp_url,
+      fetched_url,
+      status: "network_error",
+      duration_ms: Date.now() - t0,
+      error: "Could not derive origin from mcp_url",
+    };
+  }
+  const ac = new AbortController();
+  const timer = setTimeout(() => ac.abort(), PROBE_TIMEOUT_MS);
+  try {
+    const r = await fetch(fetched_url, {
+      method: "GET",
+      redirect: "manual",
+      signal: ac.signal,
+      headers: { Accept: "application/json" },
+    });
+    clearTimeout(timer);
+    if (r.status === 404) {
+      return {
+        agent_id: agent.id,
+        agent_name: agent.name,
+        agent_mcp_url: agent.mcp_url,
+        fetched_url,
+        status: "not_found",
+        http_status: 404,
+        duration_ms: Date.now() - t0,
+      };
+    }
+    if (r.status !== 200) {
+      return {
+        agent_id: agent.id,
+        agent_name: agent.name,
+        agent_mcp_url: agent.mcp_url,
+        fetched_url,
+        status: "http_error",
+        http_status: r.status,
+        duration_ms: Date.now() - t0,
+      };
+    }
+    // Read up to PROBE_MAX_BYTES and parse. If the body is bigger we
+    // truncate before parsing — keeps us from accidentally consuming
+    // a DoS-shaped peer response.
+    const buf = await r.arrayBuffer();
+    if (buf.byteLength > PROBE_MAX_BYTES) {
+      return {
+        agent_id: agent.id,
+        agent_name: agent.name,
+        agent_mcp_url: agent.mcp_url,
+        fetched_url,
+        status: "http_error",
+        http_status: r.status,
+        duration_ms: Date.now() - t0,
+        error: `Response body ${buf.byteLength} bytes exceeds ${PROBE_MAX_BYTES} cap`,
+      };
+    }
+    const text = new TextDecoder().decode(buf);
+    let payload: unknown;
+    try {
+      payload = JSON.parse(text);
+    } catch (e) {
+      return {
+        agent_id: agent.id,
+        agent_name: agent.name,
+        agent_mcp_url: agent.mcp_url,
+        fetched_url,
+        status: "schema_invalid",
+        http_status: 200,
+        duration_ms: Date.now() - t0,
+        error: `JSON parse failed: ${(e as Error).message}`,
+      };
+    }
+    const validation = validateAdagentsDocument(payload);
+    return {
+      agent_id: agent.id,
+      agent_name: agent.name,
+      agent_mcp_url: agent.mcp_url,
+      fetched_url,
+      status: validation.valid ? "ok" : "schema_invalid",
+      http_status: 200,
+      duration_ms: Date.now() - t0,
+      validation,
+      payload_preview: payload,
+    };
+  } catch (e) {
+    clearTimeout(timer);
+    const msg = (e as Error).name === "AbortError" ? "timeout" : "network_error";
+    return {
+      agent_id: agent.id,
+      agent_name: agent.name,
+      agent_mcp_url: agent.mcp_url,
+      fetched_url,
+      status: msg,
+      duration_ms: Date.now() - t0,
+      error: (e as Error).message ?? String(e),
+    };
+  }
+}
+
+/**
+ * GET /api/adagents-probe
+ *
+ * Fans out to every peer in the agent registry and returns a single
+ * summary document the demo can render. Authenticated (DEMO_API_KEY)
+ * since the probe is a privileged operation that fans out network
+ * requests; unauthenticated callers would let an attacker turn our
+ * worker into a DDoS amplifier against third parties.
+ */
+export async function handleAdagentsProbe(_request: Request, _env: Env): Promise<Response> {
+  // Lazy-import the registry to avoid a circular module load with the
+  // federation client (which depends on agentRegistry). The probe is
+  // demo-only so the slight import cost on first call is fine.
+  const { AGENT_REGISTRY } = await import("../domain/agentRegistry");
+  const probeable = AGENT_REGISTRY.filter(
+    (a: { mcp_url?: string | null }) =>
+      typeof a.mcp_url === "string" && a.mcp_url.startsWith("https://"),
+  ) as Array<{ id: string; name: string; mcp_url: string }>;
+  // Run all probes in parallel — each has its own timeout so the
+  // worst-case latency of the response is the slowest probe (3s).
+  const results = await Promise.all(probeable.map((a) => probePeerAdagents(a)));
+  const summary = {
+    spec_version: ADCP_SPEC_VERSION,
+    probed_count: results.length,
+    counts: {
+      ok: results.filter((r) => r.status === "ok").length,
+      schema_invalid: results.filter((r) => r.status === "schema_invalid").length,
+      not_found: results.filter((r) => r.status === "not_found").length,
+      http_error: results.filter((r) => r.status === "http_error").length,
+      timeout: results.filter((r) => r.status === "timeout").length,
+      network_error: results.filter((r) => r.status === "network_error").length,
+    },
+    results,
+    probed_at: new Date().toISOString(),
+  };
+  return new Response(JSON.stringify(summary, null, 2), {
+    status: 200,
+    headers: {
+      "Content-Type": "application/json",
+      "Cache-Control": "no-store",
+      "Access-Control-Allow-Origin": "*",
+    },
+  });
+}

--- a/src/routes/demo.ts
+++ b/src/routes/demo.ts
@@ -349,6 +349,7 @@ ${STYLES}
       <div class="kv"><span class="k">Client</span><span class="v mono">@adcp/5.25.1</span></div>
       <div class="kv"><span class="k">Status</span><span class="v"><span class="status-dot ok"></span>live</span></div>
       <div class="kv"><span class="k">Conformance</span><span class="v"><span class="pill pill-success">7 / 7</span></span></div>
+      <div class="kv"><span class="k">Discovery</span><span class="v"><a href="/.well-known/adagents.json" target="_blank" rel="noopener" class="mono" style="color:var(--accent);text-decoration:none" title="Our published AdCP discovery anchor — declares this worker as the authorized signals agent. The trust anchor a buyer agent reads to discover us.">📡 adagents.json ↗</a></span></div>
       <div class="theme-picker" role="group" aria-label="Theme">
         <span class="theme-picker-label">Theme</span>
         <button class="theme-swatch" data-theme-pick="midnight" title="Midnight (dark)" aria-label="Midnight theme"></button>
@@ -1481,8 +1482,27 @@ ${STYLES}
             <button class="btn-secondary" id="fed-signal-traces" title="View raw get_signals + activate_signal request/response JSON for every federated call">
               <span class="mono">{ }</span><span>Signal traces</span>
             </button>
+            <button class="btn-secondary" id="fed-discovery-probe" title="Probe each peer's /.well-known/adagents.json — surfaces which peers publish the AdCP discovery anchor (we do, most don't yet). Click to fan out a 3-second-timeout probe across the registry and render results.">
+              📡 Discovery probe
+            </button>
           </div>
         </div>
+
+        <!-- Discovery panel — slides open when "📡 Discovery probe"
+             is clicked. Shows our adagents.json on top and peer probe
+             results below. Default closed so the page stays scannable
+             until the workshop calls out the discovery anchor. -->
+        <div id="discovery-panel" class="lab-panel" style="display:none;margin-bottom:18px">
+          <div class="lab-panel-title">AdCP discovery anchor · /.well-known/adagents.json</div>
+          <p class="orch-small" style="color:var(--text-mut);margin:6px 0 14px 0">A buyer agent doing "find authorized signals agents for this domain" lands on this file. We publish a 3.0.6-conformant declaration; most peers don't yet — that gap is exactly what the AdCP standardization closes.</p>
+          <div class="lab-section-label">Our declaration</div>
+          <pre id="discovery-our-doc" class="signal-trace-json" style="max-height:300px">loading…</pre>
+          <div class="lab-section-label" style="margin-top:18px">Peer probe results <span id="discovery-peer-counts" style="color:var(--text-mut);font-weight:400;margin-left:8px"></span></div>
+          <div id="discovery-peer-results" style="display:flex;flex-direction:column;gap:6px;margin-top:8px">
+            <div class="orch-small" style="color:var(--text-mut)">Click 📡 Discovery probe to fetch each peer's adagents.json (3s timeout per peer).</div>
+          </div>
+        </div>
+
         <div class="lab-grid">
           <div class="lab-panel">
             <div class="lab-panel-title">Federated search</div>

--- a/tests/__snapshots__/demo-render-snapshot.test.ts.snap
+++ b/tests/__snapshots__/demo-render-snapshot.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`handleDemo byte-equivalence > matches the committed golden hash (LF-normalized SHA-256 of body) 1`] = `
 {
-  "hash": "30bc2bc8439c6258c4fe703117302abb88c9d10b3713fa34db640dc0496a9a80",
-  "length": 1173440,
+  "hash": "a2ab5cfadf9fa98c812647f45e3c7ba6e51d5a0dbb3c22bb683e25117b9e3d19",
+  "length": 1180822,
 }
 `;

--- a/tests/adagents-self-publish.test.ts
+++ b/tests/adagents-self-publish.test.ts
@@ -1,0 +1,118 @@
+// tests/adagents-self-publish.test.ts
+//
+// Pin two contracts on the AdCP discovery anchor we publish:
+//   1. Our /.well-known/adagents.json document validates against the
+//      vendored 3.0.6 schema. If we ever drift (new required field,
+//      removed property, etc.), the test fails before deploy.
+//   2. The build helper produces a different agent_url per origin so
+//      a preview deploy doesn't hardcode the prod URL.
+//
+// Also exercises validateAdagentsDocument's negative path so the
+// peer-probe pipeline gets coverage on its core dependency.
+
+import { describe, it, expect } from "vitest";
+import {
+  buildAdagentsDocument,
+  validateAdagentsDocument,
+  handleAdAgents,
+} from "../src/routes/adagents";
+
+function fakeRequest(url: string): Request {
+  return new Request(url, { method: "GET" });
+}
+
+describe("adagents self-publish", () => {
+  it("buildAdagentsDocument produces a 3.0.6-conformant doc", () => {
+    const doc = buildAdagentsDocument(
+      fakeRequest("https://adcp-signals-adaptor.evgeny-193.workers.dev/.well-known/adagents.json"),
+    );
+    const r = validateAdagentsDocument(doc);
+    if (!r.valid) {
+      // Surface validation errors so a regression diff is readable.
+      // eslint-disable-next-line no-console
+      console.log("Validation errors:", JSON.stringify(r.errors, null, 2));
+    }
+    expect(r.valid).toBe(true);
+    expect(r.errors).toEqual([]);
+    expect(doc.authorized_agents[0]?.url).toBe(
+      "https://adcp-signals-adaptor.evgeny-193.workers.dev/mcp",
+    );
+  });
+
+  it("agent URL adapts to the request origin (preview vs prod)", () => {
+    const previewDoc = buildAdagentsDocument(
+      fakeRequest("https://preview-abc.adcp-signals-adaptor.evgeny-193.workers.dev/.well-known/adagents.json"),
+    );
+    const localDoc = buildAdagentsDocument(
+      fakeRequest("http://localhost:8787/.well-known/adagents.json"),
+    );
+    expect(previewDoc.authorized_agents[0]?.url).toContain("preview-abc");
+    expect(localDoc.authorized_agents[0]?.url).toBe("http://localhost:8787/mcp");
+    // Both still validate.
+    expect(validateAdagentsDocument(previewDoc).valid).toBe(true);
+    expect(validateAdagentsDocument(localDoc).valid).toBe(true);
+  });
+
+  it("declares authorization for every signal via signal_tags=[\"all\"]", () => {
+    const doc = buildAdagentsDocument(fakeRequest("https://example.com/.well-known/adagents.json"));
+    const agent = doc.authorized_agents[0];
+    expect(agent?.authorization_type).toBe("signal_tags");
+    expect(agent?.signal_tags).toEqual(["all"]);
+    // The "all" tag is defined at the top level so the schema's tag
+    // resolution rule (signal_tags reference top-level signal_tags map)
+    // is satisfied.
+    expect(doc.signal_tags["all"]).toBeDefined();
+    expect(doc.signal_tags["all"]?.name).toBeTruthy();
+    expect(doc.signal_tags["all"]?.description).toBeTruthy();
+  });
+
+  it("contact info includes the responsible domain + privacy policy", () => {
+    const doc = buildAdagentsDocument(
+      fakeRequest("https://adcp-signals-adaptor.evgeny-193.workers.dev/.well-known/adagents.json"),
+    );
+    expect(doc.contact.name).toBeTruthy();
+    expect(doc.contact.domain).toBe("adcp-signals-adaptor.evgeny-193.workers.dev");
+    expect(doc.contact.privacy_policy_url).toContain("/privacy");
+  });
+
+  it("contact.domain strips port for ports-in-URL deploys (localhost:8787)", () => {
+    // Schema's domain regex doesn't allow colons; we use hostname (not host).
+    const doc = buildAdagentsDocument(fakeRequest("http://localhost:8787/.well-known/adagents.json"));
+    expect(doc.contact.domain).toBe("localhost");
+  });
+
+  it("last_updated is an ISO 8601 datetime", () => {
+    const doc = buildAdagentsDocument(fakeRequest("https://example.com/.well-known/adagents.json"));
+    // Round-trip through Date — should not produce NaN
+    const parsed = new Date(doc.last_updated);
+    expect(parsed.toString()).not.toBe("Invalid Date");
+    expect(parsed.toISOString()).toBe(doc.last_updated);
+  });
+
+  it("handleAdAgents returns 200 + JSON with cache + CORS headers", async () => {
+    const env = {} as never;
+    const res = handleAdAgents(
+      fakeRequest("https://adcp-signals-adaptor.evgeny-193.workers.dev/.well-known/adagents.json"),
+      env,
+    );
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toBe("application/json");
+    expect(res.headers.get("Cache-Control")).toContain("max-age=3600");
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBe("*");
+    const body = await res.json();
+    expect((body as { authorized_agents: unknown[] }).authorized_agents).toHaveLength(1);
+  });
+
+  it("validateAdagentsDocument flags a doc missing required authorized_agents", () => {
+    const r = validateAdagentsDocument({
+      $schema: "https://adcontextprotocol.org/schemas/v3/adagents.json",
+      contact: { name: "Test" },
+      last_updated: "2026-05-06T12:00:00Z",
+    });
+    expect(r.valid).toBe(false);
+    // The error list should mention the missing authorized_agents
+    // somewhere; we don't pin the exact path/keyword because
+    // @cfworker/json-schema's oneOf reporting is verbose.
+    expect(r.errors.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary

We weren't publishing our own AdCP discovery anchor. Now we do — and we probe every peer's to surface the coverage gap.

## What lands

### 1. Self-publish — `GET /.well-known/adagents.json`

Public, cacheable (1h), CORS-open. Schema-validated against the vendored 3.0.6 corpus. URL: \`https://adcp-signals-adaptor.evgeny-193.workers.dev/.well-known/adagents.json\`

Inline shape: \`contact\`, \`authorized_agents\` (this worker's /mcp, \`authorization_type: signal_tags\`, scoped to \`[\"all\"]\`), \`signal_tags\` resolution map, \`last_updated\`.

Agent URL derived from request origin so preview/local deploys work without rebuild.

### 2. Peer probe — \`GET /api/adagents-probe\`

Fans out to every peer in \`agentRegistry\`, fetches their adagents.json, classifies:

| status | meaning |
|---|---|
| \`ok\` | 200 + schema-valid |
| \`schema_invalid\` | 200 but fails validation |
| \`not_found\` | 404 |
| \`http_error\` | non-200/non-404 |
| \`timeout\` | exceeded 3s |
| \`network_error\` | DNS / connection / etc |

Safety: 3s timeout, 64 KB body cap, no redirect follow. Auth-gated.

### 3. Discoverability

- **Sidebar footer** gets a \`📡 adagents.json ↗\` link so it's clickable from anywhere
- **Federation tab** gets a \`📡 Discovery probe\` button → slides open a panel showing OUR doc on top + per-peer probe rows with status badge, latency, schema errors inline if invalid

### 4. Workshop story

Open \`/.well-known/adagents.json\` → that's how buyers find us. Click \`📡 Discovery probe\` → most peers (Dstillery + the sales agents) don't publish one yet. THIS is the discovery-anchor gap that AdCP standardization closes.

## Test plan

- [x] \`npx vitest run\` — **461 passed (+8 new), 12 skipped, 0 failed**
- [x] Self-published doc validates against vendored 3.0.6 schema
- [x] Origin-derivation works for prod / preview / localhost (port stripped from \`contact.domain\`)
- [x] \`validateAdagentsDocument()\` flags missing required \`authorized_agents\`
- [x] \`npx tsc --noEmit\` clean for non-test sources
- [ ] After deploy: open https://adcp-signals-adaptor.evgeny-193.workers.dev/.well-known/adagents.json — see our published declaration
- [ ] After deploy: Federation tab → \`📡 Discovery probe\` → panel renders our doc + each peer's probe result with status badges