### PR TITLE
ci: retry the spec-version smoke test to absorb CF edge propagation

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -60,12 +60,17 @@ jobs:
             echo "::error::Could not parse SPEC_VERSION from src/constants/specVersion.ts"
             exit 1
           fi
-          actual=$(curl -sSI https://adcp.signal-stack.io/.well-known/adagents.json \
-            | grep -i '^x-adcp-spec-version:' | awk '{print $2}' | tr -d '\r\n')
-          echo "Expected: $expected"
-          echo "Actual:   $actual"
-          if [ "$actual" != "$expected" ]; then
-            echo "::error::Spec version drift — header is $actual, source says $expected. Deploy may not have propagated, or constant wasn't bumped."
-            exit 1
-          fi
-          echo "X-AdCP-Spec-Version $actual matches source ✓"
+          # Retry to absorb Cloudflare edge propagation lag after deploy —
+          # the new worker version can take ~15-30s to be live globally.
+          for i in 1 2 3 4 5 6 7 8 9 10; do
+            actual=$(curl -sSI https://adcp.signal-stack.io/.well-known/adagents.json \
+              | grep -i '^x-adcp-spec-version:' | awk '{print $2}' | tr -d '\r\n' || echo "")
+            echo "Attempt $i: expected=$expected actual=$actual"
+            if [ "$actual" = "$expected" ]; then
+              echo "X-AdCP-Spec-Version $actual matches source ✓"
+              exit 0
+            fi
+            sleep 5
+          done
+          echo "::error::Spec version drift after 10 attempts — header is $actual, source says $expected. Deploy may not have propagated, or constant wasn't bumped at the emit site (src/routes/adagents.ts)."
+          exit 1


### PR DESCRIPTION
## Why
PR #253's deploy actually shipped correctly — `curl -I https://adcp.signal-stack.io/.well-known/adagents.json` shows `X-AdCP-Spec-Version: 3.0.11` as expected. But the workflow run went red because the smoke test fired immediately after `wrangler deploy` returned, raced Cloudflare edge propagation, and saw the old `3.0.8` for a few seconds before the new worker version was live globally.

The first smoke step (adagents.json reachability) already had a retry loop. This one didn't.

## What
Single-step change: wrap the version-match check in a 10-attempt × 5s loop (~50s upper bound). Real version drift still surfaces — the loop only short-circuits on an actual match — but propagation flakes stop being false reds.

## Test plan
- [ ] Workflow run on merge passes the smoke test on first attempt (or within a couple) and ends green.
- [ ] On a hypothetical real drift (forget to bump the constant), the loop runs all 10 attempts and exits 1 with the existing error message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)