### PR TITLE
Fix .probe-detail-json overflow (PR #232 targeted wrong class)

### DIFF
--- a/src/demo/styles.ts
+++ b/src/demo/styles.ts
@@ -6935,6 +6935,19 @@ textarea.lab-input { resize: vertical; line-height: 1.5; }
 .probe-detail-json {
   margin-top: 6px;
   max-height: 240px;
+  /* PR #232 fixed .signal-trace-json but the probe-row pre doesn't
+     carry that class — only .probe-detail-json. Without explicit
+     overflow, vertical content past 240px bleeds onto the schema-
+     error list AND into the rows below. Same fix applied here. */
+  overflow: auto;
+  background: var(--bg);
+  border: 1px solid var(--border-faint);
+  border-radius: 3px;
+  padding: 10px 12px;
+  font: 11.5px var(--font-mono);
+  color: var(--text);
+  white-space: pre;
+  line-height: 1.6;
 }
 .probe-detail-errlabel {
   margin-top: 8px;

--- a/tests/__snapshots__/demo-render-snapshot.test.ts.snap
+++ b/tests/__snapshots__/demo-render-snapshot.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`handleDemo byte-equivalence > matches the committed golden hash (LF-normalized SHA-256 of body) 1`] = `
 {
-  "hash": "590278704ca8b6db7480fa918abe939408021a6bc848a7ba8a9a639081bb69a8",
-  "length": 1188176,
+  "hash": "fc722dbcdb16e49c268fc40ba4cf299cd8c9782c1608d659fb37736bc7c31b23",
+  "length": 1188667,
 }
 `;


### PR DESCRIPTION
## Bug

User reported the JSON-bleed overlap is still visible after PR #232 deployed.

## Root cause

PR #232 fixed \`.signal-trace-json\` overflow. But the discovery-probe row pre uses \`class=\"probe-detail-json\"\` only — not \`signal-trace-json\`. So the prior rule never applied to the actual element bleeding past its 240px max-height.

## Fix

Add \`overflow: auto\` (plus the rest of the trace-json styling) directly to \`.probe-detail-json\` so the rule matches the element's actual class.

## Test plan

- [x] \`npx vitest run\` — green (461)
- [x] Snapshot regenerated
- [ ] After deploy: hard-refresh demo → Federation → 📡 Discovery probe → expand BidMachine row → JSON scrolls inside its 240px box, no bleed onto error list or rows below