### PR TITLE
Bump advertised client_runner to @adcp/sdk@7.11.0

### DIFF
--- a/src/domain/capabilityService.ts
+++ b/src/domain/capabilityService.ts
@@ -386,7 +386,7 @@ function buildStaticCapabilities(env: UcpCapabilityEnv): AdcpCapabilities {
       // regression).
       compliance: {
         spec_version: "adcp_3.0",
-        client_runner: "@adcp/sdk@7.5.0",
+        client_runner: "@adcp/sdk@7.11.0",
         last_run: COMPLIANCE_STATE.last_run,
         results: {
           applicable: COMPLIANCE_STATE.results.applicable,


### PR DESCRIPTION
## Summary

- Small follow-up to PR #259. The package.json + lockfile now resolve to `@adcp/sdk@7.11.0`, but the advertised `client_runner` string in `capabilityService.ts` was still hardcoded at `@adcp/sdk@7.5.0` (from PR #257's SDK migration commit).
- One-line fix: bump the literal so the advertisement matches the runner we actually verified compliance against in #259.

## Verified

Live `/get_adcp_capabilities` response right now reads:

\`\`\`
\"spec_version\": \"adcp_3.0\",
\"client_runner\": \"@adcp/sdk@7.5.0\",   ← stale
\"last_run\": \"2026-05-22\"
\`\`\`

After this merges + deploys, `client_runner` reflects the verified runner version.

## On the drift surface

The `client_runner` field is informational — it tells consumers (HoldCo procurement checks, SDK consumers debugging compliance mismatches) which runner version we last passed against. Letting it drift from the actual SDK version is small but real: a consumer reading our `/capabilities` and seeing `7.5.0` would assume we haven't re-tested against newer runners, when in fact we have.

**Follow-up target (not in this PR):** teach the compliance auto-write side effect from PR #249 to also bump this string. The auto-write currently only updates `complianceState.ts` (last_run + counts); extending it to bump `client_runner` would prevent this drift class permanently. Filed locally.

## Test plan

- [x] Single literal change; `npx tsc --noEmit` would only error on a typo (verified by inspection)
- [ ] On merge: CF auto-deploys; cache-key auto-invalidation from PR #250 will refresh the capability response **only if** `COMPLIANCE_STATE.last_run` ALSO changes — which it doesn't here. So the live response may continue to serve the stale `client_runner` until the next compliance run flips `last_run`.

**One caveat worth flagging:** because PR #250's cache key derives from `(SPEC_VERSION, COMPLIANCE_STATE.last_run)` — not from `client_runner` — this merge alone won't auto-invalidate the cache. Two options:
1. Wait for the next compliance run (or 1-hour TTL) to refresh the cache naturally.
2. Manual `wrangler kv key delete adcp_capabilities_v24_3.0.12_2026-05-22` to force immediate refresh.

I'd lean (1) — the next compliance run is the natural refresh point and this isn't a correctness issue, just a freshness one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)