### PR TITLE
chore(watcher+conformance): track latest for 3.1 line; re-verify @adcp/sdk 9.2.0

### DIFF
--- a/scripts/adcp-watch.mjs
+++ b/scripts/adcp-watch.mjs
@@ -161,6 +161,11 @@ async function buildNewState() {
   //     was pure watcher noise. Track the `adcp-3.0` / `adcp-3.1` dist-tags
   //     instead — the builds our storyboard suite actually grades against.
   //     Fires only when a conformance build moves.
+  //     Post-GA (2026-06-26): upstream RETIRED the `adcp-3.1` parallel tag.
+  //     `latest` (9.x, GA) is now the canonical 3.1 conformance build, so
+  //     conformance_3_1 falls back to `latest` when `adcp-3.1` is absent —
+  //     otherwise it reads null forever and the 3.1 line goes untracked.
+  //     (Revisit if a future 4.0 line ever claims `latest`.)
   const pkgJson = JSON.parse(readFileSync(config.client_sdk.package_json_path, "utf8"));
   const pin =
     pkgJson.devDependencies?.[config.client_sdk.package_name] ??
@@ -177,7 +182,7 @@ async function buildNewState() {
     : {
         current_pin: pin,
         conformance_3_0: distTags?.["adcp-3.0"] ?? null,
-        conformance_3_1: distTags?.["adcp-3.1"] ?? null,
+        conformance_3_1: distTags?.["adcp-3.1"] ?? distTags?.["latest"] ?? null,
       };
 
   // 3a-bis. Secondary SDKs — packages we don't pin yet but want to watch

--- a/src/constants/complianceState.ts
+++ b/src/constants/complianceState.ts
@@ -16,6 +16,7 @@
 // the updated file to deploy the new state to /capabilities.
 //
 // History (auto-prepended; manual entries also preserved across rewrites):
+//   2026-06-27 — auto-written by scripts/run-compliance.mjs (7/7 applicable, 32 skipped).
 //   2026-06-07 — auto-written by scripts/run-compliance.mjs (7/7 applicable, 32 skipped).
 //   2026-06-01 — auto-written by scripts/run-compliance.mjs (7/7 applicable, 32 skipped).
 //   2026-05-22 — auto-written by scripts/run-compliance.mjs (7/7 applicable, 32 skipped).
@@ -28,11 +29,11 @@
 
 export const COMPLIANCE_STATE = {
   /** ISO date (YYYY-MM-DD) of the last passing compliance run. */
-  last_run: "2026-06-07",
+  last_run: "2026-06-27",
 
   /** The @adcp/sdk build that executed the suite, captured live by the
    *  runner so /capabilities never advertises a stale runner version. */
-  client_runner: "@adcp/sdk@7.11.0",
+  client_runner: "@adcp/sdk@9.2.0",
 
   /** Scenario IDs that ran (i.e. were applicable to this agent's tool surface). */
   scenarios_run: [


### PR DESCRIPTION
## Why
Upstream **retired the `adcp-3.1` `@adcp/sdk` dist-tag** post-GA. The watcher logged `conformance_3_1: 9.0.0 → null` on 2026-06-26. Current tags: `adcp-3.0 = 7.11.7`, `latest = 9.2.0` — and `latest` (9.x GA) is now the canonical 3.1 conformance build.

## (a) Watcher repoint
`adcp-watch.mjs`: `conformance_3_1` now falls back to `latest` when `adcp-3.1` is absent — so the 3.1 conformance line stays tracked instead of reading `null` forever. Comment documents the post-GA retirement (and a note to revisit if a future 4.0 line claims `latest`).

## (b) Re-verify against 9.2.0
Ran the storyboard suite against `@adcp/sdk@9.2.0` (temp `--no-save` install) on the **live agent** (`adcp.signal-stack.io/mcp`):

```
7 passed, 0 failed out of 7 applicable
✅ health_check · discovery · capability_discovery(5) · error_handling
✅ validation · signals_flow(9) · schema_compliance(4)
(32 non-applicable scenarios skipped)
```

`complianceState.ts` auto-written → `client_runner: "@adcp/sdk@9.2.0"`, `last_run: 2026-06-27`, so `/capabilities` advertises the real grader version. **node_modules restored to the pinned `^7.11.0`** afterward — no `package.json` change.

## Checks
- `tsc` unchanged (88 baseline)
- No new test failures (the 2 reds are pre-existing: `x_dts`, `pagination`)
- 2 files changed