### PR TITLE
fix(capabilities): auto-capture client_runner so it can't go stale

### DIFF
--- a/scripts/run-compliance.mjs
+++ b/scripts/run-compliance.mjs
@@ -33,7 +33,14 @@ import pkg from "@adcp/sdk/testing";
 import { readFileSync, writeFileSync } from "node:fs";
 import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
+import { createRequire } from "node:module";
 const { testAllScenarios, formatSuiteResults, formatSuiteResultsJSON } = pkg;
+
+// The exact @adcp/sdk build that executes the suite. Captured here (not
+// hardcoded in capabilityService.ts) so /capabilities advertises the real
+// runner version and can never drift past a dependency bump.
+const require = createRequire(import.meta.url);
+const CLIENT_RUNNER = `@adcp/sdk@${require("@adcp/sdk/package.json").version}`;
 
 const AGENT_URL = process.env.AGENT_URL ?? "https://adcp-signals-adaptor.evgeny-193.workers.dev/mcp";
 const API_KEY = process.env.API_KEY ?? process.env.DEMO_API_KEY;
@@ -103,6 +110,10 @@ ${mergedHistory}
 export const COMPLIANCE_STATE = {
   /** ISO date (YYYY-MM-DD) of the last passing compliance run. */
   last_run: ${JSON.stringify(lastRun)},
+
+  /** The @adcp/sdk build that executed the suite, captured live by the
+   *  runner so /capabilities never advertises a stale runner version. */
+  client_runner: ${JSON.stringify(CLIENT_RUNNER)},
 
   /** Scenario IDs that ran (i.e. were applicable to this agent's tool surface). */
   scenarios_run: [

--- a/src/constants/complianceState.ts
+++ b/src/constants/complianceState.ts
@@ -30,6 +30,10 @@ export const COMPLIANCE_STATE = {
   /** ISO date (YYYY-MM-DD) of the last passing compliance run. */
   last_run: "2026-06-07",
 
+  /** The @adcp/sdk build that executed the suite, captured live by the
+   *  runner so /capabilities never advertises a stale runner version. */
+  client_runner: "@adcp/sdk@7.11.0",
+
   /** Scenario IDs that ran (i.e. were applicable to this agent's tool surface). */
   scenarios_run: [
     "capability_discovery",

--- a/src/domain/capabilityService.ts
+++ b/src/domain/capabilityService.ts
@@ -408,7 +408,7 @@ function buildStaticCapabilities(env: UcpCapabilityEnv): AdcpCapabilities {
       // /capabilities (e.g. a HoldCo procurement check) sees the score
       // and the structural ceiling without needing to read SEC42_*.md.
       //
-      // `last_run` + counts + scenarios_run live in
+      // `last_run` + `client_runner` + counts + scenarios_run live in
       // src/constants/complianceState.ts and are auto-updated by
       // scripts/run-compliance.mjs on every passing run (PR #249). The
       // 5.25 runner restored error_handling / schema_compliance /
@@ -418,7 +418,7 @@ function buildStaticCapabilities(env: UcpCapabilityEnv): AdcpCapabilities {
       // regression).
       compliance: {
         spec_version: "adcp_3.0",
-        client_runner: "@adcp/sdk@7.5.0",
+        client_runner: COMPLIANCE_STATE.client_runner,
         last_run: COMPLIANCE_STATE.last_run,
         results: {
           applicable: COMPLIANCE_STATE.results.applicable,


### PR DESCRIPTION
## Problem
Live `/capabilities` → `ext.compliance.client_runner` advertises **`@adcp/sdk@7.5.0`**, but the compliance suite actually runs under **7.11.0** (`package.json` pins `^7.11.0`). The value was a hardcoded literal at `capabilityService.ts:421` that no dependency bump ever updated — so it silently drifted ~6 patches stale.

## Fix
Treat it like `last_run`/`results`, which are already auto-written:
- `scripts/run-compliance.mjs` reads the installed `@adcp/sdk` version (via `createRequire` → `@adcp/sdk/package.json`) and writes `client_runner` into `COMPLIANCE_STATE` on every passing run.
- `capabilityService.ts` reads `COMPLIANCE_STATE.client_runner` instead of a hand-maintained string.

Now it can't drift past a dependency change — the next `npm run compliance` always re-captures the real version.

## Verification
- Regenerated `complianceState.ts` → `client_runner: "@adcp/sdk@7.11.0"`; suite re-verified **7/7 applicable, 0 failures, 0 schema warnings** live against the deployed worker.
- `tsc`: the three touched files are clean. (The repo's pre-existing 88 test-only type errors are unrelated and unchanged by this PR.)
- Capabilities/compliance runtime tests pass (mcp / security / version-unsupported — 11 tests, incl. the `get_adcp_capabilities` public carve-out).

`spec_version: "adcp_3.0"` is left unchanged (intentional — holding 3.0.15 GA per the rc.10 hold-until-GA decision).

🤖 Generated with [Claude Code](https://claude.com/claude-code)