### PR TITLE
PR B+C: MCP-style error envelope + context echo (AAO compliance)

### DIFF
--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -279,6 +279,36 @@ async function handleSingleMessage(
                             caller,
                         });
                     }
+                    // AdCP 3.1 transport binding: tool-level errors return as
+                    // JSON-RPC SUCCESS with isError:true in the result body, not
+                    // as JSON-RPC `error`. Per error_compliance_signals storyboard
+                    // (validate_transport_binding + validate_error_shape steps):
+                    // adcp_error.code must be a recognized AdCP code string AND
+                    // /context must echo back on errors too.
+                    if (err instanceof McpToolError) {
+                        const details = (err.details ?? {}) as Record<string, unknown>;
+                        const rawCode = details["code"];
+                        const code = typeof rawCode === "string" ? rawCode : "INTERNAL_ERROR";
+                        const adcpError: { code: string; message: string; recovery?: string; field?: string; details?: unknown; supported_major_versions?: number[] } = {
+                            code,
+                            message: err.message,
+                        };
+                        if (typeof details["recovery"] === "string") adcpError.recovery = details["recovery"] as string;
+                        if (typeof details["field"] === "string") adcpError.field = details["field"] as string;
+                        if (Array.isArray(details["supported_major_versions"])) adcpError.supported_major_versions = details["supported_major_versions"] as number[];
+                        // Preserve any other details (e.g. validation errors)
+                        // by attaching the original detail payload sans the
+                        // fields we've already lifted onto adcp_error.
+                        const knownKeys = new Set(["code", "recovery", "field", "supported_major_versions"]);
+                        const remainder: Record<string, unknown> = {};
+                        for (const [k, v] of Object.entries(details)) {
+                            if (!knownKeys.has(k)) remainder[k] = v;
+                        }
+                        if (Object.keys(remainder).length > 0) adcpError.details = remainder;
+                        const argObj = toolCallParams.arguments as Record<string, unknown> | undefined;
+                        const context = argObj && typeof argObj === "object" ? argObj["context"] : undefined;
+                        return rpcSuccess(id, toolError(adcpError, context));
+                    }
                     throw err;
                 }
             }
