### PR TITLE
Discovery panel polish: fix self-probe + collapsible + grouped rows

### DIFF
--- a/src/demo/script/fragments/federation.ts
+++ b/src/demo/script/fragments/federation.ts
@@ -395,15 +395,62 @@ async function _renderOurAdagents() {
   }
 }
 
-function _badgeForProbeStatus(status) {
-  var cls = "pill-mut", icon = "?";
-  if (status === "ok") { cls = "pill-success"; icon = "✓ valid"; }
-  else if (status === "schema_invalid") { cls = "pill-warn"; icon = "⚠ invalid shape"; }
-  else if (status === "not_found") { cls = "pill-mut"; icon = "404 no file"; }
-  else if (status === "http_error") { cls = "pill-warn"; icon = "HTTP error"; }
-  else if (status === "timeout") { cls = "pill-mut"; icon = "timeout"; }
-  else if (status === "network_error") { cls = "pill-mut"; icon = "network err"; }
-  return '<span class="pill ' + cls + '" style="font-size:10.5px">' + icon + '</span>';
+function _probeBadge(status) {
+  // Returns HTML for a status badge with an emoji icon + label. Order
+  // chosen so the workshop centerpieces (✓ ok / ⚠ schema_invalid)
+  // visually dominate; the "no file" / unreachable rows fade into the
+  // background so the audience focuses on the conformance signal.
+  var map = {
+    ok:             { cls: "ok",    label: "✓ published & valid" },
+    schema_invalid: { cls: "bad",   label: "⚠ invalid shape" },
+    not_found:      { cls: "skip",  label: "404 · no file" },
+    http_error:     { cls: "warn",  label: "HTTP error" },
+    timeout:        { cls: "skip",  label: "⌛ timeout" },
+    network_error:  { cls: "skip",  label: "network err" },
+  };
+  var v = map[status] || { cls: "skip", label: status || "unknown" };
+  return '<span class="probe-badge probe-badge-' + v.cls + '">' + v.label + '</span>';
+}
+
+// Status display order for grouping the results list. Workshop story
+// flows: "we publish" (already shown above) → "they publish but
+// invalid" (centerpiece — runtime drift caught) → "they don't
+// publish" (the gap) → "unreachable" (housekeeping).
+var _PROBE_ORDER = ["ok", "schema_invalid", "not_found", "http_error", "timeout", "network_error"];
+
+function _renderProbeRow(p) {
+  var detail = "";
+  if (p.status === "ok" || p.status === "schema_invalid") {
+    var shapeJson = JSON.stringify(p.payload_preview || {}, null, 2);
+    if (shapeJson.length > 1500) shapeJson = shapeJson.slice(0, 1500) + "\\n… (truncated)";
+    var summaryText = p.status === "schema_invalid"
+      ? "show response & " + ((p.validation && p.validation.errors) || []).length + " schema errors"
+      : "show response";
+    detail = '<details class="probe-detail"><summary class="probe-detail-summary">' + escapeHtml(summaryText) + '</summary>' +
+      '<pre class="probe-detail-json">' + escapeHtml(shapeJson) + '</pre>';
+    if (p.validation && p.validation.errors && p.validation.errors.length > 0) {
+      detail += '<div class="probe-detail-errlabel">' + p.validation.errors.length + ' schema error' + (p.validation.errors.length === 1 ? "" : "s") + ':</div>' +
+        '<ul class="probe-detail-errlist">' +
+        p.validation.errors.slice(0, 5).map(function (e) {
+          return '<li><code>' + escapeHtml(e.path || "(root)") + '</code> ' + escapeHtml(e.message || "") + ' <span class="probe-err-kw">[' + escapeHtml(e.keyword || "") + ']</span></li>';
+        }).join("") + '</ul>';
+    }
+    detail += '</details>';
+  } else if (p.error) {
+    detail = '<div class="probe-error-line">' + escapeHtml(p.error) + '</div>';
+  }
+  // Strip protocol from displayed URL so the host pops; full URL
+  // remains in href + title for click-through and hover.
+  var visible = (p.fetched_url || "").replace(/^https?:\\/\\//, "");
+  return '<div class="probe-row probe-row-' + escapeHtml(p.status) + '">' +
+    '<div class="probe-row-head">' +
+      '<span class="probe-row-name">' + escapeHtml(p.agent_name || p.agent_id) + '</span>' +
+      _probeBadge(p.status) +
+      '<a class="probe-row-url" href="' + escapeHtml(p.fetched_url) + '" target="_blank" rel="noopener" title="' + escapeHtml(p.fetched_url) + '">' + escapeHtml(visible) + ' ↗</a>' +
+      '<span class="probe-row-dur">' + (p.duration_ms || 0) + 'ms</span>' +
+    '</div>' +
+    detail +
+  '</div>';
 }
 
 async function _runDiscoveryProbe() {
@@ -412,7 +459,10 @@ async function _runDiscoveryProbe() {
   var resultsHost = document.getElementById("discovery-peer-results");
   var countsEl = document.getElementById("discovery-peer-counts");
   if (!panel || !resultsHost) return;
+  // The panel is a <details> element — open it AND make it visible
+  // (default display:none until first probe so the page stays clean).
   panel.style.display = "block";
+  panel.open = true;
   if (btn) btn.disabled = true;
   resultsHost.innerHTML = '<div class="empty-state"><span class="spinner"></span><div class="empty-title">Probing peer adagents.json files…</div></div>';
   await _renderOurAdagents();
@@ -421,44 +471,34 @@ async function _runDiscoveryProbe() {
     var data = await r.json();
     var counts = data.counts || {};
     if (countsEl) {
-      var parts = [];
-      if (counts.ok) parts.push(counts.ok + " published & valid");
-      if (counts.schema_invalid) parts.push(counts.schema_invalid + " published but invalid");
-      if (counts.not_found) parts.push(counts.not_found + " no file (404)");
-      if (counts.http_error || counts.timeout || counts.network_error) {
-        parts.push(((counts.http_error || 0) + (counts.timeout || 0) + (counts.network_error || 0)) + " unreachable");
-      }
-      countsEl.textContent = "· " + parts.join(" · ") + " (" + (data.probed_count || 0) + " peers)";
+      // Render counts as compact pills next to the panel title so the
+      // story ("X published valid · Y published invalid · Z no file")
+      // is visible even when the panel is collapsed.
+      var pills = "";
+      if (counts.ok) pills += '<span class="discovery-count discovery-count-ok">' + counts.ok + ' valid</span>';
+      if (counts.schema_invalid) pills += '<span class="discovery-count discovery-count-bad">' + counts.schema_invalid + ' invalid</span>';
+      if (counts.not_found) pills += '<span class="discovery-count discovery-count-skip">' + counts.not_found + ' 404</span>';
+      var unreach = (counts.http_error || 0) + (counts.timeout || 0) + (counts.network_error || 0);
+      if (unreach) pills += '<span class="discovery-count discovery-count-skip">' + unreach + ' unreachable</span>';
+      countsEl.innerHTML = pills + '<span class="discovery-count-total">' + (data.probed_count || 0) + ' peers</span>';
     }
-    var rows = (data.results || []).map(function (p) {
-      var detail = "";
-      if (p.status === "ok" || p.status === "schema_invalid") {
-        var shapeJson = JSON.stringify(p.payload_preview || {}, null, 2);
-        if (shapeJson.length > 1500) shapeJson = shapeJson.slice(0, 1500) + "\\n… (truncated)";
-        detail = '<details style="margin-top:8px"><summary style="cursor:pointer;color:var(--text-mut);font-size:11px">show response</summary>' +
-          '<pre class="signal-trace-json" style="max-height:240px;margin-top:6px">' + escapeHtml(shapeJson) + '</pre>';
-        if (p.validation && p.validation.errors && p.validation.errors.length > 0) {
-          detail += '<div style="margin-top:6px;color:#ff9b6b;font-size:11px">' + p.validation.errors.length + ' schema error' + (p.validation.errors.length === 1 ? "" : "s") + ':</div>' +
-            '<ul style="margin:4px 0 0 20px;color:#ff9b6b;font-size:10.5px">' +
-            p.validation.errors.slice(0, 5).map(function (e) {
-              return '<li><code>' + escapeHtml(e.path || "(root)") + '</code> ' + escapeHtml(e.message || "") + '</li>';
-            }).join("") + '</ul>';
-        }
-        detail += '</details>';
-      } else if (p.error) {
-        detail = '<div style="margin-top:4px;color:var(--text-mut);font-size:10.5px">' + escapeHtml(p.error) + '</div>';
-      }
-      return '<div class="signal-trace-frame" style="padding:8px 12px">' +
-        '<div style="display:flex;align-items:baseline;gap:10px;flex-wrap:wrap">' +
-          '<strong style="font-size:12.5px">' + escapeHtml(p.agent_name || p.agent_id) + '</strong>' +
-          _badgeForProbeStatus(p.status) +
-          '<a href="' + escapeHtml(p.fetched_url) + '" target="_blank" rel="noopener" style="color:var(--accent);font-size:10.5px;text-decoration:none">' + escapeHtml(p.fetched_url) + ' ↗</a>' +
-          '<span style="color:var(--text-mut);font-size:10.5px;margin-left:auto">' + (p.duration_ms || 0) + 'ms</span>' +
-        '</div>' +
-        detail +
-      '</div>';
-    }).join("");
-    resultsHost.innerHTML = rows || '<div class="empty-state"><div class="empty-title">No peers in registry</div></div>';
+    // Group results by status using the priority order. Within each
+    // group, results retain server order (which is registry order).
+    var byStatus = {};
+    (data.results || []).forEach(function (p) {
+      var k = p.status || "unknown";
+      if (!byStatus[k]) byStatus[k] = [];
+      byStatus[k].push(p);
+    });
+    var groups = _PROBE_ORDER.filter(function (s) { return byStatus[s] && byStatus[s].length > 0; });
+    if (groups.length === 0) {
+      resultsHost.innerHTML = '<div class="empty-state"><div class="empty-title">No peers in registry</div></div>';
+    } else {
+      resultsHost.innerHTML = groups.map(function (s) {
+        var rows = byStatus[s].map(_renderProbeRow).join("");
+        return rows;
+      }).join("");
+    }
   } catch (e) {
     resultsHost.innerHTML = '<div class="empty-state" style="color:var(--error)"><div class="empty-title">Probe failed: ' + escapeHtml(e && e.message ? e.message : String(e)) + '</div></div>';
   } finally {

--- a/src/demo/styles.ts
+++ b/src/demo/styles.ts
@@ -6823,6 +6823,137 @@ textarea.lab-input { resize: vertical; line-height: 1.5; }
 .trace-fix-op-value { color: var(--text-mut); }
 .trace-fix-op-reason { color: var(--text-faint); font-size: 10.5px; font-style: italic; }
 .trace-fix-foot { color: var(--text-faint); font-size: 10.5px; margin: 6px 0 0 0; line-height: 1.5; }
+
+/* ── Discovery panel (Federation tab) ────────────────────────────────── */
+.discovery-panel { padding: 0; }
+.discovery-panel[open] .discovery-panel-summary { border-bottom: 1px solid var(--border); }
+.discovery-panel-summary {
+  cursor: pointer; list-style: none;
+  display: flex; align-items: center; gap: 10px; flex-wrap: wrap;
+  padding: 12px 18px;
+  font-size: 13px; font-weight: 600;
+}
+.discovery-panel-summary::-webkit-details-marker { display: none; }
+.discovery-panel-summary::before {
+  content: "▶"; font-size: 9px; color: var(--text-mut);
+  transition: transform 120ms ease;
+}
+.discovery-panel[open] .discovery-panel-summary::before { transform: rotate(90deg); }
+.discovery-panel-icon { font-size: 16px; }
+.discovery-panel-title { color: var(--text); }
+.discovery-panel-counts {
+  margin-left: auto; display: flex; gap: 6px; flex-wrap: wrap;
+  font-weight: 400;
+}
+.discovery-count {
+  font: 10.5px var(--font-mono);
+  padding: 2px 8px; border-radius: 10px;
+}
+.discovery-count-ok    { background: rgba(95, 217, 196, 0.14); color: #5fd9c4; }
+.discovery-count-bad   { background: rgba(255, 100, 100, 0.16); color: #ff7b7b; }
+.discovery-count-skip  { background: rgba(255, 255, 255, 0.05); color: var(--text-mut); }
+.discovery-count-total { background: transparent; color: var(--text-faint); padding-left: 4px; }
+.discovery-panel-intro {
+  margin: 8px 18px 14px 18px !important;
+  color: var(--text-mut);
+  line-height: 1.5;
+}
+.discovery-our-details { margin: 0 18px 14px 18px; }
+.discovery-our-summary {
+  cursor: pointer; list-style: none;
+  display: flex; align-items: center; gap: 10px;
+  padding: 8px 12px; border-radius: 4px;
+  background: rgba(255, 255, 255, 0.03);
+  font-size: 12px;
+}
+.discovery-our-summary::-webkit-details-marker { display: none; }
+.discovery-our-summary::before {
+  content: "▶"; font-size: 9px; color: var(--text-mut);
+  transition: transform 120ms ease;
+}
+.discovery-our-details[open] .discovery-our-summary::before { transform: rotate(90deg); }
+.discovery-our-label { font-weight: 600; color: var(--text); }
+.discovery-our-meta { color: var(--text-mut); font-size: 11px; margin-left: auto; }
+.discovery-our-json { max-height: 300px; margin-top: 8px; }
+.discovery-peer-label {
+  margin: 16px 18px 8px 18px;
+  font-size: 11px; font-weight: 600;
+  text-transform: uppercase; letter-spacing: 0.08em;
+  color: var(--text-mut);
+}
+.discovery-peer-list {
+  margin: 0 18px 18px 18px;
+  display: flex; flex-direction: column; gap: 6px;
+}
+
+/* ── Probe row ────────────────────────────────────────────────────────── */
+.probe-row {
+  border: 1px solid var(--border);
+  border-left-width: 3px;
+  border-radius: 4px;
+  padding: 8px 12px;
+  background: rgba(255, 255, 255, 0.02);
+  transition: background 120ms ease;
+}
+.probe-row:hover { background: rgba(255, 255, 255, 0.04); }
+.probe-row-ok             { border-left-color: #5fd9c4; }
+.probe-row-schema_invalid { border-left-color: #ff7b7b; background: rgba(255, 100, 100, 0.05); }
+.probe-row-not_found      { border-left-color: rgba(255, 255, 255, 0.15); }
+.probe-row-http_error     { border-left-color: #ffaf6b; }
+.probe-row-timeout        { border-left-color: rgba(255, 255, 255, 0.15); }
+.probe-row-network_error  { border-left-color: rgba(255, 255, 255, 0.15); }
+.probe-row-head {
+  display: flex; align-items: center; gap: 10px; flex-wrap: wrap;
+}
+.probe-row-name { font-size: 12.5px; font-weight: 600; color: var(--text); }
+.probe-row-url {
+  color: var(--accent); text-decoration: none;
+  font: 10.5px var(--font-mono);
+  opacity: 0.75;
+}
+.probe-row-url:hover { opacity: 1; text-decoration: underline; }
+.probe-row-dur {
+  margin-left: auto;
+  color: var(--text-faint);
+  font: 10.5px var(--font-mono);
+}
+.probe-badge {
+  font: 10.5px var(--font-mono); font-weight: 600;
+  padding: 2px 8px; border-radius: 10px;
+  white-space: nowrap;
+}
+.probe-badge-ok   { background: rgba(95, 217, 196, 0.14); color: #5fd9c4; }
+.probe-badge-bad  { background: rgba(255, 100, 100, 0.16); color: #ff7b7b; }
+.probe-badge-warn { background: rgba(255, 175, 107, 0.14); color: #ffaf6b; }
+.probe-badge-skip { background: rgba(255, 255, 255, 0.05); color: var(--text-mut); }
+.probe-detail { margin-top: 8px; }
+.probe-detail-summary {
+  cursor: pointer; color: var(--text-mut); font-size: 11px;
+  padding: 2px 0;
+}
+.probe-detail-summary::marker { color: var(--text-mut); }
+.probe-detail-json {
+  margin-top: 6px;
+  max-height: 240px;
+}
+.probe-detail-errlabel {
+  margin-top: 8px;
+  color: #ff7b7b; font-size: 11px; font-weight: 600;
+}
+.probe-detail-errlist {
+  margin: 4px 0 0 18px; padding: 0;
+  color: #ff9b6b; font-size: 10.5px; line-height: 1.6;
+}
+.probe-detail-errlist code {
+  background: rgba(255, 255, 255, 0.05); padding: 1px 4px; border-radius: 2px;
+  color: var(--text); font-family: var(--font-mono);
+}
+.probe-err-kw { color: var(--text-faint); font-size: 10px; margin-left: 4px; }
+.probe-error-line {
+  margin-top: 6px;
+  color: var(--text-mut); font-size: 10.5px;
+  font-style: italic;
+}
 .signal-trace-schemalink {
   margin-left: auto;
   font: 10px var(--font-mono); color: var(--accent); text-decoration: none;

--- a/src/domain/agentRegistry.ts
+++ b/src/domain/agentRegistry.ts
@@ -28,7 +28,13 @@ export interface RegisteredAgent {
 }
 
 export const SELF_AGENT_ID = "evgeny_signals";
-export const SELF_URL = "https://adcp-signals-adaptor.evgeny-193.workers.dev";
+// Canonical user-facing URL. The worker is reachable via both this
+// custom domain (adcp.signal-stack.io, primary) and the underlying
+// workers.dev URL (legacy / fallback). We use the canonical one in
+// the registry so peer probes + federation calls hit the same domain
+// the user sees in the browser — and adagents.json's authorized_agents
+// array points at consistent origins.
+export const SELF_URL = "https://adcp.signal-stack.io";
 
 export const AGENT_REGISTRY: RegisteredAgent[] = [
   {

--- a/src/routes/adagents.ts
+++ b/src/routes/adagents.ts
@@ -332,10 +332,18 @@ export async function handleAdagentsProbe(_request: Request, _env: Env): Promise
   // Lazy-import the registry to avoid a circular module load with the
   // federation client (which depends on agentRegistry). The probe is
   // demo-only so the slight import cost on first call is fine.
-  const { AGENT_REGISTRY } = await import("../domain/agentRegistry");
+  const { AGENT_REGISTRY, SELF_AGENT_ID } = await import("../domain/agentRegistry");
+  // Filter to (a) external peers only — we already render our own doc
+  // above the peer-probe panel; including self produces a redundant
+  // row and, worse, an HTTP error if the worker can't fetch its own
+  // /.well-known path through Cloudflare's edge routing — and
+  // (b) HTTPS-only URLs since /.well-known/adagents.json discovery is
+  // explicitly an HTTPS-only protocol.
   const probeable = AGENT_REGISTRY.filter(
-    (a: { mcp_url?: string | null }) =>
-      typeof a.mcp_url === "string" && a.mcp_url.startsWith("https://"),
+    (a: { id: string; mcp_url?: string | null }) =>
+      a.id !== SELF_AGENT_ID &&
+      typeof a.mcp_url === "string" &&
+      a.mcp_url.startsWith("https://"),
   ) as Array<{ id: string; name: string; mcp_url: string }>;
   // Run all probes in parallel — each has its own timeout so the
   // worst-case latency of the response is the slowest probe (3s).

--- a/src/routes/demo.ts
+++ b/src/routes/demo.ts
@@ -1492,16 +1492,25 @@ ${STYLES}
              is clicked. Shows our adagents.json on top and peer probe
              results below. Default closed so the page stays scannable
              until the workshop calls out the discovery anchor. -->
-        <div id="discovery-panel" class="lab-panel" style="display:none;margin-bottom:18px">
-          <div class="lab-panel-title">AdCP discovery anchor · /.well-known/adagents.json</div>
-          <p class="orch-small" style="color:var(--text-mut);margin:6px 0 14px 0">A buyer agent doing "find authorized signals agents for this domain" lands on this file. We publish a 3.0.6-conformant declaration; most peers don't yet — that gap is exactly what the AdCP standardization closes.</p>
-          <div class="lab-section-label">Our declaration</div>
-          <pre id="discovery-our-doc" class="signal-trace-json" style="max-height:300px">loading…</pre>
-          <div class="lab-section-label" style="margin-top:18px">Peer probe results <span id="discovery-peer-counts" style="color:var(--text-mut);font-weight:400;margin-left:8px"></span></div>
-          <div id="discovery-peer-results" style="display:flex;flex-direction:column;gap:6px;margin-top:8px">
+        <details id="discovery-panel" class="lab-panel discovery-panel" style="display:none;margin-bottom:18px">
+          <summary class="discovery-panel-summary">
+            <span class="discovery-panel-icon">📡</span>
+            <span class="discovery-panel-title">AdCP discovery anchor · /.well-known/adagents.json</span>
+            <span id="discovery-peer-counts" class="discovery-panel-counts"></span>
+          </summary>
+          <p class="orch-small discovery-panel-intro">A buyer agent doing "find authorized signals agents for this domain" lands on this file. We publish a 3.0.6-conformant declaration; most peers don't yet — that gap is exactly what the AdCP standardization closes.</p>
+          <details class="discovery-our-details">
+            <summary class="discovery-our-summary">
+              <span class="discovery-our-label">Our declaration</span>
+              <span class="discovery-our-meta">3.0.6 conformant · click to view JSON</span>
+            </summary>
+            <pre id="discovery-our-doc" class="signal-trace-json discovery-our-json">loading…</pre>
+          </details>
+          <div class="discovery-peer-label">Peer probe results</div>
+          <div id="discovery-peer-results" class="discovery-peer-list">
             <div class="orch-small" style="color:var(--text-mut)">Click 📡 Discovery probe to fetch each peer's adagents.json (3s timeout per peer).</div>
           </div>
-        </div>
+        </details>
 
         <div class="lab-grid">
           <div class="lab-panel">

--- a/tests/__snapshots__/demo-render-snapshot.test.ts.snap
+++ b/tests/__snapshots__/demo-render-snapshot.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`handleDemo byte-equivalence > matches the committed golden hash (LF-normalized SHA-256 of body) 1`] = `
 {
-  "hash": "a2ab5cfadf9fa98c812647f45e3c7ba6e51d5a0dbb3c22bb683e25117b9e3d19",
-  "length": 1180822,
+  "hash": "742072b02bad701ee5a7d5df4504f49274a02a2055b5d1187a586d2c0770a45e",
+  "length": 1187870,
 }
 `;


### PR DESCRIPTION
## Summary

Three issues from the dry-run:

### 1. Evgeny AdCP Signals adapter showed HTTP error

\`SELF_URL\` in \`agentRegistry.ts\` was hardcoded to the underlying \`workers.dev\` URL, but the canonical user-facing deploy is at \`adcp.signal-stack.io\`. The probe was fetching a domain that doesn't serve the file. **Fix:** bumped \`SELF_URL\` to the canonical custom domain.

Also added a self-filter to the peer probe — no point probing ourselves (we render the doc above the peer panel anyway, and Cloudflare's edge often errors on a worker fetching its own \`.well-known\` path).

### 2. \"Our declaration\" took too much vertical space

The JSON pre-block was always expanded. **Fix:** wrapped in a \`<details>\` element, collapsed by default with a one-line summary (\"3.0.6 conformant · click to view JSON\"). The whole Discovery panel is now also a top-level \`<details>\` so it can be collapsed entirely once you've seen the counts.

### 3. Peer rows lacked visual hierarchy

**Fix:**
- Border-left color codes status: green (valid) / red (schema invalid) / gray (404 / unreachable)
- Schema-invalid rows get a subtle red background tint — workshop centerpiece pops
- Pill-style status badges with emoji + full label
- Schema-invalid summary text shows error count up front (\"show response & 6 schema errors\")
- Results grouped by status priority (ok → schema_invalid → not_found → unreachable) so the story flows top-down
- Counts in the panel header (\"2 valid · 6 invalid · 14 404 · 19 peers\") visible even when collapsed

## Test plan

- [x] \`npx vitest run\` — **461 passed, 12 skipped, 0 failed**
- [x] Demo-render snapshot regenerated
- [x] \`npx tsc --noEmit\` clean
- [ ] After deploy: Federation tab → 📡 Discovery probe → self row gone, peer rows grouped + color-coded by status
- [ ] After deploy: \"Our declaration\" collapsed by default, expandable on click
- [ ] After deploy: schema_invalid rows visually pop with red border + background tint