### PR TITLE
Refresh @adcp/sdk 7.5.0 → 7.11.0 + re-verify compliance

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "adcp-signals-adaptor",
       "version": "1.1.0",
       "dependencies": {
-        "@adcp/sdk": "^7.5.0",
+        "@adcp/sdk": "^7.11.0",
         "@cfworker/json-schema": "^4.1.1",
         "zod": "^4.4.3"
       },
@@ -50,9 +50,9 @@
       }
     },
     "node_modules/@adcp/sdk": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/@adcp/sdk/-/sdk-7.5.0.tgz",
-      "integrity": "sha512-0Ig0N3E08CuXP5Aykqn0atkc8ZCMjpZHJ7xciYILRhtDCaBD/6FXzR0qV0ri5zrKx1ut5fZUhB7E0vUDlj2P9g==",
+      "version": "7.11.0",
+      "resolved": "https://registry.npmjs.org/@adcp/sdk/-/sdk-7.11.0.tgz",
+      "integrity": "sha512-rwNFiKABdINH8odRHWTwmZe36ajAUDnr05IZSTU3+LVlD6/FM4LJHZpw1kNxKvK/5Z2TrJW8W+A7Ihf0+gQi0A==",
       "license": "Apache-2.0",
       "workspaces": [
         ".",
@@ -82,6 +82,7 @@
         "@modelcontextprotocol/sdk": "^1.17.5",
         "@opentelemetry/api": "^1.0.0",
         "pg": "^8.0.0",
+        "redis": "^4.6.0 || ^5.0.0",
         "zod": "^4.1.5"
       },
       "peerDependenciesMeta": {
@@ -89,6 +90,9 @@
           "optional": true
         },
         "pg": {
+          "optional": true
+        },
+        "redis": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "wrangler": "^4.72.0"
   },
   "dependencies": {
-    "@adcp/sdk": "^7.5.0",
+    "@adcp/sdk": "^7.11.0",
     "@cfworker/json-schema": "^4.1.1",
     "zod": "^4.4.3"
   }

--- a/src/constants/complianceState.ts
+++ b/src/constants/complianceState.ts
@@ -16,6 +16,7 @@
 // the updated file to deploy the new state to /capabilities.
 //
 // History (auto-prepended; manual entries also preserved across rewrites):
+//   2026-05-22 — auto-written by scripts/run-compliance.mjs (7/7 applicable, 32 skipped).
 //   2026-05-16 — auto-written by scripts/run-compliance.mjs (7/7 applicable, 32 skipped).
 //   2026-05-15 — auto-written by scripts/run-compliance.mjs (7/7 applicable, 32 skipped).
 //   2026-05-10 — auto-written by scripts/run-compliance.mjs (7/7 applicable, 32 skipped).
@@ -25,7 +26,7 @@
 
 export const COMPLIANCE_STATE = {
   /** ISO date (YYYY-MM-DD) of the last passing compliance run. */
-  last_run: "2026-05-16",
+  last_run: "2026-05-22",
 
   /** Scenario IDs that ran (i.e. were applicable to this agent's tool surface). */
   scenarios_run: [


### PR DESCRIPTION
## Summary

- Refresh `@adcp/sdk` pin from `^7.5.0` → `^7.11.0` (current latest on the 7.x line).
- Re-verify live compliance against the deployed agent — **7/7 applicable scenarios pass**, 32 correctly skipped per `supported_protocols=[\"signals\"]`.
- Auto-write side effect from PR #249 fired — `complianceState.ts` now points at `last_run=2026-05-22`.

## SDK changelog highlights (5.16 → 5.22)

SDK churned 7.5 → 7.6 → 7.7 → 7.8 → 7.9 → 7.10.x → 7.11.0 over the last week. Net effect on our runtime is zero — all minors are additive runner / discovery / SDK-side improvements. Notable ones:

| Version | Highlight | Touches us? |
|---|---|---|
| 7.6 | `AssertionResult.status` carries `silent / pass / fail` | Runner-side; no |
| 7.7 | `array_length` cardinality check for storyboards | Runner-side; no |
| 7.8 | `impairment.coherence` grades audience inverse rule | Runner-side; we're applicability-gated out |
| 7.9 | `pgCtxMetadataStore` persistence bug fix | We don't use SDK's pg backend; no |
| **7.10** | **`fetchAgentAuthorizationsFromDirectory`** — AAO inverse-lookup helper (given agent_url, fetch publishers that authorize it via `adagents.json`) | **Latent** — useful if/when we wire federation discovery |
| 7.11 | `getSignalId` / `getSignalIssuer` read helpers for `SignalID` union | Convenience only |

## Compliance run output

\`\`\`
**Result:** 7 passed, 0 failed out of 7 scenario(s)

✅ health_check          1 step(s)     3ms
✅ discovery             1 step(s)     3ms
✅ capability_discovery  5 step(s)    92ms
✅ error_handling        1 step(s)     3ms
✅ validation            1 step(s)    14ms
✅ signals_flow          9 step(s)  4062ms
✅ schema_compliance     4 step(s)   620ms
                                    ─────
                            Total  6720ms

→ wrote src/constants/complianceState.ts (last_run=2026-05-22, 7/7 applicable). Commit + push to deploy.
\`\`\`

**Notable**: `signals_flow` step count went from 13 → 9 between 7.5 and 7.11 — likely a runner consolidation (the SDK refactored steps internally), not a contract change. All 9 still pass.

## Test plan

- [x] `npm install @adcp/sdk@^7` resolves cleanly to 7.11.0; peer-dep zod@^4 satisfied
- [x] `npm run compliance` → 7/7 pass, 32 skipped, 0 failed against live agent
- [x] Auto-write triggered correctly per PR #249 contract
- [ ] On merge: cache-key auto-invalidation from PR #250 picks up `last_run=2026-05-22` → next \`/get_adcp_capabilities\` hit rebuilds cache; live response reflects new run date

## Out of scope

- **3.1.0 GA bump** (SPEC_VERSION 3.0.12 → 3.1.0 + corpus re-vendor) — separate PR when 3.1.0 GA tags on 2026-05-29. 3.1.0-beta.2 doesn't materially affect our wire surface (verified locally: we don't emit `mcp-webhook-payload` or `push_notification_config`).
- **`fetchAgentAuthorizationsFromDirectory` adoption** for Affinity Answers federation — deferred per workshop-priority.

🤖 Generated with [Claude Code](https://claude.com/claude-code)