### PR TITLE
PR A: add adcp.supported_versions + envelope adcp_version echo (AAO compliance)

### DIFF
--- a/src/domain/capabilityService.ts
+++ b/src/domain/capabilityService.ts
@@ -48,7 +48,12 @@
 // Bumps:
 //   v23 → previous baseline
 //   v24 → Sec-31v: added top-level `specialisms` for AAO badge issuance
-const CACHE_KEY_PREFIX = "adcp_capabilities_v24";
+//   v25 → added `adcp.supported_versions` (3.1 release-precision version
+//         negotiation, per the AAO `comply()` runner's
+//         `version_negotiation/capabilities_advertise_and_echo` storyboard).
+//         The cache-suffix derivation (SPEC_VERSION + last_run) wouldn't
+//         auto-invalidate a value-only field add, so we bump the prefix.
+const CACHE_KEY_PREFIX = "adcp_capabilities_v25";
 const CACHE_TTL_SECONDS = 3600;
 
 import { buildUcpCapability, type UcpCapabilityEnv } from "../ucp/vacDeclaration";
@@ -71,6 +76,16 @@ const VALID_PROTOCOLS = new Set([
 type AdcpCapabilities = {
   adcp: {
     major_versions: number[];
+    /**
+     * Release-precision version negotiation per AdCP 3.1
+     * (`version_negotiation/capabilities_advertise_and_echo` compliance
+     * storyboard). Array of release-precision strings (e.g. `["3.0"]`,
+     * `["3.0", "3.1"]`) declaring every release the seller speaks. SHOULD
+     * at 3.1, MUST at 4.0. Authoritative for buyer-side pinning. Strictly
+     * additive: `major_versions: [3]` stays as the 3.0-era surface; both
+     * fields co-exist. Buyers SHOULD prefer `supported_versions`.
+     */
+    supported_versions: string[];
     /**
      * Idempotency replay-window declaration. Required by the HEAD AdCP
      * capabilities schema (per upstream PR #2315 — the field landed without
@@ -127,6 +142,11 @@ function buildStaticCapabilities(env: UcpCapabilityEnv): AdcpCapabilities {
       // after wiring real v2-shape handlers (currently no consumer
       // demand, since 3.0 GA shipped).
       major_versions: [3],
+      // Release-precision version negotiation per AdCP 3.1
+      // (`version_negotiation/capabilities_advertise_and_echo` storyboard).
+      // We advertise 3.0 today — when we re-vendor 3.1 GA and pass conformance,
+      // bump to ["3.0", "3.1"]. SHOULD at 3.1, MUST at 4.0.
+      supported_versions: ["3.0"],
       // HEAD schema models idempotency as a discriminated union keyed on
       // `supported`. The IdempotencySupported variant requires both
       // `supported: true` and `replay_ttl_seconds` (3600..604800 per spec).

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -1342,18 +1342,36 @@ export function toolResult(text: string, structured?: unknown): unknown {
  *   submitted | working | input-required | completed | canceled |
  *   failed | rejected | auth-required | unknown
  */
+/**
+ * Release-precision version negotiation echo per AdCP 3.1 spec
+ * (`version_negotiation/capabilities_advertise_and_echo` storyboard):
+ * every response envelope carries `adcp_version` declaring the release the
+ * seller actually served. SHOULD at 3.1, MUST at 4.0. Paired with
+ * `adcp.supported_versions` on the capabilities response body (the buyer
+ * pins against the array; the envelope confirms which one was served).
+ *
+ * We serve "3.0" today; bump to "3.1" alongside `supported_versions` when
+ * we re-vendor 3.1 GA and pass conformance.
+ */
+const SERVED_ADCP_VERSION = "3.0";
+
 function withMcpEnvelope(
     envelope: { status: string; task_id?: string; context_id?: string; message?: string },
     payload: Record<string, unknown>
 ): Record<string, unknown> {
-    const out: Record<string, unknown> = { status: envelope.status };
+    const out: Record<string, unknown> = {
+        status: envelope.status,
+        adcp_version: SERVED_ADCP_VERSION,
+    };
     if (envelope.task_id !== undefined) out["task_id"] = envelope.task_id;
     if (envelope.context_id !== undefined) out["context_id"] = envelope.context_id;
     if (envelope.message !== undefined) out["message"] = envelope.message;
     for (const [k, v] of Object.entries(payload)) {
         // Spread payload over envelope fields — payload wins on collision so
         // tools that legitimately surface their own status (e.g. get_operation_status)
-        // override the default.
+        // override the default. `adcp_version` is reserved envelope territory;
+        // payloads SHOULD NOT override it (the spec says the envelope echo is
+        // authoritative for what the seller served).
         out[k] = v;
     }
     return out;


### PR DESCRIPTION
## Summary

PR A of the 4-PR fix sequence diagnosed today when AAO's `comply()` runner exposed 7 failures across 4 tracks that our `testAllScenarios()` rubric was silently passing.

Fixes `core: partial` per the `version_negotiation/capabilities_advertise_and_echo` storyboard which is the 3.1 spec's headline new feature (release-precision version negotiation).

## What changes

| File | Change |
|---|---|
| \`src/domain/capabilityService.ts\` | Adds \`adcp.supported_versions: [\"3.0\"]\` to the capability response body. Bumps cache prefix \`v24 → v25\` (shape change). |
| \`src/mcp/server.ts\` | Adds \`adcp_version: \"3.0\"\` to every response envelope via \`withMcpEnvelope()\`. |

\`adcp.major_versions: [3]\` stays — this is strictly additive.

## The 3.1 negotiation contract (from the failing storyboard)

> Response carries both halves of the negotiation contract:
> - **Body**: \`adcp.supported_versions\` (array of release-precision strings, e.g. \`[\"3.0\", \"3.1\"]\`) declaring every release the seller speaks. SHOULD at 3.1, MUST at 4.0. Authoritative for buyer-side pinning.
> - **Envelope**: \`adcp_version\` (release-precision string) echoing the release the seller actually served. SHOULD at 3.1, MUST at 4.0.

We serve \`\"3.0\"\` today (single release line). Bumps to \`[\"3.0\", \"3.1\"]\` + \`adcp_version: \"3.1\"\` when we re-vendor 3.1 GA and pass conformance.

## Test plan

- [x] \`npx tsc --noEmit\` → no new errors (pre-existing nlaq.integration noise unchanged)
- [x] \`npx vitest run\` → **485/485** (28/28 test files)
- [x] Cache prefix bumped to v25 (shape change requires manual prefix bump per PR #250 contract — the value-derived suffix only auto-invalidates on \`SPEC_VERSION\` or \`last_run\` changes)
- [ ] On merge: CF auto-deploys → first \`/get_adcp_capabilities\` hit misses the v24 cache, rebuilds with the new shape, writes to v25 key. Existing v24 blob TTLs out within 1h.
- [ ] Re-run \`comply()\` post-deploy to verify \`core: partial → pass\` (and possibly \`error_handling: partial → pass\` since version_negotiation also failed in error_compliance_signals)

## Remaining fix sequence

- **PR B** — structured \`error.code\` field on MCP errors (fixes 2 of 4 error_handling failures)
- **PR C** — echo buyer \`context\` on error responses (fixes other 2 error_handling failures)
- **PR D** — trim get_signals default response under 64KB (fixes security baseline probe + cascading auth mechanism check)
- **PR E** — swap \`scripts/run-compliance.mjs\` from \`testAllScenarios()\` to \`comply()\` so local runs match AAO grading

After A+B+C+D: expect 3 tracks → pass; \`signals: silent\` may persist (separate investigation — needs observable lifecycle activity to attest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)