### PR TITLE
Watcher: drop closed #2916 entry (phase 2 storyboard annotations landed)

### DIFF
--- a/.github/adcp-watch-config.json
+++ b/.github/adcp-watch-config.json
@@ -13,12 +13,6 @@
   "tracking_issue_label": "adcp-watcher-tracker",
   "tracked_issues": [
     {
-      "repo": "adcontextprotocol/adcp",
-      "number": 2916,
-      "kind": "issue",
-      "context": "Q3 systemic FAIL→SKIP applicability bug, half-shipped 2026-04-30. Phase 1 (runner gate): adcp-client#1063 merged into @adcp/sdk 5.25.0+; runner now honors Storyboard.required_tools and emits clean skip_reason:'missing_tool' when no required tool is advertised. We're on 5.25.1 — already have it. Phase 2 (storyboard annotations, the remaining maintainer task): past_start_enforcement + peer media-buy storyboards still need required_tools:[create_media_buy,update_media_buy] in their YAML. Doesn't affect us — we're applicability-gated out of those storyboards via supported_protocols:[signals] before the tool gate fires. Status downgraded from needs-wg-review (bokelley, 2026-05-01); milestone still 3.1.0. Drop after phase 2 lands."
-    },
-    {
       "repo": "adcontextprotocol/adcp-client",
       "number": 1062,
       "kind": "issue",


### PR DESCRIPTION
## Summary

- Drop the watcher tracker entry for upstream adcontextprotocol/adcp#2916. It closed 2026-05-27 (phase 2 storyboard annotations landed), meeting the entry's own \"Drop after phase 2 lands\" trip-wire.
- 6-line removal; watcher config still parses cleanly.

## Why now

Today's watcher state-change diff (#248 / 16:47Z) surfaced adcontextprotocol/adcp#4009 moving Evergreen → Spec Backlog. While checking that surface I confirmed #2916 itself flipped to closed. Per the original entry's documented drop condition:

> _Phase 2 (storyboard annotations, the remaining maintainer task) ... Drop after phase 2 lands._

Condition met. The entry was useful for the ~2-month phase-1-to-phase-2 window; with both phases shipped it's just tracker noise.

## What's NOT changing

- #4009 watcher entry stays (still open, even on Spec Backlog the workshop-insurance heuristic in src/mcp/server.ts:callActivateSignal remains in place until that fix ships)
- adcp-client#1062 watcher entry stays (its own drop condition is a separate spec follow-up that hasn't landed yet)

🤖 Generated with [Claude Code](https://claude.com/claude-code)