### PR TITLE
Spec proposal v2: Addie's corrections (tasks/get + reframe gap around existing field)

### DIFF
--- a/docs/SPEC_PROPOSAL_REVOKE_ACTIVATION.md
+++ b/docs/SPEC_PROPOSAL_REVOKE_ACTIVATION.md
@@ -1,8 +1,8 @@
 # AdCP Spec Proposal: `revoke_activation`
 
-**Status:** Draft (workshop close-out, 2026-05-07)
+**Status:** Draft v2 (post-Addie review — May 7, 2026)
 **Author:** Evgeny (signals adaptor — adcp.signal-stack.io)
-**Target:** AdCP 3.1 / 4.0
+**Target:** AdCP 3.1
 **Domain:** signals
 **Type:** new tool (additive)
 
@@ -10,17 +10,25 @@
 
 ## 1 · Problem statement
 
-AdCP 3.0.6 has no protocol-level way for a buyer to **stop using a signal mid-campaign** once it has been activated to a destination.
+AdCP 3.0.6 already declares an `action` field on `activate-signal-request.json` with values `"activate" | "deactivate"`. Direct quote from the schema description:
 
-`activate_signal` ships a `signal_agent_segment_id` to a DSP / clean room / agent. From that moment on, the buyer's only options are:
+> *"Deactivating removes the segment from downstream platforms, required when campaigns end to comply with data governance policies (GDPR, CCPA). Defaults to 'activate' when omitted."*
 
+The intent is real — the field carries GDPR/CCPA compliance language and a documented downstream-removal contract. But four things are missing for the field to actually work end-to-end:
+
+1. **No per-activation scoping.** The request takes `signal_agent_segment_id` + `destinations[]`. There's no way to address "the activation I started yesterday" — only "the signal, at these destinations, right now." If a buyer activated the same signal twice with different `pricing_option_id` or different `account` references, there's no protocol-level way to revoke one without affecting the other.
+2. **No reason codes.** The action is binary. There's no way for the audit trail to distinguish a buyer's discretionary cleanup from a producer-driven consent withdrawal from a fraud-detection trigger.
+3. **No async lifecycle.** `activate_signal` returns `task_id` and `tasks/get` polls for completion. The deactivate path through the same tool inherits the same lifecycle, but the task represents the deactivation request — there's no link back to the original activation `task_id` for audit-chain correlation.
+4. **No published implementation.** Per the live AdCP directory + this adaptor's federation probe (May 7, 2026), no published 3.0.x agent currently honors `action: "deactivate"` on `activate_signal`. Buyers fall back to manual destination action.
+
+The buyer's current options are:
+
+- **`activate_signal` with `action: "deactivate"`** — declared, undefined semantics, unimplemented across the live ecosystem.
 - **Manual destination action** — log into the DSP and pause the line item using the segment. Out-of-band, untraceable in the AdCP audit chain.
 - **Wait for `validity_period` expiry** — producer-set only, not buyer-triggered, and not implemented in any 3.0.x adapter today.
 - **No-op** — keep paying for a signal you've decided you don't want.
 
-The 3.0.6 schema declares an `action: "deactivate"` discriminator on `activate-signal-request.json:15-23` but no published agent reads it, and the semantics of "deactivate this signal everywhere" vs. "deactivate this specific activation" are undefined.
-
-There is no audit trail, no async lifecycle, no reason code, and no downstream propagation contract. **This is the cleanest greenfield surface in the signals domain.**
+This proposal sharpens the existing `action: "deactivate"` intent into a first-class tool with explicit per-activation scoping, reason codes, async chain linking, and a conformance harness — closing the four gaps above without breaking the existing field.
 
 ---
 
@@ -227,7 +235,7 @@ revoke_activation ─────▶ │ submitted │
 
 ## 7 · Async semantics
 
