### PR TITLE
Remove workshop-insurance heuristic (adcp#4009 verified closed)

### DIFF
--- a/.github/adcp-watch-config.json
+++ b/.github/adcp-watch-config.json
@@ -20,12 +20,6 @@
     },
     {
       "repo": "adcontextprotocol/adcp",
-      "number": 4009,
-      "kind": "issue",
-      "context": "Filed 2026-05-03. Runner bug: signal_owned/activate_on_agent storyboard step omits required `destinations` and `idempotency_key` per /schemas/3.0.1/signals/activate-signal-request.json. Schema-conformant agents have no signal of intent (agent vs platform). Workshop-insurance defensive heuristic shipped in this repo (correlation_id parsing in src/mcp/server.ts:callActivateSignal — search 'REMOVE WHEN adcp#4009 ships'). When the storyboard fix ships and Addie's evaluator confirms badge issuance, REVERT the heuristic — restore the simpler 2-stage destinationType precedence."
-    },
-    {
-      "repo": "adcontextprotocol/adcp",
       "number": 4205,
       "kind": "issue",
       "context": "Filed 2026-05-07 via Addie. RFC 9421 webhook signing migration coordination. DEFERRED — blocked on #3064 (docs default to RFC 9421) + #3360 (grade tooling fails on HMAC-only). @bokelley reframed: 'the installed base of live buyer agents is ~empty right now' — it's an on-ramp problem, not migration. Original 80% threshold was meaningless against ~zero population. Right metric: 'no new HMAC implementers after date X', enforced via four on-ramp surfaces (docs / grade tooling / SDK ✓done / storyboards-untracked). Storyboard surface is the only piece without a tracker; we self-pledged to take it (see #4205 comment 4409426562). Resurfaces when #3064 + #3360 land. Discussion artifact: docs/DISCUSSION_SIGNAL_PAYMENTS.md v5."

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -775,36 +775,22 @@ async function callActivateSignal(
     // Sec-31y: source-of-truth precedence is
     //   1. firstEntry.type (destinations[0].type)  — canonical shape
     //   2. args.destinationType                    — top-level alias
-    //   3. correlation_id heuristic                — REMOVE WHEN adcp#4009 ships
-    //   4. default "platform"                      — backward-compat
+    //   3. default "platform"                      — backward-compat
     //
     // (2) was added when AAO's signal_owned storyboard turned out to
     // sometimes send only the top-level field with no destinations
     // array — without it, those requests fell through to "platform"
     // even when the caller explicitly asked for agent.
     //
-    // (3) — REMOVE WHEN adcp#4009 ships — workshop-insurance heuristic.
-    // The signal_owned storyboard's `activate_on_agent` step sends a
-    // request with NO destinations field (and no idempotency_key — both
-    // required per /schemas/3.0.x/signals/activate-signal-request.json).
-    // Filed as runner bug at https://github.com/adcontextprotocol/adcp/issues/4009.
-    // Until that ships, we fall back to parsing the storyboard's
-    // correlation_id ("signal_owned--activate_on_agent") to recover the
-    // intended destination type. This is non-portable and applies ONLY
-    // when destinations is absent + the correlation_id signals intent.
-    // Watch the AdCP daily watcher for issue #4009 closure → revert this
-    // block + restore the simpler 2-stage precedence above.
+    // The correlation_id heuristic (formerly step 3) was removed when
+    // adcp#4009 shipped in the runner (verified closed 2026-06-01 —
+    // signal_owned/agent_activation passes cleanly with the fixed SDK
+    // sending destinations + idempotency_key). The heuristic was
+    // non-portable and applied only when destinations was absent and the
+    // correlation_id encoded the intent. No longer needed.
     const topLevelType = args["destinationType"] as string | undefined;
-    const correlationId = (args["context"] as Record<string, unknown> | undefined)?.["correlation_id"] as string | undefined;
-    const correlationHints = (() => {
-        if (raw !== undefined || topLevelType !== undefined) return undefined;
-        if (typeof correlationId !== "string") return undefined;
-        if (correlationId.includes("activate_on_agent")) return "agent" as const;
-        if (correlationId.includes("activate_on_platform")) return "platform" as const;
-        return undefined;
-    })();
     const destinationType: "platform" | "agent" =
-        firstType === "agent" || topLevelType === "agent" || correlationHints === "agent"
+        firstType === "agent" || topLevelType === "agent"
             ? "agent"
             : "platform";
 
@@ -843,11 +829,6 @@ async function callActivateSignal(
         const db = getDb(env);
         const result = await activateSignalService(db, env.SIGNALS_CACHE, req, logger);
 
-        // REMOVE WHEN adcp#4009 ships — when destinations is absent, the
-        // default mirrors destinationType (which the correlation_id heuristic
-        // above may have set to "agent"). Without this, real-signal requests
-        // with no destinations + agent intent would still emit a platform
-        // deployment.
         const inputDeployments = Array.isArray(raw)
             ? (raw as Array<Record<string, unknown>>)
             : destinationType === "agent"


### PR DESCRIPTION
## Summary

Removes the `correlation_id` heuristic that was added as step (3) in `callActivateSignal`'s `destinationType` precedence chain. Tagged `REMOVE WHEN adcp#4009 ships` since it was filed on 2026-05-03.

## Verification

Ran the `signal_owned` storyboard against the live agent (SDK 8.1.0-beta.13) today:

```
signal_owned/capability_discovery  → passed
signal_owned/discovery             → passed  
signal_owned/platform_activation   → passed
signal_owned/agent_activation      → passed  ← the specific step #4009 was about
```

The `[AdCP] Stripping fields not declared in agent "test" schema for activate_signal: destinations, account` log lines confirm the runner IS now sending `destinations` — the bug is fixed upstream. Closed adcp#4009 with the verification checklist from Brian's triage comment.

## What's removed

The heuristic parsed `correlation_id` (e.g. `"signal_owned--activate_on_agent"`) to recover the intended destination type when `destinations` was absent. Non-portable, only applied for that specific storyboard, and explicitly tagged for removal.

Simplified 2-stage precedence restored:
1. `firstEntry.type` (`destinations[0].type`) — canonical
2. `args.destinationType` — top-level alias  
3. default `"platform"` — backward-compat

Also drops the `#4009` watcher tracker entry.

## Test plan

- [x] `npx vitest run` → **485/485** passing
- [x] `signal_owned` storyboard passes on live agent (verified above)
- [x] Watcher config parses cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)