### PR TITLE
Enforce VERSION_UNSUPPORTED + fix compliance reproduce URL

### DIFF
--- a/docs/DISCUSSION_SIGNAL_PAYMENTS.md
+++ b/docs/DISCUSSION_SIGNAL_PAYMENTS.md
@@ -340,43 +340,66 @@ Two design options for the receipt envelope:
 
 **Sub-question for the sync:** when a node has multiple parents from DIFFERENT source agents, do they each contribute to the `revenue_share[]` propagation independently, or does the modeling agent collapse them into a single share split it controls? (Likely the latter, since the modeling agent is the one with the commercial relationship — but worth confirming.)
 
-### Track A.0 — pre-launch readiness criterion (sharpened v4)
+### Track A.0 — pre-launch readiness criterion (REFRAMED v5 post-WG triage)
 
-Addie's framing: Track A's launch criteria isn't a protocol question, it's an **ecosystem readiness question**. The receipt chain only executes when enough vendors publish JWKS with webhook-signing-purpose keys.
+**v4 framing (superseded):** Track A's launch criteria is an "ecosystem readiness question" — the receipt chain only executes when enough vendors publish JWKS with webhook-signing-purpose keys. ≥30% directory adoption proposed as threshold.
 
-**Empirical baseline from our adapter's federation probe** (May 7, 2026):
+**v5 reframe (post-WG triage by @bokelley):** the threshold framing assumes a population to migrate. There isn't one yet. Both this work and the parallel webhook-signing migration are **on-ramp problems, not migration problems**. Filing both as adcp issues and reading the triage:
 
