### PR TITLE
Tier 1 correctness batch: idempotency + correlation_id + /health version

### DIFF
--- a/migrations/0007_activation_idempotency_key.sql
+++ b/migrations/0007_activation_idempotency_key.sql
@@ -1,0 +1,29 @@
+-- 0007_activation_idempotency_key.sql
+--
+-- Add idempotency_key column to activation_jobs to enforce the
+-- AdCP 3.0.x activate_signal_request idempotency contract:
+--
+--   "Client-generated unique key. If a request with the same key has
+--    already been accepted, the server returns the original response
+--    without re-processing... Prevents duplicate billing on retries."
+--   — vendor/adcp/adcp-3.0.x/schemas/signals/activate-signal-request.json
+--
+-- Without this, retried activations create duplicate activation_jobs
+-- rows (same signal + destination, different operation_ids), which
+-- breaks the receipt audit chain and could double-bill in any future
+-- per-impression pricing model.
+--
+-- The column is nullable so legacy rows that pre-date enforcement are
+-- preserved; new inserts populate it. Lookup is by
+-- (idempotency_key, signal_id, destination) — same key against
+-- different (signal, destination) tuples is a different activation,
+-- not a duplicate.
+
+ALTER TABLE activation_jobs ADD COLUMN idempotency_key TEXT;
+
+-- Composite index for the dedupe lookup. Indexed only when the key
+-- is non-null (sqlite partial index syntax). The (signal_id,
+-- destination) triple is what defines uniqueness for an activation.
+CREATE INDEX IF NOT EXISTS idx_activation_jobs_idempotency
+  ON activation_jobs(idempotency_key, signal_id, destination)
+  WHERE idempotency_key IS NOT NULL;

