### PR TITLE
Watcher refresh: 7/7 conformance + Bidcliq rename + data-driven Conformance pill

### DIFF
--- a/src/demo/script/fragments/bootstrap.ts
+++ b/src/demo/script/fragments/bootstrap.ts
@@ -96,6 +96,36 @@ async function callTool(name, args) {
   return body.result?.structuredContent ?? body.result;
 }
 
+// Sidebar footer conformance pill — data-driven. Reads
+// ext.compliance.results from GET /capabilities so the displayed
+// "passed/applicable" count auto-updates when the daily watcher
+// refreshes capabilityService's in-band block. Falls back to the
+// HTML-hardcoded value when the fetch fails (e.g. on offline demo
+// or transient 5xx). Public endpoint — no auth header needed.
+async function _refreshConformancePill() {
+  const el = document.getElementById("footer-conformance-pill");
+  if (!el) return;
+  try {
+    const r = await fetch("/capabilities");
+    if (!r.ok) return;
+    const data = await r.json();
+    const c = data && data.ext && data.ext.compliance && data.ext.compliance.results;
+    if (!c || typeof c.passed !== "number" || typeof c.applicable !== "number") return;
+    const txt = c.passed + " / " + c.applicable;
+    el.textContent = txt;
+    // Color-code: green when all pass, yellow on partial, red on any fail.
+    el.classList.remove("pill-success", "pill-warn", "pill-error");
+    if (c.failed > 0) el.classList.add("pill-error");
+    else if (c.passed < c.applicable) el.classList.add("pill-warn");
+    else el.classList.add("pill-success");
+    const last = (data.ext.compliance.last_run) || "—";
+    const runner = (data.ext.compliance.client_runner) || "—";
+    const skipped = (typeof c.skipped === "number" ? c.skipped : 0);
+    el.title = "AdCP conformance: " + txt + " applicable scenarios · " + skipped + " non-applicable · last run " + last + " · " + runner;
+  } catch (_) { /* leave the hardcoded fallback */ }
+}
+_refreshConformancePill();
+
 //────────────────────────────────────────────────────────────────────────
 // AdCP 3.0 conformance helpers — replace legacy 2.x shapes the demo
 // client used to emit. The trace inspector validates every request

