### PR TITLE
feat(signals): get_signals fields selector — adcp#5017 progressive disclosure

### DIFF
--- a/src/constants/complianceState.ts
+++ b/src/constants/complianceState.ts
@@ -16,6 +16,7 @@
 // the updated file to deploy the new state to /capabilities.
 //
 // History (auto-prepended; manual entries also preserved across rewrites):
+//   2026-06-07 — auto-written by scripts/run-compliance.mjs (7/7 applicable, 32 skipped).
 //   2026-06-01 — auto-written by scripts/run-compliance.mjs (7/7 applicable, 32 skipped).
 //   2026-05-22 — auto-written by scripts/run-compliance.mjs (7/7 applicable, 32 skipped).
 //   2026-05-16 — auto-written by scripts/run-compliance.mjs (7/7 applicable, 32 skipped).
@@ -27,7 +28,7 @@
 
 export const COMPLIANCE_STATE = {
   /** ISO date (YYYY-MM-DD) of the last passing compliance run. */
-  last_run: "2026-06-01",
+  last_run: "2026-06-07",
 
   /** Scenario IDs that ran (i.e. were applicable to this agent's tool surface). */
   scenarios_run: [

--- a/src/domain/signalService.ts
+++ b/src/domain/signalService.ts
@@ -134,7 +134,7 @@ export async function searchSignalsService(
     });
   }
 
-  let summaries = toSignalSummaries(ranked);
+  let summaries = toSignalSummaries(ranked, req.fields);
 
   // Filter deployments by requested platforms. The request field is
   // `deployments` on SearchSignalsRequest (not `destinations` — that was

--- a/src/mappers/signalMapper.ts
+++ b/src/mappers/signalMapper.ts
@@ -282,7 +282,18 @@ export function buildDtsLabel(signal: CanonicalSignal): DtsV12Label {
 
 // ── Signal mapper ─────────────────────────────────────────────────────────────
 
-export function toSignalSummary(signal: CanonicalSignal): SignalSummary {
+// adcp#5017: which x_* extension fields to include. Absent = compact (none).
+// "all" includes everything. Individual names are additive.
+const EXTENSION_FIELDS = ["x_dts", "x_ucp", "x_cross_taxonomy", "x_analytics"] as const;
+type ExtensionField = (typeof EXTENSION_FIELDS)[number];
+
+function wantField(field: ExtensionField, fields?: string[]): boolean {
+  if (fields === undefined) return false; // compact by default
+  if (fields.includes("all")) return true;
+  return fields.includes(field);
+}
+
+export function toSignalSummary(signal: CanonicalSignal, fields?: string[]): SignalSummary {
   const coveragePct = signal.estimatedAudienceSize
     ? Math.min(99, Math.round((signal.estimatedAudienceSize / TOTAL_ADDRESSABLE) * 100 * 10) / 10)
     : 0;
@@ -401,23 +412,33 @@ export function toSignalSummary(signal: CanonicalSignal): SignalSummary {
       : {}),
     ...(signal.geography ? { geography: signal.geography } : {}),
     status: signal.status,
-    x_dts: buildDtsLabel(signal),
-    x_ucp: toUcpHybridPayload(signal, buildDtsLabel(signal)),
-    x_cross_taxonomy: buildCrossTaxonomy(signal),
-    x_analytics: (() => {
-      // Sec-41: derived Tier 2/3 facets. All pure functions, deterministic.
-      const seasonality = deriveSeasonality(signal);
-      return {
-        seasonality,
-        decayHalfLifeDays: deriveDecayHalfLifeDays(signal),
-        volatilityIndex: deriveVolatilityIndex(seasonality),
-        authorityScore: deriveAuthorityScore(signal),
-        idStabilityClass: deriveIdStabilityClass(signal),
-      };
-    })(),
+    // adcp#5017: extension fields gated behind the `fields` selector.
+    // Default (fields=undefined) → compact response, no x_* inline.
+    ...(wantField("x_dts", fields) ? { x_dts: buildDtsLabel(signal) } : {}),
+    ...(wantField("x_ucp", fields)
+      ? { x_ucp: toUcpHybridPayload(signal, buildDtsLabel(signal)) }
+      : {}),
+    ...(wantField("x_cross_taxonomy", fields)
+      ? { x_cross_taxonomy: buildCrossTaxonomy(signal) }
+      : {}),
+    ...(wantField("x_analytics", fields)
+      ? {
+          x_analytics: (() => {
+            // Sec-41: derived Tier 2/3 facets. All pure functions, deterministic.
+            const seasonality = deriveSeasonality(signal);
+            return {
+              seasonality,
+              decayHalfLifeDays: deriveDecayHalfLifeDays(signal),
+              volatilityIndex: deriveVolatilityIndex(seasonality),
+              authorityScore: deriveAuthorityScore(signal),
+              idStabilityClass: deriveIdStabilityClass(signal),
+            };
+          })(),
+        }
+      : {}),
   };
 }
 
-export function toSignalSummaries(signals: CanonicalSignal[]): SignalSummary[] {
-  return signals.map(toSignalSummary);
+export function toSignalSummaries(signals: CanonicalSignal[], fields?: string[]): SignalSummary[] {
+  return signals.map((s) => toSignalSummary(s, fields));
 }

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -550,6 +550,8 @@ async function callGetSignals(
     const _t0_get_signals = Date.now();
     const filters = args["filters"] as Record<string, unknown> | undefined;
     const pagination = args["pagination"] as Record<string, unknown> | undefined;
+    // adcp#5017: progressive-disclosure field selector. Absent → compact.
+    const fields = Array.isArray(args["fields"]) ? (args["fields"] as string[]) : undefined;
 
     // Sec-31w: AAO `signal_owned` storyboard's `filter_by_criteria` step
     // sends three filter keys we didn't previously honour:
@@ -633,6 +635,7 @@ async function callGetSignals(
             }
             return numArg(pagination?.["offset"], numArg(args["offset"], 0));
         })(),
+        ...(fields !== undefined ? { fields } : {}),
     };
 
     const db = getDb(env);

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -214,7 +214,7 @@ export const ADCP_TOOLS: McpToolDefinition[] = [
                 },
                 max_results: {
                     type: "number",
-                    description: "Maximum number of signals to return. Default 20, max 100.",
+                    description: "Maximum number of signals to return. Default 5, max 100.",
                 },
                 pagination: {
                     type: "object",
@@ -222,6 +222,19 @@ export const ADCP_TOOLS: McpToolDefinition[] = [
                     properties: {
                         offset: { type: "number", description: "Pagination offset. Default 0." },
                         cursor: { type: "string", description: "Pagination cursor." },
+                        max_results: { type: "number", description: "Max results (preferred over top-level max_results)." },
+                    },
+                },
+                fields: {
+                    type: "array",
+                    description:
+                        "Extension fields to include inline. Omit for a compact discovery response " +
+                        "(core fields only). Use 'all' for everything, or name specific extensions: " +
+                        "'x_dts' (IAB DTS v1.2 label), 'x_ucp' (embedding/vector payload), " +
+                        "'x_cross_taxonomy' (cross-taxonomy bridge), 'x_analytics' (derived facets).",
+                    items: {
+                        type: "string",
+                        enum: ["x_dts", "x_ucp", "x_cross_taxonomy", "x_analytics", "all"],
                     },
                 },
             },

