### PR TITLE
Spec proposal: revoke_activation — workshop Q5 close-out artifact

### DIFF
--- a/docs/SPEC_PROPOSAL_REVOKE_ACTIVATION.md
+++ b/docs/SPEC_PROPOSAL_REVOKE_ACTIVATION.md
@@ -1,0 +1,425 @@
+# AdCP Spec Proposal: `revoke_activation`
+
+**Status:** Draft (workshop close-out, 2026-05-07)
+**Author:** Evgeny (signals adaptor — adcp.signal-stack.io)
+**Target:** AdCP 3.1 / 4.0
+**Domain:** signals
+**Type:** new tool (additive)
+
+---
+
+## 1 · Problem statement
+
+AdCP 3.0.6 has no protocol-level way for a buyer to **stop using a signal mid-campaign** once it has been activated to a destination.
+
+`activate_signal` ships a `signal_agent_segment_id` to a DSP / clean room / agent. From that moment on, the buyer's only options are:
+
+- **Manual destination action** — log into the DSP and pause the line item using the segment. Out-of-band, untraceable in the AdCP audit chain.
+- **Wait for `validity_period` expiry** — producer-set only, not buyer-triggered, and not implemented in any 3.0.x adapter today.
+- **No-op** — keep paying for a signal you've decided you don't want.
+
+The 3.0.6 schema declares an `action: "deactivate"` discriminator on `activate-signal-request.json:15-23` but no published agent reads it, and the semantics of "deactivate this signal everywhere" vs. "deactivate this specific activation" are undefined.
+
+There is no audit trail, no async lifecycle, no reason code, and no downstream propagation contract. **This is the cleanest greenfield surface in the signals domain.**
+
+---
+
+## 2 · Use cases (motivation)
+
+1. **Brand-safety incident.** A signal turns out to overlap with content the brand can't be associated with. Buyer needs to stop activation across all running destinations within minutes, with an auditable receipt.
+2. **Budget reallocation.** A campaign mid-flight pivots away from a planned audience. Buyer wants to revoke specific activations without canceling the whole media buy.
+3. **Producer revocation.** The data provider learns that consent for a signal cohort was withdrawn. Producer needs to push revocation downstream to every active destination, not wait for `validity_period` expiry.
+4. **Governance enforcement.** A `check_governance` advisory comes back `denied` after activation. Governance gate needs to revoke retroactively.
+5. **Compliance audit.** A regulator asks "show me every signal that was active for this campaign and when it was revoked." Buyer needs a complete activation-to-revocation log.
+6. **Fraud / TOS violation.** Producer or platform discovers a buyer used a signal outside permitted use. Authorized agent needs to revoke and log the cause.
+
+---
+
+## 3 · Primitive name
+
+**`revoke_activation`** — chosen over alternatives:
+
+| Candidate | Why rejected |
+|---|---|
+| `deactivate_signal` | Already a semantic conflict with the existing `action: "deactivate"` discriminator (which is per-call, not per-activation). Risks breaking existing 3.0.x storyboards. |
+| `retract_signal` | "Signal" implies producer-side cancellation (kills it for everyone). Buyer-initiated revocation only affects this buyer's activation. |
+| `cancel_activation` | "Cancel" suggests pre-completion. Revocation can also fire on already-completed activations. |
+| `expire_activation` | Implies time-based, which `validity_period` already covers. |
+
+**`revoke_activation`** correctly names the surface: a specific activation (identified by `task_id`) is revoked. The signal itself remains in the catalog; other buyers' activations are unaffected.
+
+---
+
+## 4 · Request schema
+
+`/schemas/3.1/signals/revoke-activation-request.json`:
+
+```json
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "/schemas/3.1/signals/revoke-activation-request.json",
+  "title": "Revoke Activation Request",
+  "description": "Revoke a previously-activated signal at one or more of its destinations.",
+  "type": "object",
+  "properties": {
+    "adcp_major_version": { "type": "integer", "minimum": 1, "maximum": 99 },
+    "task_id": {
+      "type": "string",
+      "description": "The task_id returned by the original activate_signal call. Identifies which activation to revoke.",
+      "pattern": "^op_[A-Za-z0-9_]+$"
+    },
+    "reason_code": {
+      "$ref": "/schemas/3.1/enums/revocation-reason.json"
+    },
+    "reason_detail": {
+      "type": "string",
+      "maxLength": 500,
+      "description": "Optional human-readable detail. Audit-only; not propagated to destinations."
+    },
+    "effective_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "When the revocation should take effect. Omit for immediate. Future timestamps are scheduled. Past timestamps are rejected with VALIDATION_ERROR."
+    },
+    "destinations": {
+      "type": "array",
+      "description": "Optional: revoke only at these destinations. When omitted, revokes at every destination the original activation ran to. Identified by destination type+platform OR type+agent_url.",
+      "items": { "$ref": "/schemas/3.1/core/destination.json" },
+      "minItems": 1
+    },
+    "idempotency_key": {
+      "type": "string",
+      "pattern": "^[A-Za-z0-9_.:-]{16,255}$",
+      "description": "Idempotency key. Repeating the same key returns the original revocation task_id without creating a new one."
+    },
+    "context": { "$ref": "/schemas/3.1/core/context.json" },
+    "ext": { "$ref": "/schemas/3.1/core/ext.json" }
+  },
+  "required": ["task_id", "reason_code", "idempotency_key"],
+  "additionalProperties": true
+}
+```
+
+### Reason code enum (`/schemas/3.1/enums/revocation-reason.json`)
+
+```json
+{
+  "type": "string",
+  "enum": [
+    "buyer_decision",
+    "producer_revoke",
+    "governance_denied",
+    "consent_withdrawn",
+    "fraud_detected",
+    "policy_violation",
+    "campaign_ended",
+    "expiry"
+  ],
+  "enumDescriptions": {
+    "buyer_decision":     "Buyer-initiated discretionary revocation. No fault attribution.",
+    "producer_revoke":    "Data provider revoked authorization. Buyer notified; activation stops.",
+    "governance_denied":  "check_governance returned denied after the fact. Compliance-driven.",
+    "consent_withdrawn":  "Underlying user/audience consent revoked. Privacy-driven; mandatory.",
+    "fraud_detected":     "Fraud or invalid traffic detected against this signal's audience.",
+    "policy_violation":   "Buyer used the signal outside permitted_uses. TOS-driven.",
+    "campaign_ended":     "Campaign concluded normally. Housekeeping revocation.",
+    "expiry":             "validity_period elapsed. Producer-set; included for audit symmetry."
+  }
+}
+```
+
+---
+
+## 5 · Response schema
+
+`/schemas/3.1/signals/revoke-activation-response.json`:
+
+```json
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "/schemas/3.1/signals/revoke-activation-response.json",
+  "title": "Revoke Activation Response",
+  "type": "object",
+  "properties": {
+    "task_id": {
+      "type": "string",
+      "description": "New task_id for THIS revocation. Distinct from original_task_id."
+    },
+    "original_task_id": {
+      "type": "string",
+      "description": "Echoes the task_id from the request — the activation being revoked."
+    },
+    "status": {
+      "$ref": "/schemas/3.1/enums/task-status.json",
+      "description": "submitted | working | completed | failed | rejected"
+    },
+    "reason_code": { "$ref": "/schemas/3.1/enums/revocation-reason.json" },
+    "effective_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "revoked_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Wall-clock timestamp the agent recorded the revocation request. Set on submitted; immutable."
+    },
+    "completed_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Set when status flips to completed (or failed)."
+    },
+    "deployments": {
+      "type": "array",
+      "description": "Per-destination revocation state. One entry per destination affected.",
+      "items": {
+        "type": "object",
+        "properties": {
+          "type":         { "type": "string", "enum": ["platform", "agent"] },
+          "platform":     { "type": "string" },
+          "agent_url":    { "type": "string", "format": "uri" },
+          "is_revoked":   { "type": "boolean" },
+          "revoked_at":   { "type": "string", "format": "date-time" },
+          "ack_received": { "type": "boolean", "description": "Did the destination acknowledge the revocation?" },
+          "error":        { "type": "string", "description": "Per-destination error if revocation failed there." }
+        },
+        "required": ["type", "is_revoked"]
+      }
+    },
+    "errors":  { "$ref": "/schemas/3.1/core/errors.json" },
+    "context": { "$ref": "/schemas/3.1/core/context.json" },
+    "ext":     { "$ref": "/schemas/3.1/core/ext.json" }
+  },
+  "required": ["task_id", "original_task_id", "status", "reason_code", "revoked_at"],
+  "additionalProperties": true
+}
+```
+
+---
+
+## 6 · State machine
+
+```
+            ┌───────────┐
+revoke_activation ─────▶ │ submitted │
+            └─────┬─────┘
+                  │
+                  ▼
+            ┌───────────┐
+            │  working  │  ◀──── per-destination ack pending
+            └─────┬─────┘
+                  │
+       ┌──────────┴──────────┐
+       ▼                     ▼
+ ┌───────────┐         ┌───────────┐
+ │ completed │         │  failed   │
+ └───────────┘         └───────────┘
+   all destinations      ≥1 destination
+   acknowledged          rejected/timed out
+```
+
+- **submitted**: agent recorded the request, hasn't started fan-out yet.
+- **working**: at least one destination still pending acknowledgment.
+- **completed**: every destination in `deployments[]` has `is_revoked=true && ack_received=true`.
+- **failed**: at least one destination rejected or timed out. `deployments[i].error` populated.
+- **rejected**: request itself was invalid (unknown task_id, unauthorized buyer, expired idempotency window).
+
+---
+
+## 7 · Async semantics
+
+- **Polling**: same `get_operation_status(task_id)` surface as `activate_signal`. The new revocation `task_id` is queryable identically.
+- **Webhook**: optional `webhook_url` can be passed via `context.webhook_url` in the request. Same HMAC-SHA256 signing contract as `activate_signal` webhooks.
+- **Synchronous variant**: agents MAY choose to return `status: completed` immediately if all destinations support sync revocation. Buyers MUST handle either case.
+
+---
+
+## 8 · Audit + receipt contract
+
+Every revocation produces:
+
+1. A new **revocation task** persisted alongside the original activation (`task_id` + `original_task_id` linked).
+2. Per-state-change events in the activation audit log:
+   - `revocation_submitted`
+   - `revocation_destination_ack_received` (one per destination)
+   - `revocation_destination_failed` (when applicable)
+   - `revocation_completed`
+   - `revocation_failed`
+3. Webhook payloads on each terminal state transition.
+
+The `original_task_id ↔ revocation task_id` link MUST be queryable in both directions:
+- `GET /operations/<original_task_id>` returns `revoked_by: <revocation_task_id>` if revoked.
+- `GET /operations/<revocation_task_id>` returns `original_task_id` in response body.
+
+---
+
+## 9 · Authorization
+
+| Caller role | Permission |
+|---|---|
+| Buyer who originally activated | Always allowed. |
+| Different buyer | Rejected with `UNAUTHORIZED`. |
+| Authorized agent in producer's `adagents.json` | Allowed for `producer_revoke`, `consent_withdrawn`, `fraud_detected`, `policy_violation`, `expiry`. |
+| Producer (data_provider_domain owner, verified via DNS) | Same as authorized agent. |
+| Anonymous / unauthenticated | Rejected with `UNAUTHORIZED`. |
+
+**Reason-code-scoped authorization** is required: `buyer_decision` is buyer-only; `producer_revoke` is producer-only; `governance_denied` requires governance-domain authorization; etc.
+
+---
+
+## 10 · Backwards compatibility
+
+- **Additive only.** Adding a new tool name doesn't break any existing handler.
+- **Existing `action: "deactivate"` discriminator** on `activate-signal-request.json` is preserved but deprecated for revocation purposes. New callers SHOULD use `revoke_activation` instead. The existing field's semantics (synchronous deactivation of a specific run) remain valid.
+- **`validity_period` expiry** continues to work; expiry generates a synthetic `revocation_completed` event with `reason_code: expiry` so the audit chain is uniform regardless of trigger.
+- **Adapters that don't implement `revoke_activation`** return the standard `TOOL_NOT_FOUND` error. Buyers fall back to the manual destination action with no protocol-level audit.
+
+---
+
+## 11 · Worked example
+
+### Request (MCP tools/call)
+
+```json
+{
+  "jsonrpc": "2.0", "id": 1, "method": "tools/call",
+  "params": {
+    "name": "revoke_activation",
+    "arguments": {
+      "task_id": "op_1778079024826_f7856e532c85cd17",
+      "reason_code": "governance_denied",
+      "reason_detail": "Brand-safety overlap with restricted content category",
+      "idempotency_key": "rev_be04bba2c4b241c3bdb44c8123",
+      "context": {
+        "correlation_id": "wf_2026-05-07_brand-safety-incident-42"
+      }
+    }
+  }
+}
+```
+
+### Response (synchronous case)
+
+```json
+{
+  "task_id": "op_1778079111234_a7d9c1e3b5f0a2c4",
+  "original_task_id": "op_1778079024826_f7856e532c85cd17",
+  "status": "completed",
+  "reason_code": "governance_denied",
+  "effective_at": "2026-05-07T14:30:00Z",
+  "revoked_at":   "2026-05-07T14:30:00Z",
+  "completed_at": "2026-05-07T14:30:01Z",
+  "deployments": [
+    { "type": "platform", "platform": "the_trade_desk", "is_revoked": true,  "revoked_at": "2026-05-07T14:30:00Z", "ack_received": true },
+    { "type": "platform", "platform": "dv360",          "is_revoked": true,  "revoked_at": "2026-05-07T14:30:01Z", "ack_received": true },
+    { "type": "agent",    "agent_url": "https://liveramp.com/.well-known/adcp/signals", "is_revoked": false, "ack_received": false, "error": "Destination unreachable; will retry" }
+  ],
+  "context": { "correlation_id": "wf_2026-05-07_brand-safety-incident-42" }
+}
+```
+
+### Response (async case)
+
+```json
+{
+  "task_id": "op_1778079111234_a7d9c1e3b5f0a2c4",
+  "original_task_id": "op_1778079024826_f7856e532c85cd17",
+  "status": "submitted",
+  "reason_code": "governance_denied",
+  "effective_at": "2026-05-07T14:30:00Z",
+  "revoked_at":   "2026-05-07T14:30:00Z"
+}
+```
+
+Buyer polls `get_operation_status(op_1778079111234_a7d9c1e3b5f0a2c4)` for terminal state.
+
+---
+
+## 12 · Storyboard sketch (conformance harness)
+
+```yaml
+# /compliance/3.1/domains/signals/scenarios/revoke_activation_buyer_decision.yaml
+id: revoke_activation_buyer_decision
+phase: post_buy
+description: Buyer revokes an activation mid-campaign with reason_code=buyer_decision.
+
+steps:
+  - id: activate
+    tool: activate_signal
+    state: completed
+    capture: { task_id }
+
+  - id: revoke
+    tool: revoke_activation
+    args:
+      task_id: ${activate.task_id}
+      reason_code: buyer_decision
+      idempotency_key: rev_test_${run_id}
+    expect_status: completed
+    expect_envelope_field_present: original_task_id
+
+  - id: verify_chain
+    tool: get_operation_status
+    args: { task_id: ${activate.task_id} }
+    expect_response_field:
+      revoked_by: ${revoke.task_id}
+
+  - id: idempotency_replay
+    tool: revoke_activation
+    args:
+      task_id: ${activate.task_id}
+      reason_code: buyer_decision
+      idempotency_key: rev_test_${run_id}
+    expect_response_field:
+      task_id: ${revoke.task_id}   # same id, not a new one
+```
+
+Additional scenarios (one per reason code): `producer_revoke`, `governance_denied`, `consent_withdrawn`, `fraud_detected`, `policy_violation`, `campaign_ended`, `expiry`.
+
+---
+
+## 13 · Test plan (minimum)
+
+- Revoke same-buyer happy path → `completed` synchronously.
+- Revoke different-buyer → `UNAUTHORIZED`.
+- Revoke unknown `task_id` → `NOT_FOUND`.
+- Revoke already-revoked task → idempotent return of the original revocation `task_id`.
+- Idempotency key reuse → returns first revocation's `task_id`.
+- Async: revocation produces webhook on completion, signed per existing webhook contract.
+- Per-destination partial failure → status `failed`, errored destination has `error` populated, others `is_revoked: true`.
+- `effective_at` in past → `VALIDATION_ERROR`.
+- `effective_at` in future → revocation status stays `submitted` until effective time, then auto-promotes.
+- Reason-code-scoped authorization: `producer_revoke` from non-producer caller → `UNAUTHORIZED`.
+
+---
+
+## 14 · Open questions
+
+1. **Producer-initiated revocation**: how does a producer push revocation when the original `task_id` lives in the buyer's audit chain? Possible answer: producer calls a separate `revoke_signal_at_buyer(buyer_agent_url, signal_id)` that the buyer's agent translates into per-task revocations. Out of scope for this proposal; flag as follow-up.
+2. **Cascade semantics**: if a signal feeds an activation chain (signal → derived signal → activation), does revoking the source signal cascade? Recommend NO for v1 — explicit revocation per task only. Cascade can be a v2 concern.
+3. **Pricing reconciliation**: revoking an activation mid-billing-period — does the buyer get a refund / credit? Out of scope for the protocol; commercial layer concern.
+4. **Effective-at scheduling backend**: who runs the timer for future-dated revocations? Recommend the agent that received the request; DSPs can poll if they care.
+5. **Privacy budget restoration**: if a clean-room signal is revoked, is the privacy budget refunded? Defer to clean-room-specific spec.
+
+---
+
+## 15 · Filing path
+
+This proposal can be filed as a GitHub issue against `adcontextprotocol/adcp` with the title:
+
+> `[proposal] revoke_activation — canonical buyer/producer revocation primitive (signals domain)`
+
+Body: paste sections 1–14 above. Tag `domain:signals`, `kind:proposal`, `priority:high`.
+
+---
+
+## 16 · Related work
+
+- AdCP issue [#4009](https://github.com/adcontextprotocol/adcp/issues/4009) — storyboard `activate_on_agent` step missing required fields. Adjacent surface; the same audit-chain principles apply.
+- AdCP `validity_period` — producer-side time-bound expiry. **NOT a substitute** for buyer-initiated revocation; this proposal explicitly closes that gap.
+- AdCP `check_governance` (3.0.6) — produces governance advisories that this proposal's `governance_denied` reason code consumes.
+
+---
+
+## 17 · Workshop close-out one-liner
+
+> *"AdCP today has no canonical retraction primitive — once a signal is activated, the buyer's only options are manual destination action or `validity_period` expiry. We propose `revoke_activation`: clean, narrow, demonstrably missing, and the strongest spec-proposal candidate from this round-robin."*

--- a/docs/SPEC_PROPOSAL_REVOKE_ACTIVATION_addie.md
+++ b/docs/SPEC_PROPOSAL_REVOKE_ACTIVATION_addie.md
@@ -1,0 +1,315 @@
+# Proposal for Addie / AAO: `revoke_activation` (signals domain)
+
+Hey Addie — workshop close-out from the May 7 round-robin surfaced a gap I'd like to push through the working group. Sharing the proposal here so you can route it to whoever owns the signals-domain backlog.
+
+## TL;DR
+
+**Gap:** AdCP 3.0.6 has no protocol-level way for a buyer to stop using a signal mid-campaign once it's been activated to a destination. The buyer's only options today are manual destination action (out-of-band, untraceable) or producer-set `validity_period` (which isn't buyer-triggered and isn't implemented in any 3.0.x adapter I've seen).
+
+**Proposal:** add a new tool `revoke_activation` to the signals domain. Async-by-default, reason-coded, reason-scoped authorization, reuses `get_operation_status` + the existing webhook signing contract. Clean greenfield, additive only, backwards-compatible.
+
+**Why now:** demonstrably missing on the wire today. Walked through the workshop crowd, every adopter recognized it. Cleanest spec-proposal candidate from the round-robin.
+
+---
+
+## Design choices (1 line each)
+
+1. **Name: `revoke_activation`** — not `deactivate_signal` (conflicts with existing `action: "deactivate"` discriminator), not `retract_signal` (kills it for everyone, wrong scope), not `cancel_activation` (implies pre-completion). Revocation targets a specific `task_id`; the signal itself stays in catalog; other buyers' activations untouched.
+2. **Async-by-default** — same lifecycle as `activate_signal`. Returns a new `task_id`; buyers poll via `get_operation_status` or receive webhook. Sync return permitted when every destination supports immediate revocation.
+3. **Reason codes are required** — eight values covering buyer + producer + governance + privacy + fraud + housekeeping triggers. Audit-grade.
+4. **Reason-scoped authorization** — `buyer_decision` is buyer-only; `producer_revoke` requires DNS-verified producer ownership; `governance_denied` requires governance-domain auth. The trust gradient gets enforced at the action layer for the first time.
+5. **Per-destination acks** — response carries one entry per affected destination with `is_revoked` + `ack_received` + optional `error`. Partial-failure semantics are explicit.
+6. **Idempotent** — `idempotency_key` required (matches `activate_signal` 3.0.6 contract). Repeated calls with the same key return the original revocation `task_id`.
+
+---
+
+## Request schema sketch
+
+`/schemas/3.1/signals/revoke-activation-request.json`:
+
+```json
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "/schemas/3.1/signals/revoke-activation-request.json",
+  "title": "Revoke Activation Request",
+  "type": "object",
+  "properties": {
+    "adcp_major_version": { "type": "integer", "minimum": 1, "maximum": 99 },
+    "task_id": {
+      "type": "string",
+      "description": "task_id returned by the original activate_signal call.",
+      "pattern": "^op_[A-Za-z0-9_]+$"
+    },
+    "reason_code": { "$ref": "/schemas/3.1/enums/revocation-reason.json" },
+    "reason_detail": { "type": "string", "maxLength": 500 },
+    "effective_at": {
+      "type": "string", "format": "date-time",
+      "description": "Omit for immediate. Future = scheduled. Past = VALIDATION_ERROR."
+    },
+    "destinations": {
+      "type": "array",
+      "description": "Optional: revoke only at these destinations. When omitted, revokes everywhere the original activation ran.",
+      "items": { "$ref": "/schemas/3.1/core/destination.json" },
+      "minItems": 1
+    },
+    "idempotency_key": {
+      "type": "string",
+      "pattern": "^[A-Za-z0-9_.:-]{16,255}$"
+    },
+    "context": { "$ref": "/schemas/3.1/core/context.json" },
+    "ext":     { "$ref": "/schemas/3.1/core/ext.json" }
+  },
+  "required": ["task_id", "reason_code", "idempotency_key"],
+  "additionalProperties": true
+}
+```
+
+---
+
+## Reason code enum
+
+`/schemas/3.1/enums/revocation-reason.json`:
+
+```json
+{
+  "type": "string",
+  "enum": [
+    "buyer_decision",
+    "producer_revoke",
+    "governance_denied",
+    "consent_withdrawn",
+    "fraud_detected",
+    "policy_violation",
+    "campaign_ended",
+    "expiry"
+  ],
+  "enumDescriptions": {
+    "buyer_decision":    "Buyer-initiated discretionary revocation. No fault.",
+    "producer_revoke":   "Data provider revoked authorization.",
+    "governance_denied": "check_governance returned denied after the fact.",
+    "consent_withdrawn": "Underlying user/audience consent revoked. Mandatory.",
+    "fraud_detected":    "Fraud or invalid traffic against this signal.",
+    "policy_violation":  "Buyer used the signal outside permitted_uses.",
+    "campaign_ended":    "Campaign concluded normally. Housekeeping.",
+    "expiry":            "validity_period elapsed. Producer-set; included for audit symmetry."
+  }
+}
+```
+
+---
+
+## Response schema sketch
+
+`/schemas/3.1/signals/revoke-activation-response.json`:
+
+```json
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "/schemas/3.1/signals/revoke-activation-response.json",
+  "title": "Revoke Activation Response",
+  "type": "object",
+  "properties": {
+    "task_id":          { "type": "string", "description": "New task_id for THIS revocation." },
+    "original_task_id": { "type": "string", "description": "The activation being revoked." },
+    "status":           { "$ref": "/schemas/3.1/enums/task-status.json" },
+    "reason_code":      { "$ref": "/schemas/3.1/enums/revocation-reason.json" },
+    "effective_at":     { "type": "string", "format": "date-time" },
+    "revoked_at":       { "type": "string", "format": "date-time" },
+    "completed_at":     { "type": "string", "format": "date-time" },
+    "deployments": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "type":         { "type": "string", "enum": ["platform", "agent"] },
+          "platform":     { "type": "string" },
+          "agent_url":    { "type": "string", "format": "uri" },
+          "is_revoked":   { "type": "boolean" },
+          "revoked_at":   { "type": "string", "format": "date-time" },
+          "ack_received": { "type": "boolean" },
+          "error":        { "type": "string" }
+        },
+        "required": ["type", "is_revoked"]
+      }
+    },
+    "errors":  { "$ref": "/schemas/3.1/core/errors.json" },
+    "context": { "$ref": "/schemas/3.1/core/context.json" },
+    "ext":     { "$ref": "/schemas/3.1/core/ext.json" }
+  },
+  "required": ["task_id", "original_task_id", "status", "reason_code", "revoked_at"],
+  "additionalProperties": true
+}
+```
+
+---
+
+## State machine
+
+```
+revoke_activation ──▶ submitted ──▶ working ──┬──▶ completed   (all destinations acked)
+                                              ├──▶ failed      (≥1 destination errored)
+                                              └──▶ rejected    (request invalid)
+```
+
+Same envelope status enum as `activate_signal` — buyers reuse the existing poll/webhook plumbing.
+
+---
+
+## Authorization matrix
+
+| Caller | Permission |
+|---|---|
+| Buyer who originally activated | Always allowed for `buyer_decision` |
+| Different buyer | `UNAUTHORIZED` |
+| Authorized agent in producer's `adagents.json` | Allowed for `producer_revoke`, `consent_withdrawn`, `fraud_detected`, `policy_violation`, `expiry` |
+| DNS-verified producer | Same as authorized agent |
+| Governance-domain agent | Allowed for `governance_denied` |
+| Anonymous | `UNAUTHORIZED` |
+
+The reason-code-scoped check is the centerpiece — the *first* place AdCP enforces the trust gradient at the action layer rather than just describing it in the schema.
+
+---
+
+## Worked example (MCP tools/call)
+
+**Request — buyer-driven brand-safety incident:**
+
+```json
+{
+  "jsonrpc": "2.0", "id": 1, "method": "tools/call",
+  "params": {
+    "name": "revoke_activation",
+    "arguments": {
+      "task_id": "op_1778079024826_f7856e532c85cd17",
+      "reason_code": "governance_denied",
+      "reason_detail": "Brand-safety overlap with restricted content category",
+      "idempotency_key": "rev_be04bba2c4b241c3bdb44c8123",
+      "context": { "correlation_id": "wf_brand-safety-incident-42" }
+    }
+  }
+}
+```
+
+**Response (sync, all-acked):**
+
+```json
+{
+  "task_id": "op_1778079111234_a7d9c1e3b5f0a2c4",
+  "original_task_id": "op_1778079024826_f7856e532c85cd17",
+  "status": "completed",
+  "reason_code": "governance_denied",
+  "effective_at": "2026-05-07T14:30:00Z",
+  "revoked_at":   "2026-05-07T14:30:00Z",
+  "completed_at": "2026-05-07T14:30:01Z",
+  "deployments": [
+    { "type": "platform", "platform": "the_trade_desk", "is_revoked": true, "revoked_at": "2026-05-07T14:30:00Z", "ack_received": true },
+    { "type": "platform", "platform": "dv360",          "is_revoked": true, "revoked_at": "2026-05-07T14:30:01Z", "ack_received": true },
+    { "type": "agent", "agent_url": "https://liveramp.com/.well-known/adcp/signals", "is_revoked": false, "ack_received": false, "error": "Destination unreachable; will retry" }
+  ],
+  "context": { "correlation_id": "wf_brand-safety-incident-42" }
+}
+```
+
+**Response (async — typical case):**
+
+```json
+{
+  "task_id": "op_1778079111234_a7d9c1e3b5f0a2c4",
+  "original_task_id": "op_1778079024826_f7856e532c85cd17",
+  "status": "submitted",
+  "reason_code": "governance_denied",
+  "effective_at": "2026-05-07T14:30:00Z",
+  "revoked_at":   "2026-05-07T14:30:00Z"
+}
+```
+
+Buyer polls `get_operation_status(op_1778079111234_a7d9c1e3b5f0a2c4)` or receives the existing HMAC-signed completion webhook.
+
+---
+
+## Backwards compatibility
+
+- **Additive only.** New tool name; doesn't break any existing handler.
+- **`action: "deactivate"` discriminator** on `activate-signal-request.json` is preserved but deprecated for revocation purposes. New callers SHOULD use `revoke_activation`.
+- **`validity_period` expiry** continues to work; expiry generates a synthetic `revocation_completed` event with `reason_code: "expiry"` so the audit chain is uniform regardless of trigger.
+- **Adapters that don't implement** return the standard `TOOL_NOT_FOUND` error. Buyers fall back to manual destination action with no protocol-level audit (today's status quo).
+
+---
+
+## Conformance storyboard sketch
+
+`/compliance/3.1/domains/signals/scenarios/revoke_activation_buyer_decision.yaml`:
+
+```yaml
+id: revoke_activation_buyer_decision
+phase: post_buy
+description: Buyer revokes an activation mid-campaign with reason_code=buyer_decision.
+
+steps:
+  - id: activate
+    tool: activate_signal
+    state: completed
+    capture: { task_id }
+
+  - id: revoke
+    tool: revoke_activation
+    args:
+      task_id: ${activate.task_id}
+      reason_code: buyer_decision
+      idempotency_key: rev_test_${run_id}
+    expect_status: completed
+    expect_envelope_field_present: original_task_id
+
+  - id: verify_chain
+    tool: get_operation_status
+    args: { task_id: ${activate.task_id} }
+    expect_response_field:
+      revoked_by: ${revoke.task_id}
+
+  - id: idempotency_replay
+    tool: revoke_activation
+    args:
+      task_id: ${activate.task_id}
+      reason_code: buyer_decision
+      idempotency_key: rev_test_${run_id}
+    expect_response_field:
+      task_id: ${revoke.task_id}   # same id, not a new one
+```
+
+Plus 7 sibling scenarios — one per reason code.
+
+---
+
+## Open questions I need help with
+
+1. **Producer-initiated revocation routing.** A producer revoking a signal needs to push to every buyer who activated it. Does that go through a sibling tool (`revoke_signal_at_buyer(buyer_agent_url, signal_id)`) that the buyer's agent translates into per-task revocations, or does the producer directly call buyer agents' `revoke_activation`? Either has trade-offs.
+2. **Cascade semantics.** If a signal feeds an activation chain (signal → derived signal → activation), does revoking the source cascade? My instinct: NO for v1 — explicit per-task only. Cascade is v2.
+3. **Pricing reconciliation.** Mid-billing-period revocation — refund / credit? I think it's out of scope for the protocol (commercial-layer concern), but flag it because adopters will ask.
+4. **Effective-at scheduling.** Future-dated revocations — who runs the timer? Recommend the agent that received the request.
+5. **Privacy budget restoration.** Clean-room signal revoked → budget refunded? Defer to clean-room-specific spec.
+
+---
+
+## What I'm asking from Addie / AAO
+
+Three things:
+
+1. **File this as an issue** against `adcontextprotocol/adcp` titled `[proposal] revoke_activation — canonical buyer/producer revocation primitive (signals domain)`. I have a self-contained version at `docs/SPEC_PROPOSAL_REVOKE_ACTIVATION.md` in evgeny-193's adaptor repo if it's easier to link than paste; this chat is also paste-friendly.
+2. **Route it to the signals-domain working-group owner** for triage — I think this should target 3.1 minor.
+3. **Surface the five open questions** above so the working group can discuss them in the next sync. I'll show up to defend the design choices; happy to revise based on input.
+
+If there's prior art I missed (an existing GH issue, a thread on the working-group call, an in-flight RFC), point me at it and I'll fold this into whatever's already moving.
+
+---
+
+## Why this is the right candidate to push first
+
+- **Clean greenfield.** Zero implementation today (verified across the live AdCP directory + my adaptor's federation probe). No vendor migration to negotiate.
+- **Stakeholder coverage.** Buyer + producer + governance + privacy + platform all need this. Reason-code enum makes the cross-stakeholder contract explicit.
+- **Testable in <10 storyboards.** I sketched the buyer_decision case above; the others are trivial extensions.
+- **Reuses existing AdCP infrastructure end-to-end.** No new transport, no new auth, no new persistence shape, no new envelope. Just the new tool + two schemas + one enum.
+- **Backwards compatible.** Additive. Adapters that don't implement degrade to today's behavior.
+
+Round-robin's strongest spec-proposal candidate. Ready when you are, Addie.
+
+— Ev (adcp.signal-stack.io)


### PR DESCRIPTION
## Summary

Workshop Q5 (\"Is there a retraction primitive?\") close-out artifact. Proposes a new AdCP signals-domain tool to fill the gap surfaced live in the deck.

## What's in the proposal

`docs/SPEC_PROPOSAL_REVOKE_ACTIVATION.md` — 17 sections, ~425 lines:

- **§1** Problem statement (no buyer-triggered revocation today; \`action: \"deactivate\"\` declared but unread; \`validity_period\` is producer-only and unimplemented)
- **§2** Six concrete use cases (brand-safety, budget reallocation, producer revoke, governance, audit, fraud)
- **§3** Naming trade-off table — why \`revoke_activation\` beats deactivate/retract/cancel/expire
- **§4** Full request schema (JSON Schema draft-07, ready to vendor at `/schemas/3.1/signals/`)
- **§5** Full response schema with per-destination ack contract
- **§6** State machine (submitted → working → completed/failed/rejected)
- **§7** Async semantics — reuses \`get_operation_status\` polling + existing HMAC-signed webhook contract
- **§8** Audit + receipt contract — bidirectional \`task_id ↔ original_task_id\` linkage
- **§9** Authorization matrix — reason-code-scoped (buyer-only vs producer-only vs governance-scoped)
- **§10** Backwards compatibility — additive only
- **§11** Worked example (MCP tools/call) — sync + async response variants
- **§12** Storyboard sketch for conformance harness
- **§13** 10-case minimum test plan
- **§14** 5 open questions to bring to the working group
- **§15** Filing path — ready to paste as GitHub issue against adcontextprotocol/adcp
- **§16** Related work (issue #4009, validity_period, check_governance interplay)
- **§17** Workshop close-out one-liner

## Reason code enum (§4)

\`buyer_decision\` · \`producer_revoke\` · \`governance_denied\` · \`consent_withdrawn\` · \`fraud_detected\` · \`policy_violation\` · \`campaign_ended\` · \`expiry\`

## Why this is the strongest candidate

- Clean greenfield (zero implementation today)
- Use cases span all five stakeholder classes (buyer, producer, governance, privacy, platform)
- Reuses existing AdCP infrastructure end-to-end (no new transport, no new auth, no new persistence shape)
- Backwards-compatible
- Conformance-testable in <10 storyboards
- Demonstrably missing (deck centerpiece slide Q5)

## Test plan

- [x] Markdown renders cleanly on GitHub
- [ ] After merge: paste §1-14 as a GitHub issue at adcontextprotocol/adcp
- [ ] After merge: link this issue from the AdCP daily watcher's tracked-issues list