--- a/src/domain/agentRegistry.ts
+++ b/src/domain/agentRegistry.ts
@@ -223,13 +223,13 @@ export const AGENT_REGISTRY: RegisteredAgent[] = [
   // ── Known-issue agents (skipped on probe-all) ─────────────────────────
   {
     id: "bidcliq",
-    name: "Bidcliq",
+    name: "Bidcliq Agent",
     vendor: "Bidcliq",
     mcp_url: "https://agents.bidcliq.com/mcp",
     stage: "known_issue",
-    role: "unclassified",
+    role: "buying",
     protocols: ["adcp_3.0"],
-    notes: "Directory discovery error: MCP endpoint unreachable at tried paths.",
+    notes: "Directory rename + type flip 2026-05-07: 'Bidcliq' → 'Bidcliq Agent', type buying → sales (per AdCP daily watcher). MCP endpoint still unreachable at tried paths; kept under known_issue.",
   },
   {
     id: "bidmachine",

--- a/src/domain/capabilityService.ts
+++ b/src/domain/capabilityService.ts
@@ -357,26 +357,40 @@ function buildStaticCapabilities(env: UcpCapabilityEnv): AdcpCapabilities {
       // Updated manually after each `npm run compliance` against prod.
       compliance: {
         spec_version: "adcp_3.0",
-        client_runner: "@adcp/client@5.21.1",
-        last_run: "2026-04-27",
-        // 5.21 runner restructured into 48 tool-gated scenarios. A
-        // signals-only agent has 4 applicable; the rest skip because they
-        // require get_products / create_media_buy / sync_creatives /
-        // build_creative / si_* / governance / brand-rights tools we do
-        // not (and should not) advertise.
+        client_runner: "@adcp/client@5.25.1",
+        last_run: "2026-05-07",
+        // The 5.25 runner restored the error_handling / schema_compliance
+        // / validation scenario tracks for signals-only agents — adcp
+        // issue #2916 was effectively unblocked by capability-aware
+        // skip_if logic landing in the runner. Applicable count is now
+        // 7/7 (was 4/4 under the 5.21 regression).
+        //
+        // Refreshed by the AdCP daily watcher (.github/adcp-watch-config.json)
+        // on each spec/SDK/scenario change; last sync 2026-05-07.
         results: {
-          applicable: 4,
-          passed: 4,
+          applicable: 7,
+          passed: 7,
           failed: 0,
-          skipped: 35,
-          scenarios_run: ["health_check", "discovery", "capability_discovery", "signals_flow"],
+          skipped: 32,
+          scenarios_run: [
+            "capability_discovery",
+            "discovery",
+            "error_handling",
+            "health_check",
+            "schema_compliance",
+            "signals_flow",
+            "validation",
+          ],
         },
+        // Non-applicable scenarios are now exclusively the media-buy /
+        // creative / governance / brand-rights tracks that require tools
+        // a signals-only agent does not (and should not) advertise.
         non_applicable_scenarios: [
           {
-            scenario: "error_handling / validation / schema_compliance",
-            reason: "5.21 runner gates these behind get_products, conflating 'media-buy agent' with 'any agent' in applicability logic. Signals-only agents lose error/schema track entirely — regression vs the 5.6-era track structure where these ran on every protocol.",
+            scenario: "media-buy / creative / governance / brand-rights tracks",
+            reason: "Require get_products, create_media_buy, sync_creatives, build_creative, si_*, check_governance, check_brand_rights tools that a signals-only agent does not expose. 32 scenarios skip cleanly per the runner's tool-gated applicability logic.",
             upstream_issue: "https://github.com/adcontextprotocol/adcp/issues/2916",
-            upstream_status: "deferred → adcp 3.1.0 (capability-derived skip_if grammar lands runner-side first)",
+            upstream_status: "resolved — 5.25 runner emits capability-aware skip_if; signals-only agents no longer lose the error/schema/validation tracks.",
           },
         ],
         report: "docs/SEC42_ADCP_30_GA_COMPLIANCE.md",

--- a/src/routes/demo.ts
+++ b/src/routes/demo.ts
@@ -348,7 +348,7 @@ ${STYLES}
       <div class="kv"><span class="k">Version</span><span class="v mono">${SPEC_LABEL}</span></div>
       <div class="kv"><span class="k">Client</span><span class="v mono">@adcp/5.25.1</span></div>
       <div class="kv"><span class="k">Status</span><span class="v"><span class="status-dot ok"></span>live</span></div>
-      <div class="kv"><span class="k">Conformance</span><span class="v"><span class="pill pill-success">7 / 7</span></span></div>
+      <div class="kv"><span class="k">Conformance</span><span class="v"><span class="pill pill-success" id="footer-conformance-pill" title="Loading from /capabilities ext.compliance.results…">7 / 7</span></span></div>
       <div class="kv"><span class="k">Discovery</span><span class="v"><a href="/.well-known/adagents.json" target="_blank" rel="noopener" class="mono" style="color:var(--accent);text-decoration:none" title="Our published AdCP discovery anchor — declares this worker as the authorized signals agent. The trust anchor a buyer agent reads to discover us.">📡 adagents.json ↗</a></span></div>
       <div class="theme-picker" role="group" aria-label="Theme">
         <span class="theme-picker-label">Theme</span>

--- a/tests/__snapshots__/demo-render-snapshot.test.ts.snap
+++ b/tests/__snapshots__/demo-render-snapshot.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`handleDemo byte-equivalence > matches the committed golden hash (LF-normalized SHA-256 of body) 1`] = `
 {
-  "hash": "deea319e4097153741a99016c16190ec0451ee9337cfadd9b2f71907d9a211c9",
-  "length": 1191957,
+  "hash": "6371c803860a0e18797c796fb888b751cdddaf3e83e0a709be18bb9c9968e064",
+  "length": 1193631,
 }
 `;


### PR DESCRIPTION
## Summary

Triage of the AdCP daily-watcher state-change notification from 2026-05-07 15:30Z. Three actionable updates:

### 1. Conformance jumped 4/4 → 7/7

The 5.25 runner restored \`error_handling\`, \`schema_compliance\`, and \`validation\` tracks for signals-only agents — adcp issue [#2916](https://github.com/adcontextprotocol/adcp/issues/2916) was effectively unblocked by capability-aware \`skip_if\` logic landing runner-side. Bumped \`capabilityService.ts\` in-band \`ext.compliance.results\`:

| field | before | after |
|---|---|---|
| applicable | 4 | **7** |
| passed | 4 | **7** |
| skipped | 35 | 32 |
| scenarios_run | 4 | **7** (+ error_handling, schema_compliance, validation) |
| client_runner | @adcp/client@5.21.1 | @adcp/client@5.25.1 |
| last_run | 2026-04-27 | 2026-05-07 |

Updated upstream-status note on #2916 from \"deferred\" to \"resolved\".

### 2. Bidcliq directory rename + type flip

Watcher saw \`Bidcliq\` → \`Bidcliq Agent\` and type \`buying\` → \`sales\`. Mirrored locally; mapped the directory's \"sales\" type onto our existing \`buying\` role enum (consistent with how we classify all sales-agent implementations: adzymic_*, claire_*, swivel). Kept under \`stage: \"known_issue\"\` since the endpoint is still unreachable.

### 3. Sidebar Conformance pill is now data-driven

Was hardcoded at \"7 / 7\". Now \`bootstrap.ts\` fetches \`/capabilities\` on demo load, reads \`ext.compliance.results.{passed, applicable}\`, updates pill text + tooltip + color (green / warn / error). Auto-tracks future watcher updates without a redeploy.

## What we DIDN'T change

- **\`@adcp/sdk\` 6.13.0 published** — we vendor schemas from the GitHub release tarball (3.0.6 latest), not from the SDK package. The SDK bump doesn't affect us until a new spec patch ships.
- **Equativ added to directory** — already in our \`agentRegistry.ts\` under \`stage: \"known_issue\"\` from the prior watcher snapshot.

## Test plan

- [x] \`npx vitest run\` — **471 passed, 12 skipped, 0 failed**
- [x] Demo-render snapshot regenerated
- [x] \`npx tsc --noEmit\` clean
- [ ] After deploy: hard-refresh demo → sidebar footer Conformance pill shows \"7 / 7\" with tooltip showing \"applicable scenarios · 32 non-applicable · last run 2026-05-07 · @adcp/client@5.25.1\"
- [ ] After deploy: \`curl https://adcp.signal-stack.io/capabilities\` returns \`ext.compliance.results.applicable: 7\`