### PR TITLE
Auto-write compliance state on each passing run

### DIFF
--- a/scripts/run-compliance.mjs
+++ b/scripts/run-compliance.mjs
@@ -12,16 +12,30 @@
 // suite into 24 tool-gated scenarios. Default-export destructure is needed
 // because the published bundle is CJS without named ESM re-exports.
 //
+// Side effect on success: writes src/constants/complianceState.ts so the
+// /capabilities response's `ext.compliance.last_run` + counts reflect the
+// passing run. The write fires ONLY when failed_count === 0 — a failed run
+// leaves the previous passing baseline untouched, so the deployed pointer
+// never advertises a regression. Pass `--no-write` to skip the side effect
+// (e.g. for ad-hoc probes against staging); --json mode skips it too.
+// PR #249 introduced the side effect; see src/constants/complianceState.ts
+// for the data shape.
+//
 // Usage:
 //   API_KEY=demo-key-adcp-signals-v1 npm run compliance
 //   API_KEY=... AGENT_URL=https://... node scripts/run-compliance.mjs --json
+//   node scripts/run-compliance.mjs --no-write    # read-only probe
 
 import pkg from "@adcp/client/testing";
+import { readFileSync, writeFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
 const { testAllScenarios, formatSuiteResults, formatSuiteResultsJSON } = pkg;
 
 const AGENT_URL = process.env.AGENT_URL ?? "https://adcp-signals-adaptor.evgeny-193.workers.dev/mcp";
 const API_KEY = process.env.API_KEY ?? process.env.DEMO_API_KEY;
 const jsonOutput = process.argv.includes("--json");
+const skipWrite = process.argv.includes("--no-write") || jsonOutput;
 
 if (!API_KEY) {
   console.error("ERROR: API_KEY not set (or DEMO_API_KEY)");
@@ -43,6 +57,93 @@ const testOptions = {
   },
 };
 
+/**
+ * Render the canonical src/constants/complianceState.ts content from a
+ * passing result. The runner overwrites the whole file (not just fields)
+ * so the format stays stable and a stale comment can't drift from the
+ * data. The History block from the prior file is preserved by prepending
+ * today's entry to it.
+ */
+function renderComplianceState(result, prevSource) {
+  const lastRun = (result.tested_at ?? new Date().toISOString()).slice(0, 10);
+  const scenariosRun = [...result.scenarios_run].sort();
+  const applicable = result.scenarios_run.length;
+  const skipped = result.scenarios_skipped?.length ?? 0;
+  const passed = result.passed_count;
+  const failed = result.failed_count;
+
+  const prevHistory = extractHistoryLines(prevSource);
+  const todayEntry = `//   ${lastRun} — auto-written by scripts/run-compliance.mjs (${passed}/${applicable} applicable, ${skipped} skipped).`;
+  const mergedHistory = dedupePreservingOrder([todayEntry, ...prevHistory]).join("\n");
+  const scenarioBlock = scenariosRun.map((s) => `    ${JSON.stringify(s)},`).join("\n");
+
+  return `// src/constants/complianceState.ts
+//
+// SINGLE SOURCE OF TRUTH for the most recent compliance run against the
+// deployed Worker. Read by capabilityService.ts so /capabilities advertises
+// the current pass state without drift.
+//
+// ⚠️  AUTO-GENERATED. Do not hand-edit individual fields — they will be
+//    overwritten on the next successful \`npm run compliance\` run.
+//
+// To refresh:
+//   API_KEY=$DEMO_API_KEY npm run compliance
+//
+// The runner (scripts/run-compliance.mjs) overwrites this file when (and
+// ONLY when) the suite passes with failed_count === 0 — so \`last_run\`
+// always points at the last passing run, never a regression. Commit + push
+// the updated file to deploy the new state to /capabilities.
+//
+// History (auto-prepended; manual entries also preserved across rewrites):
+${mergedHistory}
+
+export const COMPLIANCE_STATE = {
+  /** ISO date (YYYY-MM-DD) of the last passing compliance run. */
+  last_run: ${JSON.stringify(lastRun)},
+
+  /** Scenario IDs that ran (i.e. were applicable to this agent's tool surface). */
+  scenarios_run: [
+${scenarioBlock}
+  ],
+
+  /** Pass / fail / skip counts from the last passing run. */
+  results: {
+    applicable: ${applicable},
+    passed: ${passed},
+    failed: ${failed},
+    skipped: ${skipped},
+  },
+} as const;
+`;
+}
+
+function extractHistoryLines(prevSource) {
+  if (!prevSource) return [];
+  const lines = prevSource.split(/\r?\n/);
+  const startIdx = lines.findIndex((l) => /^\/\/ History/i.test(l));
+  if (startIdx < 0) return [];
+  const out = [];
+  for (let i = startIdx + 1; i < lines.length; i++) {
+    const l = lines[i];
+    // History block ends at the first non-comment line (e.g. blank line
+    // before `export const`).
+    if (!l.startsWith("//")) break;
+    out.push(l);
+  }
+  return out;
+}
+
+function dedupePreservingOrder(arr) {
+  const seen = new Set();
+  const out = [];
+  for (const item of arr) {
+    if (seen.has(item)) continue;
+    seen.add(item);
+    out.push(item);
+  }
+  return out;
+}
+
 try {
   const result = await testAllScenarios(AGENT_URL, testOptions);
   if (jsonOutput) {
@@ -50,6 +151,29 @@ try {
   } else {
     console.log(formatSuiteResults(result));
   }
+
+  // Side effect: bump complianceState.ts on a clean pass. Suppressed in
+  // --json mode (CI) and --no-write mode (ad-hoc probes).
+  if (!skipWrite && result.failed_count === 0 && result.passed_count > 0) {
+    const __filename = fileURLToPath(import.meta.url);
+    const statePath = resolve(dirname(__filename), "..", "src", "constants", "complianceState.ts");
+    let prev = "";
+    try {
+      prev = readFileSync(statePath, "utf8");
+    } catch {
+      // First run on a fresh checkout: no previous file, history starts fresh.
+    }
+    const next = renderComplianceState(result, prev);
+    if (next !== prev) {
+      writeFileSync(statePath, next, "utf8");
+      console.log(`\n→ wrote ${statePath} (last_run=${(result.tested_at ?? "").slice(0, 10)}, ${result.passed_count}/${result.scenarios_run.length} applicable). Commit + push to deploy.`);
+    } else {
+      console.log(`\n→ ${statePath} already up to date.`);
+    }
+  } else if (!skipWrite && result.failed_count > 0) {
+    console.log(`\n→ skipped writing complianceState.ts (${result.failed_count} failed) — previous passing baseline preserved.`);
+  }
+
   process.exit(result.failed_count > 0 ? 3 : 0);
 } catch (err) {
   console.error(`compliance run failed: ${err?.message ?? err}`);

--- a/src/constants/complianceState.ts
+++ b/src/constants/complianceState.ts
@@ -1,0 +1,46 @@
+// src/constants/complianceState.ts
+//
+// SINGLE SOURCE OF TRUTH for the most recent compliance run against the
+// deployed Worker. Read by capabilityService.ts so /capabilities advertises
+// the current pass state without drift.
+//
+// ⚠️  AUTO-GENERATED. Do not hand-edit individual fields — they will be
+//    overwritten on the next successful `npm run compliance` run.
+//
+// To refresh:
+//   API_KEY=$DEMO_API_KEY npm run compliance
+//
+// The runner (scripts/run-compliance.mjs) overwrites this file when (and
+// ONLY when) the suite passes with failed_count === 0 — so `last_run`
+// always points at the last passing run, never a regression. Commit + push
+// the updated file to deploy the new state to /capabilities.
+//
+// History (auto-prepended; manual entries also preserved across rewrites):
+//   2026-05-10 — auto-written by scripts/run-compliance.mjs (7/7 applicable, 32 skipped).
+//   2026-05-10 — bumped from 2026-05-08 in PR #249; introduced auto-write.
+//   2026-05-08 — first full 7/7 against 5.25.1 after VERSION_UNSUPPORTED
+//                enforcement (PR #246).
+
+export const COMPLIANCE_STATE = {
+  /** ISO date (YYYY-MM-DD) of the last passing compliance run. */
+  last_run: "2026-05-10",
+
+  /** Scenario IDs that ran (i.e. were applicable to this agent's tool surface). */
+  scenarios_run: [
+    "capability_discovery",
+    "discovery",
+    "error_handling",
+    "health_check",
+    "schema_compliance",
+    "signals_flow",
+    "validation",
+  ],
+
+  /** Pass / fail / skip counts from the last passing run. */
+  results: {
+    applicable: 7,
+    passed: 7,
+    failed: 0,
+    skipped: 32,
+  },
+} as const;

--- a/src/domain/capabilityService.ts
+++ b/src/domain/capabilityService.ts
@@ -44,6 +44,7 @@ const CACHE_KEY = "adcp_capabilities_v24";
 const CACHE_TTL_SECONDS = 3600;
 
 import { buildUcpCapability, type UcpCapabilityEnv } from "../ucp/vacDeclaration";
+import { COMPLIANCE_STATE } from "../constants/complianceState";
 
 const VALID_PROTOCOLS = new Set([
   "media_buy",
@@ -361,33 +362,25 @@ function buildStaticCapabilities(env: UcpCapabilityEnv): AdcpCapabilities {
       // scenario explanations. Surfaced in-band so any reviewer hitting
       // /capabilities (e.g. a HoldCo procurement check) sees the score
       // and the structural ceiling without needing to read SEC42_*.md.
-      // Updated manually after each `npm run compliance` against prod.
+      //
+      // `last_run` + counts + scenarios_run live in
+      // src/constants/complianceState.ts and are auto-updated by
+      // scripts/run-compliance.mjs on every passing run (PR #249). The
+      // 5.25 runner restored error_handling / schema_compliance /
+      // validation tracks for signals-only agents — adcp#2916 was
+      // effectively unblocked by capability-aware skip_if landing in
+      // the runner. Applicable count is now 7/7 (was 4/4 under the 5.21
+      // regression).
       compliance: {
         spec_version: "adcp_3.0",
         client_runner: "@adcp/client@5.25.1",
-        last_run: "2026-05-08",
-        // The 5.25 runner restored the error_handling / schema_compliance
-        // / validation scenario tracks for signals-only agents — adcp
-        // issue #2916 was effectively unblocked by capability-aware
-        // skip_if logic landing in the runner. Applicable count is now
-        // 7/7 (was 4/4 under the 5.21 regression).
-        //
-        // Refreshed by the AdCP daily watcher (.github/adcp-watch-config.json)
-        // on each spec/SDK/scenario change; last sync 2026-05-07.
+        last_run: COMPLIANCE_STATE.last_run,
         results: {
-          applicable: 7,
-          passed: 7,
-          failed: 0,
-          skipped: 32,
-          scenarios_run: [
-            "capability_discovery",
-            "discovery",
-            "error_handling",
-            "health_check",
-            "schema_compliance",
-            "signals_flow",
-            "validation",
-          ],
+          applicable: COMPLIANCE_STATE.results.applicable,
+          passed: COMPLIANCE_STATE.results.passed,
+          failed: COMPLIANCE_STATE.results.failed,
+          skipped: COMPLIANCE_STATE.results.skipped,
+          scenarios_run: COMPLIANCE_STATE.scenarios_run,
         },
         // Non-applicable scenarios are now exclusively the media-buy /
         // creative / governance / brand-rights tracks that require tools


### PR DESCRIPTION
## Summary

- Closes the \`ext.compliance.last_run\` drift surfaced after PR #247's compliance baseline run — the date was hand-bumped 2026-05-08 but the live agent had runs through 2026-05-10. Without automation it always drifts.
- Extracts last_run + counts + scenarios_run into \`src/constants/complianceState.ts\`; \`scripts/run-compliance.mjs\` writes that file on every passing run.
- Audit trail in git, no runtime KV write, no drift between deployed code and advertised pointer.

## Shape

1. **\`src/constants/complianceState.ts\` (new)** — single source of truth, exports \`COMPLIANCE_STATE { last_run, scenarios_run, results }\`. Auto-generated header warns against hand-edits; History block at top is preserved across rewrites.
2. **\`src/domain/capabilityService.ts\`** — replaces the hardcoded last_run/applicable/passed/failed/skipped/scenarios_run literals with \`COMPLIANCE_STATE.*\` lookups. Identical wire output today; refreshes on every passing run going forward.
3. **\`scripts/run-compliance.mjs\`** — on a passing run (\`failed_count === 0\`, \`passed_count > 0\`), renders + writes the canonical \`complianceState.ts\` template. Suppressed in \`--json\` mode (CI) and \`--no-write\` mode (ad-hoc probes). **Failed runs leave the previous passing baseline untouched** so \`/capabilities\` never advertises a regression.

## Why this shape (and not KV / build-injection / runtime fetch)

- **Source of truth in repo** = version-controlled, auditable. Every refresh produces a small reviewable diff (date + counts).
- **User has to commit + push** for the update to publish. That's a feature: the deployed \`/capabilities\` reflects what was tested against the deployed code at deploy time, never \"some random laptop ran this last Tuesday.\"
- **Failed runs preserve the baseline.** The runner skips the write if any scenario failed — so the pointer always advertises the last passing state, not a regression-in-flight.
- **No runtime side effects.** Pure read in the Worker, simple template-render in Node-land. No KV cost, no race conditions, no eventual-consistency window.

## Verified end-to-end

\`\`\`
$ DEMO_API_KEY=demo-key-adcp-signals-v1 node scripts/run-compliance.mjs
... 7 passed, 0 failed out of 7 scenario(s) ...
→ wrote src/constants/complianceState.ts (last_run=2026-05-10, 7/7 applicable). Commit + push to deploy.

$ DEMO_API_KEY=demo-key-adcp-signals-v1 node scripts/run-compliance.mjs
... 7 passed, 0 failed ...
→ src/constants/complianceState.ts already up to date.    # idempotent
\`\`\`

## Test plan

- [x] \`npm run compliance\` → 7/7 pass → file rewritten → \"commit + push to deploy\" message
- [x] Second run on identical state → \"already up to date\" (idempotent, no spurious diff)
- [x] \`npx tsc --noEmit\` → no errors involving the new module or \`capabilityService.ts\`
- [x] \`npx vitest run\` → 484/484 (1 pre-existing flake in \`activation-idempotency.test.ts\` — unrelated, passes in isolation)
- [x] History block manually verified to merge correctly (today's entry on top, prior manual entries preserved)
- [x] \`--no-write\` flag honored
- [x] \`--json\` mode skips the side effect (CI-safe)

## Out of scope

- The 1 flaky pre-existing test (\`activation-idempotency.test.ts:244\` — \`submittedAt\` timing race under parallel CPU load). Not introduced by this PR.
- Updating \`ext.compliance.client_runner\` automatically — that's the SDK version (\`@adcp/client@5.25.1\`), which lives in package.json and should be bumped via PR + re-validation, not auto-refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)