### PR TITLE
fix: X-AdCP-Spec-Version header reads from SOT, not vendored corpus

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,71 @@
+name: Deploy
+
+on:
+  push:
+    branches: [main, master]
+
+concurrency:
+  group: deploy-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    name: Deploy to Cloudflare
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Install deps
+        run: npm ci
+
+      # Apply D1 migrations BEFORE the worker deploys so new code can never
+      # reference a column that doesn't exist yet. Wrangler's native migration
+      # system tracks state in d1_migrations on the remote DB — no bootstrap
+      # required.
+      - name: Apply D1 migrations
+        run: npx wrangler d1 migrations apply adcp-signals-db --remote
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+
+      - name: Deploy Worker
+        run: npx wrangler deploy
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+
+      - name: Smoke test — adagents.json reachable
+        run: |
+          set -euo pipefail
+          for i in 1 2 3 4 5; do
+            code=$(curl -sS -o /tmp/adagents.json -w "%{http_code}" https://adcp.signal-stack.io/.well-known/adagents.json || echo "000")
+            echo "Attempt $i: HTTP $code"
+            if [ "$code" = "200" ]; then
+              break
+            fi
+            sleep 3
+            [ "$i" = "5" ] && { echo "::error::adagents.json did not return 200 after 5 attempts"; exit 1; }
+          done
+          # Body must be valid JSON with a $schema field
+          node -e "const j=require('/tmp/adagents.json');if(!j['\$schema'])throw new Error('missing \$schema');console.log('schema:',j['\$schema']);"
+
+      - name: Smoke test — X-AdCP-Spec-Version matches source
+        run: |
+          set -euo pipefail
+          # Source of truth: src/constants/specVersion.ts
+          expected=$(grep -oE 'SPEC_VERSION = "[0-9.]+"' src/constants/specVersion.ts | grep -oE '[0-9.]+')
+          if [ -z "$expected" ]; then
+            echo "::error::Could not parse SPEC_VERSION from src/constants/specVersion.ts"
+            exit 1
+          fi
+          actual=$(curl -sSI https://adcp.signal-stack.io/.well-known/adagents.json \
+            | grep -i '^x-adcp-spec-version:' | awk '{print $2}' | tr -d '\r\n')
+          echo "Expected: $expected"
+          echo "Actual:   $actual"
+          if [ "$actual" != "$expected" ]; then
+            echo "::error::Spec version drift — header is $actual, source says $expected. Deploy may not have propagated, or constant wasn't bumped."
+            exit 1
+          fi
+          echo "X-AdCP-Spec-Version $actual matches source ✓"

--- a/src/constants/specVersion.ts
+++ b/src/constants/specVersion.ts
@@ -14,6 +14,28 @@ export const ADCP_MAJOR_LINE = "3.0 GA";
 /** Specific spec patch version we're tested against. Bump on each
  *  successful conformance pass against a new patch.
  *
+ *  3.0.11 (2026-05-11): storyboard-only — collapses the
+ *  `key_reuse_conflict` phase of `universal/idempotency.yaml` into
+ *  `replay_same_payload` as a fourth step, to make an adcp-client
+ *  runner fix safe to land. Release notes: "no behavior change for
+ *  sellers, only restructures the storyboard." Wire format unchanged.
+ *
+ *  3.0.10 (2026-05-10): storyboard-only — converts the remaining
+ *  12 static `idempotency_key` literals across error / governance /
+ *  signal / schema-validation / creative-ad-server scenarios to
+ *  `$generate:uuid_v4#<alias>` form. Prevents idempotency-cache
+ *  collisions on re-runs. Wire format unchanged.
+ *
+ *  3.0.9 (between 3.0.8 and 3.0.10): patch-eligible, no normative
+ *  change for sellers; bundled here for completeness as we jumped
+ *  the version straight from 3.0.8 → 3.0.11.
+ *
+ *  Schema corpus remains vendored at 3.0.8 — 3.0.9 / 3.0.10 / 3.0.11
+ *  made no schema changes (all storyboard / harness patches), so
+ *  re-running scripts/vendor-adcp-schemas.mjs would produce a
+ *  bit-identical tree with only the `$id` paths bumped. Re-vendor
+ *  on the next spec release that actually touches schemas.
+ *
  *  3.0.8 (2026-05-08): conformance-harness fix — UUID-aliased
  *  idempotency_keys across 15 storyboard steps in 9 scenarios
  *  (extends the #4218 precedent to the rest of the suite). Affects
@@ -53,7 +75,7 @@ export const ADCP_MAJOR_LINE = "3.0 GA";
  *  scripts/vendor-adcp-schemas.mjs; the trace inspector validates
  *  every payload against /schemas/<this-version>/ identifiers.
  */
-export const SPEC_VERSION = "3.0.8";
+export const SPEC_VERSION = "3.0.11";
 
 /** Composite label for UI display: "3.0 GA · 3.0.4". */
 export const SPEC_LABEL = ADCP_MAJOR_LINE + " · " + SPEC_VERSION;

--- a/src/routes/adagents.ts
+++ b/src/routes/adagents.ts
@@ -28,6 +28,7 @@
 import type { Env } from "../types/env";
 import { Validator } from "@cfworker/json-schema";
 import { loadAdcpCorpus, ADCP_SPEC_VERSION } from "../schemas/adcp";
+import { SPEC_VERSION } from "../constants/specVersion";
 
 export interface AdagentsDocument {
   $schema: string;
@@ -107,7 +108,12 @@ export function handleAdAgents(request: Request, _env: Env): Response {
       "Content-Type": "application/json",
       "Cache-Control": "public, max-age=3600",
       "Access-Control-Allow-Origin": "*",
-      "X-AdCP-Spec-Version": ADCP_SPEC_VERSION,
+      // Conformance-claim version, not the vendored-schema corpus version.
+      // The two can diverge for storyboard/harness-only spec patches (3.0.9
+      // -> 3.0.10 -> 3.0.11 made no schema changes); the corpus stays pinned
+      // at 3.0.8 until a spec release actually touches schemas. SPEC_VERSION
+      // is the single source of truth for what we claim to conform to.
+      "X-AdCP-Spec-Version": SPEC_VERSION,
     },
   });
 }