-- **Polling**: same `get_operation_status(task_id)` surface as `activate_signal`. The new revocation `task_id` is queryable identically.
+- **Polling**: same `tasks/get` surface as `activate_signal` (per `vendor/adcp/adcp-3.0.6/schemas/bundled/core/tasks-get-response.json`). The new revocation `task_id` is queryable identically — buyer calls `tasks/get` with the revocation `task_id` to get terminal state.
 - **Webhook**: optional `webhook_url` can be passed via `context.webhook_url` in the request. Same HMAC-SHA256 signing contract as `activate_signal` webhooks.
 - **Synchronous variant**: agents MAY choose to return `status: completed` immediately if all destinations support sync revocation. Buyers MUST handle either case.
 
@@ -246,9 +254,11 @@ Every revocation produces:
    - `revocation_failed`
 3. Webhook payloads on each terminal state transition.
 
-The `original_task_id ↔ revocation task_id` link MUST be queryable in both directions:
-- `GET /operations/<original_task_id>` returns `revoked_by: <revocation_task_id>` if revoked.
-- `GET /operations/<revocation_task_id>` returns `original_task_id` in response body.
+The `original_task_id ↔ revocation task_id` link MUST be queryable in both directions via `tasks/get`:
+- `tasks/get` with `task_id = <original_task_id>` returns `revoked_by: <revocation_task_id>` in the task envelope when revoked.
+- `tasks/get` with `task_id = <revocation_task_id>` returns `original_task_id` in the response payload.
+
+This linkage is the auditable correlation between the activation lifecycle and its revocation lifecycle — neither task is the other's parent; they're peer tasks bound by `original_task_id`.
 
 ---
 
@@ -269,9 +279,10 @@ The `original_task_id ↔ revocation task_id` link MUST be queryable in both dir
 ## 10 · Backwards compatibility
 
 - **Additive only.** Adding a new tool name doesn't break any existing handler.
-- **Existing `action: "deactivate"` discriminator** on `activate-signal-request.json` is preserved but deprecated for revocation purposes. New callers SHOULD use `revoke_activation` instead. The existing field's semantics (synchronous deactivation of a specific run) remain valid.
-- **`validity_period` expiry** continues to work; expiry generates a synthetic `revocation_completed` event with `reason_code: expiry` so the audit chain is uniform regardless of trigger.
-- **Adapters that don't implement `revoke_activation`** return the standard `TOOL_NOT_FOUND` error. Buyers fall back to the manual destination action with no protocol-level audit.
+- **Existing `action: "deactivate"` field on `activate_signal` is preserved.** Its GDPR/CCPA-driven downstream-removal semantics (per the schema description) carry into `revoke_activation` as the equivalent of `reason_code: "consent_withdrawn"` or `reason_code: "campaign_ended"`. New callers SHOULD migrate to `revoke_activation` for the per-activation scoping + reason-code audit trail; the existing field continues to work for callers who don't need either.
+- **Spec text alignment.** `activate-signal-request.json` description references "data governance policies (GDPR, CCPA)" — the new tool's `consent_withdrawn` reason code is the canonical surface for that exact use case. Cross-link the schema descriptions when the proposal lands.
+- **`validity_period` expiry** continues to work; expiry generates a synthetic `revocation_completed` event with `reason_code: "expiry"` so the audit chain is uniform regardless of trigger.
+- **Adapters that don't implement `revoke_activation`** return the standard `TOOL_NOT_FOUND` error. Buyers fall back to the existing `activate_signal` `action: "deactivate"` field (with all its undefined-scoping caveats) or to manual destination action.
 
 ---
 
