### PR TITLE
ci: auto-deploy worker + D1 migrations on push

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,71 @@
+name: Deploy
+
+on:
+  push:
+    branches: [main, master]
+
+concurrency:
+  group: deploy-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    name: Deploy to Cloudflare
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Install deps
+        run: npm ci
+
+      # Apply D1 migrations BEFORE the worker deploys so new code can never
+      # reference a column that doesn't exist yet. Wrangler's native migration
+      # system tracks state in d1_migrations on the remote DB — no bootstrap
+      # required.
+      - name: Apply D1 migrations
+        run: npx wrangler d1 migrations apply adcp-signals-db --remote
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+
+      - name: Deploy Worker
+        run: npx wrangler deploy
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+
+      - name: Smoke test — adagents.json reachable
+        run: |
+          set -euo pipefail
+          for i in 1 2 3 4 5; do
+            code=$(curl -sS -o /tmp/adagents.json -w "%{http_code}" https://adcp.signal-stack.io/.well-known/adagents.json || echo "000")
+            echo "Attempt $i: HTTP $code"
+            if [ "$code" = "200" ]; then
+              break
+            fi
+            sleep 3
+            [ "$i" = "5" ] && { echo "::error::adagents.json did not return 200 after 5 attempts"; exit 1; }
+          done
+          # Body must be valid JSON with a $schema field
+          node -e "const j=require('/tmp/adagents.json');if(!j['\$schema'])throw new Error('missing \$schema');console.log('schema:',j['\$schema']);"
+
+      - name: Smoke test — X-AdCP-Spec-Version matches source
+        run: |
+          set -euo pipefail
+          # Source of truth: src/constants/specVersion.ts
+          expected=$(grep -oE 'SPEC_VERSION = "[0-9.]+"' src/constants/specVersion.ts | grep -oE '[0-9.]+')
+          if [ -z "$expected" ]; then
+            echo "::error::Could not parse SPEC_VERSION from src/constants/specVersion.ts"
+            exit 1
+          fi
+          actual=$(curl -sSI https://adcp.signal-stack.io/.well-known/adagents.json \
+            | grep -i '^x-adcp-spec-version:' | awk '{print $2}' | tr -d '\r\n')
+          echo "Expected: $expected"
+          echo "Actual:   $actual"
+          if [ "$actual" != "$expected" ]; then
+            echo "::error::Spec version drift — header is $actual, source says $expected. Deploy may not have propagated, or constant wasn't bumped."
+            exit 1
+          fi
+          echo "X-AdCP-Spec-Version $actual matches source ✓"

--- a/src/constants/specVersion.ts
+++ b/src/constants/specVersion.ts
@@ -14,6 +14,28 @@ export const ADCP_MAJOR_LINE = "3.0 GA";
 /** Specific spec patch version we're tested against. Bump on each
  *  successful conformance pass against a new patch.
  *
+ *  3.0.11 (2026-05-11): storyboard-only — collapses the
+ *  `key_reuse_conflict` phase of `universal/idempotency.yaml` into
+ *  `replay_same_payload` as a fourth step, to make an adcp-client
+ *  runner fix safe to land. Release notes: "no behavior change for
+ *  sellers, only restructures the storyboard." Wire format unchanged.
+ *
+ *  3.0.10 (2026-05-10): storyboard-only — converts the remaining
+ *  12 static `idempotency_key` literals across error / governance /
+ *  signal / schema-validation / creative-ad-server scenarios to
+ *  `$generate:uuid_v4#<alias>` form. Prevents idempotency-cache
+ *  collisions on re-runs. Wire format unchanged.
+ *
+ *  3.0.9 (between 3.0.8 and 3.0.10): patch-eligible, no normative
+ *  change for sellers; bundled here for completeness as we jumped
+ *  the version straight from 3.0.8 → 3.0.11.
+ *
+ *  Schema corpus remains vendored at 3.0.8 — 3.0.9 / 3.0.10 / 3.0.11
+ *  made no schema changes (all storyboard / harness patches), so
+ *  re-running scripts/vendor-adcp-schemas.mjs would produce a
+ *  bit-identical tree with only the `$id` paths bumped. Re-vendor
+ *  on the next spec release that actually touches schemas.
+ *
  *  3.0.8 (2026-05-08): conformance-harness fix — UUID-aliased
  *  idempotency_keys across 15 storyboard steps in 9 scenarios
  *  (extends the #4218 precedent to the rest of the suite). Affects
@@ -53,7 +75,7 @@ export const ADCP_MAJOR_LINE = "3.0 GA";
  *  scripts/vendor-adcp-schemas.mjs; the trace inspector validates
  *  every payload against /schemas/<this-version>/ identifiers.
  */
-export const SPEC_VERSION = "3.0.8";
+export const SPEC_VERSION = "3.0.11";
 
 /** Composite label for UI display: "3.0 GA · 3.0.4". */
 export const SPEC_LABEL = ADCP_MAJOR_LINE + " · " + SPEC_VERSION;


### PR DESCRIPTION
## Why
PR #251 (SPEC_VERSION 3.0.8 → 3.0.11) was merged 2026-05-11. 24+ hours later production is still serving `X-AdCP-Spec-Version: 3.0.8`. Cloudflare's git integration either isn't wired up or fires silently. This adds an explicit, observable deploy pipeline.

## What
New `.github/workflows/deploy.yml`. Triggers on push to `main` or `master`:

1. **`wrangler d1 migrations apply adcp-signals-db --remote`** — runs *before* the worker deploys so new code can't 500 against a missing column. Uses wrangler's native migration tracking; the existing `migrations/0001_*.sql … 0007_*.sql` files are already in the right format.
2. **`wrangler deploy`** — ships the worker.
3. **Smoke test 1:** `GET https://adcp.signal-stack.io/.well-known/adagents.json`, retry up to 5x, require 200 and valid JSON with a `$schema` field.
4. **Smoke test 2:** parse `SPEC_VERSION` from `src/constants/specVersion.ts` and require the live `X-AdCP-Spec-Version` response header to match exactly. Direct regression guard for the "merged but didn't deploy" mode we hit yesterday.

## Prereq
The repo's `CLOUDFLARE_API_TOKEN` secret needs `Workers Scripts: Edit` and `D1: Edit` scopes. Signal-stack's token already has both — likely the same shared token here, but worth confirming.

## Test plan
- [ ] Merge → workflow runs end-to-end and finishes green
- [ ] Live `X-AdCP-Spec-Version` flips to `3.0.11` (catches up #251)
- [ ] Subsequent merges deploy without manual intervention

🤖 Generated with [Claude Code](https://claude.com/claude-code)