--- a/src/domain/activationService.ts
+++ b/src/domain/activationService.ts
@@ -17,6 +17,7 @@ import type { DB } from "../storage/db";
 import {
   createActivationJob,
   findOperationById,
+  findActivationByIdempotencyKey,
   updateJobStatus,
   markWebhookFired,
   recordWebhookAttempt,
@@ -66,6 +67,47 @@ export async function activateSignalService(
   if (!signal.activationSupported) {
     throw new ValidationError(`Signal ${req.signalId} does not support activation`);
   }
+
+  // Idempotency enforcement (AdCP 3.0.x activate_signal_request contract).
+  // If the caller supplied an idempotency_key AND we have a prior job
+  // with the same (key, signal, destination) triple, return the
+  // ORIGINAL task_id without creating a new row. Prevents duplicate
+  // activations on retries — closes a gap the workshop deck audit
+  // flagged. Triple-match (not key-only) so reuse against a different
+  // signal-or-destination legitimately mints a fresh activation.
+  if (req.idempotencyKey) {
+    const existing = await findActivationByIdempotencyKey(
+      db,
+      req.idempotencyKey,
+      req.signalId,
+      req.destination,
+    );
+    if (existing) {
+      logger.info("activation_idempotent_replay", {
+        idempotencyKey: req.idempotencyKey,
+        operationId: existing.operationId,
+        signalId: req.signalId,
+        destination: req.destination,
+      });
+      // Map the broader OperationStatus enum onto ActivateSignalResponse's
+      // narrower 4-state surface. "submitted" → "pending" preserves the
+      // wire-format we emit on first call; "working" → "processing"
+      // mirrors the lazy state machine; terminal states pass through.
+      const responseStatus =
+        existing.status === "submitted" ? "pending" :
+        existing.status === "working" ? "processing" :
+        existing.status === "completed" ? "completed" :
+        "failed";
+      return {
+        task_id: existing.operationId,
+        status: responseStatus,
+        signal_agent_segment_id: req.signalId,
+        ...(existing.webhookUrl ? { webhook_url: existing.webhookUrl } : {}),
+        operationId: existing.operationId,
+        submittedAt: existing.submittedAt,
+      };
+    }
+  }
   // Per-signal destinations list is now advisory metadata, not a rejection
   // gate (Sec-12 round 2). The AdCP signals storyboard activates against
   // arbitrary platform names (the-trade-desk, dv360, etc.) and the agent
@@ -95,6 +137,7 @@ export async function activateSignalService(
     ...(req.campaignId !== undefined ? { campaignId: req.campaignId } : {}),
     ...(req.notes !== undefined ? { notes: req.notes } : {}),
     ...(req.webhookUrl !== undefined ? { webhookUrl: req.webhookUrl } : {}),
+    ...(req.idempotencyKey !== undefined ? { idempotencyKey: req.idempotencyKey } : {}),
   });
 
   logger.info("activation_submitted", {

--- a/src/federation/dstilleryClient.ts
+++ b/src/federation/dstilleryClient.ts
@@ -19,6 +19,7 @@
 //     once on session error.
 
 import { safeRecordSignalTrace, persistSignalTrace } from "../domain/signalTrace";
+import { correlationId } from "../utils/ids";
 import type { Env } from "../types/env";
 
 export const DSTILLERY_MCP_URL = "https://adcp-signals-agent.dstillery.com/mcp";
@@ -125,8 +126,7 @@ export interface DstillerySearchResult {
 
 async function callGetSignalsOnce(
   sessionId: string,
-  brief: string,
-  maxResults: number,
+  args: Record<string, unknown>,
 ): Promise<{ signals: DstillerySignal[]; error?: string }> {
   const res = await fetch(DSTILLERY_MCP_URL, {
     method: "POST",
@@ -139,14 +139,12 @@ async function callGetSignalsOnce(
       jsonrpc: "2.0",
       id: Date.now(),
       method: "tools/call",
-      params: {
-        name: "get_signals",
-        // Top-level max_results only. Dstillery's get_signals validator
-        // (Pydantic 2.12) rejects the `pagination` envelope as an
-        // "Unexpected keyword argument" — strict-additionalProperties
-        // schemas don't tolerate forward-compat fields.
-        arguments: { signal_spec: brief, max_results: maxResults },
-      },
+      // args carries the canonical request payload — signal_spec,
+      // max_results, AND context.correlation_id. Dstillery's get_signals
+      // validator (Pydantic 2.12) rejects the `pagination` envelope as an
+      // "Unexpected keyword argument", but accepts context per AdCP MUST
+      // (the v2.13.1 peer echoes context.correlation_id back on response).
+      params: { name: "get_signals", arguments: args },
     }),
     signal: AbortSignal.timeout(15_000),
   });
@@ -165,13 +163,25 @@ export async function dstillerySearch(
   brief: string,
   maxResults: number = 10,
   env?: Env,
+  inboundCorrelationId?: string,
 ): Promise<DstillerySearchResult> {
   const start = Date.now();
   // Track the request payload separately so we can record it even when
   // the network call throws. The trace recorder captures both successful
   // and failed federation outbounds — same posture as callAgentTool's
   // recorder in genericMcpClient.ts.
-  const requestPayload = { signal_spec: brief, max_results: maxResults };
+  //
+  // Inject context.correlation_id (matches the genericMcpClient
+  // propagation pattern). When the caller threads an inbound
+  // correlation_id, we reuse it; otherwise we generate one. The
+  // peer's get_signals response (Dstillery v2.13.1) currently echoes
+  // context per spec MUST, so the buyer-side trace can chain.
+  const cid = inboundCorrelationId ?? correlationId();
+  const requestPayload: Record<string, unknown> = {
+    signal_spec: brief,
+    max_results: maxResults,
+    context: { correlation_id: cid },
+  };
   try {
     let session = await ensureSession();
     if (!session) {
@@ -183,13 +193,13 @@ export async function dstillerySearch(
       return failResult;
     }
 
-    let r = await callGetSignalsOnce(session, brief, maxResults);
+    let r = await callGetSignalsOnce(session, requestPayload);
 
     // If session-related error, retry once with a fresh session
     if (r.error && /session/i.test(r.error)) {
       _sessionId = null;
       session = await ensureSession();
-      if (session) r = await callGetSignalsOnce(session, brief, maxResults);
+      if (session) r = await callGetSignalsOnce(session, requestPayload);
     }
 
     const result: DstillerySearchResult = {

--- a/src/federation/genericMcpClient.ts
+++ b/src/federation/genericMcpClient.ts
@@ -22,6 +22,7 @@
 
 import { AGENT_REGISTRY } from "../domain/agentRegistry";
 import { safeRecordSignalTrace, persistSignalTrace, type AdcpToolName } from "../domain/signalTrace";
+import { correlationId } from "../utils/ids";
 import type { Env } from "../types/env";
 
 const SESSION_TTL_MS = 9 * 60 * 1000;
@@ -315,13 +316,33 @@ type SelfToolHook = (url: string, name: string, args: Record<string, unknown>) =
 let SELF_TOOL_HOOK: SelfToolHook | null = null;
 export function installSelfToolHook(hook: SelfToolHook | null): void { SELF_TOOL_HOOK = hook; }
 
-export async function callAgentTool(url: string, name: string, args: Record<string, unknown>, opts?: { timeoutMs?: number; env?: Env }): Promise<ToolCallResult> {
+export async function callAgentTool(url: string, name: string, args: Record<string, unknown>, opts?: { timeoutMs?: number; env?: Env; correlation_id?: string }): Promise<ToolCallResult> {
   const timeoutMs = opts?.timeoutMs ?? 20_000;
   const start = Date.now();
+
+  // Cross-protocol correlation_id propagation (closes the gap flagged
+  // in the workshop deck audit and the v4 payments discussion). Every
+  // outbound peer tools/call now carries `args.context.correlation_id`
+  // so the trace recorder can chain inbound → outbound → response
+  // under a single audit handle. Behavior:
+  //
+  //   1. If args.context.correlation_id is already set, respect it
+  //      (caller knows what they're doing — e.g. the orchestrator
+  //      passes the same id to every peer in a fanout).
+  //   2. Else if opts.correlation_id is set, use that.
+  //   3. Else generate a fresh one.
+  //
+  // Result: every outbound trace has a correlation_id, even when
+  // intermediate code didn't bother threading one through.
+  const incomingCtx = (args["context"] as Record<string, unknown> | undefined) ?? {};
+  const incomingCid = typeof incomingCtx["correlation_id"] === "string" ? incomingCtx["correlation_id"] as string : undefined;
+  const cid = incomingCid ?? opts?.correlation_id ?? correlationId();
+  const argsWithCtx: Record<string, unknown> = { ...args, context: { ...incomingCtx, correlation_id: cid } };
+
   // Sec-48b: if this is a call against our own URL, use the in-process hook
   // to avoid Cloudflare Workers' self-fetch restriction.
   if (SELF_TOOL_HOOK) {
-    const selfResult = SELF_TOOL_HOOK(url, name, args);
+    const selfResult = SELF_TOOL_HOOK(url, name, argsWithCtx);
     if (selfResult) {
       try { return await selfResult; }
       catch (e) { return { ok: false, error: String((e as Error).message || e), latency_ms: Date.now() - start }; }
@@ -333,11 +354,11 @@ export async function callAgentTool(url: string, name: string, args: Record<stri
     if (!session) {
       result = { ok: false, error: "session_init_failed", latency_ms: Date.now() - start };
     } else {
-      let r = await callToolOnce(url, session, name, args, timeoutMs);
+      let r = await callToolOnce(url, session, name, argsWithCtx, timeoutMs);
       if (r.error && /session/i.test(r.error)) {
         invalidateSession(url);
         session = await ensureSession(url, { timeoutMs });
-        if (session) r = await callToolOnce(url, session, name, args, timeoutMs);
+        if (session) r = await callToolOnce(url, session, name, argsWithCtx, timeoutMs);
       }
       result = r;
     }
@@ -384,7 +405,11 @@ export async function callAgentTool(url: string, name: string, args: Record<stri
         // does Dstillery live?" on every call. Surface the answer.
         endpoint_url: url,
         peer_server_info: peerServerInfo,
-        request_payload: args,
+        // Trace what we ACTUALLY sent — the args after correlation_id
+        // injection — so the trace's correlation_id field matches
+        // what the peer received.
+        request_payload: argsWithCtx,
+        correlation_id: cid,
         response_payload: result.ok
           ? (result.structured_content ?? result.content ?? null)
           : { error: result.error ?? "unknown_error" },

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,6 +29,7 @@ import { handleSimulateHandshake } from "./routes/handshake";
 import { handleGetProjector } from "./routes/getProjector";
 import { handleUcpProjection, handleUcpSimilarity } from "./routes/ucpProjection";
 import { handleEmbedText } from "./routes/embedText";
+import { ADCP_SPEC_VERSION } from "./schemas/adcp";
 import {
   handleQueryVector,
   handleArithmetic,
@@ -491,10 +492,17 @@ export default {
                 response = await handleSignalTraceById(traceId, env);
 
             } else if (method === "GET" && path === "/health") {
+                // Version fields derive from ADCP_SPEC_VERSION (vendored
+                // schema corpus pin). The bare "3.0" major-line stays
+                // alongside the patch-versioned `adcp_spec_version` for
+                // back-compat with consumers that key on either string.
+                // Bumping the corpus auto-bumps these without an
+                // index.ts edit.
                 response = jsonResponse({
                     status: "ok",
-                    version: "3.0",          // AdCP protocol version (kept for back-compat)
-                    adcp_version: "3.0",
+                    version: "3.0",                            // major-line, back-compat
+                    adcp_version: "3.0",                       // major-line, back-compat
+                    adcp_spec_version: ADCP_SPEC_VERSION,      // patch (e.g. 3.0.8)
                     worker_version: WORKER_VERSION,
                     built_at: builtAt(),
                 });

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -747,6 +747,12 @@ async function callActivateSignal(
             campaignId: args["campaignId"] as string | undefined,
             notes: args["notes"] as string | undefined,
             webhookUrl,
+            // AdCP 3.0.x activate_signal_request idempotency contract:
+            // canonical wire field is `idempotency_key` (snake_case);
+            // we accept that AND legacy camelCase `idempotencyKey` for
+            // back-compat with callers that sent the camelCase form
+            // before the spec settled.
+            idempotencyKey: (args["idempotency_key"] ?? args["idempotencyKey"]) as string | undefined,
         }),
     };
 

--- a/src/routes/activateSignal.ts
+++ b/src/routes/activateSignal.ts
@@ -19,6 +19,15 @@ export async function handleActivateSignal(
     return errorResponse("INVALID_BODY", "Request body must be valid JSON", 400);
   }
 
+  // Accept both AdCP 3.0.x canonical `idempotency_key` (snake_case)
+  // and legacy camelCase `idempotencyKey`. Prefer the canonical form
+  // when both are present. Internal type is camelCase; downstream
+  // service enforces dedup via (idempotencyKey, signal, destination).
+  const bodyAny = body as unknown as Record<string, unknown>;
+  if (typeof bodyAny["idempotency_key"] === "string" && !body.idempotencyKey) {
+    body.idempotencyKey = bodyAny["idempotency_key"] as string;
+  }
+
   const validation = validateActivateRequest(body);
   if (!validation.ok) {
     // ApiError uses `error` (not `message`) for the human-readable string.

--- a/src/storage/activationRepo.ts
+++ b/src/storage/activationRepo.ts
@@ -19,6 +19,7 @@ interface JobRow {
   updated_at: string;
   completed_at: string | null;
   error_message: string | null;
+  idempotency_key: string | null;
 }
 
 function rowToOperation(row: JobRow): OperationRecord {
@@ -50,14 +51,15 @@ export async function createActivationJob(
     campaignId?: string;
     notes?: string;
     webhookUrl?: string;
+    idempotencyKey?: string;
   }
 ): Promise<void> {
   const now = new Date().toISOString();
   await execute(
     db,
     `INSERT INTO activation_jobs
-      (operation_id, signal_id, destination, account_id, campaign_id, notes, webhook_url, status, submitted_at, updated_at)
-     VALUES (?,?,?,?,?,?,?,?,?,?)`,
+      (operation_id, signal_id, destination, account_id, campaign_id, notes, webhook_url, status, submitted_at, updated_at, idempotency_key)
+     VALUES (?,?,?,?,?,?,?,?,?,?,?)`,
     [
       job.operationId,
       job.signalId,
@@ -69,10 +71,37 @@ export async function createActivationJob(
       "submitted",
       now,
       now,
+      job.idempotencyKey ?? null,
     ]
   );
 
   await appendEvent(db, job.operationId, "submitted", "Activation job submitted");
+}
+
+/**
+ * Idempotency lookup: find an existing activation job that matches the
+ * (idempotency_key, signal_id, destination) triple. Used by
+ * activateSignalService to short-circuit duplicate requests with the
+ * original task_id instead of creating a new row.
+ *
+ * Triple-key match (not key-only) prevents accidental cross-activation
+ * collisions: a buyer who reuses the same key against a different
+ * signal-or-destination tuple legitimately gets a fresh activation.
+ */
+export async function findActivationByIdempotencyKey(
+  db: DB,
+  idempotencyKey: string,
+  signalId: string,
+  destination: string,
+): Promise<OperationRecord | null> {
+  const row = await queryFirst<JobRow>(
+    db,
+    `SELECT * FROM activation_jobs
+     WHERE idempotency_key = ? AND signal_id = ? AND destination = ?
+     LIMIT 1`,
+    [idempotencyKey, signalId, destination],
+  );
+  return row ? rowToOperation(row) : null;
 }
 
 export async function findOperationById(

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -208,6 +208,19 @@ export interface ActivateSignalRequest {
   notes?: string;
   webhookUrl?: string;       // optional: POST status updates here when complete
   proposalData?: import("../types/signal").CanonicalSignal;  // for lazy custom signal creation
+  /**
+   * Per AdCP 3.0.x activate_signal_request: client-generated UUID-style
+   * key (^[A-Za-z0-9_.:-]{16,255}$) that prevents duplicate activations
+   * on retries. The server enforces idempotency by:
+   *   1. Looking up an existing activation_jobs row with this key
+   *   2. If found → return the original task_id (no new row created)
+   *   3. If not found → create the row with this key in idempotency_key column
+   *
+   * Optional in our adapter for back-compat with callers who haven't
+   * migrated yet; the SCHEMA marks it required. Recommend migrating
+   * all clients to send it before AdCP 4.0 makes it strictly required.
+   */
+  idempotencyKey?: string;
 }
 
 export interface ActivateSignalResponse {

--- a/src/utils/ids.ts
+++ b/src/utils/ids.ts
@@ -63,6 +63,23 @@ export function requestId(): string {
   return `req_${Date.now()}_${randomHex(6)}`;
 }
 
+/**
+ * Generate a workflow-scoped correlation ID for cross-protocol tracing.
+ *
+ * Threaded into outbound peer `tools/call` args as
+ * `context.correlation_id` by the federation client when the caller
+ * doesn't supply one explicitly. Lets the trace recorder chain
+ * inbound discovery → outbound peer fan-out → response under a single
+ * audit handle.
+ *
+ * Format: `cid_<36-base-timestamp>_<8-hex>`. Distinct prefix from
+ * requestId so REST log lines and outbound trace correlation IDs are
+ * not confused at a glance.
+ */
+export function correlationId(): string {
+  return `cid_${Date.now().toString(36)}_${randomHex(8)}`;
+}
+
 function randomHex(bytes: number): string {
   const arr = new Uint8Array(bytes);
   crypto.getRandomValues(arr);

--- a/tests/activation-idempotency.test.ts
+++ b/tests/activation-idempotency.test.ts
@@ -1,0 +1,246 @@
+// tests/activation-idempotency.test.ts
+//
+// Pin the activate_signal idempotency contract:
+//   * Same idempotency_key + same (signal, destination) → original task_id
+//   * Same idempotency_key + DIFFERENT signal-or-destination → fresh activation
+//   * Missing idempotency_key → fresh activation each call (back-compat)
+//
+// Closes the workshop deck audit gap: schema requires idempotency_key on
+// activate_signal_request but the server previously read + ignored it,
+// creating duplicate activation_jobs rows on retries.
+
+import { describe, it, expect, vi } from "vitest";
+import { activateSignalService } from "../src/domain/activationService";
+import type { CanonicalSignal } from "../src/types/signal";
+
+function makeKv(): KVNamespace {
+  const store = new Map<string, string>();
+  return {
+    async get(k: string) { return store.get(k) ?? null; },
+    async put(k: string, v: string) { store.set(k, v); },
+    async delete(k: string) { store.delete(k); },
+    async list() { return { keys: [...store.keys()].map((name) => ({ name })), list_complete: true } as never; },
+    async getWithMetadata() { return { value: null, metadata: null } as never; },
+  } as unknown as KVNamespace;
+}
+
+const fakeLogger = {
+  debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn(),
+} as never;
+
+const sampleSignal: CanonicalSignal = {
+  signalId: "sig_test_audience",
+  taxonomySystem: "iab" as never,
+  name: "Test Audience",
+  description: "synthetic signal for idempotency tests",
+  categoryType: "demographic",
+  sourceSystems: ["test"],
+  destinations: ["mock_dsp"],
+  activationSupported: true,
+  estimatedAudienceSize: 1_000_000,
+  accessPolicy: "public" as never,
+  generationMode: "deterministic",
+  status: "available" as never,
+  createdAt: "2026-01-01T00:00:00Z",
+  updatedAt: "2026-01-01T00:00:00Z",
+};
+
+/**
+ * In-memory D1 fake that supports the queries activationService runs:
+ *   - SELECT * FROM signals WHERE signal_id = ? (catalog lookup)
+ *   - SELECT * FROM activation_jobs WHERE idempotency_key = ? AND ... (dedup lookup)
+ *   - INSERT INTO activation_jobs (...)
+ *   - INSERT INTO activation_events (...)
+ */
+function makeDb(seedSignals: CanonicalSignal[]) {
+  const signals = new Map(seedSignals.map((s) => [s.signalId, s]));
+  const activationJobs: Array<Record<string, unknown>> = [];
+
+  const db = {
+    prepare(sql: string) {
+      let bound: unknown[] = [];
+      return {
+        bind(...args: unknown[]) { bound = args; return this; },
+        async first<T>() {
+          // Catalog lookup
+          if (sql.includes("FROM signals WHERE signal_id")) {
+            const sig = signals.get(bound[0] as string);
+            if (!sig) return null as unknown as T;
+            return {
+              signal_id: sig.signalId,
+              name: sig.name,
+              description: sig.description,
+              category_type: sig.categoryType,
+              taxonomy_system: sig.taxonomySystem,
+              source_systems: JSON.stringify(sig.sourceSystems),
+              destinations: JSON.stringify(sig.destinations),
+              activation_supported: sig.activationSupported ? 1 : 0,
+              estimated_audience_size: sig.estimatedAudienceSize ?? null,
+              access_policy: sig.accessPolicy,
+              generation_mode: sig.generationMode,
+              status: sig.status,
+              created_at: sig.createdAt,
+              updated_at: sig.updatedAt,
+            } as unknown as T;
+          }
+          // Idempotency dedup lookup
+          if (sql.includes("WHERE idempotency_key")) {
+            const [key, sigId, dest] = bound as string[];
+            const match = activationJobs.find(
+              (j) => j["idempotency_key"] === key && j["signal_id"] === sigId && j["destination"] === dest,
+            );
+            return (match ?? null) as unknown as T;
+          }
+          return null as unknown as T;
+        },
+        async all<T>() { return { results: [] as T[] }; },
+        async run() {
+          // Capture activation_jobs INSERT
+          if (sql.startsWith("INSERT INTO activation_jobs")) {
+            // Order from createActivationJob:
+            //   operation_id, signal_id, destination, account_id,
+            //   campaign_id, notes, webhook_url, status, submitted_at,
+            //   updated_at, idempotency_key
+            activationJobs.push({
+              operation_id: bound[0],
+              signal_id: bound[1],
+              destination: bound[2],
+              account_id: bound[3],
+              campaign_id: bound[4],
+              notes: bound[5],
+              webhook_url: bound[6],
+              status: bound[7],
+              submitted_at: bound[8],
+              updated_at: bound[9],
+              idempotency_key: bound[10],
+              webhook_fired: 0,
+              webhook_attempts: 0,
+              webhook_next_attempt_at: null,
+              completed_at: null,
+              error_message: null,
+            });
+          }
+          return { success: true, meta: {} } as unknown as D1Result;
+        },
+      };
+    },
+    async batch(stmts: Array<{ run: () => Promise<D1Result> }>) {
+      const out = [];
+      for (const s of stmts) out.push(await s.run());
+      return out;
+    },
+  } as unknown as D1Database;
+
+  return { db, getRows: () => activationJobs };
+}
+
+describe("activate_signal idempotency enforcement", () => {
+  it("same idempotency_key + same (signal, destination) returns original task_id", async () => {
+    const { db, getRows } = makeDb([sampleSignal]);
+    const kv = makeKv();
+    const key = "ik_abcdef0123456789";
+
+    const r1 = await activateSignalService(db, kv, {
+      signalId: "sig_test_audience",
+      destination: "mock_dsp",
+      idempotencyKey: key,
+    }, fakeLogger);
+
+    const r2 = await activateSignalService(db, kv, {
+      signalId: "sig_test_audience",
+      destination: "mock_dsp",
+      idempotencyKey: key,
+    }, fakeLogger);
+
+    expect(r2.task_id).toBe(r1.task_id);
+    expect(r2.operationId).toBe(r1.operationId);
+    expect(getRows()).toHaveLength(1);
+  });
+
+  it("same idempotency_key + DIFFERENT signal mints a fresh activation", async () => {
+    const sig2 = { ...sampleSignal, signalId: "sig_test_audience_2" };
+    const { db, getRows } = makeDb([sampleSignal, sig2]);
+    const kv = makeKv();
+    const key = "ik_shared_key_across_signals";
+
+    const r1 = await activateSignalService(db, kv, {
+      signalId: "sig_test_audience",
+      destination: "mock_dsp",
+      idempotencyKey: key,
+    }, fakeLogger);
+
+    const r2 = await activateSignalService(db, kv, {
+      signalId: "sig_test_audience_2",
+      destination: "mock_dsp",
+      idempotencyKey: key,
+    }, fakeLogger);
+
+    expect(r2.task_id).not.toBe(r1.task_id);
+    expect(getRows()).toHaveLength(2);
+  });
+
+  it("same idempotency_key + DIFFERENT destination mints a fresh activation", async () => {
+    const sig = { ...sampleSignal, destinations: ["mock_dsp", "mock_dsp_alt"] };
+    const { db, getRows } = makeDb([sig]);
+    const kv = makeKv();
+    const key = "ik_shared_key_across_destinations";
+
+    const r1 = await activateSignalService(db, kv, {
+      signalId: "sig_test_audience",
+      destination: "mock_dsp",
+      idempotencyKey: key,
+    }, fakeLogger);
+
+    const r2 = await activateSignalService(db, kv, {
+      signalId: "sig_test_audience",
+      destination: "mock_dsp_alt",
+      idempotencyKey: key,
+    }, fakeLogger);
+
+    expect(r2.task_id).not.toBe(r1.task_id);
+    expect(getRows()).toHaveLength(2);
+  });
+
+  it("MISSING idempotency_key creates fresh activation each call (back-compat)", async () => {
+    const { db, getRows } = makeDb([sampleSignal]);
+    const kv = makeKv();
+
+    const r1 = await activateSignalService(db, kv, {
+      signalId: "sig_test_audience",
+      destination: "mock_dsp",
+      // no idempotencyKey
+    }, fakeLogger);
+
+    const r2 = await activateSignalService(db, kv, {
+      signalId: "sig_test_audience",
+      destination: "mock_dsp",
+      // no idempotencyKey
+    }, fakeLogger);
+
+    expect(r2.task_id).not.toBe(r1.task_id);
+    expect(getRows()).toHaveLength(2);
+  });
+
+  it("idempotent replay preserves the original submittedAt timestamp", async () => {
+    const { db } = makeDb([sampleSignal]);
+    const kv = makeKv();
+    const key = "ik_timestamp_check_xyz123";
+
+    const r1 = await activateSignalService(db, kv, {
+      signalId: "sig_test_audience",
+      destination: "mock_dsp",
+      idempotencyKey: key,
+    }, fakeLogger);
+
+    // Wait a beat to ensure new Date().toISOString() WOULD differ
+    await new Promise((resolve) => setTimeout(resolve, 5));
+
+    const r2 = await activateSignalService(db, kv, {
+      signalId: "sig_test_audience",
+      destination: "mock_dsp",
+      idempotencyKey: key,
+    }, fakeLogger);
+
+    expect(r2.submittedAt).toBe(r1.submittedAt);
+  });
+});


### PR DESCRIPTION
## Summary

Three correctness gaps the workshop deck audit flagged. Each is a real bug that didn't bite during the demo but would surface under production load.

## 1. Idempotency_key enforcement on activate_signal

**The gap:** AdCP 3.0.x \`activate_signal_request\` schema requires \`idempotency_key\`: *\"Client-generated unique key. If a request with the same key has already been accepted, the server returns the original response without re-processing. Prevents duplicate billing on retries.\"*

We read the field via comments but never enforced it. Retries — common with MCP transport loops + webhook bounded retries — created duplicate \`activation_jobs\` rows.

**The fix:**

- \`migrations/0007\` adds \`idempotency_key\` column + partial index on \`(key, signal_id, destination)\`
- \`findActivationByIdempotencyKey()\` in activationRepo
- \`activateSignalService\` checks BEFORE creating a new row; on hit returns the original task_id + submittedAt
- **Triple-key match** (not key-only) — same key against different signal-or-destination legitimately mints a fresh activation
- MCP + REST handlers accept both \`idempotency_key\` (canonical) and \`idempotencyKey\` (legacy camelCase)

**Tests** (\`tests/activation-idempotency.test.ts\`, 5 cases):
- [x] Same key + same (signal, dest) → original task_id, no new row
- [x] Same key + different signal → fresh activation
- [x] Same key + different destination → fresh activation
- [x] Missing key → fresh activation each call (back-compat)
- [x] Replay preserves original submittedAt

## 2. correlation_id outbound propagation in federation clients

**The gap:** v4 payments discussion (PR #241) flagged that inbound MCP threads \`context.correlation_id\` but outbound peer \`tools/call args\` don't. Chain breaks at the federation boundary.

**The fix:**

- \`correlationId()\` helper in \`src/utils/ids.ts\` (\`cid_<base36>_<hex>\`)
- \`callAgentTool\` in \`genericMcpClient.ts\` injects into \`args.context\` with three-tier precedence:
  1. Caller-set \`args.context.correlation_id\` wins (e.g. orchestrator passing same id to every peer in a fanout)
  2. \`opts.correlation_id\` next
  3. Fresh generated cid otherwise
- \`dstilleryClient.dstillerySearch\` takes optional \`inboundCorrelationId\`; bakes it into the wire payload
- Trace recorder captures the corrected args so the trace's \`correlation_id\` field matches what the peer received

Result: every outbound trace has a \`correlation_id\`, even when intermediate code didn't thread one through.

## 3. /health version label derived from ADCP_SPEC_VERSION

\`/health\` was emitting hardcoded \`\"version\": \"3.0\"\` — stale after every spec bump. Now adds \`adcp_spec_version: ADCP_SPEC_VERSION\` (e.g. \`\"3.0.8\"\`) alongside the bare major-line for back-compat. Auto-tracks future corpus bumps.

## Test plan

- [x] \`npx vitest run\` — **476 passed (+5 new), 12 skipped, 0 failed**
- [x] \`npx tsc --noEmit\` clean
- [ ] After deploy: \`curl /health\` shows \`adcp_spec_version: 3.0.8\`
- [ ] After deploy: replay \`activate_signal\` twice with same idempotency_key → second response returns the original task_id (D1 row count stays at 1)
- [ ] After deploy: trace inspector shows \`correlation_id\` populated on every outbound federation trace