@@ -330,7 +341,7 @@ The `original_task_id ↔ revocation task_id` link MUST be queryable in both dir
 }
 ```
 
-Buyer polls `get_operation_status(op_1778079111234_a7d9c1e3b5f0a2c4)` for terminal state.
+Buyer polls `tasks/get` with `task_id=op_1778079111234_a7d9c1e3b5f0a2c4` for terminal state.
 
 ---
 
@@ -358,7 +369,7 @@ steps:
     expect_envelope_field_present: original_task_id
 
   - id: verify_chain
-    tool: get_operation_status
+    tool: tasks/get
     args: { task_id: ${activate.task_id} }
     expect_response_field:
       revoked_by: ${revoke.task_id}

--- a/docs/SPEC_PROPOSAL_REVOKE_ACTIVATION_addie.md
+++ b/docs/SPEC_PROPOSAL_REVOKE_ACTIVATION_addie.md
@@ -1,12 +1,17 @@
-# Proposal for Addie / AAO: `revoke_activation` (signals domain)
+# Proposal for Addie / AAO: `revoke_activation` (signals domain) — v2
 
-Hey Addie — workshop close-out from the May 7 round-robin surfaced a gap I'd like to push through the working group. Sharing the proposal here so you can route it to whoever owns the signals-domain backlog.
+Hey Addie — thanks for the prior-art check + the two corrections (`tasks/get` not `get_operation_status`; the `action: "deactivate"` field has GDPR/CCPA intent, not a stub). Both verified against `vendor/adcp/adcp-3.0.6/schemas/`. Reframed proposal below.
 
 ## TL;DR
 
-**Gap:** AdCP 3.0.6 has no protocol-level way for a buyer to stop using a signal mid-campaign once it's been activated to a destination. The buyer's only options today are manual destination action (out-of-band, untraceable) or producer-set `validity_period` (which isn't buyer-triggered and isn't implemented in any 3.0.x adapter I've seen).
+**Gap (reframed):** AdCP 3.0.6 declares `action: "deactivate"` on `activate-signal-request.json` with GDPR/CCPA-driven intent — *"Deactivating removes the segment from downstream platforms, required when campaigns end to comply with data governance policies (GDPR, CCPA)."* The intent is real. Four things are missing for the field to actually work end-to-end:
 
-**Proposal:** add a new tool `revoke_activation` to the signals domain. Async-by-default, reason-coded, reason-scoped authorization, reuses `get_operation_status` + the existing webhook signing contract. Clean greenfield, additive only, backwards-compatible.
+1. **No per-activation scoping** — request takes signal_id + destinations, no way to address "the activation I started yesterday."
+2. **No reason codes** — binary action; can't distinguish buyer cleanup from consent-withdrawal from fraud.
+3. **No async chain linking** — the deactivate task isn't linked back to the original activation `task_id` for audit-chain correlation.
+4. **No published implementation** — per the AdCP directory + this adaptor's federation probe (May 7), no 3.0.x agent honors `action: "deactivate"` on `activate_signal` today.
+
+**Proposal:** add a new tool `revoke_activation` that sharpens the existing intent into a first-class primitive — explicit per-activation scoping, reason codes, async chain linking, conformance harness. Reuses `tasks/get` for polling + the existing webhook signing contract. Additive, backwards-compatible.
 
 **Why now:** demonstrably missing on the wire today. Walked through the workshop crowd, every adopter recognized it. Cleanest spec-proposal candidate from the round-robin.
 
@@ -15,7 +20,7 @@ Hey Addie — workshop close-out from the May 7 round-robin surfaced a gap I'd l
 ## Design choices (1 line each)
 
 1. **Name: `revoke_activation`** — not `deactivate_signal` (conflicts with existing `action: "deactivate"` discriminator), not `retract_signal` (kills it for everyone, wrong scope), not `cancel_activation` (implies pre-completion). Revocation targets a specific `task_id`; the signal itself stays in catalog; other buyers' activations untouched.
-2. **Async-by-default** — same lifecycle as `activate_signal`. Returns a new `task_id`; buyers poll via `get_operation_status` or receive webhook. Sync return permitted when every destination supports immediate revocation.
+2. **Async-by-default** — same lifecycle as `activate_signal`. Returns a new `task_id`; buyers poll via `tasks/get` (the spec primitive — confirmed in `vendor/adcp/adcp-3.0.6/schemas/bundled/core/tasks-get-response.json`) or receive webhook. Sync return permitted when every destination supports immediate revocation.
 3. **Reason codes are required** — eight values covering buyer + producer + governance + privacy + fraud + housekeeping triggers. Audit-grade.
 4. **Reason-scoped authorization** — `buyer_decision` is buyer-only; `producer_revoke` requires DNS-verified producer ownership; `governance_denied` requires governance-domain auth. The trust gradient gets enforced at the action layer for the first time.
 5. **Per-destination acks** — response carries one entry per affected destination with `is_revoked` + `ack_received` + optional `error`. Partial-failure semantics are explicit.
@@ -223,7 +228,7 @@ The reason-code-scoped check is the centerpiece — the *first* place AdCP enfor
 }
 ```
 