--- a/src/routes/audienceAnalytics.ts
+++ b/src/routes/audienceAnalytics.ts
@@ -72,7 +72,7 @@ import {
 async function loadCatalog(env: Env, _logger: Logger): Promise<SignalSummary[]> {
   const db = getDb(env);
   const { signals } = await searchSignals(db, { limit: 1000, offset: 0 });
-  return signals.map(toSignalSummary);
+  return signals.map((s) => toSignalSummary(s));
 }
 
 function indexById(catalog: SignalSummary[]): Map<string, SignalSummary> {

--- a/src/routes/portfolioEndpoints.ts
+++ b/src/routes/portfolioEndpoints.ts
@@ -40,7 +40,7 @@ import {
 async function loadAllSignals(env: Env, _logger: Logger) {
   const db = getDb(env);
   const { signals } = await searchSignals(db, { limit: 1000, offset: 0 });
-  const summaries = signals.map(toSignalSummary);
+  const summaries = signals.map((s) => toSignalSummary(s));
   return { cats: signals, summaries };
 }
 

--- a/src/routes/searchSignals.ts
+++ b/src/routes/searchSignals.ts
@@ -45,6 +45,12 @@ export async function handleSearchSignals(
     }),
     limit: body?.limit ?? parseInt(url.searchParams.get("limit") ?? "20", 10),
     offset: body?.offset ?? parseInt(url.searchParams.get("offset") ?? "0", 10),
+    // adcp#5017: fields selector — comma-separated in query string, array in body
+    ...(body?.fields
+      ? { fields: body.fields }
+      : url.searchParams.has("fields")
+        ? { fields: url.searchParams.get("fields")!.split(",").map((f) => f.trim()) }
+        : {}),
   };
 
   const validation = validateSearchRequest(req);

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -44,6 +44,10 @@ export interface SearchSignalsRequest {
   offset?: number;
   // AdCP brief — natural language, triggers custom segment proposals
   brief?: string;
+  // adcp#5017: progressive-disclosure field selector. When absent the response
+  // is compact (core fields only, no x_* extensions). Pass extension field
+  // names or "all" to include them inline.
+  fields?: string[];
 }
 
 export interface SearchSignalsResponse {


### PR DESCRIPTION
## Summary

Implements the `fields` parameter on `get_signals` per [adcontextprotocol/adcp#5017](https://github.com/adcontextprotocol/adcp/pull/5017) (merged 2026-05-29). Resolves the 88KB payload problem flagged in the upstream discussion.

## Behavior change

Default response is now **compact** — core fields only, no `x_*` extensions inline. Callers opt in:

```json
{ "fields": ["x_dts"] }
{ "fields": ["x_dts", "x_ucp", "x_cross_taxonomy", "x_analytics"] }
{ "fields": ["all"] }
```

**Before:** 5 signals → ~88KB (over AAO's 64KB security_baseline ceiling)
**After:** 5 signals → ~15KB compact; full payload only when explicitly requested

## Files

| File | Change |
|---|---|
| `src/mappers/signalMapper.ts` | `wantField()` predicate gates all 4 x_* blocks; `toSignalSummaries` forwards `fields` |
| `src/mcp/tools.ts` | `fields` in `inputSchema` with enum; fix max_results description (5 not 20) |
| `src/mcp/server.ts` | Extract `fields` from args, spread into req |
| `src/routes/searchSignals.ts` | Parse `fields` from body array or comma-separated query param |
| `src/types/api.ts` | `fields?: string[]` on `SearchSignalsRequest` |
| `src/domain/signalService.ts` | Thread `req.fields` through to `toSignalSummaries` |
| `src/routes/audienceAnalytics.ts` | Lambda-wrap `.map(toSignalSummary)` (index was bleeding into `fields` param) |
| `src/routes/portfolioEndpoints.ts` | Same fix |

## Test plan

- [x] `npm run type-check` — zero new src/ errors
- [x] `npm run compliance` — 7/7 passing; `signals_flow` (9 steps) validates against compact response
- [x] `comply()` AAO-style diagnostic — Core Protocol 21/21, Signals 9/9

🤖 Generated with [Claude Code](https://claude.com/claude-code)