@@ -288,8 +318,16 @@ async function handleSingleMessage(
         }
     } catch (err) {
         if (id === undefined || id === null) return null;
+        // Tool-level errors are handled in the tools/call inner catch (they
+        // return MCP-style isError:true results, not JSON-RPC errors). This
+        // outer catch is for transport-level failures (invalid request,
+        // unknown method, unhandled exceptions outside tool dispatch).
+        // McpToolError shouldn't reach here in practice but keeping the
+        // branch for defensiveness — convert to MCP shape if it does.
         if (err instanceof McpToolError) {
-            return rpcError(id, MCP_TOOL_ERROR, err.message, err.details);
+            const details = (err.details ?? {}) as Record<string, unknown>;
+            const code = typeof details["code"] === "string" ? details["code"] as string : "INTERNAL_ERROR";
+            return rpcSuccess(id, toolError({ code, message: err.message }, undefined));
         }
         logger.error("mcp_unhandled_error", { method, error: String(err) });
         return rpcError(id, RPC_INTERNAL_ERROR, "Internal error");
@@ -978,7 +1016,16 @@ async function callActivateSignal(
             (p) => signalId.startsWith(p)
         );
         if (err instanceof NotFoundError && !isStoryboardFixture) {
-            throw new McpToolError(`Signal not found: ${signalId}`, { code: -32000 });
+            // AdCP spec error code for unresolvable references (per
+            // error_compliance_signals/nonexistent_signal storyboard).
+            // Previous `-32000` was the JSON-RPC transport code, not an
+            // AdCP error code — the compliance grader checks
+            // adcp_error.code against the spec enum.
+            throw new McpToolError(`Signal not found: ${signalId}`, {
+                code: "REFERENCE_NOT_FOUND",
+                recovery: "correctable",
+                field: "/signal_agent_segment_id",
+            });
         }
         if (err instanceof NotFoundError) {
             // Sec-31y: synthetic response MUST honor destinationType as
@@ -1181,7 +1228,11 @@ async function callGetSimilarSignals(
     const db = getDb(env);
 
     const refSignal = await findSignalById(db, signalId);
-    if (!refSignal) throw new McpToolError(`Signal not found: ${signalId}`);
+    if (!refSignal) throw new McpToolError(`Signal not found: ${signalId}`, {
+        code: "REFERENCE_NOT_FOUND",
+        recovery: "correctable",
+        field: "/signal_agent_segment_id",
+    });
 
     const { signals: allSignals } = await searchSignals(db, { limit: 200, offset: 0 });
     const candidates = allSignals.filter((s) => s.signalId !== signalId);
@@ -1315,6 +1366,54 @@ export function toolResult(text: string, structured?: unknown): unknown {
         result["structuredContent"] = structured;
     }
     return result;
+}
+
+/**
+ * Build the MCP-style error tool-result per AdCP 3.1 transport binding.
+ * Per the `error_compliance_signals` storyboard's `validate_transport_binding`
+ * expectation: error responses are JSON-RPC SUCCESS with the failure surfaced
+ * via MCP's `isError: true` flag + content carrying an `adcp_error` block.
+ *
+ * Shape:
+ *   {
+ *     content: [{ type: "text", text: JSON.stringify(structuredContent) }],
+ *     isError: true,
+ *     structuredContent: {
+ *       status: "failed",
+ *       adcp_version: "3.0",
+ *       adcp_error: { code, message, recovery?, field?, details? },
+ *       context?: <echoed buyer context>,
+ *     }
+ *   }
+ *
+ * Replaces the prior pattern of letting McpToolError bubble to a JSON-RPC
+ * `error: {-32000, ...}` envelope. That shape worked for the SDK's
+ * `testAllScenarios()` rubric but FAILS the `comply()` storyboards (the
+ * runner AAO actually uses). Both `error_compliance_signals/validate_error_shape`
+ * and `error_compliance_signals/validate_transport_binding` expect the
+ * structured-success shape.
+ *
+ * `context` is echoed when present so buyer agents can correlate the
+ * error to the originating request — `error_compliance_signals` also
+ * checks `field_present: /context` for context round-trip.
+ */
+export function toolError(
+    adcpError: { code: string; message: string; recovery?: string; field?: string; details?: unknown; supported_major_versions?: number[] },
+    context?: unknown,
+): unknown {
+    const structuredContent: Record<string, unknown> = {
+        status: "failed",
+        adcp_version: SERVED_ADCP_VERSION,
+        adcp_error: adcpError,
+    };
+    if (context !== undefined && context !== null && typeof context === "object" && !Array.isArray(context)) {
+        structuredContent["context"] = context;
+    }
+    return {
+        content: [{ type: "text", text: JSON.stringify(structuredContent, null, 2) }],
+        isError: true,
+        structuredContent,
+    };
 }
 
 /**

--- a/tests/version-unsupported.test.ts
+++ b/tests/version-unsupported.test.ts
@@ -6,7 +6,12 @@
 //   * adcp_major_version in supported set ([3]) → ok
 //     Narrowed from [2, 3] -> [3] in PR #247 (v2 claim was paper-only).
 //   * adcp_major_version OUT of supported set → error with code
-//     VERSION_UNSUPPORTED in the JSON-RPC error.data
+//     VERSION_UNSUPPORTED — AdCP 3.1 transport binding (PR #263):
+//     returned as JSON-RPC SUCCESS with result.isError=true and
+//     result.structuredContent.adcp_error.code = "VERSION_UNSUPPORTED".
+//     Previously body.error.data.code (JSON-RPC error shape) — the
+//     `comply()` storyboard runner's validate_transport_binding step
+//     expects the isError-wrapped MCP shape, not JSON-RPC error.
 //   * Recovery carve-out: get_adcp_capabilities with unsupported
 //     version → still returns capabilities (so the buyer can discover
 //     the supported set and retry — the spec's documented recovery
@@ -33,7 +38,29 @@ function mcpReq(rpc: unknown, authHeader = `Bearer ${KEY}`): Request {
   });
 }
 
-async function call(req: Request): Promise<{ status: number; body: { id?: number; result?: unknown; error?: { code: number; message: string; data?: unknown } } }> {
+type McpResultBody = {
+  id?: number;
+  result?: {
+    isError?: boolean;
+    content?: unknown;
+    structuredContent?: {
+      status?: string;
+      adcp_version?: string;
+      adcp_error?: {
+        code?: string;
+        message?: string;
+        recovery?: string;
+        field?: string;
+        supported_major_versions?: number[];
+      };
+      context?: unknown;
+      [k: string]: unknown;
+    };
+  };
+  error?: { code: number; message: string; data?: unknown };
+};
+
+async function call(req: Request): Promise<{ status: number; body: McpResultBody }> {
   const res = await handleMcpRequest(req, env, logger);
   const text = await res.text();
   return { status: res.status, body: text ? JSON.parse(text) : {} };
@@ -61,6 +88,13 @@ describe("VERSION_UNSUPPORTED enforcement", () => {
     expect(body.result).toBeDefined();
   });
 
+  // Helper — extract adcp_error from the new MCP-style isError-wrapped result.
+  // PR #263 moved tool-level errors from JSON-RPC `error: {data: {...}}` to
+  // result.structuredContent.adcp_error per the AdCP 3.1 transport binding.
+  function adcpErrorOf(body: McpResultBody) {
+    return body.result?.structuredContent?.adcp_error;
+  }
+
   it("get_signals with adcp_major_version: 99 returns VERSION_UNSUPPORTED", async () => {
     const { body } = await call(mcpReq({
       jsonrpc: "2.0", id: 3, method: "tools/call",
@@ -69,14 +103,12 @@ describe("VERSION_UNSUPPORTED enforcement", () => {
         arguments: { signal_spec: "anything", adcp_major_version: 99 },
       },
     }));
-    expect(body.error).toBeDefined();
-    expect(body.error?.code).toBe(-32000); // MCP_TOOL_ERROR transport marker
-    expect(body.error?.message).toContain("VERSION_UNSUPPORTED" === "VERSION_UNSUPPORTED" ? "not supported" : "");
-    expect(body.error?.message).toContain("[3]");
-    // Spec error code travels in error.data per rpcError helper
-    const data = body.error?.data as { code?: string; supported_major_versions?: number[] };
-    expect(data?.code).toBe("VERSION_UNSUPPORTED");
-    expect(data?.supported_major_versions).toEqual([3]);
+    expect(body.error).toBeUndefined(); // AdCP 3.1: tool errors are JSON-RPC SUCCESS
+    expect(body.result).toBeDefined();
+    expect(body.result?.isError).toBe(true);
+    const adcp_error = adcpErrorOf(body);
+    expect(adcp_error?.code).toBe("VERSION_UNSUPPORTED");
+    expect(adcp_error?.supported_major_versions).toEqual([3]);
   });
 
   it("get_signals with adcp_major_version: 1 (below range) returns VERSION_UNSUPPORTED", async () => {
@@ -84,9 +116,8 @@ describe("VERSION_UNSUPPORTED enforcement", () => {
       jsonrpc: "2.0", id: 4, method: "tools/call",
       params: { name: "get_signals", arguments: { signal_spec: "anything", adcp_major_version: 1 } },
     }));
-    expect(body.error).toBeDefined();
-    const data = body.error?.data as { code?: string };
-    expect(data?.code).toBe("VERSION_UNSUPPORTED");
+    expect(body.result?.isError).toBe(true);
+    expect(adcpErrorOf(body)?.code).toBe("VERSION_UNSUPPORTED");
   });
 
   it("get_signals with adcp_major_version: 3 (in range) does NOT trip version check", async () => {
@@ -97,9 +128,8 @@ describe("VERSION_UNSUPPORTED enforcement", () => {
       jsonrpc: "2.0", id: 5, method: "tools/call",
       params: { name: "get_signals", arguments: { signal_spec: "anything", adcp_major_version: 3 } },
     }));
-    if (body.error) {
-      const data = body.error.data as { code?: string } | undefined;
-      expect(data?.code).not.toBe("VERSION_UNSUPPORTED");
+    if (body.result?.isError) {
+      expect(adcpErrorOf(body)?.code).not.toBe("VERSION_UNSUPPORTED");
     }
   });
 
@@ -108,9 +138,8 @@ describe("VERSION_UNSUPPORTED enforcement", () => {
       jsonrpc: "2.0", id: 6, method: "tools/call",
       params: { name: "get_signals", arguments: { signal_spec: "anything" } },
     }));
-    if (body.error) {
-      const data = body.error.data as { code?: string } | undefined;
-      expect(data?.code).not.toBe("VERSION_UNSUPPORTED");
+    if (body.result?.isError) {
+      expect(adcpErrorOf(body)?.code).not.toBe("VERSION_UNSUPPORTED");
     }
   });
 
@@ -122,9 +151,8 @@ describe("VERSION_UNSUPPORTED enforcement", () => {
         arguments: { signal_agent_segment_id: "sig_test", destinations: [{ type: "platform", platform: "mock_dsp" }], idempotency_key: "ik_smoke_aaaaaaaaaaaaaa", adcp_major_version: 4 },
       },
     }));
-    expect(body.error).toBeDefined();
-    const data = body.error?.data as { code?: string };
-    expect(data?.code).toBe("VERSION_UNSUPPORTED");
+    expect(body.result?.isError).toBe(true);
+    expect(adcpErrorOf(body)?.code).toBe("VERSION_UNSUPPORTED");
   });
 
   it("non-integer adcp_major_version (string '99') returns VERSION_UNSUPPORTED", async () => {
@@ -134,9 +162,8 @@ describe("VERSION_UNSUPPORTED enforcement", () => {
       jsonrpc: "2.0", id: 8, method: "tools/call",
       params: { name: "get_signals", arguments: { signal_spec: "anything", adcp_major_version: 3.5 } },
     }));
-    expect(body.error).toBeDefined();
-    const data = body.error?.data as { code?: string };
-    expect(data?.code).toBe("VERSION_UNSUPPORTED");
+    expect(body.result?.isError).toBe(true);
+    expect(adcpErrorOf(body)?.code).toBe("VERSION_UNSUPPORTED");
   });
 
   it("get_adcp_capabilities recovery error message tells buyer how to recover", async () => {
@@ -144,6 +171,6 @@ describe("VERSION_UNSUPPORTED enforcement", () => {
       jsonrpc: "2.0", id: 9, method: "tools/call",
       params: { name: "get_signals", arguments: { signal_spec: "anything", adcp_major_version: 99 } },
     }));
-    expect(body.error?.message).toContain("get_adcp_capabilities without adcp_major_version");
+    expect(adcpErrorOf(body)?.message).toContain("get_adcp_capabilities without adcp_major_version");
   });
 });


### PR DESCRIPTION
## Summary

Combined PR B+C of the 4-PR fix sequence — both touch the same error emission path so they ship together. Fixes all 4 failures from `comply()`'s `error_compliance_signals` storyboard:

- `nonexistent_signal` expected `adcp_error.code: \"REFERENCE_NOT_FOUND\"` or `\"INVALID_REQUEST\"` (we emitted JSON-RPC transport code -32000)
- `unsupported_major_version` expected `adcp_error.code: \"VERSION_UNSUPPORTED\"` in the AAO-readable structure
- `validate_error_shape` checks `field_present: /context` on errors
- `validate_transport_binding` checks same `/context` echo + isError: true wrapping

## Root cause

Our error path used JSON-RPC \`error: {-32000, data}\`. The AdCP 3.1 transport binding for tool-level errors is JSON-RPC SUCCESS with \`result.isError: true\` + content carrying an \`adcp_error\` block + \`/context\` echoed back. JSON-RPC \`error\` is reserved for transport-level failures (parse errors, unknown methods) — tool failures use MCP's isError mechanism.

## What changes

| File | Change |
|---|---|
| \`src/mcp/server.ts\` | New \`toolError()\` helper next to \`toolResult()\`; tools/call catch converts McpToolError → rpcSuccess(toolError()) with context echoed from toolCallParams.arguments.context; outer catch defensively converted too; \"Signal not found\" throws (2 sites) now use AdCP code \`REFERENCE_NOT_FOUND\` with recovery + field |
| \`tests/version-unsupported.test.ts\` | Updated 9 assertions from \`body.error.data.code\` shape to \`body.result.structuredContent.adcp_error.code\` shape; added McpResultBody type; helper \`adcpErrorOf(body)\` keeps verbosity tight |

## New error wire shape (per AdCP 3.1 transport binding)

\`\`\`json
{
  \"jsonrpc\": \"2.0\",
  \"id\": 3,
  \"result\": {
    \"content\": [{ \"type\": \"text\", \"text\": \"{...}\" }],
    \"isError\": true,
    \"structuredContent\": {
      \"status\": \"failed\",
      \"adcp_version\": \"3.0\",
      \"adcp_error\": {
        \"code\": \"VERSION_UNSUPPORTED\",
        \"message\": \"adcp_major_version 99 not supported. ...\",
        \"recovery\": \"fatal\",
        \"supported_major_versions\": [3]
      },
      \"context\": { \"correlation_id\": \"abc123\" }
    }
  }
}
\`\`\`

vs. the OLD shape (JSON-RPC error envelope):

\`\`\`json
{
  \"jsonrpc\": \"2.0\",
  \"id\": 3,
  \"error\": {
    \"code\": -32000,
    \"message\": \"adcp_major_version 99 not supported. ...\",
    \"data\": { \"code\": \"VERSION_UNSUPPORTED\", \"supported_major_versions\": [3] }
  }
}
\`\`\`

## Backwards-compat caveat

This is a **wire-format breaking change** for any buyer that was checking \`body.error.code === -32000\` to detect tool errors. The AAO grader was already on the new shape so the change brings us **into** compliance; pre-AdCP-3.1 buyers reading \`body.error\` will need to update to \`body.result.isError\`.

If we have any known live buyers on the old shape, they'd need to migrate — happy to defer this PR if you know of any. Our own internal tests (covered in version-unsupported.test.ts) are the only consumer I'm aware of, and they're updated in this PR.

## Test plan

- [x] \`npx tsc --noEmit\` → clean on changed files
- [x] \`npx vitest run\` → **485/485** (28/28 test files passing)
- [x] \`npx vitest run tests/version-unsupported.test.ts\` → 9/9 on new shape
- [ ] On merge: CF auto-deploys; the cache-key derivation doesn't change (this PR doesn't touch the capability response surface) — error path changes are not capability-cached
- [ ] Re-run \`comply()\` post-deploy to verify \`error_handling: partial → pass\` (4 failures should resolve)

## Remaining

- **PR D** — trim get_signals default response under 64KB (security baseline probe fix)
- **PR E** — swap \`scripts/run-compliance.mjs\` from \`testAllScenarios()\` to \`comply()\` so local runs match AAO

🤖 Generated with [Claude Code](https://claude.com/claude-code)