-| Adoption surface | Count | % of probed peers (19) |
+- **#4205 (webhook signing migration coordination):** deferred, blocked on #3064 + #3360. WG reframe — *"the installed base of live buyer agents is ~empty right now"* — so 80% migration thresholds are meaningless. The right metric is *"no new HMAC implementers after date X,"* enforced by docs + grade tooling + SDK defaults. SDK already correct.
+- **#4206 (Track A.0 JWKS adoption):** deferred, blocked on #4205. Same on-ramp logic applies — 30% of an empty installed base is the wrong target.
+
+**What this means for the design:**
+
+- The empirical baseline data (84% reachable, 10% adagents.json, 0% schema-valid) **stays useful** — but as a *named-partner inventory* feeding #3360's grade-tooling scope, NOT as a WG-vote threshold target.
+- Track A.0's gating dependency is now: **on-ramp surfaces consistently emit RFC 9421 + JWKS** (docs default, grade tooling fails on legacy, SDK ✓ done, storyboards untracked). Once those are clean, every NEW agent built off the SDK lands chain-of-custody-ready by default.
+- The "30% threshold" question stops being a sync agenda item. The right sync question becomes: *"do the four on-ramp surfaces (docs / grade tooling / SDK / storyboards) all emit RFC 9421 by the time we ship Track A schema?"* — that's a checklist, not a vote.
+
+**The four on-ramp surfaces** (per @bokelley's #4205 triage, generalized to apply to BOTH #4205 and Track A.0):
+
+| Surface | Track | Status | Owner |
+|---|---|---|---|
+| Docs default to RFC 9421; HMAC as legacy footnote | shared | open | #3064 / @benminer |
+| Grade tooling fails on HMAC-only / non-JWKS config | shared | open | #3360 / @bokelley |
+| SDK generates RFC 9421 keys by default | shared | ✓ done | `@adcp/client` signing module |
+| Storyboard / getting-started paths use RFC 9421 end-to-end | shared | **untracked** | needs a home |
+
+**Empirical adoption snapshot** (kept for historical reference + named-partner inventory baseline; superseded as a threshold target):
+
+Source: adcp.signal-stack.io federation probe, May 7, 2026, 19 peers.
+
+| Adoption surface | Count | % of probed peers |
 |---|---|---|
 | Peers with reachable MCP endpoint | ~16 | 84% |
 | Peers publishing `/.well-known/adagents.json` | 2 (BidMachine, AdCP Test Agent) | 10% |
 | Peers publishing schema-valid 3.0.6 adagents.json | 0 | 0% |
-| Peers publishing `brand.json` `jwks_uri` | unknown — not yet probed | TBD |
-| Peers publishing JWKS with `key_ops`/`use` for webhook-signing | unknown — not yet probed | TBD |
+| Peers publishing `brand.json` `jwks_uri` | TBD | TBD |
+| Peers publishing JWKS with `key_ops`/`use` for webhook-signing | TBD | TBD |
 
-**Implication:** Track A.0 (pre-launch) needs concrete adoption targets before Track A schema work makes sense:
+The numbers underline @bokelley's point — the "directory" is mostly-dormant agents. Surveying it for migration completeness produces noise, not signal.
 
-- **Threshold proposal:** ≥30% of the AdCP signals-domain directory publishes a JWKS with at least one webhook-signing key by the time Track A schema lands. Below that, the spec has no audience.
-- **Signal of progress:** the daily watcher (already running per `.github/adcp-watch-config.json`) could probe peer JWKS endpoints alongside `/.well-known/adagents.json` — auto-track the adoption curve. Three lines of code in our adapter; valuable as ecosystem telemetry.
+### Webhook-signing migration — tracked, but NOT as we framed it (resolved v5)
 
-**This is worth filing as a separate tracked item** independent of the payments thread — JWKS publication adoption gates the entire signed-receipt design AND is presumably already a gating concern for the existing webhook-signing migration.
+v4 said: *"Addie offered to check open issues. If no tracked item exists, that's a gap itself."* She did, we filed #4205, and @bokelley triaged it with the on-ramp reframe above. Filing the issue surfaced the framing error, which is the WG mechanism working as intended.
 
-### Webhook-signing migration — does it have a tracked owner?
+**Updated rollup:**
 
-Addie offered to check open issues for a tracking item. Worth doing before the sync. Two outcomes:
+- **Tracked migration owner DRI:** not needed. Existing surface owners (@benminer #3064, @bokelley #3360) cover the cross-cutting work. SDK already correct.
+- **Telemetry:** narrower than directory-wide. Folds into #3360's grade-tooling scope (named-partner check + on-ramp surface inspection).
+- **Algorithm choice + key publication format:** already settled in 3.0.6 corpus per the v4 audit (`vendor/.../bundled/creative/sync-creatives-request.json:4871` → RFC 9421 default, HMAC legacy opt-in removed in 4.0). Not a sync question.
+- **Storyboard item:** the one piece that doesn't have a home in #3064 or #3360. Self-pledge to file a follow-up against the AdCP storyboard repo if no other owner steps up before #3064 + #3360 land.
 
-- **If a tracked migration item exists:** loop that owner into Track A's design discussion now (before the sync). Algorithm choice is shared; key publication is shared; adoption telemetry is shared. Two parallel decisions choosing different defaults would be worse than one coordinated decision.
-- **If no tracked item exists:** that's a gap itself. The migration is happening (per release notes) but without a coordination point. Filing a tracking issue at the same time as the Track A.0 readiness item kills two birds.
-
-### Recommendation for the sync (v4)
+### Recommendation for the sync (v5 post-triage)
 
 Lead with **Option 5 (hybrid)** as the termination model. Frame Option 3's chain-pruning detection as a security feature — strict-mode verification catches dishonest termination claims by attempting upstream verification. Adopt **Option (a) `prev_receipt_hashes[]` plural** for DAG support so modeled-lookalike pipelines work cleanly.
 
-**Skip the algorithm-negotiation discussion** — RFC 9421 is the spec baseline; the sync should not relitigate it. Instead, frame Track A.0 (JWKS adoption) as the gating dependency before Track A schema work.
+**Skip the algorithm-negotiation discussion** — RFC 9421 is the spec baseline; the sync should not relitigate it.
 
-Defer the receipt envelope schema details to a follow-up Technical Standards thread once the WG aligns on (a) the termination model, (b) the DAG shape, and (c) the Track A.0 adoption threshold.
+**Skip the threshold-vote discussion (v5 update).** Per @bokelley's #4205 triage, neither webhook migration nor Track A.0 has an installed base to migrate — both are on-ramp problems. The right sync agenda item is the four on-ramp surfaces above, not "what % of vendors publish JWKS." Storyboard surface (item 4) is the one that doesn't have a tracker; everything else is in #3064 / #3360 / SDK.
 
-This sharpens **why Track A is the gating dependency**: chain integrity + JWKS adoption is what makes Tracks B (revenue_share[]), C (vendor-to-vendor report_usage), and D (settlement close-out) verifiable. Without JWKS adoption hitting threshold, every downstream primitive falls back to bilateral-trust commercial agreements regardless of how cleanly the schemas are designed.
+Defer the receipt envelope schema details to a follow-up Technical Standards thread once the WG aligns on (a) the termination model, (b) the DAG shape, and (c) which storyboard / getting-started paths get the RFC 9421 update.
+
+**Why Track A is still the gating dependency** (refined v5): chain integrity + JWKS adoption is what makes Tracks B (revenue_share[]), C (vendor-to-vendor report_usage), and D (settlement close-out) verifiable. The on-ramp framing makes that gating dependency *executable* — it's not "wait for adoption to hit X%" (vote-style), it's "land the four on-ramp surfaces" (checklist-style). Cleaner, faster, doesn't block on commercial framing that won't resolve in WG meetings.
 
 ---
 

--- a/src/domain/capabilityService.ts
+++ b/src/domain/capabilityService.ts
@@ -394,7 +394,7 @@ function buildStaticCapabilities(env: UcpCapabilityEnv): AdcpCapabilities {
           },
         ],
         report: "docs/SEC42_ADCP_30_GA_COMPLIANCE.md",
-        reproduce: "API_KEY=$DEMO_API_KEY AGENT_URL=https://adcp-signals-adaptor.evgeny-193.workers.dev/mcp npm run compliance",
+        reproduce: "API_KEY=$DEMO_API_KEY AGENT_URL=https://adcp.signal-stack.io/mcp npm run compliance",
       },
       // ext.ucp now mirrors the real engine. Previously this was a static
       // UCP_CAPABILITY constant that always declared the pseudo bridge,

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -359,6 +359,54 @@ async function handleInitialize(
     };
 }
 
