### PR TITLE
feat(signals): AdCP 3.1 wholesale feed mirroring + discovery_modes

### DIFF
--- a/src/domain/capabilityService.ts
+++ b/src/domain/capabilityService.ts
@@ -65,7 +65,10 @@
 //         promotion (2026-06-18). The v26 re-add condition is now met — the
 //         live agent passes the v3.1.0 GA storyboard suite 7/7. Prefix bump
 //         so the new field isn't served from a stale v26 blob.
-const CACHE_KEY_PREFIX = "adcp_capabilities_v27";
+//   v28 → added signals.discovery_modes ["brief","wholesale"] +
+//         signals.in_flight_max_seconds (3.1 wholesale-feed mirroring). Prefix
+//         bump so the new fields aren't served from a stale v27 blob.
+const CACHE_KEY_PREFIX = "adcp_capabilities_v28";
 const CACHE_TTL_SECONDS = 3600;
 
 import { buildUcpCapability, type UcpCapabilityEnv } from "../ucp/vacDeclaration";
@@ -247,6 +250,15 @@ function buildStaticCapabilities(env: UcpCapabilityEnv): AdcpCapabilities {
       "temporal.volatility_index",
     ],
     signals: {
+      // AdCP 3.1 — declare the discovery enumeration modes we support:
+      // `brief` = NL/filter discovery via get_signals; `wholesale` = full
+      // catalog mirroring with a wholesale_feed_version token for ETag-style
+      // conditional fetch (if_wholesale_feed_version → unchanged:true).
+      discovery_modes: ["brief", "wholesale"],
+      // AdCP 3.1 — max wall-clock for an in-flight get_signals call. Our
+      // discovery is fully synchronous (one D1 query + map), so this is a
+      // conservative ceiling, not a typical latency.
+      in_flight_max_seconds: 30,
       // Sec-42: declare GA-required fields (additive; ext fields kept
       // for backward-compat + our own tooling).
       data_provider_domains: ["evgeny.dev"],

--- a/src/domain/signalService.ts
+++ b/src/domain/signalService.ts
@@ -587,6 +587,42 @@ export async function getAllSignalsForCatalog(db: DB): Promise<CatalogSignal[]> 
   }));
 }
 
