### PR TITLE
chore: refresh compliance baseline 2026-06-07 (7/7 applicable, live)

### DIFF
--- a/src/constants/complianceState.ts
+++ b/src/constants/complianceState.ts
@@ -16,6 +16,7 @@
 // the updated file to deploy the new state to /capabilities.
 //
 // History (auto-prepended; manual entries also preserved across rewrites):
+//   2026-06-07 — auto-written by scripts/run-compliance.mjs (7/7 applicable, 32 skipped).
 //   2026-06-01 — auto-written by scripts/run-compliance.mjs (7/7 applicable, 32 skipped).
 //   2026-05-22 — auto-written by scripts/run-compliance.mjs (7/7 applicable, 32 skipped).
 //   2026-05-16 — auto-written by scripts/run-compliance.mjs (7/7 applicable, 32 skipped).
@@ -27,7 +28,7 @@
 
 export const COMPLIANCE_STATE = {
   /** ISO date (YYYY-MM-DD) of the last passing compliance run. */
-  last_run: "2026-06-01",
+  last_run: "2026-06-07",
 
   /** Scenario IDs that ran (i.e. were applicable to this agent's tool surface). */
   scenarios_run: [


### PR DESCRIPTION
Re-ran the storyboard suite (`npm run compliance` → `@adcp/sdk@7.11.0` `testAllScenarios`) against the **deployed worker**.

## Result
```
7 passed, 0 failed out of 7 scenario(s)   ·   0 schema warnings   ·   exit 0
```
| Scenario | Steps |
|---|---|
| health_check | 1 ✅ |
| discovery | 1 ✅ |
| capability_discovery | 5 ✅ |
| error_handling | 1 ✅ |
| validation | 1 ✅ |
| signals_flow | 9 ✅ |
| schema_compliance | 4 ✅ |

32 non-signals scenarios skipped (media-buy / creative / governance / SI / brand — tools not advertised).

## Change
Auto-written by `scripts/run-compliance.mjs`: only the `last_run` date (2026-06-01 → **2026-06-07**) and a history line change. Scenario set + counts identical to the prior baseline. Deploying advances the date `/capabilities` advertises via `ext.compliance.last_run`.

## Note
Suite targets the **3.0.12** storyboard (SDK 7.11.0's pinned `adcpVersion`), not 3.1.0-rc.10. A separate rc.10 certification probe (via `@adcp/sdk@9.0.0-beta`) is being run independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)