### PR TITLE
ci: smoke test uses GET, not HEAD

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -62,8 +62,12 @@ jobs:
           fi
           # Retry to absorb Cloudflare edge propagation lag after deploy —
           # the new worker version can take ~15-30s to be live globally.
+          # NOTE: must be a GET, not HEAD — the .well-known route doesn't
+          # currently register a HEAD handler and returns 404 to HEAD requests.
+          # Using `-D -` to dump headers + `-o /dev/null` to drop the body keeps
+          # the method as GET while only exposing the header lines to grep.
           for i in 1 2 3 4 5 6 7 8 9 10; do
-            actual=$(curl -sSI https://adcp.signal-stack.io/.well-known/adagents.json \
+            actual=$(curl -sS -D - -o /dev/null https://adcp.signal-stack.io/.well-known/adagents.json \
               | grep -i '^x-adcp-spec-version:' | awk '{print $2}' | tr -d '\r\n' || echo "")
             echo "Attempt $i: expected=$expected actual=$actual"
             if [ "$actual" = "$expected" ]; then


### PR DESCRIPTION
## Why
PR #254's retry loop wasn't the actual fix — the smoke test was still red on every attempt because the request was HEAD, not GET. The worker's \`/.well-known/adagents.json\` route registers GET only; HEAD gets a generic 404 with no \`X-AdCP-Spec-Version\` header, so every retry parsed an empty string regardless of how long propagation had to settle.

Verified locally:
\`\`\`
\$ curl -sI https://adcp.signal-stack.io/.well-known/adagents.json | head -1
HTTP/1.1 404 Not Found
\$ curl -sI -X GET https://adcp.signal-stack.io/.well-known/adagents.json | head -1
HTTP/1.1 200 OK
\`\`\`

## What
\`curl -sSI\` → \`curl -sS -D - -o /dev/null\`. Same effect (headers to stdout, body discarded), but the underlying request stays GET so it hits the registered handler.

## Follow-up worth flagging (not bundled)
The worker probably *should* answer HEAD on this route. Bots, generic health-checkers, and some monitoring tools default to HEAD for cheap availability probes, and 404-on-HEAD-but-200-on-GET surprises people. Separate PR.

## Test plan
- [ ] Workflow run on merge: smoke test should hit on attempt 1 or 2 (the worker is already serving 3.0.11) and the run ends green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)