### PR TITLE
Emit cache_scope: "public" on get_signals — AAO 3.1-readiness fix

### DIFF
--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -700,6 +700,25 @@ async function callGetSignals(
     const cleanResponse: Record<string, unknown> = {
         signals: result.signals,
         pagination: paginationBlock,
+        // AdCP 3.1 added `cache_scope` as required on every get_signals
+        // response. Spec: "When the request did NOT include `account`, the
+        // agent MUST return `cache_scope: 'public'`. When the request
+        // included `account`, the agent MUST return either 'public' (this
+        // account prices off the public rate card — caller dedupes) or
+        // 'account' (account-specific overrides exist)."
+        //
+        // We have no account-overlay pricing — every signal in our catalog
+        // is on the public rate card regardless of caller — so we always
+        // return 'public'. Forward-compat with 3.1 (the field is required
+        // when schema validates against 3.1), back-compat with 3.0 (3.0
+        // schemas don't validate `cache_scope` so the extra field is
+        // permissive).
+        //
+        // Discovered via AAO registry grader marking us 'partial' on the
+        // signals track despite our internal 7.x SDK runs showing pass —
+        // 8.x runner + 3.1-beta schemas enforce this requirement that
+        // 7.x didn't surface.
+        cache_scope: "public" as const,
     };
     const proposals = (result as { proposals?: unknown[] }).proposals;
     if (proposals && proposals.length > 0) cleanResponse["proposals"] = proposals;


### PR DESCRIPTION
## Summary

- AAO registry grader marks us **\"Compliance: Degraded — 2 partial, 1 silent\"** (https://agenticadvertising.org/registry/#agent/signals/no-fluff-advisory---evgeny-(ev)-popov).
- Probe with `@adcp/sdk@8.1.0-beta.13` (the runner version AAO likely uses) surfaces: \`Schema validation failed for get_signals (non-blocking): /cache_scope: must have required property 'cache_scope'\`.
- AdCP 3.1 made `cache_scope` REQUIRED on every `get_signals` response. We didn't emit it. 7.x SDK didn't enforce, so our internal `npm run compliance` showed 7/7 pass.
- Fix: emit `cache_scope: \"public\"` — we have no account-overlay pricing, so the published rate card is always the operative scope.

## Why \"public\"

Per the 3.1 spec:
- `\"public\"`: response describes the agent's published rate card; caller MAY dedupe under `(agent, discovery_mode, filters, destinations, countries)` without scoping by account.
- `\"account\"`: response includes account-specific overrides; caller MUST cache under the account key.

We have no account-overlay pricing. Every signal in our catalog is on the public rate card regardless of caller. Always `public`.

## Back/forward-compat

- **Forward-compat 3.1**: field is now present, satisfies the 3.1 schema's `if/then/else` constraint (`signals` + `cache_scope` required when `unchanged: true` is absent)
- **Back-compat 3.0**: 3.0 schemas don't validate `cache_scope`, so the extra field is permissive. Existing 7.x SDK consumers ignore it.

The 3.1 spec note (verbatim): _\"For responses with `adcp_version` starting `3.0`, the 3.1 cache_scope-required constraint MUST be relaxed — pre-3.1 agents correctly emit no cache_scope and remain conformant to their declared version.\"_ — so 7.x doesn't surface this against our 3.0-declared agent. AAO's 8.x grader appears to enforce regardless of `adcp_version` pivot, OR treats it as 3.1-readiness warning. Either way, emitting the field clears the gap.

## Test plan

- [x] `npx vitest run tests/mcp.test.ts tests/storyboard-conformance.test.ts tests/rest-trace-canonical.test.ts tests/security.test.ts tests/version-unsupported.test.ts` → **119/119 pass**
- [x] Local 7.11 SDK compliance still 7/7 (no regression)
- [x] 8.x SDK probe locally: cache_scope schema error fires twice on get_signals against current live; will be clean post-deploy
- [ ] On merge + deploy: AAO grader re-runs on 12-hour cadence (last_checked_at: 2026-05-26T19:11:47Z); signals track should flip from `silent` → `pass` or `partial` → `pass` at the next check

## Open follow-up

AAO also marks `core` and `error_handling` as `partial`. The headline says \"2 partial, 1 silent\" — cache_scope explains the signals `silent`. The two `partial` markers are likely additional 8.x runner assertions beyond pure schema validation that the public API doesn't expose. We'll see what AAO grader returns after this fix lands; remaining gaps surface as a follow-up if any.

🤖 Generated with [Claude Code](https://claude.com/claude-code)