-Buyer polls `get_operation_status(op_1778079111234_a7d9c1e3b5f0a2c4)` or receives the existing HMAC-signed completion webhook.
+Buyer polls `tasks/get` with `task_id = op_1778079111234_a7d9c1e3b5f0a2c4` or receives the existing HMAC-signed completion webhook.
 
 ---
 
@@ -261,7 +266,7 @@ steps:
     expect_envelope_field_present: original_task_id
 
   - id: verify_chain
-    tool: get_operation_status
+    tool: tasks/get
     args: { task_id: ${activate.task_id} }
     expect_response_field:
       revoked_by: ${revoke.task_id}


### PR DESCRIPTION
## Summary

Addie's prior-art check flagged two real issues with v1 of the \`revoke_activation\` proposal. Both verified against the vendored 3.0.6 corpus; v2 incorporates them.

### Correction 1: \`tasks/get\` is canonical, not \`get_operation_status\`

\`vendor/adcp/adcp-3.0.6/schemas/bundled/core/tasks-get-response.json\` (line 87): *\"Task accepted and queued for long-running execution... Client should poll with tasks/get or provide webhook_url at protocol level.\"*

V1 used \`get_operation_status\` — that's our adaptor's MCP-layer tool name (an alias we expose), not the spec primitive. Fixed across:
- §7 async semantics
- §8 audit-chain queries
- §11 worked example
- §12 storyboard \`verify_chain\` step

### Correction 2: \`action: \"deactivate\"\` is not a stub — it carries GDPR/CCPA intent

\`vendor/adcp/adcp-3.0.6/schemas/signals/activate-signal-request.json\`: *\"Deactivating removes the segment from downstream platforms, required when campaigns end to comply with data governance policies (GDPR, CCPA). Defaults to 'activate' when omitted.\"*

V1's gap statement read as if the field were a stub. That would have made the proposal easy to dismiss as duplicate. V2 reframes around four concrete things missing from the existing field:

1. **No per-activation scoping** — request takes signal_id + destinations, no way to address \"the activation I started yesterday\"
2. **No reason codes** — binary action; can't distinguish buyer cleanup from consent withdrawal from fraud
3. **No async chain linking** — deactivate task isn't linked back to the original activation \`task_id\`
4. **No published implementation** — no 3.0.x agent honors the field per live AdCP directory + this adaptor's federation probe

Plus §10 (backwards compat) now explicitly preserves the existing field's GDPR/CCPA semantics by mapping \`consent_withdrawn\` / \`campaign_ended\` reason codes onto it.

## Files changed

- \`docs/SPEC_PROPOSAL_REVOKE_ACTIVATION.md\` (long-form, working-group / GitHub-issue body)
- \`docs/SPEC_PROPOSAL_REVOKE_ACTIVATION_addie.md\` (chat-shareable; TL;DR explicitly thanks Addie for both corrections)

## What stays unchanged

Other repo files mentioning \`get_operation_status\` — \`WORKSHOP_PROMPT.md\`, \`SEC42_ADCP_30_GA_COMPLIANCE.md\`, \`docs/conformance-evidence/*.json\` — describe **this adaptor's actual tool name** (we expose it via MCP). Those are accurate as-is.

## Once merged

Addie said: *\"I don't have a direct path to the Signals domain triage owner — once the issue is filed, ping the Signals & Measurement WG and drop the issue number; that's the standard triage entry point.\"*

Plan: paste long-form §1-14 as a GitHub issue against \`adcontextprotocol/adcp\`, then ping the Signals & Measurement WG with the issue number. If you want Addie to post a heads-up to the WG on your behalf, say the word back to her.