### PR TITLE
Fix activate_signal input schema: declare destinations[], idempotency_key, account

### DIFF
--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -261,9 +261,43 @@ export const ADCP_TOOLS: McpToolDefinition[] = [
                         "The signal to activate. From get_signals catalog or proposals array. " +
                         "Example: 'sig_high_income_households'",
                 },
+                // AdCP spec canonical top-level destinations array.
+                // The compliance runner (and spec-conformant buyers) send
+                // destinations[] directly at the top level. We also accept
+                // the legacy deliver_to.deployments nesting for back-compat
+                // with earlier callers — both are read in callActivateSignal.
+                destinations: {
+                    type: "array",
+                    description:
+                        "Spec-canonical activation targets. Each item is either " +
+                        "{ type: 'platform', platform: '...', account?: '...' } or " +
+                        "{ type: 'agent', agent_url: '...' }.",
+                    items: {
+                        type: "object",
+                        properties: {
+                            type: { type: "string", enum: ["platform", "agent"] },
+                            platform: { type: "string" },
+                            agent_url: { type: "string" },
+                            account: { type: "string" },
+                        },
+                        required: ["type"],
+                    },
+                },
+                // idempotency_key: required by the spec on every mutating
+                // tool. Declared here so the runner's field isn't stripped.
+                idempotency_key: {
+                    type: "string",
+                    description: "UUID v4 idempotency key. Reuse the same key on retries.",
+                },
+                // account: spec-level buyer account reference.
+                account: {
+                    type: "object",
+                    description: "Buyer account context (spec field — accepted and ignored for demo).",
+                    additionalProperties: true,
+                },
                 deliver_to: {
                     type: "object",
-                    description: "Required. Specifies where to activate the signal.",
+                    description: "Legacy nested shape — use destinations[] for new integrations.",
                     properties: {
                         deployments: {
                             type: "array",
@@ -304,7 +338,7 @@ export const ADCP_TOOLS: McpToolDefinition[] = [
                     description: "Optional notes about this activation.",
                 },
             },
-            required: ["signal_agent_segment_id", "deliver_to"],
+            required: ["signal_agent_segment_id"],
         },
         outputSchema: {
             type: "object",

--- a/tests/mcp.test.ts
+++ b/tests/mcp.test.ts
@@ -52,11 +52,14 @@ describe("MCP tool definitions", () => {
     expect(getToolByName("generate_custom_signal")).toBeUndefined();
   });
 
-  it("activate_signal requires signal_agent_segment_id and deliver_to", () => {
+  it("activate_signal requires signal_agent_segment_id; accepts both destinations[] and deliver_to", () => {
     const tool = getToolByName("activate_signal")!;
     expect(tool.inputSchema.required).toContain("signal_agent_segment_id");
-    // Bug #10: required field is "deliver_to" (spec name), not "deployments" (old name)
-    expect(tool.inputSchema.required).toContain("deliver_to");
+    // deliver_to is now optional (back-compat) — spec-canonical callers use destinations[]
+    // Both are declared in the schema so the runner doesn't strip either.
+    expect(tool.inputSchema.properties).toHaveProperty("destinations");
+    expect(tool.inputSchema.properties).toHaveProperty("deliver_to");
+    expect(tool.inputSchema.properties).toHaveProperty("idempotency_key");
     expect(tool.inputSchema.required).not.toContain("deployments");
   });
 


### PR DESCRIPTION
## Summary

The comply() storyboard audit revealed `signal_owned/agent_activation` failing with `actual: "platform"` when the runner sends `destinations: [{type:"agent", agent_url:"..."}]`.

## Root cause

Our `activate_signal` input schema only declared `deliver_to.deployments` (our legacy nested shape) — not the spec-canonical top-level `destinations[]`. The SDK's input-schema validator was **stripping** `destinations`, `account`, and `idempotency_key` before our handler saw them (visible in `[AdCP] Stripping fields not declared in agent "test" schema for activate_signal: destinations, account`). With destinations stripped, `destinationType` fell back to `"platform"`.

This is what the correlation_id heuristic (removed in PR #269) was masking — the heuristic worked around the stripped field rather than fixing the schema.

## Fix

Add the spec-canonical fields to the input schema:

- **`destinations[]`** — top-level array per AdCP spec (`{type, platform?, agent_url?, account?}`)
- **`idempotency_key`** — required by spec on every mutating tool (declaring it prevents stripping)
- **`account`** — buyer account context (accepted, logged, not required for our demo)
- **`deliver_to`** — kept for back-compat with legacy callers, now optional

## Result

```
signal_owned/capability_discovery  → pass
signal_owned/discovery             → pass
signal_owned/platform_activation   → pass
signal_owned/agent_activation      → pass  ✅
```

## Test plan

- [x] `npx vitest run` → **485/485** (test updated to reflect dual-shape schema)
- [x] `comply()` `signal_owned` storyboard: all 4 scenarios pass
- [ ] On merge: CF auto-deploys; next AAO regrade should show signals track improvement

🤖 Generated with [Claude Code](https://claude.com/claude-code)