### PR TITLE
Bind capabilities cache key to SPEC_VERSION + COMPLIANCE_STATE.last_run

### DIFF
--- a/src/domain/capabilityService.ts
+++ b/src/domain/capabilityService.ts
@@ -37,14 +37,27 @@
 // changes, so clients that cache by key pick up the new fields.
 // Cache key carries a monotonic version suffix. Bump on every change to
 // the static capability shape so already-warmed KV entries don't serve
-// stale fields after a deploy. Bumps:
+// stale fields after a deploy. The manual `v24/v25/…` prefix bumps on
+// *shape* changes (new fields, removed fields, schema-version cliffs).
+// *Value* refreshes piggyback automatically via the suffix derived from
+// SPEC_VERSION + COMPLIANCE_STATE.last_run — that way a `complianceState.ts`
+// rewrite from `npm run compliance` or a `specVersion.ts` bump immediately
+// invalidates the cache without anyone remembering to touch this file.
+// PR #249's stale-cache incident (the new last_run sat behind a v24 blob
+// for 7 minutes after deploy until manual KV delete) was the catalyst.
+// Bumps:
 //   v23 → previous baseline
 //   v24 → Sec-31v: added top-level `specialisms` for AAO badge issuance
-const CACHE_KEY = "adcp_capabilities_v24";
+const CACHE_KEY_PREFIX = "adcp_capabilities_v24";
 const CACHE_TTL_SECONDS = 3600;
 
 import { buildUcpCapability, type UcpCapabilityEnv } from "../ucp/vacDeclaration";
 import { COMPLIANCE_STATE } from "../constants/complianceState";
+import { SPEC_VERSION } from "../constants/specVersion";
+
+/** Cache key folds in the spec version + compliance-state pointer so any
+ *  value-only refresh auto-invalidates without a manual prefix bump. */
+const CACHE_KEY = `${CACHE_KEY_PREFIX}_${SPEC_VERSION}_${COMPLIANCE_STATE.last_run}`;
 
 const VALID_PROTOCOLS = new Set([
   "media_buy",


### PR DESCRIPTION
## Summary

- Follow-up to PR #249. After the merge, the new \`last_run: 2026-05-10\` sat invisible for 7 minutes — the KV blob under \`adcp_capabilities_v24\` was still the pre-deploy build. Manual \`wrangler kv key delete adcp_capabilities_v24\` flipped it live; every future \`complianceState.ts\` refresh would hit the same trap.
- Cache key now incorporates \`SPEC_VERSION\` and \`COMPLIANCE_STATE.last_run\` so any value-only refresh auto-invalidates without a manual prefix bump or KV delete.
- Manual prefix bumps (v24 → v25 …) still gate on real shape changes — semantics unchanged.

## Shape

\`\`\`ts
const CACHE_KEY_PREFIX = \"adcp_capabilities_v24\";
const CACHE_KEY = \`\${CACHE_KEY_PREFIX}_\${SPEC_VERSION}_\${COMPLIANCE_STATE.last_run}\`;
\`\`\`

After this:

| Change                                                  | Auto-invalidates? |
|---------------------------------------------------------|-------------------|
| \`npm run compliance\` rewrites \`complianceState.ts\`  | ✅ via last_run suffix |
| Patch bump in \`specVersion.ts\` (e.g. 3.0.8 → 3.0.9)   | ✅ via SPEC_VERSION suffix |
| Schema-shape change (new top-level fields)              | ❌ — still bump prefix manually (correct: shape changes deserve a deliberate cliff) |

## Test plan

- [x] \`npx tsc --noEmit\` — no new errors involving capabilityService / complianceState / specVersion
- [x] \`npx vitest run -t \"capabilit\"\` — 11/11 capability tests passing
- [x] Live agent already serves \`last_run=2026-05-10\` (verified post manual KV delete); this PR locks in the auto-invalidation going forward
- [ ] On merge: deploy fires → next \`/get_adcp_capabilities\` hit misses cache (different key) → fresh build → new blob written under new key. Old v24-only blob garbage-collects via existing 1-hour TTL.

## Out of scope

- Dropping the KV cache entirely. The capability response is ~1ms to assemble from constants; the KV cache buys marginal latency and creates correctness hazards (this incident being the proof). Worth considering as a separate follow-up. For now: keep the cache, automate its invalidation, accept the marginal complexity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)