+/**
+ * Major versions this agent supports. Synced with /capabilities
+ * `adcp.major_versions` and the get_adcp_capabilities response. Bump
+ * here + in capabilityService.ts when we add support for a new major
+ * line; both surfaces must agree or buyers see contradictory metadata.
+ */
+const SUPPORTED_MAJOR_VERSIONS: ReadonlyArray<number> = [2, 3];
+
+/**
+ * Per AdCP 3.0.x (vendor/.../signals/get-signals-request.json:10):
+ *   "Sellers validate against their supported major_versions and
+ *    return VERSION_UNSUPPORTED if unsupported."
+ *
+ * Per error-code.json:96 the error carries recovery semantics:
+ *   "correctable (call get_adcp_capabilities without
+ *    adcp_major_version to discover supported major_versions, then
+ *    retry with a supported version)."
+ *
+ * Recovery carve-out: `get_adcp_capabilities` MUST remain callable
+ * regardless of the declared version, because that's the discovery
+ * surface the recovery loop depends on. If we erred on
+ * capabilities-with-unsupported-version too, the buyer couldn't
+ * self-heal — they'd get an error with no path forward.
+ *
+ * Omitted version: per spec, *"the seller assumes its highest
+ * supported version"* — also valid. Only an EXPLICIT, OUT-OF-RANGE
+ * value triggers the error.
+ *
+ * Throws McpToolError with code: "VERSION_UNSUPPORTED" so the existing
+ * JSON-RPC -> MCP_TOOL_ERROR transport-marker pipeline applies. The
+ * code travels in the error's `details.code` field which the
+ * rpcError helper places in `error.data` on the wire — buyers
+ * inspect it to drive the documented recovery flow.
+ */
+function validateAdcpMajorVersion(toolName: string, args: Record<string, unknown>): void {
+    // Recovery carve-out — see comment above.
+    if (toolName === "get_adcp_capabilities") return;
+    const v = args["adcp_major_version"];
+    if (v === undefined || v === null) return; // omitted ⇒ seller's highest
+    const num = typeof v === "number" ? v : Number(v);
+    if (!Number.isInteger(num) || !SUPPORTED_MAJOR_VERSIONS.includes(num)) {
+        throw new McpToolError(
+            `adcp_major_version ${v} not supported. This seller supports: [${SUPPORTED_MAJOR_VERSIONS.join(", ")}]. Call get_adcp_capabilities without adcp_major_version to discover supported versions, then retry with a supported version.`,
+            { code: "VERSION_UNSUPPORTED", supported_major_versions: [...SUPPORTED_MAJOR_VERSIONS] },
+        );
+    }
+}
+
 async function handleToolCall(
     params: McpCallToolParams,
     env: Env,
@@ -374,6 +422,11 @@ async function handleToolCall(
     const resolvedName = TOOL_ALIASES[name] ?? name;
     const toolDef = getToolByName(resolvedName);
     if (!toolDef) throw new McpToolError(`Unknown tool: ${name}`);
+
+    // Version negotiation — must run BEFORE per-tool dispatch so the
+    // error surfaces uniformly across every state-changing tool. The
+    // get_adcp_capabilities carve-out is encoded inside the helper.
+    validateAdcpMajorVersion(resolvedName, args as Record<string, unknown>);
 
     logger.info("mcp_tool_call", { tool: resolvedName });
 

--- a/tests/version-unsupported.test.ts
+++ b/tests/version-unsupported.test.ts
@@ -1,0 +1,148 @@
+// tests/version-unsupported.test.ts
+//
+// Pin the AdCP 3.0.x VERSION_UNSUPPORTED contract:
+//
+//   * adcp_major_version omitted → ok (seller assumes its highest)
+//   * adcp_major_version in supported set ([2, 3]) → ok
+//   * adcp_major_version OUT of supported set → error with code
+//     VERSION_UNSUPPORTED in the JSON-RPC error.data
+//   * Recovery carve-out: get_adcp_capabilities with unsupported
+//     version → still returns capabilities (so the buyer can discover
+//     the supported set and retry — the spec's documented recovery
+//     loop)
+//
+// Closes the live-compliance gap: prior to enforcement, the agent
+// silently accepted adcp_major_version: 99 with status: completed.
+// Verified live against https://adcp.signal-stack.io/mcp before the
+// fix; verified rejected after.
+
+import { describe, it, expect } from "vitest";
+import { handleMcpRequest } from "../src/mcp/server";
+import { createLogger } from "../src/utils/logger";
+
+const KEY = "demo-key-version-test";
+const env = { DEMO_API_KEY: KEY } as unknown as import("../src/types/env").Env;
+const logger = createLogger("test-req");
+
+function mcpReq(rpc: unknown, authHeader = `Bearer ${KEY}`): Request {
+  return new Request("https://example.com/mcp", {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Authorization: authHeader },
+    body: JSON.stringify(rpc),
+  });
+}
+
+async function call(req: Request): Promise<{ status: number; body: { id?: number; result?: unknown; error?: { code: number; message: string; data?: unknown } } }> {
+  const res = await handleMcpRequest(req, env, logger);
+  const text = await res.text();
+  return { status: res.status, body: text ? JSON.parse(text) : {} };
+}
+
+describe("VERSION_UNSUPPORTED enforcement", () => {
+  it("get_adcp_capabilities WITHOUT adcp_major_version returns capabilities (discovery)", async () => {
+    const { body } = await call(mcpReq({
+      jsonrpc: "2.0", id: 1, method: "tools/call",
+      params: { name: "get_adcp_capabilities", arguments: {} },
+    }));
+    expect(body.error).toBeUndefined();
+    expect(body.result).toBeDefined();
+  });
+
+  it("get_adcp_capabilities WITH unsupported version 99 STILL returns capabilities (recovery carve-out)", async () => {
+    // The spec's recovery semantics depend on this — buyer who sent
+    // a bad version needs to discover the supported set without
+    // hitting the same error wall they're trying to escape.
+    const { body } = await call(mcpReq({
+      jsonrpc: "2.0", id: 2, method: "tools/call",
+      params: { name: "get_adcp_capabilities", arguments: { adcp_major_version: 99 } },
+    }));
+    expect(body.error).toBeUndefined();
+    expect(body.result).toBeDefined();
+  });
+
+  it("get_signals with adcp_major_version: 99 returns VERSION_UNSUPPORTED", async () => {
+    const { body } = await call(mcpReq({
+      jsonrpc: "2.0", id: 3, method: "tools/call",
+      params: {
+        name: "get_signals",
+        arguments: { signal_spec: "anything", adcp_major_version: 99 },
+      },
+    }));
+    expect(body.error).toBeDefined();
+    expect(body.error?.code).toBe(-32000); // MCP_TOOL_ERROR transport marker
+    expect(body.error?.message).toContain("VERSION_UNSUPPORTED" === "VERSION_UNSUPPORTED" ? "not supported" : "");
+    expect(body.error?.message).toContain("[2, 3]");
+    // Spec error code travels in error.data per rpcError helper
+    const data = body.error?.data as { code?: string; supported_major_versions?: number[] };
+    expect(data?.code).toBe("VERSION_UNSUPPORTED");
+    expect(data?.supported_major_versions).toEqual([2, 3]);
+  });
+
+  it("get_signals with adcp_major_version: 1 (below range) returns VERSION_UNSUPPORTED", async () => {
+    const { body } = await call(mcpReq({
+      jsonrpc: "2.0", id: 4, method: "tools/call",
+      params: { name: "get_signals", arguments: { signal_spec: "anything", adcp_major_version: 1 } },
+    }));
+    expect(body.error).toBeDefined();
+    const data = body.error?.data as { code?: string };
+    expect(data?.code).toBe("VERSION_UNSUPPORTED");
+  });
+
+  it("get_signals with adcp_major_version: 3 (in range) does NOT trip version check", async () => {
+    // We can't fully execute the call without a working DB/KV stub,
+    // but we CAN verify the version check itself doesn't fire — any
+    // error returned must NOT be VERSION_UNSUPPORTED.
+    const { body } = await call(mcpReq({
+      jsonrpc: "2.0", id: 5, method: "tools/call",
+      params: { name: "get_signals", arguments: { signal_spec: "anything", adcp_major_version: 3 } },
+    }));
+    if (body.error) {
+      const data = body.error.data as { code?: string } | undefined;
+      expect(data?.code).not.toBe("VERSION_UNSUPPORTED");
+    }
+  });
+
+  it("get_signals WITHOUT adcp_major_version does NOT trip version check (omitted = highest)", async () => {
+    const { body } = await call(mcpReq({
+      jsonrpc: "2.0", id: 6, method: "tools/call",
+      params: { name: "get_signals", arguments: { signal_spec: "anything" } },
+    }));
+    if (body.error) {
+      const data = body.error.data as { code?: string } | undefined;
+      expect(data?.code).not.toBe("VERSION_UNSUPPORTED");
+    }
+  });
+
+  it("activate_signal with adcp_major_version: 4 returns VERSION_UNSUPPORTED (uniform across tools)", async () => {
+    const { body } = await call(mcpReq({
+      jsonrpc: "2.0", id: 7, method: "tools/call",
+      params: {
+        name: "activate_signal",
+        arguments: { signal_agent_segment_id: "sig_test", destinations: [{ type: "platform", platform: "mock_dsp" }], idempotency_key: "ik_smoke_aaaaaaaaaaaaaa", adcp_major_version: 4 },
+      },
+    }));
+    expect(body.error).toBeDefined();
+    const data = body.error?.data as { code?: string };
+    expect(data?.code).toBe("VERSION_UNSUPPORTED");
+  });
+
+  it("non-integer adcp_major_version (string '99') returns VERSION_UNSUPPORTED", async () => {
+    // Per spec the field is `integer`. Accept string-coerced numbers
+    // for buyer-side leniency, but reject non-integer values.
+    const { body } = await call(mcpReq({
+      jsonrpc: "2.0", id: 8, method: "tools/call",
+      params: { name: "get_signals", arguments: { signal_spec: "anything", adcp_major_version: 3.5 } },
+    }));
+    expect(body.error).toBeDefined();
+    const data = body.error?.data as { code?: string };
+    expect(data?.code).toBe("VERSION_UNSUPPORTED");
+  });
+
+  it("get_adcp_capabilities recovery error message tells buyer how to recover", async () => {
+    const { body } = await call(mcpReq({
+      jsonrpc: "2.0", id: 9, method: "tools/call",
+      params: { name: "get_signals", arguments: { signal_spec: "anything", adcp_major_version: 99 } },
+    }));
+    expect(body.error?.message).toContain("get_adcp_capabilities without adcp_major_version");
+  });
+});


### PR DESCRIPTION
## Two findings from today's live compliance run

### 1. \`VERSION_UNSUPPORTED\` was silently accepted

Live probe found: agent declares \`major_versions: [2, 3]\`, but \`tools/call get_adcp_capabilities { adcp_major_version: 99 }\` returned \`isError: false, status: completed\`. Spec violation per \`vendor/.../signals/get-signals-request.json:10\`:

> *\"Sellers validate against their supported major_versions and return VERSION_UNSUPPORTED if unsupported.\"*

The \`@adcp/client@5.25.1\` testing-kit run (7/7 pass) didn't flag this — there's no dedicated version-negotiation scenario; it tested with valid versions only. Manual probe surfaced it.

**Fix:** \`validateAdcpMajorVersion()\` in \`handleToolCall\`, runs BEFORE per-tool dispatch so the error surfaces uniformly across every state-changing tool. Throws \`McpToolError\` with \`code: \"VERSION_UNSUPPORTED\"\` → JSON-RPC -32000 + \`error.data\` carries \`{ code, supported_major_versions }\` so buyers can drive the documented recovery loop.

**Recovery carve-out:** \`get_adcp_capabilities\` is exempt. Per \`error-code.json:96\`, the recovery semantics tell the buyer to *\"call get_adcp_capabilities without adcp_major_version to discover supported major_versions, then retry.\"* If we erred on capabilities too, the recovery would be impossible — buyer hits the same wall they're trying to escape.

**Omitted version is valid:** per spec, *\"the seller assumes its highest supported version when omitted.\"* Only explicit, out-of-range values trigger the error.

### 2. \`ext.compliance.reproduce\` URL was stale

\`capabilityService.ts:383\` still pointed at the workers.dev URL after SELF_URL canonicalization (PR #231). One-line fix.

## Tests (\`tests/version-unsupported.test.ts\`, 9 cases)

- [x] get_adcp_capabilities WITHOUT version → ok
- [x] get_adcp_capabilities WITH unsupported 99 → ok (carve-out preserves recovery)
- [x] get_signals adcp_major_version=99 → VERSION_UNSUPPORTED + structured \`error.data\`
- [x] get_signals adcp_major_version=1 (below range) → VERSION_UNSUPPORTED
- [x] get_signals adcp_major_version=3 (in range) → not version-checked
- [x] get_signals omitted → not version-checked
- [x] activate_signal adcp_major_version=4 → VERSION_UNSUPPORTED (uniform across tools)
- [x] non-integer 3.5 → VERSION_UNSUPPORTED
- [x] error message contains the recovery instruction
- [x] \`npx vitest run\` — **485 passed (+9 new), 12 skipped, 0 failed**

## Re-verify after deploy

\`\`\`bash
SID=\$(curl -sD- -X POST https://adcp.signal-stack.io/mcp \
  -H \"Content-Type: application/json\" -H \"Accept: application/json, text/event-stream\" \
  -d '{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{\"protocolVersion\":\"2024-11-05\",\"capabilities\":{},\"clientInfo\":{\"name\":\"vtest\",\"version\":\"1.0\"}}}' \
  | grep -i mcp-session-id | awk '{print \$2}' | tr -d '\r')

# Should now return error.data.code = VERSION_UNSUPPORTED
curl -s -X POST https://adcp.signal-stack.io/mcp \
  -H \"Mcp-Session-Id: \$SID\" -H \"Authorization: Bearer demo-key-adcp-signals-v1\" \
  -H \"Content-Type: application/json\" -H \"Accept: application/json, text/event-stream\" \
  -d '{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/call\",\"params\":{\"name\":\"get_signals\",\"arguments\":{\"signal_spec\":\"x\",\"adcp_major_version\":99}}}'
\`\`\`