### PR TITLE
Add db:migrate:remote + db:seed:remote scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
     "compliance": "node scripts/run-compliance.mjs",
     "type-check": "tsc --noEmit",
     "db:migrate": "wrangler d1 migrations apply adcp-signals-db",
+    "db:migrate:remote": "wrangler d1 migrations apply adcp-signals-db --remote",
     "db:seed": "wrangler d1 execute adcp-signals-db --file=./migrations/seed.sql",
+    "db:seed:remote": "wrangler d1 execute adcp-signals-db --file=./migrations/seed.sql --remote",
     "lint": "eslint src --ext .ts"
   },
   "devDependencies": {


### PR DESCRIPTION
## Why

Hit this gotcha applying PR #243's idempotency migration to production today: \`npm run db:migrate\` runs locally only. \`wrangler d1 migrations apply\` defaults to \`.wrangler/state/v3/d1\`; production needs \`--remote\`.

## What

Adds explicit \`:remote\` variants. Base scripts stay local-default (matches wrangler convention; prevents accidental production writes during development).

\`\`\`
npm run db:migrate          → local D1
npm run db:migrate:remote   → production D1
npm run db:seed             → local D1
npm run db:seed:remote      → production D1
\`\`\`

## Test

- [x] Already verified \`db:migrate:remote\` runs successfully on production (today, applied 0006 + 0007)
- [x] Production \`activation_jobs.idempotency_key\` column confirmed via \`PRAGMA table_info\`