+// ── AdCP 3.1 wholesale feed mirroring ─────────────────────────────────────────
+
+/** FNV-1a (32-bit) → 8-char hex. Same hash family used across the mock vendors. */
+function fnv1aHex(s: string): string {
+  let h = 0x811c9dc5;
+  for (let i = 0; i < s.length; i++) {
+    h ^= s.charCodeAt(i);
+    h = Math.imul(h, 0x01000193);
+  }
+  return (h >>> 0).toString(16).padStart(8, "0");
+}
+
+/**
+ * AdCP 3.1 wholesale feed mirroring: a deterministic version token over the
+ * full signal catalog. A buyer caches it from a get_signals response and passes
+ * it back as `if_wholesale_feed_version` for ETag-style conditional fetch — when
+ * it matches, the seller answers `unchanged: true` and skips the payload. The
+ * token rolls whenever a signal is added, removed, renamed, or re-sized, so it
+ * is a faithful catalog fingerprint (opaque to callers, per spec).
+ */
+/** Pure: deterministic feed token from a catalog snapshot. Order-independent. */
+export function feedTokenFor(
+  signals: Array<{ signalId: string; name: string; estimatedAudienceSize?: number | null }>,
+): string {
+  const material = signals
+    .map((s) => `${s.signalId}:${s.name}:${s.estimatedAudienceSize ?? 0}`)
+    .sort()
+    .join("|");
+  return `wf_${signals.length}_${fnv1aHex(material)}`;
+}
+
+export async function getWholesaleFeedVersion(db: DB): Promise<string> {
+  const { signals } = await searchSignals(db, { limit: 500, offset: 0 });
+  return feedTokenFor(signals);
+}
+
 /**
  * Infers dimension rules from signal IDs so the NL query resolver's
  * Pass 1 (exact rule match) fires correctly against the real D1 catalog.

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -24,7 +24,7 @@ import { findSignalById, searchSignals } from "../storage/signalRepo";
 import { createEmbeddingEngine } from "../ucp/embeddingEngine";
 import { cosineSimilarity } from "../domain/semanticResolver";
 import { toSignalSummary } from "../mappers/signalMapper";
-import { getAllSignalsForCatalog } from "../domain/signalService";
+import { getAllSignalsForCatalog, getWholesaleFeedVersion } from "../domain/signalService";
 import { handleNLQuery } from "../domain/nlQueryHandler";
 import { handleConceptToolCall } from "../domain/conceptHandler";
 import { compactObj } from "../utils/objects";
@@ -658,6 +658,39 @@ async function callGetSignals(
     };
 
     const db = getDb(env);
+
+    // AdCP 3.1 wholesale feed mirroring (ETag-style conditional fetch). A
+    // catalog-fingerprint token is emitted on every response; when the caller
+    // echoes a matching `if_wholesale_feed_version`, the catalog is unchanged
+    // since their last pull — answer `unchanged: true` and skip the (possibly
+    // large) payload entirely. Purely additive: 3.0 callers omit the field and
+    // always get the full response.
+    const wholesaleFeedVersion = await getWholesaleFeedVersion(db);
+    const ifWholesaleFeedVersion =
+        typeof args["if_wholesale_feed_version"] === "string"
+            ? (args["if_wholesale_feed_version"] as string)
+            : null;
+    if (ifWholesaleFeedVersion && ifWholesaleFeedVersion === wholesaleFeedVersion) {
+        const unchanged = withMcpEnvelope({ status: "completed" }, {
+            signals: [],
+            pagination: { has_more: false },
+            cache_scope: "public" as const,
+            wholesale_feed_version: wholesaleFeedVersion,
+            unchanged: true,
+        });
+        const _trace_unchanged = safeRecordSignalTrace({
+            tool_name: "get_signals",
+            direction: "inbound",
+            source: "mcp_external",
+            request_payload: args,
+            response_payload: unchanged,
+            response_status: "ok",
+            duration_ms: Date.now() - _t0_get_signals,
+        });
+        await persistSignalTrace(env, _trace_unchanged);
+        return toolResultJson(unchanged);
+    }
+
     // The compactObj-stripped req widens enum-typed fields (categoryType,
     // generationMode) to plain string. The runtime values are still the
     // canonical AdCP enum members — cast to satisfy the stricter typed
@@ -779,6 +812,9 @@ async function callGetSignals(
         // 8.x runner + 3.1-beta schemas enforce this requirement that
         // 7.x didn't surface.
         cache_scope: "public" as const,
+        // AdCP 3.1 wholesale feed mirroring — opaque catalog-version token the
+        // caller echoes as `if_wholesale_feed_version` for conditional fetch.
+        wholesale_feed_version: wholesaleFeedVersion,
     };
     const proposals = (result as { proposals?: unknown[] }).proposals;
     if (proposals && proposals.length > 0) cleanResponse["proposals"] = proposals;

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -237,6 +237,14 @@ export const ADCP_TOOLS: McpToolDefinition[] = [
                         enum: ["x_dts", "x_ucp", "x_cross_taxonomy", "x_analytics", "all"],
                     },
                 },
+                if_wholesale_feed_version: {
+                    type: "string",
+                    description:
+                        "AdCP 3.1 wholesale feed mirroring. Echo the wholesale_feed_version " +
+                        "token from a prior response for ETag-style conditional fetch: if the " +
+                        "catalog is unchanged the response is { unchanged: true, signals: [] } " +
+                        "instead of the full payload.",
+                },
             },
             required: ["signal_spec", "deliver_to"],
         },

--- a/tests/wholesale-feed-version.test.ts
+++ b/tests/wholesale-feed-version.test.ts
@@ -1,0 +1,56 @@
+// tests/wholesale-feed-version.test.ts
+//
+// AdCP 3.1 wholesale feed mirroring — pins the `wholesale_feed_version` token
+// contract. The token is an opaque catalog fingerprint a buyer echoes as
+// `if_wholesale_feed_version` for ETag-style conditional fetch; it MUST be
+// deterministic for an unchanged catalog and MUST roll when the catalog's
+// composition or per-signal content changes.
+
+import { describe, it, expect } from "vitest";
+import { feedTokenFor } from "../src/domain/signalService";
+
+const sig = (id: string, name: string, size = 1000) => ({
+  signalId: id,
+  name,
+  estimatedAudienceSize: size,
+});
+
+describe("AdCP 3.1 wholesale_feed_version token", () => {
+  it("is deterministic for the same catalog", () => {
+    const cat = [sig("sig_a", "Alpha"), sig("sig_b", "Beta")];
+    expect(feedTokenFor(cat)).toBe(feedTokenFor(cat));
+  });
+
+  it("is order-independent (material is sorted before hashing)", () => {
+    expect(feedTokenFor([sig("sig_a", "Alpha"), sig("sig_b", "Beta")])).toBe(
+      feedTokenFor([sig("sig_b", "Beta"), sig("sig_a", "Alpha")]),
+    );
+  });
+
+  it("rolls when a signal is added", () => {
+    const v1 = feedTokenFor([sig("sig_a", "Alpha")]);
+    const v2 = feedTokenFor([sig("sig_a", "Alpha"), sig("sig_b", "Beta")]);
+    expect(v2).not.toBe(v1);
+  });
+
+  it("rolls when a signal is renamed", () => {
+    expect(feedTokenFor([sig("sig_a", "Alpha")])).not.toBe(
+      feedTokenFor([sig("sig_a", "Alpha v2")]),
+    );
+  });
+
+  it("rolls when a signal is re-sized", () => {
+    expect(feedTokenFor([sig("sig_a", "Alpha", 1000)])).not.toBe(
+      feedTokenFor([sig("sig_a", "Alpha", 2000)]),
+    );
+  });
+
+  it("encodes the catalog count and a wf_ prefix (opaque but well-formed)", () => {
+    const v = feedTokenFor([sig("sig_a", "Alpha"), sig("sig_b", "Beta")]);
+    expect(v).toMatch(/^wf_2_[0-9a-f]{8}$/);
+  });
+
+  it("handles an empty catalog", () => {
+    expect(feedTokenFor([])).toMatch(/^wf_0_[0-9a-f]{8}$/);
+  });
+});


### PR DESCRIPTION
## What
Tier-1 of the 3.1 signals review — the marquee new **signals** surface in AdCP 3.1, plus the discovery-mode capability declarations. **Fully additive**: 3.0 callers omit the new field and always get the full response.

## Changes
- **`get_signals` emits `wholesale_feed_version`** — an opaque, deterministic catalog fingerprint (FNV-1a over the sorted signal set + per-signal content). Rolls when a signal is added / removed / renamed / re-sized.
- **Honors `if_wholesale_feed_version`** for ETag-style conditional fetch — a match short-circuits to `{ unchanged: true, signals: [] }` and skips the payload *and the search query* entirely.
- **Capabilities:** `signals.discovery_modes: ["brief","wholesale"]` + `signals.in_flight_max_seconds`. Cache prefix `v27 → v28`.
- **`get_signals` inputSchema** declares `if_wholesale_feed_version`.

## Why these (from the 3.1 signals review)
The 3.1 release adds wholesale feed mirroring + `discovery_modes` as the main *new optional signal surfaces*. We already satisfy everything required (`cache_scope`, version negotiation, `last_updated`). This is the highest-leverage additive enhancement and directly demonstrates 3.1 leadership in the domain we're a WG member for.

## Validation
- `tsc` unchanged (88 baseline) · worker bundles clean (wrangler dry-run)
- New `feedTokenFor` unit test: **7/7** (determinism, order-independence, rolls on add/rename/resize, format, empty catalog)
- Full suite: no new failures (only the 2 pre-existing reds)
- **Post-merge:** re-verify against the AAO 9.2.0 storyboard grader on the live agent + probe the conditional-fetch round-trip + confirm the badge holds.

## Deferred (follow-ups)
Signal webhooks (`signal.{created,updated,priced,removed}`), `pricing_version`, `SignalRef` identity migration, and the Tier-3 polish bundle.