@@ -349,7 +355,7 @@ export async function handleAdagentsProbe(_request: Request, _env: Env): Promise
   // worst-case latency of the response is the slowest probe (3s).
   const results = await Promise.all(probeable.map((a) => probePeerAdagents(a)));
   const summary = {
-    spec_version: ADCP_SPEC_VERSION,
+    spec_version: SPEC_VERSION,
     probed_count: results.length,
     counts: {
       ok: results.filter((r) => r.status === "ok").length,


### PR DESCRIPTION
## Why
PR #251 bumped `SPEC_VERSION` 3.0.8 → 3.0.11 but the live `X-AdCP-Spec-Version` header stayed pinned at 3.0.8 — including after PR #252's CI auto-deploy successfully shipped the worker. The smoke test added in #252 caught it.

## Root cause
Two version constants exist for two distinct concerns; the header was reading from the wrong one:

| Constant | Lives in | Means | Bumps when |
|---|---|---|---|
| `SPEC_VERSION` | `src/constants/specVersion.ts` (manual SOT) | Conformance claim | Each successful conformance pass — storyboard/harness/prose patches included |
| `ADCP_SPEC_VERSION` | `src/schemas/adcp/index.ts` (auto-generated) | Vendored schema corpus version | `scripts/vendor-adcp-schemas.mjs` re-runs against a release that touches schemas |

These legitimately diverge: 3.0.9/3.0.10/3.0.11 made zero schema changes, so the corpus stays at 3.0.8 while conformance moves forward.

The header was reading `ADCP_SPEC_VERSION`, so a bare bump of `SPEC_VERSION` had no observable effect.

## Fix
- `src/routes/adagents.ts:110` — header now reads `SPEC_VERSION`, with a comment explaining the split.
- `src/routes/adagents.ts:352` — peer-probe diagnostic's `spec_version` field similarly switched to `SPEC_VERSION` (it advertises conformance, not corpus).
- `src/routes/adagents.ts:131` left untouched: that's a `corpus.find($id === /schemas/X/...)` schema lookup, which correctly stays at `ADCP_SPEC_VERSION`.

## Verification
- `npm test tests/adagents-self-publish.test.ts` — 8 tests pass locally. The schema-validated served document is unchanged (only header + a diagnostic field switched).
- After merge, the auto-deploy workflow's smoke test should now pass green, and `curl -I https://adcp.signal-stack.io/.well-known/adagents.json` should return `X-AdCP-Spec-Version: 3.0.11`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)