### PR TITLE
Fix .signal-trace-json overflow: JSON bled onto error list on tall payloads

### DIFF
--- a/src/demo/styles.ts
+++ b/src/demo/styles.ts
@@ -7072,7 +7072,12 @@ textarea.lab-input { resize: vertical; line-height: 1.5; }
   padding: 10px 12px; margin: 0;
   font: 11.5px var(--font-mono);
   color: var(--text);
-  overflow-x: auto;
+  /* Both axes must scroll within the box. With only overflow-x: auto
+     the vertical default is visible, so JSON taller than max-height
+     bleeds into the sibling below — caused the 'IAB tags rendered on
+     top of the error list' overlap reported on the BidMachine row in
+     the discovery probe. */
+  overflow: auto;
   max-height: 360px;
   white-space: pre;
   line-height: 1.6;

--- a/tests/__snapshots__/demo-render-snapshot.test.ts.snap
+++ b/tests/__snapshots__/demo-render-snapshot.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`handleDemo byte-equivalence > matches the committed golden hash (LF-normalized SHA-256 of body) 1`] = `
 {
-  "hash": "742072b02bad701ee5a7d5df4504f49274a02a2055b5d1187a586d2c0770a45e",
-  "length": 1187870,
+  "hash": "590278704ca8b6db7480fa918abe939408021a6bc848a7ba8a9a639081bb69a8",
+  "length": 1188176,
 }
 `;


### PR DESCRIPTION
## Bug

User screenshot from the Discovery probe showed BidMachine's JSON response (IAB tag array) rendered **on top of** the schema-error list below it.

## Cause

\`.signal-trace-json\` had:

\`\`\`css
overflow-x: auto;
max-height: 360px;
\`\`\`

When only \`overflow-x\` is declared, browsers default \`overflow-y\` to \`visible\`. So any payload taller than 360px spilled vertically and overlapped whatever rendered next.

## Fix

\`overflow: auto\` (both axes). The pre now scrolls vertically inside the 360px box.

Same fix benefits every panel using \`.signal-trace-json\`: trace inspector, discovery probe, race canvas, etc.

## Test

- [x] \`npx vitest run\` — green (461)
- [x] Snapshot regenerated (CSS-only change, byte-equivalent JS)